### PR TITLE
zmq_streamer: Rename DOWNSTREAM/UPSTREAM to PUSH/PULL

### DIFF
--- a/devices/zmq_streamer/zmq_streamer.cpp
+++ b/devices/zmq_streamer/zmq_streamer.cpp
@@ -53,8 +53,8 @@ int main (int argc, char *argv [])
 
     //  TODO: make the number of I/O threads configurable.
     zmq::context_t ctx (1);
-    zmq::socket_t in_socket (ctx, ZMQ_UPSTREAM);
-    zmq::socket_t out_socket (ctx, ZMQ_DOWNSTREAM);
+    zmq::socket_t in_socket (ctx, ZMQ_PULL);
+    zmq::socket_t out_socket (ctx, ZMQ_PUSH);
 
     int n = 0;
     while (true) {


### PR DESCRIPTION
I went on to create a "pipeline" device until I realized it was the streamer... Doing so I noticed zmq_streamer used the legacy names, I personally feel PUSH/PULL is much clearer.
