### PR TITLE
Resolve "warning: function declaration isn’t a prototype" in zmq.h,zmq_utils.h

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -108,7 +108,7 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 /*  of this function is to make the code 100% portable, including where 0MQ   */
 /*  compiled with certain CRT library (on Windows) is linked to an            */
 /*  application that uses different CRT library.                              */
-ZMQ_EXPORT int zmq_errno ();
+ZMQ_EXPORT int zmq_errno (void);
 
 /*  Resolves system errors and 0MQ errors to human-readable string.           */
 ZMQ_EXPORT const char *zmq_strerror (int errnum);

--- a/include/zmq_utils.h
+++ b/include/zmq_utils.h
@@ -45,7 +45,7 @@ extern "C" {
 /*  about minutiae of time-related functions on different OS platforms.       */
 
 /*  Starts the stopwatch. Returns the handle to the watch.                    */
-ZMQ_EXPORT void *zmq_stopwatch_start ();
+ZMQ_EXPORT void *zmq_stopwatch_start (void);
 
 /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
 /*  the stopwatch was started.                                                */


### PR DESCRIPTION
When I compile against zeromq, I get a few of these warnings:
    warning: function declaration isn’t a prototype

changing the declarations from f(); to f(void); resolves the warnings.
