### PR TITLE
Corrected discarding of remainder of message when request ID invalid

### DIFF
--- a/tests/test_invalid_rep.cpp
+++ b/tests/test_invalid_rep.cpp
@@ -20,6 +20,7 @@
 
 #include "../include/zmq.h"
 #include <assert.h>
+//#include <stdio.h>
 
 int main (int argc, char *argv [])
 {
@@ -55,11 +56,79 @@ int main (int argc, char *argv [])
     rc = zmq_recv (xrep_socket, body, sizeof (body), 0);
     assert (rc == 1);
 
-    //  Send invalid reply.
+    //  Send invalid reply (addr not label).
     rc = zmq_send (xrep_socket, addr, 4, 0);
     assert (rc == 4);
 
-    //  Send valid reply.
+    rc = zmq_recv (req_socket, body, sizeof (body), ZMQ_DONTWAIT);
+    assert (rc == -1);
+
+    //  Send invalid reply (ID not label).
+    rc = zmq_send (xrep_socket, addr, 4, ZMQ_SNDLABEL);
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, seqn, 4, 0);             // right ID, not label!
+    assert (rc == 4);
+
+    rc = zmq_recv (req_socket, body, sizeof (body), ZMQ_DONTWAIT);
+    assert (rc == -1);
+
+    // Send invalid reply (bad ID labels, followed by good label, invalid data),
+    // ensuring that we always discard entire message (and not leak), if ID
+    // is found to be invalid.
+    rc = zmq_send (xrep_socket, addr, 4, ZMQ_SNDLABEL);  // right address
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, seqn, 3, ZMQ_SNDLABEL);  // wrong ID size
+    assert (rc == 3);
+    rc = zmq_send (xrep_socket, seqn, 3, ZMQ_SNDLABEL);  // ''
+    assert (rc == 3);
+    rc = zmq_send (xrep_socket, seqn, 3, ZMQ_SNDLABEL);  // ''
+    assert (rc == 3);
+    rc = zmq_send (xrep_socket, seqn, 3, ZMQ_SNDLABEL);  // ''
+    assert (rc == 3);
+    rc = zmq_send (xrep_socket, seqn, 3, ZMQ_SNDLABEL);  // ''
+    assert (rc == 3);
+    rc = zmq_send (xrep_socket, seqn, 3, ZMQ_SNDLABEL);  // ''
+    assert (rc == 3);
+    rc = zmq_send (xrep_socket, seqn, 4, ZMQ_SNDLABEL);  // right ID!
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, "v", 1, 0);              // but bad data
+    assert (rc == 1);
+
+    rc = zmq_recv (req_socket, body, sizeof (body), ZMQ_DONTWAIT);
+    assert (rc == -1);
+
+    // Send invalid reply (bad ID label, followed by good label, invalid data).
+    rc = zmq_send (xrep_socket, addr, 4, ZMQ_SNDLABEL);  // right address
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, addr, 4, ZMQ_SNDLABEL);  // wrong ID value
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, seqn, 4, ZMQ_SNDLABEL);  // right ID!
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, seqn, 4, ZMQ_SNDLABEL);  // ''
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, "w", 1, 0);              // but bad data
+    assert (rc == 1);
+
+    rc = zmq_recv (req_socket, body, sizeof (body), ZMQ_DONTWAIT);
+    assert (rc == -1);
+
+    // Send invalid reply (not label, followed by good label, invalid data).
+    rc = zmq_send (xrep_socket, addr, 4, ZMQ_SNDLABEL);  // right address
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, seqn, 4, ZMQ_SNDMORE);   // right ID, but not a label
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, addr, 4, ZMQ_SNDLABEL);  // right address
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, seqn, 4, ZMQ_SNDLABEL);  // right ID!
+    assert (rc == 4);
+    rc = zmq_send (xrep_socket, "x", 1, 0);              // but bad data
+    assert (rc == 1);
+
+    rc = zmq_recv (req_socket, body, sizeof (body), ZMQ_DONTWAIT);
+    assert (rc == -1);
+
+
+    // Send valid reply.
     rc = zmq_send (xrep_socket, addr, 4, ZMQ_SNDLABEL);
     assert (rc == 4);
     rc = zmq_send (xrep_socket, seqn, 4, ZMQ_SNDLABEL);
@@ -67,10 +136,15 @@ int main (int argc, char *argv [])
     rc = zmq_send (xrep_socket, "b", 1, 0);
     assert (rc == 1);
 
-    //  Check whether we've got the valid reply.
+    //  Check whether we've got only the (final) valid reply (and no more).
     rc = zmq_recv (req_socket, body, sizeof (body), 0);
     assert (rc == 1);
-	assert (body [0] == 'b');
+    //printf( "body: %c\n", *body );
+    assert (body [0] == 'b');
+
+    rc = zmq_recv (req_socket, body, sizeof (body), ZMQ_DONTWAIT);
+    assert (rc == -1);
+
 
     //  Tear down the wiring.
     rc = zmq_close (xrep_socket);


### PR DESCRIPTION
When zmq::req_t::xrecv detects that a response has no request ID
label, or the ID is the wrong size, it would return an EAGAIN, but
would not discard the remainder of the message.  This could allow the
remainder of the message to incorrectly "leak" into a future response,
if it is crafted to look like a reply with a valid response ID.
Discard all remaining message blocks, if the ID is invalid in any way.

Signed-off-by: Perry Kundert perry@kundert.ca
