### PR TITLE
Patch from Mikko Koppanen for #LIBZMQ-301

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -174,6 +174,8 @@ case "${host_os}" in
         # Define on HP-UX to enable all library features
         CPPFLAGS="-D_POSIX_C_SOURCE=200112L $CPPFLAGS"
         AC_DEFINE(ZMQ_HAVE_HPUX, 1, [Have HPUX OS])
+        LIBZMQ_CHECK_LANG_FLAG_PREPEND([-Ae])
+        AC_CHECK_FUNCS(gethrtime)
         ;;
     *mingw32*)
         AC_DEFINE(ZMQ_HAVE_WINDOWS, 1, [Have Windows OS])

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -34,7 +34,7 @@
 #include <sys/time.h>
 #endif
 
-#if defined HAVE_CLOCK_GETTIME
+#if defined HAVE_CLOCK_GETTIME || defined HAVE_GETHRTIME
 #include <time.h>
 #endif
 
@@ -65,13 +65,17 @@ uint64_t zmq::clock_t::now_us ()
     double ticks_div = (double) (ticksPerSecond.QuadPart / 1000000);     
     return (uint64_t) (tick.QuadPart / ticks_div);
 
-#elif defined HAVE_CLOCK_GETTIME
+#elif defined HAVE_CLOCK_GETTIME && defined CLOCK_MONOTONIC
 
     //  Use POSIX clock_gettime function to get precise monotonic time.
     struct timespec tv;
     int rc = clock_gettime (CLOCK_MONOTONIC, &tv);
     errno_assert (rc == 0);
     return (tv.tv_sec * (uint64_t) 1000000 + tv.tv_nsec / 1000);
+
+#elif defined HAVE_GETHRTIME
+
+    return (gethrtime () / 1000);
 
 #else
 


### PR DESCRIPTION
Add the '-Ae' flag and check for gethrtime() on HPUX

Check if CLOCK_MONOTONIC defined before using it - if not, use
gethrtime() if it's available, otherwise fall back to the old
behavior.

Signed-off-by: AJ Lewis aj.lewis@quantum.com
