### PR TITLE
mato: merge patch to close libzmq-303

### DIFF
--- a/src/pgm_sender.cpp
+++ b/src/pgm_sender.cpp
@@ -98,8 +98,8 @@ void zmq::pgm_sender_t::plug (io_thread_t *io_thread_, session_base_t *session_)
     msg_t msg;
     msg.init_size (1);
     *(unsigned char*) msg.data () = 1;
-    bool ok = session_->write (&msg);
-    zmq_assert (ok);
+    int rc = session_->write (&msg);
+    errno_assert (rc == 0);
     session_->flush ();
 }
 


### PR DESCRIPTION
Matos maintains his own repository outside of github. I have volunteered to act as the go-between by pulling his changes into my fork and submitting a pull request on his behalf. This complies with the rule:

All direct commits to libzmq are forbidden, no exceptions.

I will then commit the pull request.
