### PR TITLE
Semicolon missing

### DIFF
--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -79,7 +79,7 @@ void zmq::xpub_t::xread_activated (pipe_t *pipe_)
                     sub.size ()));
         }
 
-        sub.close()
+        sub.close();
     }
 }
 


### PR DESCRIPTION
Fixing missing semicolon in xpub, as reported on list: [zeromq-dev] xpub.cpp line 82
