### PR TITLE
provide type safe sockets and contexts

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -18,6 +18,8 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+#define ZMQ_TYPE_UNSAFE
+#include "../include/zmq.h"
 
 #include "platform.hpp"
 


### PR DESCRIPTION
Two new types are provided:

zmq_socket_t
zmq_ctx_t

which should be used for sockets and contexts, respectively. 

The definitions of these types depends on the definedness of three macros:

ZMQ_TYPE_SAFE forces a type safe interface
ZMQ_TYPE_UNSAFE forces a type unsafe interface
ZMQ_EMULATE_TYPE_SAFE forces a type safe interface if neither of the above is set

If none of these macros are set, type safe interface is selected by 
ZMQ_VERSION_MAJOR > 3

The intended effect is:

If you do nothing, in version 3 you get the current unsafe interface.
In version 4, you get the safe interface. This will break unconverted application code.
You can override this by one of the first two macros.

In order to migrate your code you do this:
# define ZMQ_EMULATE_TYPE_SAFE
# include "zmq.h"

Now, you fix compile errors for a while. When you get bored, you can just
comment out the ZMQ_EMULATE_TYPE_SAFE macro definition.
The converted code will always work, unconverted code will fail at version 4.

The unsafe definitions are the current void_.
The safe definitions use a struct value containing a void_.

CAVEAT. The C binding is compiled with ZMQ_TYPE_UNSAFE.
Because C does not have type safe linkage, it cannot tell if the header
file used in application code is using the safe interface or not.
The safe interface uses a value the same size as a void_, and most compilers
will happily pass this value the same way they'd pass a void_.
Technically, we're cheating in C and in C++ we're breaking the One Definition Rule.

The current implementation WILL BREAK if this is not the case.
This can easily be fixed by conditional definition in zmq.cpp, 
however that requires rebuilding the library. The current cheat method
does not require rebuilding the library.

The ZMQ_EMULATE_TYPE_SAFE macro provides a good way to
hunt for errors, and then avoid the above caveat by removing it.
We're back to the unsafe interface then, but the compile time checks
have been done.
