### PR TITLE
Resolve addresses in the calling thread on connect.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,6 +6,7 @@ pkgconfig_DATA = libzmq.pc
 include_HEADERS = ../include/zmq.h ../include/zmq_utils.h
 
 libzmq_la_SOURCES = \
+    address.hpp \
     array.hpp \
     atomic_counter.hpp \
     atomic_ptr.hpp \
@@ -76,6 +77,7 @@ libzmq_la_SOURCES = \
     xsub.hpp \
     ypipe.hpp \
     yqueue.hpp \
+    address.cpp \
     clock.cpp \
     ctx.cpp \
     decoder.cpp \

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -1,0 +1,50 @@
+/*
+    Copyright (c) 2012 Spotify AB
+    Copyright (c) 2012 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "address.hpp"
+#include "err.hpp"
+#include "tcp_address.hpp"
+#include "ipc_address.hpp"
+
+#include <string.h>
+
+zmq::address_t::address_t (
+    const std::string &protocol_, const std::string &address_)
+    : protocol (protocol_),
+      address (address_)
+{
+    memset (&resolved, 0, sizeof (resolved));
+}
+
+zmq::address_t::~address_t ()
+{
+    if (protocol == "tcp") {
+        if (resolved.tcp_addr) {
+            delete resolved.tcp_addr;
+            resolved.tcp_addr = 0;
+        }
+    }
+    else if (protocol == "ipc") {
+        if (resolved.ipc_addr) {
+            delete resolved.ipc_addr;
+            resolved.ipc_addr = 0;
+        }
+    }
+}

--- a/src/address.hpp
+++ b/src/address.hpp
@@ -1,0 +1,48 @@
+/*
+    Copyright (c) 2012 Spotify AB
+    Copyright (c) 2012 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __ZMQ_ADDRESS_HPP_INCLUDED__
+#define __ZMQ_ADDRESS_HPP_INCLUDED__
+
+#include <string>
+
+namespace zmq
+{
+    class tcp_address_t;
+    class ipc_address_t;
+
+    struct address_t {
+        address_t (const std::string &protocol_, const std::string &address_);
+
+        ~address_t ();
+
+        const std::string protocol;
+        const std::string address;
+
+        //  Protocol specific resolved address
+        union {
+            tcp_address_t *tcp_addr;
+            ipc_address_t *ipc_addr;
+        } resolved;
+    };
+
+}
+
+#endif

--- a/src/ipc_address.cpp
+++ b/src/ipc_address.cpp
@@ -47,12 +47,12 @@ int zmq::ipc_address_t::resolve (const char *path_)
     return 0;
 }
 
-sockaddr *zmq::ipc_address_t::addr ()
+const sockaddr *zmq::ipc_address_t::addr () const
 {
     return (sockaddr*) &address;
 }
 
-socklen_t zmq::ipc_address_t::addrlen ()
+socklen_t zmq::ipc_address_t::addrlen () const
 {
     return (socklen_t) sizeof (address);
 }

--- a/src/ipc_address.hpp
+++ b/src/ipc_address.hpp
@@ -41,8 +41,8 @@ namespace zmq
         //  This function sets up the address for UNIX domain transport.
         int resolve (const char* path_);
 
-        sockaddr *addr ();
-        socklen_t addrlen ();
+        const sockaddr *addr () const;
+        socklen_t addrlen () const;
 
     private:
 

--- a/src/ipc_connecter.hpp
+++ b/src/ipc_connecter.hpp
@@ -29,13 +29,13 @@
 #include "own.hpp"
 #include "stdint.hpp"
 #include "io_object.hpp"
-#include "ipc_address.hpp"
 
 namespace zmq
 {
 
     class io_thread_t;
     class session_base_t;
+    struct address_t;
 
     class ipc_connecter_t : public own_t, public io_object_t
     {
@@ -45,7 +45,7 @@ namespace zmq
         //  connection process.
         ipc_connecter_t (zmq::io_thread_t *io_thread_,
             zmq::session_base_t *session_, const options_t &options_,
-            const char *address_, bool delay_);
+            const address_t *addr_, bool delay_);
         ~ipc_connecter_t ();
 
     private:
@@ -72,9 +72,6 @@ namespace zmq
         //  Returns the currently used interval
         int get_new_reconnect_ivl ();
 
-        //  Set address to connect to.
-        int set_address (const char *addr_);
-
         //  Open IPC connecting socket. Returns -1 in case of error,
         //  0 if connect was successfull immediately. Returns -1 with
         //  EAGAIN errno if async connect was launched.
@@ -87,8 +84,8 @@ namespace zmq
         //  retired_fd if the connection was unsuccessfull.
         fd_t connect ();
 
-        //  Address to connect to.
-        ipc_address_t address;
+        //  Address to connect to. Owned by session_base_t.
+        const address_t *addr;
 
         //  Underlying socket.
         fd_t s;

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -88,7 +88,7 @@ void zmq::ipc_listener_t::in_event ()
 
     //  Create and launch a session object. 
     session_base_t *session = session_base_t::create (io_thread, false, socket,
-        options, NULL, NULL);
+        options, NULL);
     errno_assert (session);
     session->inc_seqnum ();
     launch_child (session);

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -119,9 +119,8 @@ bool zmq::pair_t::xhas_out ()
 
 zmq::pair_session_t::pair_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    session_base_t (io_thread_, connect_, socket_, options_, protocol_,
-         address_)
+      const address_t *addr_) :
+    session_base_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/pair.hpp
+++ b/src/pair.hpp
@@ -65,7 +65,7 @@ namespace zmq
 
         pair_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~pair_session_t ();
 
     private:

--- a/src/pub.cpp
+++ b/src/pub.cpp
@@ -46,9 +46,8 @@ bool zmq::pub_t::xhas_in ()
 
 zmq::pub_session_t::pub_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    xpub_session_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    xpub_session_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/pub.hpp
+++ b/src/pub.hpp
@@ -55,7 +55,7 @@ namespace zmq
 
         pub_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             zmq::socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~pub_session_t ();
 
     private:

--- a/src/pull.cpp
+++ b/src/pull.cpp
@@ -62,9 +62,8 @@ bool zmq::pull_t::xhas_in ()
 
 zmq::pull_session_t::pull_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    session_base_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    session_base_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/pull.hpp
+++ b/src/pull.hpp
@@ -67,7 +67,7 @@ namespace zmq
 
         pull_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~pull_session_t ();
 
     private:

--- a/src/push.cpp
+++ b/src/push.cpp
@@ -62,9 +62,8 @@ bool zmq::push_t::xhas_out ()
 
 zmq::push_session_t::push_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    session_base_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    session_base_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/push.hpp
+++ b/src/push.hpp
@@ -66,7 +66,7 @@ namespace zmq
 
         push_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~push_session_t ();
 
     private:

--- a/src/rep.cpp
+++ b/src/rep.cpp
@@ -114,9 +114,8 @@ bool zmq::rep_t::xhas_out ()
 
 zmq::rep_session_t::rep_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    xrep_session_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    xrep_session_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/rep.hpp
+++ b/src/rep.hpp
@@ -66,7 +66,7 @@ namespace zmq
 
         rep_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             zmq::socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~rep_session_t ();
 
     private:

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -139,9 +139,8 @@ bool zmq::req_t::xhas_out ()
 
 zmq::req_session_t::req_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    xreq_session_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_),
+      const address_t *addr_) :
+    xreq_session_t (io_thread_, connect_, socket_, options_, addr_),
     state (identity)
 {
 }

--- a/src/req.hpp
+++ b/src/req.hpp
@@ -67,7 +67,7 @@ namespace zmq
 
         req_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             zmq::socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~req_session_t ();
 
         //  Overloads of the functions from session_base_t.

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -36,6 +36,7 @@ namespace zmq
     class io_thread_t;
     class socket_base_t;
     struct i_engine;
+    struct address_t;
 
     class session_base_t :
         public own_t,
@@ -47,8 +48,7 @@ namespace zmq
         //  Create a session of the particular type.
         static session_base_t *create (zmq::io_thread_t *io_thread_,
             bool connect_, zmq::socket_base_t *socket_,
-            const options_t &options_, const char *protocol_,
-            const char *address_);
+            const options_t &options_, const address_t *addr_);
 
         //  To be used once only, when creating the session.
         void attach_pipe (zmq::pipe_t *pipe_);
@@ -69,8 +69,8 @@ namespace zmq
 
         session_base_t (zmq::io_thread_t *io_thread_, bool connect_,
             zmq::socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
-        ~session_base_t ();
+            const address_t *addr_);
+        virtual ~session_base_t ();
 
     private:
 
@@ -129,8 +129,7 @@ namespace zmq
         bool recv_identity;
 
         //  Protocol and address to use when connecting.
-        std::string protocol;
-        std::string address;
+        const address_t *addr;
 
         session_base_t (const session_base_t&);
         const session_base_t &operator = (const session_base_t&);

--- a/src/sub.cpp
+++ b/src/sub.cpp
@@ -82,9 +82,8 @@ bool zmq::sub_t::xhas_out ()
 
 zmq::sub_session_t::sub_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    xsub_session_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    xsub_session_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/sub.hpp
+++ b/src/sub.hpp
@@ -57,7 +57,7 @@ namespace zmq
 
         sub_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             zmq::socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~sub_session_t ();
 
     private:

--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -419,12 +419,12 @@ int zmq::tcp_address_t::resolve (const char *name_, bool local_, bool ipv4only_)
     return 0;
 }
 
-sockaddr *zmq::tcp_address_t::addr ()
+const sockaddr *zmq::tcp_address_t::addr () const
 {
     return &address.generic;
 }
 
-socklen_t zmq::tcp_address_t::addrlen ()
+socklen_t zmq::tcp_address_t::addrlen () const
 {
     if (address.generic.sa_family == AF_INET6)
         return (socklen_t) sizeof (address.ipv6);
@@ -433,9 +433,9 @@ socklen_t zmq::tcp_address_t::addrlen ()
 }
 
 #if defined ZMQ_HAVE_WINDOWS
-unsigned short zmq::tcp_address_t::family ()
+unsigned short zmq::tcp_address_t::family () const
 #else
-sa_family_t zmq::tcp_address_t::family ()
+sa_family_t zmq::tcp_address_t::family () const
 #endif
 {
     return address.generic.sa_family;

--- a/src/tcp_address.hpp
+++ b/src/tcp_address.hpp
@@ -48,12 +48,12 @@ namespace zmq
         int resolve (const char* name_, bool local_, bool ipv4only_);
 
 #if defined ZMQ_HAVE_WINDOWS
-        unsigned short family ();
+        unsigned short family () const;
 #else
-        sa_family_t family ();
+        sa_family_t family () const;
 #endif
-        sockaddr *addr ();
-        socklen_t addrlen ();
+        const sockaddr *addr () const;
+        socklen_t addrlen () const;
 
     private:
 

--- a/src/tcp_connecter.hpp
+++ b/src/tcp_connecter.hpp
@@ -26,13 +26,13 @@
 #include "own.hpp"
 #include "stdint.hpp"
 #include "io_object.hpp"
-#include "tcp_address.hpp"
 
 namespace zmq
 {
 
     class io_thread_t;
     class session_base_t;
+    struct address_t;
 
     class tcp_connecter_t : public own_t, public io_object_t
     {
@@ -42,7 +42,7 @@ namespace zmq
         //  connection process.
         tcp_connecter_t (zmq::io_thread_t *io_thread_,
             zmq::session_base_t *session_, const options_t &options_,
-            const char *address_, bool delay_);
+            const address_t *addr_, bool delay_);
         ~tcp_connecter_t ();
 
     private:
@@ -69,9 +69,6 @@ namespace zmq
         //  Returns the currently used interval
         int get_new_reconnect_ivl ();
 
-        //  Set address to connect to.
-        int set_address (const char *addr_);
-
         //  Open TCP connecting socket. Returns -1 in case of error,
         //  0 if connect was successfull immediately. Returns -1 with
         //  EAGAIN errno if async connect was launched.
@@ -84,8 +81,8 @@ namespace zmq
         //  retired_fd if the connection was unsuccessfull.
         fd_t connect ();
 
-        //  Address to connect to.
-        tcp_address_t address;
+        //  Address to connect to. Owned by session_base_t.
+        const address_t *addr;
 
         //  Underlying socket.
         fd_t s;

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -100,7 +100,7 @@ void zmq::tcp_listener_t::in_event ()
 
     //  Create and launch a session object. 
     session_base_t *session = session_base_t::create (io_thread, false, socket,
-        options, NULL, NULL);
+        options, NULL);
     errno_assert (session);
     session->inc_seqnum ();
     launch_child (session);

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -176,9 +176,8 @@ void zmq::xpub_t::send_unsubscription (unsigned char *data_, size_t size_,
 
 zmq::xpub_session_t::xpub_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    session_base_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    session_base_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -91,7 +91,7 @@ namespace zmq
 
         xpub_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~xpub_session_t ();
 
     private:

--- a/src/xrep.cpp
+++ b/src/xrep.cpp
@@ -309,9 +309,8 @@ bool zmq::xrep_t::xhas_out ()
 
 zmq::xrep_session_t::xrep_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    session_base_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    session_base_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/xrep.hpp
+++ b/src/xrep.hpp
@@ -110,7 +110,7 @@ namespace zmq
 
         xrep_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~xrep_session_t ();
 
     private:

--- a/src/xreq.cpp
+++ b/src/xreq.cpp
@@ -117,9 +117,8 @@ void zmq::xreq_t::xterminated (pipe_t *pipe_)
 
 zmq::xreq_session_t::xreq_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    session_base_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    session_base_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/xreq.hpp
+++ b/src/xreq.hpp
@@ -78,7 +78,7 @@ namespace zmq
 
         xreq_session_t (zmq::io_thread_t *io_thread_, bool connect_,
             zmq::socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~xreq_session_t ();
 
     private:

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -220,9 +220,8 @@ void zmq::xsub_t::send_subscription (unsigned char *data_, size_t size_,
 
 zmq::xsub_session_t::xsub_session_t (io_thread_t *io_thread_, bool connect_,
       socket_base_t *socket_, const options_t &options_,
-      const char *protocol_, const char *address_) :
-    session_base_t (io_thread_, connect_, socket_, options_, protocol_,
-        address_)
+      const address_t *addr_) :
+    session_base_t (io_thread_, connect_, socket_, options_, addr_)
 {
 }
 

--- a/src/xsub.hpp
+++ b/src/xsub.hpp
@@ -93,7 +93,7 @@ namespace zmq
 
         xsub_session_t (class io_thread_t *io_thread_, bool connect_,
             socket_base_t *socket_, const options_t &options_,
-            const char *protocol_, const char *address_);
+            const address_t *addr_);
         ~xsub_session_t ();
 
     private:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,7 +11,8 @@ noinst_PROGRAMS = test_pair_inproc \
                   test_reqrep_device \
                   test_sub_forward \
                   test_invalid_rep \
-                  test_msg_flags
+                  test_msg_flags \
+                  test_connect_resolve
 
 if !ON_MINGW
 noinst_PROGRAMS += test_shutdown_stress \
@@ -30,6 +31,7 @@ test_reqrep_device_SOURCES = test_reqrep_device.cpp
 test_sub_forward_SOURCES = test_sub_forward.cpp
 test_invalid_rep_SOURCES = test_invalid_rep.cpp
 test_msg_flags_SOURCES = test_msg_flags.cpp
+test_connect_resolve_SOURCES = test_connect_resolve.cpp
 
 if !ON_MINGW
 test_shutdown_stress_SOURCES = test_shutdown_stress.cpp

--- a/tests/test_connect_resolve.cpp
+++ b/tests/test_connect_resolve.cpp
@@ -1,0 +1,54 @@
+/*
+    Copyright (c) 2012 Spotify AB
+    Copyright (c) 2012 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <assert.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "../include/zmq.h"
+
+int main (int argc, char *argv [])
+{
+    fprintf (stderr, "test_connect_resolve running...\n");
+
+    void *ctx = zmq_init (1);
+    assert (ctx);
+
+    //  Create pair of socket, each with high watermark of 2. Thus the total
+    //  buffer space should be 4 messages.
+    void *sock = zmq_socket (ctx, ZMQ_PUB);
+    assert (sock);
+
+    int rc = zmq_connect (sock, "tcp://localhost:1234");
+    assert (rc == 0);
+
+    rc = zmq_connect (sock, "tcp://foobar123xyz:1234");
+    assert (rc == -1);
+    assert (errno == EINVAL);
+
+    rc = zmq_close (sock);
+    assert (rc == 0);
+
+    rc = zmq_term (ctx);
+    assert (rc == 0);
+
+    return 0;
+}


### PR DESCRIPTION
This allows us to actually report an error to the caller on resolve
failure, rather than asserting later on in the io thread.

Signed-off-by: Staffan Gimåker staffan@spotify.com
