### PR TITLE
Minor cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tests/test_sub_forward
 tests/test_invalid_rep
 tests/test_msg_flags
 tests/test_ts_context
+tests/test_connect_resolve
 src/platform.hpp*
 src/stamp-h1
 perf/local_lat

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -1,6 +1,6 @@
 /*
+    Copyright (c) 2007-2012 iMatix Corporation
     Copyright (c) 2009-2011 250bpm s.r.o.
-    Copyright (c) 2007-2009 iMatix Corporation
     Copyright (c) 2007-2011 Other contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
@@ -202,7 +202,7 @@ void *zmq::msg_t::data ()
     }
 }
 
-size_t zmq::msg_t::size ()
+ssize_t zmq::msg_t::size ()
 {
     //  Check the validity of the message.
     zmq_assert (check ());

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -24,6 +24,7 @@
 #define __ZMQ_MSG_HPP_INCLUDE__
 
 #include <stddef.h>
+#include <stdio.h>
 
 #include "config.hpp"
 #include "atomic_counter.hpp"
@@ -64,7 +65,7 @@ namespace zmq
         int move (msg_t &src_);
         int copy (msg_t &src_);
         void *data ();
-        size_t size ();
+        ssize_t size ();
         unsigned char flags ();
         void set_flags (unsigned char flags_);
         void reset_flags (unsigned char flags_);
@@ -95,7 +96,7 @@ namespace zmq
         struct content_t
         {
             void *data;
-            size_t size;
+            ssize_t size;
             msg_free_fn *ffn;
             void *hint;
             zmq::atomic_counter_t refcnt;

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -535,9 +535,11 @@ int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_)
         return -1;
     }
     zmq::socket_base_t *s = (zmq::socket_base_t *) s_;
-    if(s->thread_safe()) s->lock();
-    int result = inner_sendmsg (s, msg_, flags_);
-    if(s->thread_safe()) s->unlock();
+    if (s->thread_safe())
+        s->lock();
+    int result = s_sendmsg (s, msg_, flags_);
+    if (s->thread_safe())
+        s->unlock();
     return result;
 }
 
@@ -548,9 +550,11 @@ int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_)
         return -1;
     }
     zmq::socket_base_t *s = (zmq::socket_base_t *) s_;
-    if(s->thread_safe()) s->lock();
-    int result = inner_recvmsg(s, msg_, flags_);
-    if(s->thread_safe()) s->unlock();
+    if (s->thread_safe())
+        s->lock();
+    int result = s_recvmsg (s, msg_, flags_);
+    if (s->thread_safe())
+        s->unlock();
     return result;
 }
 


### PR DESCRIPTION
- Fixed use of ssize_t in zmq_msg_t class
- Corrected error after merge, old reference to inner_fctname (broke build)
