### PR TITLE
Revert null checks in the API

### DIFF
--- a/doc/zmq_msg_size.txt
+++ b/doc/zmq_msg_size.txt
@@ -9,7 +9,7 @@ zmq_msg_size - retrieve message content size in bytes
 
 SYNOPSIS
 --------
-*ssize_t zmq_msg_size (zmq_msg_t '*msg');*
+*size_t zmq_msg_size (zmq_msg_t '*msg');*
 
 
 DESCRIPTION
@@ -29,15 +29,7 @@ message content in bytes.
 
 ERRORS
 ------
-The _zmq_msg_size()_ function shall return a positive integer (0 or higher)
-if successful. Otherwise it shall return `-1` and set 'errno' to one of the
-values defined below.
-
-
-ERRORS
-------
-*EFAULT*::
-The provided 'msg' was NULL.
+No errors are defined.
 
 
 SEE ALSO

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -168,7 +168,7 @@ ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_move (zmq_msg_t *dest, zmq_msg_t *src);
 ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest, zmq_msg_t *src);
 ZMQ_EXPORT void *zmq_msg_data (zmq_msg_t *msg);
-ZMQ_EXPORT ssize_t zmq_msg_size (zmq_msg_t *msg);
+ZMQ_EXPORT size_t zmq_msg_size (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_more (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_get (zmq_msg_t *msg, int option, void *optval,
                             size_t *optvallen);

--- a/perf/inproc_lat.cpp
+++ b/perf/inproc_lat.cpp
@@ -35,7 +35,7 @@
 #include <pthread.h>
 #endif
 
-static ssize_t message_size;
+static size_t message_size;
 static int roundtrip_count;
 
 #if defined ZMQ_HAVE_WINDOWS

--- a/perf/inproc_thr.cpp
+++ b/perf/inproc_thr.cpp
@@ -36,7 +36,7 @@
 #endif
 
 static int message_count;
-static ssize_t message_size;
+static size_t message_size;
 
 #if defined ZMQ_HAVE_WINDOWS
 static unsigned int __stdcall worker (void *ctx_)

--- a/perf/local_lat.cpp
+++ b/perf/local_lat.cpp
@@ -28,7 +28,7 @@ int main (int argc, char *argv [])
 {
     const char *bind_to;
     int roundtrip_count;
-    ssize_t message_size;
+    size_t message_size;
     void *ctx;
     void *s;
     int rc;

--- a/perf/local_thr.cpp
+++ b/perf/local_thr.cpp
@@ -28,7 +28,7 @@ int main (int argc, char *argv [])
 {
     const char *bind_to;
     int message_count;
-    ssize_t message_size;
+    size_t message_size;
     void *ctx;
     void *s;
     int rc;

--- a/perf/remote_lat.cpp
+++ b/perf/remote_lat.cpp
@@ -29,7 +29,7 @@ int main (int argc, char *argv [])
 {
     const char *connect_to;
     int roundtrip_count;
-    ssize_t message_size;
+    size_t message_size;
     void *ctx;
     void *s;
     int rc;

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -202,7 +202,7 @@ void *zmq::msg_t::data ()
     }
 }
 
-ssize_t zmq::msg_t::size ()
+size_t zmq::msg_t::size ()
 {
     //  Check the validity of the message.
     zmq_assert (check ());

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -65,7 +65,7 @@ namespace zmq
         int move (msg_t &src_);
         int copy (msg_t &src_);
         void *data ();
-        ssize_t size ();
+        size_t size ();
         unsigned char flags ();
         void set_flags (unsigned char flags_);
         void reset_flags (unsigned char flags_);
@@ -96,7 +96,7 @@ namespace zmq
         struct content_t
         {
             void *data;
-            ssize_t size;
+            size_t size;
             msg_free_fn *ffn;
             void *hint;
             zmq::atomic_counter_t refcnt;

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -34,7 +34,7 @@
     defined ZMQ_HAVE_NETBSD
 #define ZMQ_POLL_BASED_ON_POLL
 #elif defined ZMQ_HAVE_WINDOWS || defined ZMQ_HAVE_OPENVMS ||\
-	defined ZMQ_HAVE_CYGWIN
+     defined ZMQ_HAVE_CYGWIN
 #define ZMQ_POLL_BASED_ON_SELECT
 #endif
 
@@ -430,7 +430,7 @@ int zmq_recv (void *s_, void *buf_, size_t len_, int flags_)
     rc = zmq_msg_close (&msg);
     errno_assert (rc == 0);
 
-    return nbytes;    
+    return nbytes;
 }
 
 // Receive a multi-part message
@@ -495,36 +495,24 @@ int zmq_recviov (void *s_, iovec *a_, size_t *count_, int flags_)
     }
     if (s->thread_safe())
         s->unlock();
-    return nread;    
+    return nread;
 }
 
 // Message manipulators.
 
 int zmq_msg_init (zmq_msg_t *msg_)
 {
-    if (!msg_) {
-        errno = EFAULT;
-        return -1;
-    }
     return ((zmq::msg_t*) msg_)->init ();
 }
 
 int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_)
 {
-    if (!msg_) {
-        errno = EFAULT;
-        return -1;
-    }
     return ((zmq::msg_t*) msg_)->init_size (size_);
 }
 
 int zmq_msg_init_data (zmq_msg_t *msg_, void *data_, size_t size_,
     zmq_free_fn *ffn_, void *hint_)
 {
-    if (!msg_) {
-        errno = EFAULT;
-        return -1;
-    }
     return ((zmq::msg_t*) msg_)->init_data (data_, size_, ffn_, hint_);
 }
 
@@ -560,46 +548,26 @@ int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_)
 
 int zmq_msg_close (zmq_msg_t *msg_)
 {
-    if (!msg_) {
-        errno = EFAULT;
-        return -1;
-    }
     return ((zmq::msg_t*) msg_)->close ();
 }
 
 int zmq_msg_move (zmq_msg_t *dest_, zmq_msg_t *src_)
 {
-    if (!dest_ || !src_) {
-        errno = EFAULT;
-        return -1;
-    }
     return ((zmq::msg_t*) dest_)->move (*(zmq::msg_t*) src_);
 }
 
 int zmq_msg_copy (zmq_msg_t *dest_, zmq_msg_t *src_)
 {
-    if (!dest_ || !src_) {
-        errno = EFAULT;
-        return -1;
-    }
     return ((zmq::msg_t*) dest_)->copy (*(zmq::msg_t*) src_);
 }
 
 void *zmq_msg_data (zmq_msg_t *msg_)
 {
-    if (!msg_) {
-        errno = EFAULT;
-        return NULL;
-    }
     return ((zmq::msg_t*) msg_)->data ();
 }
 
-ssize_t zmq_msg_size (zmq_msg_t *msg_)
+size_t zmq_msg_size (zmq_msg_t *msg_)
 {
-    if (!msg_) {
-        errno = EFAULT;
-        return -1;
-    }
     return ((zmq::msg_t*) msg_)->size ();
 }
 
@@ -615,10 +583,6 @@ int zmq_msg_more (zmq_msg_t *msg_)
 int zmq_msg_get (zmq_msg_t *msg_, int option_, void *optval_,
     size_t *optvallen_)
 {
-    if (!msg_) {
-        errno = EFAULT;
-        return -1;
-    }
     switch (option_) {
         case ZMQ_MORE:
             if (*optvallen_ < sizeof (int)) {
@@ -638,10 +602,6 @@ int zmq_msg_get (zmq_msg_t *msg_, int option_, void *optval_,
 int zmq_msg_set (zmq_msg_t *msg_, int option_, const void *optval_,
     size_t *optvallen_)
 {
-    if (!msg_) {
-        errno = EFAULT;
-        return -1;
-    }
     //  No options supported at present
     errno = EINVAL;
     return -1;
@@ -820,12 +780,6 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
         return usleep (timeout_ * 1000);
 #endif
     }
-
-    if (!items_) {
-        errno = EFAULT;
-        return -1;
-    }
-
     zmq::clock_t clock;
     uint64_t now = 0;
     uint64_t end = 0;


### PR DESCRIPTION
I don't believe that we should be doing this. The reason for this is that there are plenty of functions that die on NULL parameters so this is inconsistent. I believe that from API design point of view we should declare a contract that all pointer parameters need to be valid unless otherwise stated.
