### PR TITLE
More fixes based on CentOS 6.2 results

### DIFF
--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -125,7 +125,7 @@ int zmq::tcp_listener_t::get_address (std::string &addr_)
     struct sockaddr_storage ss;
     char host [NI_MAXHOST];
     char serv_info [NI_MAXSERV];
-    int port, rc;
+    int rc;
     std::stringstream address;
 
     // Get the details of the TCP socket
@@ -135,7 +135,7 @@ int zmq::tcp_listener_t::get_address (std::string &addr_)
         return rc;
     }
 
-    rc = getnameinfo ((struct sockaddr *) &ss, ss.ss_len, host, NI_MAXHOST, serv_info, NI_MAXSERV, NI_NUMERICHOST);
+    rc = getnameinfo ((struct sockaddr *) &ss, sizeof (ss), host, NI_MAXHOST, serv_info, NI_MAXSERV, NI_NUMERICHOST);
     if (rc != 0) {
         return rc;
     }


### PR DESCRIPTION
Unused variable 'port' and sizeof instead of ss_len. Not sure how this compiled on Mac.
