### PR TITLE
patch for LIBZMQ-328

### DIFF
--- a/src/trie.cpp
+++ b/src/trie.cpp
@@ -186,6 +186,7 @@ bool zmq::trie_t::rm (unsigned char *prefix_, size_t size_)
                      //  The pruned node is the left-most node ptr in the
                      //  node table => keep the right-most node
                      node = next.table [count - 1];
+                     min += count - 1;
                  }
                  else if (c == min + count - 1) {
                      //  The pruned node is the right-most node ptr in the


### PR DESCRIPTION
See: https://zeromq.jira.com/browse/LIBZMQ-328

The lower bound was not being updated when topics removed from the subscriber. This lead to different topic matching on the publisher to the subscriber which in turn meant messages get silently dropped.
