### PR TITLE
Fix IPC transport domain socket stream file not being removed when connection is closed

### DIFF
--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -144,6 +144,7 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
     if (rc != 0)
         return -1;
 
+    filename.assign(addr_);
     has_file = true;
 
     //  Listen for incomming connections.


### PR DESCRIPTION
in ipc_listener.cpp

zmq::ipc_listener_t::set_address()  never performs a filename.assign() call using the addr_ string.

This means that zmq::ipc_listener_t::close() will never attempt to remove the file due to the check:

if (has_file && !filename.empty ()) {
...
}
