### PR TITLE
Changed wrong file name in VC++ project.

### DIFF
--- a/builds/msvc/libzmq/libzmq.vcproj
+++ b/builds/msvc/libzmq/libzmq.vcproj
@@ -247,7 +247,7 @@
 			UniqueIdentifier="{4FC737F1-C7A5-4376-A066-2A32D752A2FF}"
 			>
 			<File
-				RelativePath="..\..\..\src\adress.cpp"
+				RelativePath="..\..\..\src\address.cpp"
 				>
 			</File>
 			<File


### PR DESCRIPTION
Name of the file in the project does not match actual file name:
adress.cpp VS. address.cpp
