### PR TITLE
Add WinCE support.

### DIFF
--- a/builds/msvc/errno.cpp
+++ b/builds/msvc/errno.cpp
@@ -1,0 +1,32 @@
+#if defined WINCE
+
+//#include "..\..\include\zmq.h"
+#include "..\..\src\err.hpp"
+
+int errno;
+int _doserrno;
+int _sys_nerr;
+
+char* error_desc_buff = NULL;
+
+char* strerror(int errno)
+{
+	if (NULL != error_desc_buff)
+	{
+		LocalFree(error_desc_buff);
+		error_desc_buff = NULL;
+	}
+
+	FormatMessage(
+		FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_ALLOCATE_BUFFER,
+		NULL,
+		errno,
+		0,
+		(LPTSTR)&error_desc_buff,
+		1024,
+		NULL
+	);
+	return error_desc_buff;
+}
+
+#endif

--- a/builds/msvc/errno.hpp
+++ b/builds/msvc/errno.hpp
@@ -1,0 +1,56 @@
+#ifndef ERRNO_H
+#define ERRNO_H 1
+
+//#define EPERM           1
+//#define ENOENT          2
+//#define ESRCH           3
+#define EINTR           4
+//#define EIO             5
+//#define ENXIO           6
+//#define E2BIG           7
+//#define ENOEXEC         8
+#define EBADF           9
+//#define ECHILD          10
+#define EAGAIN          11
+//#define ENOMEM          12
+//#define EACCES          13
+#define EFAULT          14
+//#define EOSERR          15 // rk
+//#define EBUSY           16
+//#define EEXIST          17
+//#define EXDEV           18
+//#define ENODEV          19
+//#define ENOTDIR         20
+//#define EISDIR          21
+#define EINVAL          22
+//#define ENFILE          23
+#define EMFILE          24
+//#define ENOTTY          25
+//#define EFBIG           27
+//#define ENOSPC          28
+//#define ESPIPE          29
+//#define EROFS           30
+//#define EMLINK          31
+//#define EPIPE           32
+//#define EDOM            33
+//#define ERANGE          34
+//#define EDEADLK         36
+//#define ENOSYS          37
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int errno;
+extern int _doserrno;
+extern int _sys_nerr;
+
+char* strerror(int errno);
+
+#define sys_nerr _sys_nerr
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/builds/msvc/libzmq/libzmq.vcproj
+++ b/builds/msvc/libzmq/libzmq.vcproj
@@ -283,6 +283,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\errno.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\..\src\fq.cpp"
 				>
 			</File>
@@ -526,6 +530,10 @@
 			</File>
 			<File
 				RelativePath="..\..\..\src\err.hpp"
+				>
+			</File>
+			<File
+				RelativePath="..\errno.hpp"
 				>
 			</File>
 			<File

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -27,7 +27,9 @@
 extern "C" {
 #endif
 
+#if !defined WINCE
 #include <errno.h>
+#endif
 #include <stddef.h>
 #include <stdio.h>
 #if defined _WIN32

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -27,7 +27,11 @@
 #include <stddef.h>
 
 #if defined _MSC_VER
+#if defined WINCE
+#include <cmnintrin.h>
+#else
 #include <intrin.h>
+#endif
 #endif
 
 #if !defined ZMQ_HAVE_WINDOWS

--- a/src/err.cpp
+++ b/src/err.cpp
@@ -202,9 +202,15 @@ const char *zmq::wsa_error_no (int no_)
 void zmq::win_error (char *buffer_, size_t buffer_size_)
 {
     DWORD errcode = GetLastError ();
+#if defined WINCE
+    DWORD rc = FormatMessage (FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS, NULL, errcode, MAKELANGID(LANG_NEUTRAL,
+        SUBLANG_DEFAULT), (LPWSTR)buffer_, buffer_size_ / sizeof(wchar_t), NULL );
+#else
     DWORD rc = FormatMessageA (FORMAT_MESSAGE_FROM_SYSTEM |
         FORMAT_MESSAGE_IGNORE_INSERTS, NULL, errcode, MAKELANGID(LANG_NEUTRAL,
         SUBLANG_DEFAULT), buffer_, (DWORD) buffer_size_, NULL );
+#endif
     zmq_assert (rc);
 }
 

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -26,7 +26,11 @@
 #include "../include/zmq.h"
 
 #include <assert.h>
+#if defined WINCE
+#include "..\builds\msvc\errno.hpp"
+#else
 #include <errno.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -23,7 +23,6 @@
 #include "../include/zmq.h"
 
 #include <string.h>
-#include <errno.h>
 #include <stdlib.h>
 #include <new>
 

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -238,7 +238,7 @@ int zmq::signaler_t::make_fdpair (fd_t *r_, fd_t *w_)
     //  two instances of the library don't accidentally create signaler
     //  crossing the process boundary.
     //  We'll use named event object to implement the critical section.
-    HANDLE sync = CreateEvent (NULL, FALSE, TRUE, "zmq-signaler-port-sync");
+    HANDLE sync = CreateEvent (NULL, FALSE, TRUE, TEXT("zmq-signaler-port-sync"));
     win_assert (sync != NULL);
 
     //  Enter the critical section.

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -29,7 +29,11 @@
 #if defined ZMQ_HAVE_WINDOWS
 #include "windows.hpp"
 #if defined _MSC_VER
+#if defined WINCE
+#include <cmnintrin.h>
+#else
 #include <intrin.h>
+#endif
 #endif
 #else
 #include <unistd.h>

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -27,7 +27,11 @@
 
 extern "C"
 {
+#if defined _WIN32_WCE
+	static DWORD thread_routine (LPVOID arg_)
+#else
     static unsigned int __stdcall thread_routine (void *arg_)
+#endif
     {
         zmq::thread_t *self = (zmq::thread_t*) arg_;
         self->tfn (self->arg);
@@ -39,8 +43,13 @@ void zmq::thread_t::start (thread_fn *tfn_, void *arg_)
 {
     tfn = tfn_;
     arg =arg_;
+#if defined WINCE
+    descriptor = (HANDLE) CreateThread (NULL, 0,
+        &::thread_routine, this, 0 , NULL);
+#else
     descriptor = (HANDLE) _beginthreadex (NULL, 0,
         &::thread_routine, this, 0 , NULL);
+#endif
     win_assert (descriptor != NULL);    
 }
 

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -170,7 +170,9 @@
 
 #include <ws2tcpip.h>
 #include <ipexport.h>
+#if !defined WINCE
 #include <process.h>
+#endif
 
 //  In MinGW environment AI_NUMERICSERV is not defined.
 #ifndef AI_NUMERICSERV

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -65,7 +65,6 @@ struct iovec {
 
 
 #include <string.h>
-#include <errno.h>
 #include <stdlib.h>
 #include <new>
 


### PR DESCRIPTION
- Added two new files: errno.hpp and errno.cpp. They are required to use errno functionality on WM.
- zmq.cpp, msg.h: removed inclusion of errno.h because it is included in zmq.h that is also included by .cpp.
- windows.hpp: process.h is included only for desktop builds.
- thread.cpp: on CE CreateThread is used instead of __beginthreadex
- socket_base.cpp, clock.cpp: on CE include cmnintrin.h instead on intrin.h
- signaler.cpp: on Windows should use special macro around event name (for unicode builds)
- err.hpp: make it include errno.hpp (my file) instead on errno.h when building for CE
- err.cpp: use FormatMessage when building for CE (because CE does not have ANSI API functions)
- zmq.h: do not include errno.h whe building for CE
- libzmq.vcproj: add tro new files
