### PR TITLE
Disable reconnection option

### DIFF
--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -223,7 +223,7 @@ ZMQ_RECONNECT_IVL: Retrieve reconnection interval
 The 'ZMQ_RECONNECT_IVL' option shall retrieve the initial reconnection interval
 for the specified 'socket'.  The reconnection interval is the period 0MQ shall
 wait between attempts to reconnect disconnected peers when using
-connection-oriented transports.
+connection-oriented transports. The value -1 means no reconnection.
 
 NOTE: The reconnection interval may be randomized by 0MQ to prevent
 reconnection storms in topologies with a large number of peers per socket.

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -232,7 +232,7 @@ ZMQ_RECONNECT_IVL: Set reconnection interval
 The 'ZMQ_RECONNECT_IVL' option shall set the initial reconnection interval for
 the specified 'socket'.  The reconnection interval is the period 0MQ
 shall wait between attempts to reconnect disconnected peers when using
-connection-oriented transports.
+connection-oriented transports. The value -1 means no reconnection.
 
 NOTE: The reconnection interval may be randomized by 0MQ to prevent
 reconnection storms in topologies with a large number of peers per socket.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -140,7 +140,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             errno = EINVAL;
             return -1;
         }
-        if (*((int*) optval_) < 0) {
+        if (*((int*) optval_) < -1) {
             errno = EINVAL;
             return -1;
         }

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -375,7 +375,8 @@ void zmq::session_base_t::detached ()
     }
 
     //  Reconnect.
-    start_connecting (true);
+	if (options.reconnect_ivl != -1)
+    	start_connecting (true);
 
     //  For subscriber sockets we hiccup the inbound pipe, which will cause
     //  the socket object to resend all the subscriptions.


### PR DESCRIPTION
Add value -1 to the ZMQ_RECONNECT_IVL option to disable the reconnection algorithm
