### PR TITLE
Fixed issue LIBZMQ-345 - race condition in ctx.socket/term allows segfault

### DIFF
--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -126,7 +126,7 @@ namespace zmq
 
         //  Synchronisation of accesses to global slot-related data:
         //  sockets, empty_slots, terminating. It also synchronises
-        //  access to zombie sockets as such (as oposed to slots) and provides
+        //  access to zombie sockets as such (as opposed to slots) and provides
         //  a memory barrier to ensure that all CPU cores see the same data.
         mutex_t slot_sync;
 


### PR DESCRIPTION
- Ensures now that term and create_socket cannot conflict with each other. Keeps term open to allow multiple threads to term at the same time.
- Since the change affects shutdown, there may be other race conditions in this code still.
