### PR TITLE
Mark sockets as invalid when closed, not reaped

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -136,9 +136,6 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_, uint32_t tid_, int sid_) :
 zmq::socket_base_t::~socket_base_t ()
 {
     zmq_assert (destroyed);
-
-    //  Mark the socket as dead.
-    tag = 0xdeadbeef;
 }
 
 zmq::mailbox_t *zmq::socket_base_t::get_mailbox ()
@@ -666,6 +663,9 @@ int zmq::socket_base_t::recv (msg_t *msg_, int flags_)
 
 int zmq::socket_base_t::close ()
 {
+    //  Mark the socket as dead
+    tag = 0xdeadbeef;
+    
     //  Transfer the ownership of the socket from this application thread
     //  to the reaper thread which will take care of the rest of shutdown
     //  process.


### PR DESCRIPTION
Previously, sockets were still "valid" after being closed and only marked
as invalid when destroyed. This meant programs could access closed sockets.
Now the socket is marked "invalid" when closed.
