### PR TITLE
router: always respect message boundaries

### DIFF
--- a/src/router.cpp
+++ b/src/router.cpp
@@ -154,11 +154,9 @@ int zmq::router_t::xsend (msg_t *msg_, int flags_)
                 current_out = it->second.pipe;
                 if (!current_out->check_write ()) {
                     it->second.active = false;
-                    more_out = false;
                     current_out = NULL;
                 }
             } else if(fail_unroutable) {
-                more_out = false;
                 errno = EHOSTUNREACH;
                 retval = -1;
             }


### PR DESCRIPTION
The current implementaion of router socket does not
handle the full pipe and unroutable messages properly.
Namely, in those cases, the socket could route some
message parts into a wrong connection.
