### PR TITLE
Flush identity message for inproc transport

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -434,6 +434,7 @@ int zmq::socket_base_t::connect (const char *addr_)
             id.set_flags (msg_t::identity);
             bool written = pipes [0]->write (&id);
             zmq_assert (written);
+            pipes [0]->flush ();
         }
 
         //  Attach remote end of the pipe to the peer socket. Note that peer's


### PR DESCRIPTION
The scoket implementation for inproc transfer failed to flush
identity message. The result was that the identity message
was not delivered until after the user sent the first message.

The identity message was never delivered if the user
used the socket only to receive messages.
