### PR TITLE
Fix identity exchange for inproc transport

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -437,6 +437,18 @@ int zmq::socket_base_t::connect (const char *addr_)
             pipes [0]->flush ();
         }
 
+        //  If required, send the identity of the peer to the local socket.
+        if (peer.options.send_identity) {
+            msg_t id;
+            rc = id.init_size (peer.options.identity_size);
+            zmq_assert (rc == 0);
+            memcpy (id.data (), peer.options.identity, peer.options.identity_size);
+            id.set_flags (msg_t::identity);
+            bool written = pipes [1]->write (&id);
+            zmq_assert (written);
+            pipes [1]->flush ();
+        }
+
         //  Attach remote end of the pipe to the peer socket. Note that peer's
         //  seqnum was incremented in find_endpoint function. We don't need it
         //  increased here.


### PR DESCRIPTION
The socket connecting using the inproc transport never
received the identity of the remote peer.
