### PR TITLE
Implement ZMQ_TCP_ACCEPT_FILTER setsockopt() for listening TCP sockets. 

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -415,6 +415,22 @@ Default value:: -1 (leave to OS default)
 Applicable socket types:: all, when using TCP transports.
 
 
+ZMQ_TCP_ACCEPT_FILTER: Assign filters to allow new TCP connections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Assign arbitrary number of filters that will be applied for each new TCP transport
+connection on a listening socket.
+If no filters applied, then TCP transport allows connections from any ip.
+If at least one filter is applied then new connection source ip should be matched.
+To clear all filters call zmq_setsockopt(socket, ZMQ_TCP_ACCEPT_FILTER, NULL, 0).
+Filter is a null-terminated string with ipv6 or ipv4 CIDR.
+
+[horizontal]
+Option value type:: binary data
+Option value unit:: N/A
+Default value:: no filters (allow from all)
+Applicable socket types:: all listening sockets, when using TCP transports.
+
+
 RETURN VALUE
 ------------
 The _zmq_setsockopt()_ function shall return zero if successful. Otherwise it

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -226,6 +226,7 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_TCP_KEEPALIVE_CNT 35
 #define ZMQ_TCP_KEEPALIVE_IDLE 36
 #define ZMQ_TCP_KEEPALIVE_INTVL 37
+#define ZMQ_TCP_ACCEPT_FILTER 38
 
 
 /*  Message options                                                           */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -287,6 +287,32 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
 #endif
             return 0;
         }
+
+    case ZMQ_TCP_ACCEPT_FILTER:
+        {
+            if (optvallen_ == 0 && optval_ == NULL) {
+                tcp_accept_filters.clear ();
+                return 0;
+            }
+            else
+            if (optvallen_ < 1 || optvallen_ > 255 || optval_ == NULL || *((const char*) optval_) == 0) {
+                errno = EINVAL;
+                return -1;
+            }
+            else {
+                std::string filter_str ((const char*) optval_, optvallen_);
+
+                tcp_address_mask_t filter;
+                int rc = filter.resolve (filter_str.c_str (), ipv4only ? true : false);
+                if (rc != 0) {
+                    errno = EINVAL;
+                    return -1;
+                }
+                tcp_accept_filters.push_back(filter);
+
+                return 0;
+            }
+        }
     }
     errno = EINVAL;
     return -1;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -24,9 +24,11 @@
 #define __ZMQ_OPTIONS_HPP_INCLUDED__
 
 #include <string>
+#include <vector>
 
 #include "stddef.h"
 #include "stdint.hpp"
+#include "tcp_address.hpp"
 
 namespace zmq
 {
@@ -117,6 +119,10 @@ namespace zmq
         int tcp_keepalive_cnt;
         int tcp_keepalive_idle;
         int tcp_keepalive_intvl;
+
+        // TCP accept() filters
+        typedef std::vector <tcp_address_mask_t> tcp_accept_filters_t;
+        tcp_accept_filters_t tcp_accept_filters;
 
         //  ID of the socket.
         int socket_id;

--- a/src/tcp_address.hpp
+++ b/src/tcp_address.hpp
@@ -55,7 +55,7 @@ namespace zmq
         const sockaddr *addr () const;
         socklen_t addrlen () const;
 
-    private:
+    protected:
 
         int resolve_nic_name (const char *nic_, bool ipv4only_);
         int resolve_interface (const char *interface_, bool ipv4only_);
@@ -66,12 +66,28 @@ namespace zmq
             sockaddr_in ipv4;
             sockaddr_in6 ipv6;
         } address;
-
-        tcp_address_t (const tcp_address_t&);
-        const tcp_address_t &operator = (const tcp_address_t&);
     };
-    
+
+    class tcp_address_mask_t : public tcp_address_t
+    {
+    public:
+
+        tcp_address_mask_t ();
+
+        // This function enhances tcp_address_t::resolve() with ability to parse
+        // additional cidr-like(/xx) mask value at the end of the name string.
+        // Works only with remote hostnames.
+        int resolve (const char* name_, bool ipv4only_);
+
+        const int mask () const;
+
+        const bool match_address (const struct sockaddr *sa, socklen_t ss_len) const;
+
+    private:
+
+        int address_mask;
+    };
+
 }
 
 #endif
-

--- a/src/tcp_listener.hpp
+++ b/src/tcp_listener.hpp
@@ -62,7 +62,8 @@ namespace zmq
 
         //  Accept the new connection. Returns the file descriptor of the
         //  newly created connection. The function may return retired_fd
-        //  if the connection was dropped while waiting in the listen backlog.
+        //  if the connection was dropped while waiting in the listen backlog
+        //  or was denied because of accept filters.
         fd_t accept ();
 
         //  Address to listen on.


### PR DESCRIPTION
Assign arbitrary number of filters that will be applied for each new TCP transport
connection on a listening socket.
If no filters applied, then TCP transport allows connections from any ip.
If at least one filter is applied then new connection source ip should be matched.
To clear all filters call zmq_setsockopt(socket, ZMQ_TCP_ACCEPT_FILTER, NULL, 0).
Filter is a null-terminated string with ipv6 or ipv4 CIDR.

For example:
localhost
127.0.0.1
mail.ru/24
::1
::1/128
3ffe:1::
3ffe:1::/56

Returns -1 if the filter couldn't be assigned(format error or ipv6 filter with ZMQ_IPV4ONLY set)

P.S.
The only thing that worries me is that I had to re-enable 'default assign by reference constructor/operator'
for 'tcp_address_t' (and for my inherited class tcp_address_mask_t) to store it in std::vector in 'options_t'...
