### PR TITLE
Small patch to instantiate clock_t once

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -46,7 +46,6 @@
 #include "io_thread.hpp"
 #include "session_base.hpp"
 #include "config.hpp"
-#include "clock.hpp"
 #include "pipe.hpp"
 #include "err.hpp"
 #include "ctx.hpp"
@@ -560,7 +559,6 @@ int zmq::socket_base_t::send (msg_t *msg_, int flags_)
 
     //  Compute the time when the timeout should occur.
     //  If the timeout is infite, don't care. 
-    clock_t clock ;
     int timeout = options.sndtimeo;
     uint64_t end = timeout < 0 ? 0 : (clock.now_ms () + timeout);
 
@@ -643,7 +641,6 @@ int zmq::socket_base_t::recv (msg_t *msg_, int flags_)
 
     //  Compute the time when the timeout should occur.
     //  If the timeout is infite, don't care. 
-    clock_t clock ;
     int timeout = options.rcvtimeo;
     uint64_t end = timeout < 0 ? 0 : (clock.now_ms () + timeout);
 

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -33,6 +33,7 @@
 #include "i_poll_events.hpp"
 #include "mailbox.hpp"
 #include "stdint.hpp"
+#include "clock.hpp"
 #include "pipe.hpp"
 
 namespace zmq
@@ -193,6 +194,9 @@ namespace zmq
 
         //  True if the last message received had MORE flag set.
         bool rcvmore;
+
+        //  Improves efficiency of time measurement.
+        clock_t clock;
 
         socket_base_t (const socket_base_t&);
         const socket_base_t &operator = (const socket_base_t&);


### PR DESCRIPTION
Taken from an XS patch by Martin Sustrik: 

This patch instantiate a clock_t instance for each XS socket. Thus, it
is shared between subsequent calls to xs_recv (and xs_send). That in
turn significantly limits the number of invocations of  getimeofday (or
similar) when timeouts are used and recv/send is called in a
tight loop.

Martin
