### PR TITLE
implement zmq_unbind(),zmq_disconnect(), zmq->sock->getsockopt(ZMQ_LAST_ENDPOINT_ID)

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -227,6 +227,7 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_TCP_KEEPALIVE_IDLE 36
 #define ZMQ_TCP_KEEPALIVE_INTVL 37
 #define ZMQ_TCP_ACCEPT_FILTER 38
+#define ZMQ_LAST_ENDPOINT_ID 39
 
 
 /*  Message options                                                           */
@@ -244,6 +245,8 @@ ZMQ_EXPORT int zmq_getsockopt (void *s, int option, void *optval,
     size_t *optvallen);
 ZMQ_EXPORT int zmq_bind (void *s, const char *addr);
 ZMQ_EXPORT int zmq_connect (void *s, const char *addr);
+ZMQ_EXPORT int zmq_unbind (void *s, void *ep);
+ZMQ_EXPORT int zmq_disconnect (void *s, void *ep);
 ZMQ_EXPORT int zmq_send (void *s, const void *buf, size_t len, int flags);
 ZMQ_EXPORT int zmq_recv (void *s, void *buf, size_t len, int flags);
 

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -23,7 +23,8 @@
 #include "tcp_address.hpp"
 #include "ipc_address.hpp"
 
-#include <string.h>
+#include <string>
+#include <sstream>
 
 zmq::address_t::address_t (
     const std::string &protocol_, const std::string &address_)
@@ -49,4 +50,29 @@ zmq::address_t::~address_t ()
         }
     }
 #endif
+}
+
+int zmq::address_t::to_string (std::string &addr_)
+{
+    if (protocol == "tcp") {
+        if (resolved.tcp_addr) {
+            return resolved.tcp_addr->to_string(addr_);
+        }
+    }
+#if !defined ZMQ_HAVE_WINDOWS && !defined ZMQ_HAVE_OPENVMS
+    else if (protocol == "ipc") {
+        if (resolved.ipc_addr) {
+            return resolved.tcp_addr->to_string(addr_);
+        }
+    }
+#endif
+
+    if (!protocol.empty () && !address.empty ()) {
+        std::stringstream s;
+        s << protocol << "://" << address;
+        addr_ = s.str ();
+        return 0;
+    }
+    addr_.clear ();
+    return -1;
 }

--- a/src/address.hpp
+++ b/src/address.hpp
@@ -44,6 +44,8 @@ namespace zmq
             ipc_address_t *ipc_addr;
 #endif
         } resolved;
+
+        int to_string (std::string &addr_);
     };
 }
 

--- a/src/ipc_address.cpp
+++ b/src/ipc_address.cpp
@@ -24,11 +24,22 @@
 
 #include "err.hpp"
 
-#include <string.h>
+#include <string>
+#include <sstream>
 
 zmq::ipc_address_t::ipc_address_t ()
 {
     memset (&address, 0, sizeof (address));
+}
+
+zmq::ipc_address_t::ipc_address_t (const sockaddr *sa, socklen_t sa_len)
+{
+    zmq_assert(sa && sa_len > 0);
+
+    memset (&address, 0, sizeof (address));
+    if (sa->sa_family == AF_UNIX) {
+        memcpy(&address, sa, sa_len);
+    }
 }
 
 zmq::ipc_address_t::~ipc_address_t ()
@@ -44,6 +55,19 @@ int zmq::ipc_address_t::resolve (const char *path_)
 
     address.sun_family = AF_UNIX;
     strcpy (address.sun_path, path_);
+    return 0;
+}
+
+int zmq::ipc_address_t::to_string (std::string &addr_)
+{
+    if (address.sun_family != AF_UNIX) {
+        addr_.clear ();
+        return -1;
+    }
+
+    std::stringstream s;
+    s << "ipc://" << address.sun_path;
+    addr_ = s.str ();
     return 0;
 }
 

--- a/src/ipc_address.hpp
+++ b/src/ipc_address.hpp
@@ -21,6 +21,8 @@
 #ifndef __ZMQ_IPC_ADDRESS_HPP_INCLUDED__
 #define __ZMQ_IPC_ADDRESS_HPP_INCLUDED__
 
+#include <string>
+
 #include "platform.hpp"
 
 #if !defined ZMQ_HAVE_WINDOWS && !defined ZMQ_HAVE_OPENVMS
@@ -36,10 +38,14 @@ namespace zmq
     public:
 
         ipc_address_t ();
+        ipc_address_t (const sockaddr *sa, socklen_t sa_len);
         ~ipc_address_t ();
 
         //  This function sets up the address for UNIX domain transport.
         int resolve (const char* path_);
+
+        //  The opposite to resolve()
+        int to_string (std::string &addr_);
 
         const sockaddr *addr () const;
         socklen_t addrlen () const;

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -98,22 +98,15 @@ void zmq::ipc_listener_t::in_event ()
 int zmq::ipc_listener_t::get_address (std::string &addr_)
 {
     struct sockaddr_storage ss;
-    int rc;
-
-    // Get the details of the IPC socket
     socklen_t sl = sizeof (ss);
-    rc = getsockname (s, (sockaddr *) &ss, &sl);
+    int rc = getsockname (s, (sockaddr *) &ss, &sl);
     if (rc != 0) {
+        addr_.clear ();
         return rc;
     }
 
-    // Store the address for retrieval by users using wildcards
-    addr_ = std::string ("ipc://");
-    struct sockaddr_un saddr;
-    memcpy (&saddr, &ss, sizeof (saddr));
-
-    addr_.append (saddr.sun_path);
-    return 0;
+    ipc_address_t addr ((struct sockaddr *) &ss, sl);
+    return addr.to_string (addr_);
 }
 
 int zmq::ipc_listener_t::set_address (const char *addr_)

--- a/src/ipc_listener.hpp
+++ b/src/ipc_listener.hpp
@@ -48,7 +48,7 @@ namespace zmq
 
         //  Set address to listen on.
         int set_address (const char *addr_);
-        
+
         // Get the bound address for use with wildcards
         int get_address (std::string &addr_);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -30,6 +30,7 @@ zmq::options_t::options_t () :
     rcvhwm (1000),
     affinity (0),
     identity_size (0),
+    last_endpoint_id(NULL),
     rate (100),
     recovery_ivl (10000),
     multicast_hops (1),
@@ -528,6 +529,15 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_)
         }
         memcpy (optval_, last_endpoint.c_str(), last_endpoint.size()+1);
         *optvallen_ = last_endpoint.size()+1;
+        return 0;
+
+    case ZMQ_LAST_ENDPOINT_ID:
+        if (*optvallen_ < sizeof (void *)) {
+            errno = EINVAL;
+            return -1;
+        }
+        *((void **) optval_) = last_endpoint_id;
+        *optvallen_ = sizeof (void *);
         return 0;
     }
 

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -53,6 +53,8 @@ namespace zmq
 
         // Last socket endpoint URI
         std::string last_endpoint;
+        // Last socket endpoint ID
+        void *last_endpoint_id;
 
         //  Maximum tranfer rate [kb/s]. Default 100kb/s.
         int rate;

--- a/src/own.cpp
+++ b/src/own.cpp
@@ -80,6 +80,11 @@ void zmq::own_t::launch_child (own_t *object_)
     send_own (this, object_);
 }
 
+void zmq::own_t::term_child (own_t *object_)
+{
+    process_term_req (object_);
+}
+
 void zmq::own_t::process_term_req (own_t *object_)
 {
     //  When shutting down we can ignore termination requests from owned

--- a/src/own.hpp
+++ b/src/own.hpp
@@ -70,6 +70,9 @@ namespace zmq
         //  Launch the supplied object and become its owner.
         void launch_child (own_t *object_);
 
+        //  Terminate owned object
+        void term_child (own_t *object_);
+
         //  Ask owner object to terminate this object. It may take a while
         //  while actual termination is started. This function should not be
         //  called more than once.

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -318,11 +318,16 @@ int zmq::socket_base_t::bind (const char *addr_)
 
     if (protocol == "inproc") {
         endpoint_t endpoint = {this, options};
-        return register_endpoint (addr_, endpoint);
+        int rc = register_endpoint (addr_, endpoint);
+        if (rc == 0) {
+            // Save last endpoint info
+            options.last_endpoint.clear ();
+            options.last_endpoint_id = NULL;
+        }
+        return rc;
     }
 
     if (protocol == "pgm" || protocol == "epgm") {
-
         //  For convenience's sake, bind can be used interchageable with
         //  connect for PGM and EPGM transports.
         return connect (addr_);
@@ -346,7 +351,10 @@ int zmq::socket_base_t::bind (const char *addr_)
             return -1;
         }
 
-        rc = listener->get_address (options.last_endpoint);
+        // Save last endpoint info
+        options.last_endpoint_id = (void *) ((own_t *) listener);
+        listener->get_address (options.last_endpoint);
+
         launch_child (listener);
         return 0;
     }
@@ -362,7 +370,10 @@ int zmq::socket_base_t::bind (const char *addr_)
             return -1;
         }
 
-        rc = listener->get_address (options.last_endpoint);
+        // Save last endpoint info
+        options.last_endpoint_id = (void *) ((own_t *) listener);
+        listener->get_address (options.last_endpoint);
+
         launch_child (listener);
         return 0;
     }
@@ -454,6 +465,10 @@ int zmq::socket_base_t::connect (const char *addr_)
         //  increased here.
         send_bind (peer.socket, pipes [1], false);
 
+        // Save last endpoint info
+        options.last_endpoint.clear ();
+        options.last_endpoint_id = NULL;
+
         return 0;
     }
 
@@ -513,6 +528,10 @@ int zmq::socket_base_t::connect (const char *addr_)
 
     //  Attach remote end of the pipe to the session object later on.
     session->attach_pipe (pipes [1]);
+
+    // Save last endpoint info
+    paddr->to_string (options.last_endpoint);
+    options.last_endpoint_id = (void *) ((own_t *) session);
 
     //  Activate the session. Make it a child of this socket.
     launch_child (session);
@@ -583,6 +602,16 @@ int zmq::socket_base_t::send (msg_t *msg_, int flags_)
             }
         }
     }
+    return 0;
+}
+
+int zmq::socket_base_t::term_endpoint (void *ep_)
+{
+    if (unlikely (ctx_terminated)) {
+        errno = ETERM;
+        return -1;
+    }
+    term_child ((own_t *) ep_);
     return 0;
 }
 

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -71,6 +71,7 @@ namespace zmq
         int getsockopt (int option_, void *optval_, size_t *optvallen_);
         int bind (const char *addr_);
         int connect (const char *addr_);
+        int term_endpoint (void *ep_);
         int send (zmq::msg_t *msg_, int flags_);
         int recv (zmq::msg_t *msg_, int flags_);
         int close ();

--- a/src/tcp_address.hpp
+++ b/src/tcp_address.hpp
@@ -39,6 +39,7 @@ namespace zmq
     public:
 
         tcp_address_t ();
+        tcp_address_t (const sockaddr *sa, socklen_t sa_len);
         ~tcp_address_t ();
 
         //  This function translates textual TCP address into an address
@@ -46,6 +47,9 @@ namespace zmq
         //  names. If it is false, names are resolved as remote hostnames.
         //  If 'ipv4only' is true, the name will never resolve to IPv6 address.
         int resolve (const char* name_, bool local_, bool ipv4only_);
+
+        //  The opposite to resolve()
+        virtual int to_string (std::string &addr_);
 
 #if defined ZMQ_HAVE_WINDOWS
         unsigned short family () const;
@@ -78,6 +82,9 @@ namespace zmq
         // additional cidr-like(/xx) mask value at the end of the name string.
         // Works only with remote hostnames.
         int resolve (const char* name_, bool ipv4only_);
+
+        // The opposite to resolve()
+        int to_string (std::string &addr_);
 
         const int mask () const;
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -293,6 +293,26 @@ int zmq_connect (void *s_, const char *addr_)
     return result;
 }
 
+int zmq_unbind (void *s_, void *ep_)
+{
+    if (!s_ || !((zmq::socket_base_t*) s_)->check_tag ()) {
+        errno = ENOTSOCK;
+        return -1;
+    }
+    zmq::socket_base_t *s = (zmq::socket_base_t *) s_;
+    return s->term_endpoint (ep_);
+}
+
+int zmq_disconnect (void *s_, void *ep_)
+{
+    if (!s_ || !((zmq::socket_base_t*) s_)->check_tag ()) {
+        errno = ENOTSOCK;
+        return -1;
+    }
+    zmq::socket_base_t *s = (zmq::socket_base_t *) s_;
+    return s->term_endpoint (ep_);
+}
+
 // Sending functions.
 
 static int


### PR DESCRIPTION
The usage scheme:

After _EACH_ successful call to sock->bind() or sock->connect() you can call
sock->getsockopt(ZMQ_LAST_ENDPOINT) to obtain resolved endpoint address string and
sock->getsockopt(ZMQ_LAST_ENDPOINT_ID) to obtain 'void *' endpoint handle.

Later on you can call sock->unbind() or sock->disconnect() with saved endpoint handle to terminate endpoint.
(Of  course if we want to do it _right_ we need to change sock->bind() and sock->connect() to return endpoint handle if succeeded, but API change is almost impossible...)

Current implementation cons/incompatibilities (and potential improvements):
- doesn't work with 'inproc' transport(just unset ZMQ_LAST_ENDPOINT and ZMQ_LAST_ENDPOINT_ID after every call to bind(inproc://) or connect(inproc://). I just don't know how it works :(
- no specific error code/confirmation that endpoint handle passed to unbind()/disconnect() is actually valid and terminated. Easily could be implemented if needed.
- ZMQ_LAST_ENDPOINT changed more often than before(after _EACH_ successful call to bind()/connect() )
- *address_t->to_string() hierarchy could be improved.
