### PR TITLE
add process_commands() to the beginning of zmq_connect() and zmq_bind()

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -305,10 +305,15 @@ int zmq::socket_base_t::bind (const char *addr_)
         return -1;
     }
 
+    //  Process pending commands, if any.
+    int rc = process_commands (0, false);
+    if (unlikely (rc != 0))
+        return -1;
+
     //  Parse addr_ string.
     std::string protocol;
     std::string address;
-    int rc = parse_uri (addr_, protocol, address);
+    rc = parse_uri (addr_, protocol, address);
     if (rc != 0)
         return -1;
 
@@ -387,10 +392,15 @@ int zmq::socket_base_t::connect (const char *addr_)
         return -1;
     }
 
+    //  Process pending commands, if any.
+    int rc = process_commands (0, false);
+    if (unlikely (rc != 0))
+        return -1;
+
     //  Parse addr_ string.
     std::string protocol;
     std::string address;
-    int rc = parse_uri (addr_, protocol, address);
+    rc = parse_uri (addr_, protocol, address);
     if (rc != 0)
         return -1;
 


### PR DESCRIPTION
I believe there was a conception that zmq_connect() and zmq_bind() will be called
only at the socket creation time and therefore don't need it.
Now it is not true anymore.
