### PR TITLE
fq: remove unused parameter

### DIFF
--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -70,7 +70,7 @@ int zmq::dealer_t::xrecv (msg_t *msg_, int flags_)
 
     //  DEALER socket doesn't use identities. We can safely drop it and 
     while (true) {
-        int rc = fq.recv (msg_, flags_);
+        int rc = fq.recv (msg_);
         if (rc != 0)
             return rc;
         if (likely (!(msg_->flags () & msg_t::identity)))

--- a/src/fq.cpp
+++ b/src/fq.cpp
@@ -63,12 +63,12 @@ void zmq::fq_t::activated (pipe_t *pipe_)
     active++;
 }
 
-int zmq::fq_t::recv (msg_t *msg_, int flags_)
+int zmq::fq_t::recv (msg_t *msg_)
 {
-    return recvpipe (msg_, flags_, NULL);
+    return recvpipe (msg_, NULL);
 }
 
-int zmq::fq_t::recvpipe (msg_t *msg_, int flags_, pipe_t **pipe_)
+int zmq::fq_t::recvpipe (msg_t *msg_, pipe_t **pipe_)
 {
     //  Deallocate old content of the message.
     int rc = msg_->close ();

--- a/src/fq.hpp
+++ b/src/fq.hpp
@@ -44,8 +44,8 @@ namespace zmq
         void activated (pipe_t *pipe_);
         void terminated (pipe_t *pipe_);
 
-        int recv (msg_t *msg_, int flags_);
-        int recvpipe (msg_t *msg_, int flags_, pipe_t **pipe_);
+        int recv (msg_t *msg_);
+        int recvpipe (msg_t *msg_, pipe_t **pipe_);
         bool has_in ();
 
     private:

--- a/src/pull.cpp
+++ b/src/pull.cpp
@@ -52,7 +52,7 @@ void zmq::pull_t::xterminated (pipe_t *pipe_)
 
 int zmq::pull_t::xrecv (msg_t *msg_, int flags_)
 {
-    return fq.recv (msg_, flags_);
+    return fq.recv (msg_);
 }
 
 bool zmq::pull_t::xhas_in ()

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -212,7 +212,7 @@ int zmq::router_t::xrecv (msg_t *msg_, int flags_)
     }
 
     pipe_t *pipe = NULL;
-    int rc = fq.recvpipe (msg_, flags_, &pipe);
+    int rc = fq.recvpipe (msg_, &pipe);
     if (rc != 0) {
         errno = EAGAIN;
         return -1;
@@ -268,7 +268,7 @@ bool zmq::router_t::xhas_in ()
     //  Try to read the next message.
     //  The message, if read, is kept in the pre-fetch buffer.
     pipe_t *pipe = NULL;
-    int rc = fq.recvpipe (&prefetched_msg, ZMQ_DONTWAIT, &pipe);
+    int rc = fq.recvpipe (&prefetched_msg, &pipe);
     if (rc != 0)
         return false;
 

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -132,7 +132,7 @@ int zmq::xsub_t::xrecv (msg_t *msg_, int flags_)
     while (true) {
 
         //  Get a message using fair queueing algorithm.
-        int rc = fq.recv (msg_, flags_);
+        int rc = fq.recv (msg_);
 
         //  If there's no message available, return immediately.
         //  The same when error occurs.
@@ -149,7 +149,7 @@ int zmq::xsub_t::xrecv (msg_t *msg_, int flags_)
         //  Message doesn't match. Pop any remaining parts of the message
         //  from the pipe.
         while (msg_->flags () & msg_t::more) {
-            rc = fq.recv (msg_, ZMQ_DONTWAIT);
+            rc = fq.recv (msg_);
             zmq_assert (rc == 0);
         }
     }
@@ -171,7 +171,7 @@ bool zmq::xsub_t::xhas_in ()
     while (true) {
 
         //  Get a message using fair queueing algorithm.
-        int rc = fq.recv (&message, ZMQ_DONTWAIT);
+        int rc = fq.recv (&message);
 
         //  If there's no message available, return immediately.
         //  The same when error occurs.
@@ -189,7 +189,7 @@ bool zmq::xsub_t::xhas_in ()
         //  Message doesn't match. Pop any remaining parts of the message
         //  from the pipe.
         while (message.flags () & msg_t::more) {
-            rc = fq.recv (&message, ZMQ_DONTWAIT);
+            rc = fq.recv (&message);
             zmq_assert (rc == 0);
         }
     }


### PR DESCRIPTION
The recv function accepted flags parameter but this was unused.
