### PR TITLE
Do not crash when multiple peers connect to PAIR socket

### DIFF
--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -38,14 +38,20 @@ zmq::pair_t::~pair_t ()
 
 void zmq::pair_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
 {
-    zmq_assert (!pipe);
-    pipe = pipe_;
+    zmq_assert (pipe_ != NULL);
+
+    //  ZMQ_PAIR socket can only be connected to a single peer.
+    //  The socket rejects any further connection requests.
+    if (pipe == NULL)
+        pipe = pipe_;
+    else
+        pipe_->terminate (false);
 }
 
 void zmq::pair_t::xterminated (pipe_t *pipe_)
 {
-    zmq_assert (pipe_ == pipe);
-    pipe = NULL;
+    if (pipe_ == pipe)
+        pipe = NULL;
 }
 
 void zmq::pair_t::xread_activated (pipe_t *pipe_)


### PR DESCRIPTION
When more then one peer connected to a ZMQ_PAIR socket,
an application aborted due to assertion failure.
This patch changes the ZMQ_PAIR socket behaviour so that
it rejects any further connection requests.
