### PR TITLE
Fix issue #264

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -51,6 +51,11 @@ void zmq::decoder_t::set_session (session_base_t *session_)
     session = session_;
 }
 
+bool zmq::decoder_t::stalled () const
+{
+    return next == &decoder_t::message_ready;
+}
+
 bool zmq::decoder_t::one_byte_size_ready ()
 {
     //  First byte of size is read. If it is 0xff read 8-byte size.

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -52,9 +52,9 @@ namespace zmq
     public:
 
         inline decoder_base_t (size_t bufsize_) :
+            next (NULL),
             read_pos (NULL),
             to_read (0),
-            next (NULL),
             bufsize (bufsize_)
         {
             buf = (unsigned char*) malloc (bufsize_);
@@ -165,6 +165,11 @@ namespace zmq
             next = NULL;
         }
 
+        //  Next step. If set to NULL, it means that associated data stream
+        //  is dead. Note that there can be still data in the process in such
+        //  case.
+        step_t next;
+
     private:
 
         //  Where to store the read data.
@@ -172,11 +177,6 @@ namespace zmq
 
         //  How much data to read before taking next step.
         size_t to_read;
-
-        //  Next step. If set to NULL, it means that associated data stream
-        //  is dead. Note that there can be still data in the process in such
-        //  case.
-        step_t next;
 
         //  The duffer for data to decode.
         size_t bufsize;
@@ -196,6 +196,10 @@ namespace zmq
         ~decoder_t ();
 
         void set_session (zmq::session_base_t *session_);
+
+        //  Returns true if there is a decoded message
+        //  waiting to be delivered to the session.
+        bool stalled () const;
 
     private:
 

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -83,6 +83,7 @@ namespace zmq
         unsigned char *inpos;
         size_t insize;
         decoder_t decoder;
+        bool input_error;
 
         unsigned char *outpos;
         size_t outsize;


### PR DESCRIPTION
Before this patch, the stream engine terminated itself
whenever it had detected an IO error. If this happened
when sending a message, the engine lost all
in-flight messages, messages waiting to be decoded,
and the last decoded message that had not been accepted,
if there was one.

The new behaviour is to terminate the engine only after
the input error has been detected and the last decoded
