### PR TITLE
Async connect error handling

### DIFF
--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -186,6 +186,13 @@ int zmq::ipc_connecter_t::open ()
     //  Connect was successfull immediately.
     if (rc == 0)
         return 0;
+        
+    //  Translate other error codes indicating asynchronous connect has been
+    //  launched to a uniform EINPROGRESS.
+    if (rc == -1 && errno == EINTR) {
+        errno = EINPROGRESS;
+        return -1;
+    }
 
     //  Forward the error.
     return -1;


### PR DESCRIPTION
Patch from Mato that fixes a subtle connect bug: 

EAGAIN was being used as a translation value for EINPROGRESS, thus
shadowing a real EAGAIN return value from the OS.  This caused later
assertions of "Invalid argument" in stream_engine.cpp when it attempted to
use a socket which was not connected.

I also add EINTR to mean EINPROGRESS, as per the POSIX and FreeBSD
documentation which specifies that a connect() call interrupted due to a
signal will complete asynchronously.

Signed-off-by: Martin Lucina martin@lucina.net
