### PR TITLE
Fix #366 - On Windows, preventing sockets to be inherited by child processes.

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -57,6 +57,12 @@ zmq::fd_t zmq::open_socket (int domain_, int type_, int protocol_)
     errno_assert (rc != -1);
 #endif
 
+    //  On Windows, preventing sockets to be inherited by child processes.
+#if defined ZMQ_HAVE_WINDOWS && defined HANDLE_FLAG_INHERIT
+    BOOL brc = SetHandleInformation ((HANDLE) s, HANDLE_FLAG_INHERIT, 0);
+    win_assert (brc);
+#endif
+
     return s;
 }
 

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -164,6 +164,9 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
         wsa_error_to_errno ();
         return -1;
     }
+    //  On Windows, preventing sockets to be inherited by child processes.
+    BOOL brc = SetHandleInformation ((HANDLE) s, HANDLE_FLAG_INHERIT, 0);
+    win_assert (brc);
 #else
     if (s == -1)
         return -1;
@@ -227,6 +230,9 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
             WSAGetLastError () == WSAECONNRESET);
         return retired_fd;
     }
+    //  On Windows, preventing sockets to be inherited by child processes.
+    BOOL brc = SetHandleInformation ((HANDLE) sock, HANDLE_FLAG_INHERIT, 0);
+    win_assert (brc);
 #else
     if (sock == -1) {
         errno_assert (errno == EAGAIN || errno == EWOULDBLOCK ||


### PR DESCRIPTION
On Windows platform, in order to prevent child processes to inherit parent sockets, SetHandleInformation (http://msdn.microsoft.com/en-us/library/windows/desktop/ms724935(v=vs.85).aspx) should be called on the socket handle.

This fix was included in branch zeromq2-x, pull request https://github.com/zeromq/zeromq2-x/pull/51

Bug ref: https://zeromq.jira.com/browse/LIBZMQ-366

Thanks
