### PR TITLE
Fix issue #268

### DIFF
--- a/src/encoder.cpp
+++ b/src/encoder.cpp
@@ -51,7 +51,7 @@ bool zmq::encoder_t::size_ready ()
 {
     //  Write message body into the buffer.
     next_step (in_progress.data (), in_progress.size (),
-        &encoder_t::message_ready, false);
+        &encoder_t::message_ready, !(in_progress.flags () & msg_t::more));
     return true;
 }
 
@@ -90,15 +90,13 @@ bool zmq::encoder_t::message_ready ()
     if (size < 255) {
         tmpbuf [0] = (unsigned char) size;
         tmpbuf [1] = (in_progress.flags () & msg_t::more);
-        next_step (tmpbuf, 2, &encoder_t::size_ready,
-            !(in_progress.flags () & msg_t::more));
+        next_step (tmpbuf, 2, &encoder_t::size_ready, false);
     }
     else {
         tmpbuf [0] = 0xff;
         put_uint64 (tmpbuf + 1, size);
         tmpbuf [9] = (in_progress.flags () & msg_t::more);
-        next_step (tmpbuf, 10, &encoder_t::size_ready,
-            !(in_progress.flags () & msg_t::more));
+        next_step (tmpbuf, 10, &encoder_t::size_ready, false);
     }
     return true;
 }

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -79,18 +79,16 @@ namespace zmq
                 //  If there are still no data, return what we already have
                 //  in the buffer.
                 if (!to_write) {
+                    //  If we are to encode the beginning of a new message,
+                    //  adjust the message offset.
+                    if (beginning)
+                        if (offset_ && *offset_ == -1)
+                            *offset_ = static_cast <int> (pos);
+
                     if (!(static_cast <T*> (this)->*next) ()) {
                         *data_ = buffer;
                         *size_ = pos;
                         return;
-                    }
-
-                    //  If beginning of the message was processed, adjust the
-                    //  first-message-offset.
-                    if (beginning) { 
-                        if (offset_ && *offset_ == -1)
-                            *offset_ = (int) pos;
-                        beginning = false;
                     }
                 }
 


### PR DESCRIPTION
This patch fixes a bug in the message encoder which was
responsible for computing incorrect message offset.
The bug affected PGM receiver making it unable to
decode inital messages.
