### PR TITLE
Solaris/SunCC build fix: could not find a match for std::multimap<...>::insert(std::pair<...,...>)

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -547,7 +547,7 @@ void zmq::socket_base_t::add_endpoint (const char *addr_, own_t *endpoint_)
 {
     //  Activate the session. Make it a child of this socket.
     launch_child (endpoint_);
-    endpoints.insert (std::make_pair (std::string (addr_), endpoint_));
+    endpoints.insert (endpoints_t::value_type (std::string (addr_), endpoint_));
 }
 
 int zmq::socket_base_t::term_endpoint (const char *addr_)


### PR DESCRIPTION
Error: Could not find a match for std::multimap<...>::insert(std::pair<...,...>)
Compiler: Sun C++ 5.12 (latest version of Solaris Studio C++: 12.3)
Cause: the multimap classes don't have a method insert(pair<First, Second>), only insert(pair<const First, Second>).
Solution: Instead of insert(make_pair(first, second)), use insert(mm::value_type(first, second)).
