### PR TITLE
Doc improvement: document interface omission in zmq_pgm.txt

### DIFF
--- a/doc/zmq.txt
+++ b/doc/zmq.txt
@@ -19,7 +19,7 @@ DESCRIPTION
 The 0MQ lightweight messaging kernel is a library which extends the standard
 socket interfaces with features traditionally provided by specialised
 _messaging middleware_ products. 0MQ sockets provide an abstraction of
-asynchronous  _message queues_, multiple _messaging patterns_, message
+asynchronous _message queues_, multiple _messaging patterns_, message
 filtering (_subscriptions_), seamless access to multiple _transport protocols_
 and more.
 
@@ -208,8 +208,8 @@ by C programmers. The intent is that programmers using 0MQ from other languages
 shall refer to this documentation alongside any documentation provided by the
 vendor of their language binding.
 
-Language bindings (Python, PHP, Ruby, Java and more) are provided by members
-of the 0MQ community and pointers can be found on the 0MQ website.
+Language bindings ($$C++$$, Python, PHP, Ruby, Java and more) are provided by
+members of the 0MQ community and pointers can be found on the 0MQ website.
 
 
 AUTHORS

--- a/doc/zmq_pgm.txt
+++ b/doc/zmq_pgm.txt
@@ -60,7 +60,8 @@ An 'interface' may be specified by either of the following:
 NOTE: Interface names are not standardised in any way and should be assumed to
 be arbitrary and platform dependent. On Win32 platforms no short interface
 names exist, thus only the primary IPv4 address may be used to specify an
-'interface'.
+'interface'. The 'interface' part can be omitted, in that case the default one
+will be selected.
 
 A 'multicast address' is specified by an IPv4 multicast address in it's numeric
 representation.


### PR DESCRIPTION
The PGM transport supports the omission of the network interface to
select the default one like:

  announce.connect("epgm://eth0;239.255.128.46:64646"); // Use eth0
  announce.connect("epgm://239.255.128.46:64646"); // Use the default

Also, mention C++ in the additional community bindings of 0MQ in
zmq.txt.
