### PR TITLE
Fix issue #369

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -387,6 +387,10 @@ void zmq::session_base_t::detached ()
         return;
     }
 
+    //  Restore identity flags.
+    send_identity = options.send_identity;
+    recv_identity = options.recv_identity;
+
     //  Reconnect.
     if (options.reconnect_ivl != -1)
         start_connecting (true);


### PR DESCRIPTION
The bug was that after reconnect, the session did not
handle identity messages properly.
