### PR TITLE
Fix issue #370

### DIFF
--- a/src/req.cpp
+++ b/src/req.cpp
@@ -178,3 +178,8 @@ int zmq::req_session_t::write (msg_t *msg_)
     return -1;
 }
 
+void zmq::req_session_t::reset ()
+{
+    session_base_t::reset ();
+    state = identity;
+}

--- a/src/req.hpp
+++ b/src/req.hpp
@@ -72,6 +72,7 @@ namespace zmq
 
         //  Overloads of the functions from session_base_t.
         int write (msg_t *msg_);
+        void reset ();
 
     private:
 

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -190,6 +190,13 @@ int zmq::session_base_t::write (msg_t *msg_)
     return -1;
 }
 
+void zmq::session_base_t::reset ()
+{
+    //  Restore identity flags.
+    send_identity = options.send_identity;
+    recv_identity = options.recv_identity;
+}
+
 void zmq::session_base_t::flush ()
 {
     if (pipe)
@@ -388,9 +395,7 @@ void zmq::session_base_t::detached ()
         return;
     }
 
-    //  Restore identity flags.
-    send_identity = options.send_identity;
-    recv_identity = options.recv_identity;
+    reset ();
 
     //  Reconnect.
     if (options.reconnect_ivl != -1)

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -56,6 +56,7 @@ namespace zmq
         //  Following functions are the interface exposed towards the engine.
         virtual int read (msg_t *msg_);
         virtual int write (msg_t *msg_);
+        virtual void reset ();
         void flush ();
         void detach ();
 


### PR DESCRIPTION
The patch extends the internal session's API with the reset method.
This method is used to reset a session's state so that it can
handle a new connection.
