### PR TITLE
Prevent connection starvation

### DIFF
--- a/src/fq.cpp
+++ b/src/fq.cpp
@@ -46,10 +46,13 @@ void zmq::fq_t::attach (pipe_t *pipe_)
 
 void zmq::fq_t::terminated (pipe_t *pipe_)
 {
+    const pipes_t::size_type index = pipes.index (pipe_);
+
     //  Remove the pipe from the list; adjust number of active pipes
     //  accordingly.
-    if (pipes.index (pipe_) < active) {
+    if (index < active) {
         active--;
+        pipes.swap (index, active);
         if (current == active)
             current = 0;
     }

--- a/src/lb.cpp
+++ b/src/lb.cpp
@@ -58,6 +58,7 @@ void zmq::lb_t::terminated (pipe_t *pipe_)
     //  accordingly.
     if (index < active) {
         active--;
+        pipes.swap (index, active);
         if (current == active)
             current = 0;
     }


### PR DESCRIPTION
When removing a pipe from the lb or fq component,
make sure we do not remove another pipe from the active set.
