### PR TITLE
Change connection failure test to use an invalid hostname

### DIFF
--- a/tests/test_connect_resolve.cpp
+++ b/tests/test_connect_resolve.cpp
@@ -40,7 +40,7 @@ int main (int argc, char *argv [])
     int rc = zmq_connect (sock, "tcp://localhost:1234");
     assert (rc == 0);
 
-    rc = zmq_connect (sock, "tcp://foobar123xyz:1234");
+    rc = zmq_connect (sock, "tcp://0mq.is.teh.best:1234");
     assert (rc == -1);
     assert (errno == EINVAL);
 


### PR DESCRIPTION
In _tests/test_connect_resolve.cpp_:
- Invalid hostname set to "0mq.is.teh.best" (naturally!)
- Issue happens as other valid-like non-existent hostnames were redirected by buggy Cable/ISP DNS servers
