### PR TITLE
Fix the message decoder to ignore reserved flags.

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -145,7 +145,7 @@ bool zmq::decoder_t::eight_byte_size_ready ()
 bool zmq::decoder_t::flags_ready ()
 {
     //  Store the flags from the wire into the message structure.
-    in_progress.set_flags (tmpbuf [0]);
+    in_progress.set_flags (tmpbuf [0] & msg_t::more);
 
     next_step (in_progress.data (), in_progress.size (),
         &decoder_t::message_ready);


### PR DESCRIPTION
Failing to clear the reserved flags, the decoder may produce
messages with 'identity' and 'shared' flags set.
This unintended modification of message flags can lead to memory
errors or asserion failures.

Fixes issue #309
