### PR TITLE
Fix race conditions in {tcp,ipc}_connecter

### DIFF
--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -59,13 +59,9 @@ zmq::ipc_connecter_t::ipc_connecter_t (class io_thread_t *io_thread_,
 
 zmq::ipc_connecter_t::~ipc_connecter_t ()
 {
-    if (wait)
-        cancel_timer (reconnect_timer_id);
-    if (handle_valid)
-        rm_fd (handle);
-
-    if (s != retired_fd)
-        close ();
+    zmq_assert (!wait);
+    zmq_assert (!handle_valid);
+    zmq_assert (s == retired_fd);
 }
 
 void zmq::ipc_connecter_t::process_plug ()
@@ -74,6 +70,24 @@ void zmq::ipc_connecter_t::process_plug ()
         add_reconnect_timer();
     else
         start_connecting ();
+}
+
+void zmq::ipc_connecter_t::process_term (int linger_)
+{
+    if (wait) {
+        cancel_timer (reconnect_timer_id);
+        wait = false;
+    }
+
+    if (handle_valid) {
+        rm_fd (handle);
+        handle_valid = false;
+    }
+
+    if (s != retired_fd)
+        close ();
+
+    own_t::process_term (linger_);
 }
 
 void zmq::ipc_connecter_t::in_event ()

--- a/src/ipc_connecter.hpp
+++ b/src/ipc_connecter.hpp
@@ -55,6 +55,7 @@ namespace zmq
 
         //  Handlers for incoming commands.
         void process_plug ();
+        void process_term (int linger_);
 
         //  Handlers for I/O events.
         void in_event ();

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -52,8 +52,7 @@ zmq::ipc_listener_t::ipc_listener_t (io_thread_t *io_thread_,
 
 zmq::ipc_listener_t::~ipc_listener_t ()
 {
-    if (s != retired_fd)
-        close ();
+    zmq_assert (s == retired_fd);
 }
 
 void zmq::ipc_listener_t::process_plug ()

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -69,13 +69,9 @@ zmq::tcp_connecter_t::tcp_connecter_t (class io_thread_t *io_thread_,
 
 zmq::tcp_connecter_t::~tcp_connecter_t ()
 {
-    if (wait)
-        cancel_timer (reconnect_timer_id);
-    if (handle_valid)
-        rm_fd (handle);
-
-    if (s != retired_fd)
-        close ();
+    zmq_assert (!wait);
+    zmq_assert (!handle_valid);
+    zmq_assert (s == retired_fd);
 }
 
 void zmq::tcp_connecter_t::process_plug ()
@@ -84,6 +80,24 @@ void zmq::tcp_connecter_t::process_plug ()
         add_reconnect_timer();
     else
         start_connecting ();
+}
+
+void zmq::tcp_connecter_t::process_term (int linger_)
+{
+    if (wait) {
+        cancel_timer (reconnect_timer_id);
+        wait = false;
+    }
+
+    if (handle_valid) {
+        rm_fd (handle);
+        handle_valid = false;
+    }
+
+    if (s != retired_fd)
+        close ();
+
+    own_t::process_term (linger_);
 }
 
 void zmq::tcp_connecter_t::in_event ()

--- a/src/tcp_connecter.hpp
+++ b/src/tcp_connecter.hpp
@@ -53,6 +53,7 @@ namespace zmq
 
         //  Handlers for incoming commands.
         void process_plug ();
+        void process_term (int linger_);
 
         //  Handlers for I/O events.
         void in_event ();

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -61,8 +61,7 @@ zmq::tcp_listener_t::tcp_listener_t (io_thread_t *io_thread_,
 
 zmq::tcp_listener_t::~tcp_listener_t ()
 {
-    if (s != retired_fd)
-        close ();
+    zmq_assert (s == retired_fd);
 }
 
 void zmq::tcp_listener_t::process_plug ()


### PR DESCRIPTION
Once the object has been terminated, it is unsafe for this object
to refer to its parent.

The bug was responsible for occasional
test_shutdown_stress failures.
