### PR TITLE
Correct typo: add missing single quote.

### DIFF
--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -166,7 +166,7 @@ Deprecated alias: 'ZMQ_XREP'.
 
 [horizontal]
 .Summary of ZMQ_ROUTER characteristics
-Compatible peer sockets:: 'ZMQ_DEALER', 'ZMQ_REQ
+Compatible peer sockets:: 'ZMQ_DEALER', 'ZMQ_REQ'
 Direction:: Bidirectional
 Send/receive pattern:: Unrestricted
 Outgoing routing strategy:: See text


### PR DESCRIPTION
In the ZMQ_ROUTER section.
