### PR TITLE
declare struct iovec

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -342,6 +342,8 @@ ZMQ_EXPORT int zmq_sendmsg (void *s, zmq_msg_t *msg, int flags);
 ZMQ_EXPORT int zmq_recvmsg (void *s, zmq_msg_t *msg, int flags);
 
 /*  Experimental                                                              */
+struct iovec;
+
 ZMQ_EXPORT int zmq_sendiov (void *s, struct iovec *iov, size_t count, int flags);
 ZMQ_EXPORT int zmq_recviov (void *s, struct iovec *iov, size_t *count, int flags);
 


### PR DESCRIPTION
avoids warnings of the form:

> warning: 'struct iovec' declared inside parameter list
> warning: its scope is only this definition or declaration, which is probably not what you want

when building downstream projects.

This would cause czmq builds to fail, since it (inappropriately?) uses `-Werror`, balking at any warning.

Being a fairly crappy C-programmer, I don't know if this is preferable to `#include <sys/uio.h>`, though I understand that that is a Linux/Unix-specific header, so some Windows-handling would be necessary.
