### PR TITLE
Making Android&pyzmq friendly version with -avoid-version

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -75,8 +75,9 @@ libzmq_werror="yes"
 # By default use DSO visibility
 libzmq_dso_visibility="yes"
 
-# Whether we are on mingw or not.
+# Whether we are on mingw or android or not.
 libzmq_on_mingw32="no"
+libzmq_on_android="no"
 
 # Set some default features required by 0MQ code.
 CPPFLAGS="-D_REENTRANT -D_THREAD_SAFE $CPPFLAGS"
@@ -96,6 +97,7 @@ case "${host_os}" in
         case "${host_os}" in
             *android*)
                 AC_DEFINE(ZMQ_HAVE_ANDROID, 1, [Have Android OS])
+                libzmq_on_android="yes"
             ;;
         esac
         ;;
@@ -373,6 +375,7 @@ AC_LANG_POP([C++])
 
 AM_CONDITIONAL(BUILD_PGM, test "x$libzmq_pgm_ext" = "xyes")
 AM_CONDITIONAL(ON_MINGW, test "x$libzmq_on_mingw32" = "xyes")
+AM_CONDITIONAL(ON_ANDROID, test "x$libzmq_on_android" = "xyes")
 
 # Checks for library functions.
 AC_TYPE_SIGNAL

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -140,7 +140,11 @@ libzmq_la_SOURCES = \
 if ON_MINGW
 libzmq_la_LDFLAGS = -no-undefined -avoid-version -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@
 else
+if ON_ANDROID
+libzmq_la_LDFLAGS = -avoid-version -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@
+else
 libzmq_la_LDFLAGS = -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@
+endif
 endif
 
 libzmq_la_CXXFLAGS = @LIBZMQ_EXTRA_CXXFLAGS@


### PR DESCRIPTION
pyzmq bundles a copy of libzmq.so and this fails to load on android. I suspect the reason is that the loaded library libzmq.so refers to itself as libzmq.so.3 and that latter file can't load. I am not 100% sure this patch is the way to go but:
- this or modifying bundling in pyzmq is required, this works fine
- I read somewhere else that -avoid-version was needed for Android
