### PR TITLE
Be more conservative about when to generate ZMQ_EVENT_CLOSE_FAILED

### DIFF
--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -224,10 +224,7 @@ int zmq::ipc_connecter_t::close ()
 {
     zmq_assert (s != retired_fd);
     int rc = ::close (s);
-    if (rc != 0) {
-        session->monitor_event (ZMQ_EVENT_CLOSE_FAILED, endpoint.c_str(), zmq_errno());
-        return -1;
-    }
+    errno_assert (rc == 0);
     session->monitor_event (ZMQ_EVENT_CLOSED, endpoint.c_str(), s);
     s = retired_fd;
     return 0;

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -169,10 +169,7 @@ int zmq::ipc_listener_t::close ()
 {
     zmq_assert (s != retired_fd);
     int rc = ::close (s);
-    if (rc != 0) {
-        socket->monitor_event (ZMQ_EVENT_CLOSE_FAILED, endpoint.c_str(), zmq_errno());
-        return -1;
-    }
+    errno_assert (rc == 0);
 
     //  If there's an underlying UNIX domain socket, get rid of the file it
     //  is associated with.

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -298,13 +298,9 @@ void zmq::tcp_connecter_t::close ()
     zmq_assert (s != retired_fd);
 #ifdef ZMQ_HAVE_WINDOWS
     int rc = closesocket (s);
-    if (unlikely (rc != SOCKET_ERROR))
-        session->monitor_event (ZMQ_EVENT_CLOSE_FAILED, endpoint.c_str(), zmq_errno());
     wsa_assert (rc != SOCKET_ERROR);
 #else
     int rc = ::close (s);
-    if (unlikely (rc == 0))
-        session->monitor_event (ZMQ_EVENT_CLOSE_FAILED, endpoint.c_str(), zmq_errno());
     errno_assert (rc == 0);
 #endif
     session->monitor_event (ZMQ_EVENT_CLOSED, endpoint.c_str(), s);

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -116,13 +116,9 @@ void zmq::tcp_listener_t::close ()
     zmq_assert (s != retired_fd);
 #ifdef ZMQ_HAVE_WINDOWS
     int rc = closesocket (s);
-    if (unlikely (rc != SOCKET_ERROR))
-        socket->monitor_event (ZMQ_EVENT_CLOSE_FAILED, endpoint.c_str(), zmq_errno());
     wsa_assert (rc != SOCKET_ERROR);
 #else
     int rc = ::close (s);
-    if (unlikely (rc == 0))
-        socket->monitor_event (ZMQ_EVENT_CLOSE_FAILED, endpoint.c_str(), zmq_errno());
     errno_assert (rc == 0);
 #endif
     socket->monitor_event (ZMQ_EVENT_CLOSED, endpoint.c_str(), s);


### PR DESCRIPTION
This also fixes a bug in tcp_connecter and tcp_listener, which
generated the event not when they failed to close the socket but
when the succeed to close it.
