### PR TITLE
Revert zmq_poll NULL poll items check to 2.2 behavior - let the poll items count filter out empty poll sets and not return a sometimes unexpected EFAULT error status

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -608,10 +608,6 @@ int zmq_msg_set (zmq_msg_t *msg_, int option_, int optval_)
 
 int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
 {
-    if (!items_) {
-        errno = EFAULT;
-        return -1;
-    }
 #if defined ZMQ_POLL_BASED_ON_POLL
     if (unlikely (nitems_ < 0)) {
         errno = EINVAL;
@@ -630,6 +626,12 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
         return usleep (timeout_ * 1000);
 #endif
     }
+
+    if (!items_) {
+        errno = EFAULT;
+        return -1;
+    }
+
     zmq::clock_t clock;
     uint64_t now = 0;
     uint64_t end = 0;


### PR DESCRIPTION
Hi Guys,

I noticed the following commit injected a NULL poll items check for the zmq_poll API before the item count "assertions " :

https://github.com/zeromq/libzmq/commit/dc09da456936e84e68e220a8c950e1abc2ebbd0b

Then reverted by Mikko in :

https://github.com/zeromq/libzmq/commit/da1920d94457ca614b50b060a64fe849ec3f0ec8

However, it's still inconsistent with 2.2 behavior in https://github.com/zeromq/zeromq2-x/blob/master/src/zmq.cpp#L401-423

This breaks zloop (errno == EFAULT) in czmq for the use case where there's only timers and no sockets attached to the reactor - https://github.com/zeromq/czmq/blob/master/src/zloop.c#L363 .

With this changeset, the check on number of poll items would abort the poll request with return value 0 before we can fail with EFAULT. I noticed this when upgrading a Ruby binding against czmq to the yet unreleased 3.2. This also means there's coverage missing for czmq and I'll be happy to spawn a PULL request there if I'm not seriously overlooking something here.
- Lourens
