### PR TITLE
Correction for LIBZMQ-335

### DIFF
--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -249,9 +249,9 @@ int zmq::signaler_t::make_fdpair (fd_t *r_, fd_t *w_)
     //  Note that if the event object already exists, the CreateEvent requests
     //  EVENT_ALL_ACCESS access right. If this fails, we try to open
     //  the event object asking for SYNCHRONIZE access only.
-    HANDLE sync = CreateEvent (&sa, FALSE, TRUE, TEXT ("zmq-signaler-port-sync"));
+    HANDLE sync = CreateEvent (&sa, FALSE, TRUE, TEXT ("Global\\zmq-signaler-port-sync"));
     if (sync == NULL && GetLastError () == ERROR_ACCESS_DENIED)
-      sync = OpenEvent (SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, TEXT ("zmq-signaler-port-sync"));
+      sync = OpenEvent (SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, TEXT ("Global\\zmq-signaler-port-sync"));
 
     win_assert (sync != NULL);
 


### PR DESCRIPTION
Correction for LIBZMQ-335 by using a SECURITY_DESCRIPTOR and placing the events in the "Global\" namespace.
