### PR TITLE
Fix issue #406

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -232,6 +232,11 @@ void zmq::msg_t::reset_flags (unsigned char flags_)
     u.base.flags &= ~flags_;
 }
 
+bool zmq::msg_t::is_identity () const
+{
+    return (u.base.flags & identity) == identity;
+}
+
 bool zmq::msg_t::is_delimiter ()
 {
     return u.base.type == type_delimiter;

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -69,6 +69,7 @@ namespace zmq
         unsigned char flags ();
         void set_flags (unsigned char flags_);
         void reset_flags (unsigned char flags_);
+        bool is_identity () const;
         bool is_delimiter ();
         bool is_vsm ();
 


### PR DESCRIPTION
When a peer reconnects, the router socket receives an identity
message containing this peer id. When this happens, the current
implementation crashes.

This patch makes a router socket to silently ignore all identity
messages coming from reconnected peers.
