### PR TITLE
[LIBZMQ-414] Fix an error in the inline assembly for Thumb2.

### DIFF
--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -141,6 +141,7 @@ namespace zmq
                 "1:     ldrex   %1, [%3]\n\t"
                 "       mov     %0, #0\n\t"
                 "       teq     %1, %4\n\t"
+                "       it      eq\n\t"
                 "       strexeq %0, %5, [%3]\n\t"
                 "       teq     %0, #0\n\t"
                 "       bne     1b\n\t"


### PR DESCRIPTION
Notice that ZeroMQ has never been compiled for Thumb2 before,
and I personally don't make any guarantees that it will actually
behave correctly once compiled. But after this patch, it is at
least _possible_ to compile it for Thumb2.

(Thumb2 is the target for most iOS devices.)
