### PR TITLE
Fix a bug reported on the mailing list.

### DIFF
--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -36,39 +36,39 @@ void socket_monitor (void *s, int event_, zmq_event_data_t *data_)
     // listener specific
     case ZMQ_EVENT_LISTENING:
         assert (data_->listening.fd > 0);
-        assert (memcmp (data_->listening.addr, addr, 22));
+        assert (!strcmp (data_->listening.addr, addr));
         events |= ZMQ_EVENT_LISTENING;
         break;
     case ZMQ_EVENT_ACCEPTED:
         assert (data_->accepted.fd > 0);
-        assert (memcmp (data_->accepted.addr, addr, 22));
+        assert (!strcmp (data_->accepted.addr, addr));
         events |= ZMQ_EVENT_ACCEPTED;
         break;
     // connecter specific
     case ZMQ_EVENT_CONNECTED:
         assert (data_->connected.fd > 0);
-        assert (memcmp (data_->connected.addr, addr, 22));
+        assert (!strcmp (data_->connected.addr, addr));
         events |= ZMQ_EVENT_CONNECTED;
         break;
     case ZMQ_EVENT_CONNECT_DELAYED:
         assert (data_->connect_delayed.err != 0);
-        assert (memcmp (data_->connect_delayed.addr, addr, 22));
+        assert (!strcmp (data_->connect_delayed.addr, addr));
         events |= ZMQ_EVENT_CONNECT_DELAYED;
         break;
     // generic - either end of the socket
     case ZMQ_EVENT_CLOSE_FAILED:
         assert (data_->close_failed.err != 0);
-        assert (memcmp (data_->close_failed.addr, addr, 22));
+        assert (!strcmp (data_->close_failed.addr, addr));
         events |= ZMQ_EVENT_CLOSE_FAILED;
         break;
     case ZMQ_EVENT_CLOSED:
         assert (data_->closed.fd != 0);
-        assert (memcmp (data_->closed.addr, addr, 22));
+        assert (!strcmp (data_->closed.addr, addr));
         events |= ZMQ_EVENT_CLOSED;
         break;
     case ZMQ_EVENT_DISCONNECTED:
         assert (data_->disconnected.fd != 0);
-        assert (memcmp (data_->disconnected.addr, addr, 22));
+        assert (!strcmp (data_->disconnected.addr, addr));
         events |= ZMQ_EVENT_DISCONNECTED;
         break;
     default:


### PR DESCRIPTION
Both memcmp and strcmp return zero on equal, nonzero on nonequal;
so all of these tests were backwards.

The original committer fixed the failure by comparing 22 bytes instead
of the correct 21, so that the assertions would trigger only if the
22nd byte happened to match exactly --- which was rare.

The correct fix is to compare the right number of bytes with the
right sense.  (I think all of the ".addr" fields are null-terminated,
in which case it's more appropriate to use strcmp throughout.)
