### PR TITLE
Add "#undef NDEBUG" to all tests.

### DIFF
--- a/tests/test_connect_delay.cpp
+++ b/tests/test_connect_delay.cpp
@@ -18,15 +18,15 @@ You should have received a copy of the GNU Lesser General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-#include <assert.h>
-#include <cstdlib>
-#include <cstring>
-#include <iostream>
-#include <errno.h>
-#include <unistd.h>
-
 #include "../include/zmq.h"
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <string>
+
+#undef NDEBUG
+#include <assert.h>
 
 static void *server (void *)
 {

--- a/tests/test_connect_resolve.cpp
+++ b/tests/test_connect_resolve.cpp
@@ -18,12 +18,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-#include <assert.h>
+#include "../include/zmq.h"
 #include <stdio.h>
 #include <errno.h>
 
-#include "../include/zmq.h"
+#undef NDEBUG
+#include <assert.h>
 
 int main (void)
 {

--- a/tests/test_hwm.cpp
+++ b/tests/test_hwm.cpp
@@ -19,9 +19,7 @@
 */
 
 
-#include <assert.h>
 #include <stdio.h>
-
 #include "testutil.hpp"
 
 int main (void)

--- a/tests/test_invalid_rep.cpp
+++ b/tests/test_invalid_rep.cpp
@@ -20,8 +20,10 @@
 */
 
 #include "../include/zmq.h"
-#include <assert.h>
 #include <stdio.h>
+
+#undef NDEBUG
+#include <assert.h>
 
 int main (void)
 {

--- a/tests/test_last_endpoint.cpp
+++ b/tests/test_last_endpoint.cpp
@@ -19,10 +19,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
+#include "../include/zmq.h"
 #include <string.h>
 
-#include "../include/zmq.h"
+#undef NDEBUG
+#include <assert.h>
 
 static void do_bind_and_verify (void *s, const char *endpoint)
 {

--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -19,12 +19,10 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
-#include <string.h>
-#include "testutil.hpp"
-
 #include "../include/zmq.h"
 #include "../include/zmq_utils.h"
+#include <string.h>
+#include "testutil.hpp"
 
 static int events;
 

--- a/tests/test_msg_flags.cpp
+++ b/tests/test_msg_flags.cpp
@@ -19,10 +19,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
+#include "../include/zmq.h"
 #include <string.h>
 
-#include "../include/zmq.h"
+#undef NDEBUG
+#include <assert.h>
 
 int main (void)
 {

--- a/tests/test_pair_inproc.cpp
+++ b/tests/test_pair_inproc.cpp
@@ -18,7 +18,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <stdio.h>
 #include "testutil.hpp"
 

--- a/tests/test_pair_ipc.cpp
+++ b/tests/test_pair_ipc.cpp
@@ -18,7 +18,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <stdio.h>
 #include "testutil.hpp"
 

--- a/tests/test_pair_tcp.cpp
+++ b/tests/test_pair_tcp.cpp
@@ -19,7 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <stdio.h>
 #include "testutil.hpp"
 

--- a/tests/test_reqrep_device.cpp
+++ b/tests/test_reqrep_device.cpp
@@ -19,11 +19,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
-#include <string.h>
-#include <stdio.h>
-
 #include "../include/zmq.h"
+#include <stdio.h>
+#include <string.h>
+
+#undef NDEBUG
+#include <assert.h>
 
 int main (void)
 {

--- a/tests/test_reqrep_inproc.cpp
+++ b/tests/test_reqrep_inproc.cpp
@@ -18,7 +18,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <stdio.h>
 #include "testutil.hpp"
 

--- a/tests/test_reqrep_ipc.cpp
+++ b/tests/test_reqrep_ipc.cpp
@@ -18,7 +18,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <stdio.h>
 #include "testutil.hpp"
 

--- a/tests/test_reqrep_tcp.cpp
+++ b/tests/test_reqrep_tcp.cpp
@@ -19,7 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <stdio.h>
 #include "testutil.hpp"
 

--- a/tests/test_router_behavior.cpp
+++ b/tests/test_router_behavior.cpp
@@ -19,7 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
 #include <stdio.h>
 #include "testutil.hpp"
 

--- a/tests/test_shutdown_stress.cpp
+++ b/tests/test_shutdown_stress.cpp
@@ -20,10 +20,12 @@
 */
 
 #include "../include/zmq.h"
-#include <assert.h>
 #include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
+
+#undef NDEBUG
+#include <assert.h>
 
 #define THREAD_COUNT 100
 

--- a/tests/test_sub_forward.cpp
+++ b/tests/test_sub_forward.cpp
@@ -19,11 +19,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
-#include <stdio.h>
-
 #include "../include/zmq.h"
 #include "../include/zmq_utils.h"
+#include <stdio.h>
+
+#undef NDEBUG
+#include <assert.h>
 
 int main (void)
 {

--- a/tests/test_term_endpoint.cpp
+++ b/tests/test_term_endpoint.cpp
@@ -1,10 +1,31 @@
-#include <assert.h>
-#include <string.h>
-#include <unistd.h>
+/*
+    Copyright (c) 2010-2011 250bpm s.r.o.
+    Copyright (c) 2011 iMatix Corporation
+    Copyright (c) 2010-2011 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #include "../include/zmq.h"
 #include "../include/zmq_utils.h"
+#include <string.h>
+#include <unistd.h>
 
+#undef NDEBUG
+#include <assert.h>
 
 int main (void)
 {

--- a/tests/test_timeo.cpp
+++ b/tests/test_timeo.cpp
@@ -18,13 +18,14 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <assert.h>
-#include <string.h>
-#include <pthread.h>
-#include <stdio.h>
-
 #include "../include/zmq.h"
 #include "../include/zmq_utils.h"
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+
+#undef NDEBUG
+#include <assert.h>
 
 extern "C"
 {

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -22,10 +22,11 @@
 #ifndef __ZMQ_TEST_TESTUTIL_HPP_INCLUDED__
 #define __ZMQ_TEST_TESTUTIL_HPP_INCLUDED__
 
-#include <assert.h>
+#include "../include/zmq.h"
 #include <string.h>
 
-#include "../include/zmq.h"
+#undef NDEBUG
+#include <assert.h>
 
 inline void bounce (void *sb, void *sc)
 {


### PR DESCRIPTION
This change makes sure that even if the tests are built in a
"release" configuration (with optimizations and NDEBUG turned on),
the assertions won't get compiled out of the tests themselves.

The C standard guarantees that the most recent inclusion of
<assert.h> is the one that counts, so it's important that the
"#undef NDEBUG/#include <assert.h>" come as the last thing in
the block of header files.

"testutil.hpp" includes <assert.h>, so I've left <assert.h> out
of any test that #includes "testutil.hpp", just for the sake of
brevity.
