### PR TITLE
Always treat randomness with love

### DIFF
--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -171,7 +171,7 @@ int zmq::ipc_connecter_t::get_new_reconnect_ivl ()
 {
     //  The new interval is the current interval + random value.
     int this_interval = current_reconnect_ivl +
-        (generate_random () % options.reconnect_ivl);
+        (zmq::random.generate () % options.reconnect_ivl);
 
     //  Only change the current reconnect interval  if the maximum reconnect
     //  interval was set and if it's larger than the reconnect interval.

--- a/src/pgm_socket.cpp
+++ b/src/pgm_socket.cpp
@@ -277,8 +277,8 @@ int zmq::pgm_socket_t::init (bool udp_encapsulation_, const char *network_)
 
     //  Create random GSI.
     uint32_t buf [2];
-    buf [0] = generate_random ();
-    buf [1] = generate_random ();
+    buf [0] = zmq::random.generate ();
+    buf [1] = zmq::random.generate ();
     if (!pgm_gsi_create_from_data (&addr.sa_addr.gsi, (uint8_t*) buf, 8))
         goto err_abort;
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -31,22 +31,68 @@
 #include "stdint.hpp"
 #include "clock.hpp"
 
-void zmq::seed_random ()
+void zmq::mersenne_twister_t::seed (uint32_t seed)
 {
+	if (seed == 0) {
 #if defined ZMQ_HAVE_WINDOWS
-    int pid = (int) GetCurrentProcessId ();
+		seed = (uint32_t) GetCurrentProcessId ();
 #else
-    int pid = (int) getpid ();
+		seed = (uint32_t) getpid ();
 #endif
-    srand ((unsigned int) (clock_t::now_us () + pid));
+
+		seed += clock_t::now_us ();
+	}
+
+	mt[0] = seed;
+	for (mti = 1; mti < _MT32_N; ++mti)
+		mt[mti] = (1812433253UL * (mt[mti - 1] ^ (mt[mti - 1] >> 30)) + mti);
 }
 
-uint32_t zmq::generate_random ()
+/**
+ * Thread-safe Mersenne Twister 
+ *
+ * Based on the original implementation, copyright (C) 1997 - 2002,
+ * Makoto Matsumoto and Takuji Nishimura, All rights reserved.  
+ *
+ * Originally licensed under BSD
+ *
+ * See: http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
+ */
+uint32_t zmq::mersenne_twister_t::generate ()
 {
-    //  Compensate for the fact that rand() returns signed integer.
-    uint32_t low = (uint32_t) rand ();
-    uint32_t high = (uint32_t) rand ();
-    high <<= (sizeof (int) * 8 - 1);
-    return high | low;
+	uint32_t y;
+
+	state_sync.lock ();
+
+	if (mti >= _MT32_N) {
+		uintptr_t kk;
+
+		for (kk = 0; kk < _MT32_N-_MT32_M; ++kk) {
+			uint32_t x = (mt[kk] & _MT32_UPPER_MASK) | (mt[kk+1] & _MT32_LOWER_MASK);
+			mt[kk] = mt[kk + _MT32_M] ^ (x >> 1) ^ ((x & 1) * _MT32_MATRIX_A);
+		}
+
+		for (; kk<_MT32_N-1; ++kk) {
+			uint32_t x = (mt[kk] & _MT32_UPPER_MASK) | (mt[kk+1] & _MT32_LOWER_MASK);
+			mt[kk] = mt[kk + (_MT32_M - _MT32_N)] ^ (x >> 1) ^ ((x & 1) * _MT32_MATRIX_A);
+		}
+
+		uint32_t x = (mt[_MT32_N - 1] & _MT32_UPPER_MASK) | (mt[0] & _MT32_LOWER_MASK);
+
+		mt[_MT32_N - 1] = mt[_MT32_M - 1] ^ (x >> 1) ^ ((x & 1) * _MT32_MATRIX_A);
+		mti = 0;
+	}
+
+	y = mt[mti++];
+	state_sync.unlock ();
+
+	y ^= (y >> 11);
+	y ^= (y << 7) & 0x9d2c5680UL;
+	y ^= (y << 15) & 0xefc60000UL;
+	y ^= (y >> 18);
+
+	return y;
 }
+
+zmq::mersenne_twister_t zmq::random;
 

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -22,16 +22,29 @@
 #define __ZMQ_RANDOM_HPP_INCLUDED__
 
 #include "stdint.hpp"
+#include "mutex.hpp"
 
 namespace zmq
 {
+	class mersenne_twister_t
+	{
+		static const uint32_t _MT32_N = 624;
+		static const uint32_t _MT32_M = 397;
+		static const uint32_t _MT32_MATRIX_A = 0x9908b0dfUL;   /* constant vector a */
+		static const uint32_t _MT32_UPPER_MASK = 0x80000000UL; /* most significant w-r bits */
+		static const uint32_t _MT32_LOWER_MASK = 0x7fffffffUL; /* least significant r bits */
 
-    //  Seeds the random number generator.
-    void seed_random ();
+		uint32_t mt[_MT32_N];
+		uintptr_t mti;
+		mutex_t state_sync;
 
-    //  Generates random value.
-    uint32_t generate_random ();
+	public:
+		mersenne_twister_t () { seed (); }
+		void seed (uint32_t seed = 0x0);
+		uint32_t generate ();
+	};
 
+	extern mersenne_twister_t random;
 }
 
 #endif

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -34,7 +34,7 @@ zmq::router_t::router_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
     more_in (false),
     current_out (NULL),
     more_out (false),
-    next_peer_id (generate_random ()),
+    next_peer_id (zmq::random.generate ()),
     report_unroutable(false)
 {
     options.type = ZMQ_ROUTER;

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -185,7 +185,7 @@ int zmq::tcp_connecter_t::get_new_reconnect_ivl ()
 {
     //  The new interval is the current interval + random value.
     int this_interval = current_reconnect_ivl +
-        (generate_random () % options.reconnect_ivl);
+        (zmq::random.generate () % options.reconnect_ivl);
 
     //  Only change the current reconnect interval  if the maximum reconnect
     //  interval was set and if it's larger than the reconnect interval.


### PR DESCRIPTION
Hey!

I've been doing some internal reviews of the ZMQ source code for GitHub. I'm a tad concerned about the way you treat randomness in the library (`random.cpp`, mostly).

The original `generate_random()` has a few critical flaws:

``` cpp
uint32_t zmq::generate_random ()
{
    //  Compensate for the fact that rand() returns signed integer.
    uint32_t low = (uint32_t) rand ();
    uint32_t high = (uint32_t) rand ();
    high <<= (sizeof (int) * 8 - 1);
    return high | low;
}
```
- `rand()` does not return a "signed integer", it returns _integers in the range `[0, {RAND_MAX}]`_, which to be fair, is not saying much. `RAND_MAX` can be as low as 32767, and it's not being checked anywhere. Assuming that it has the default value of 2147483647 (2^31) like it does on GlibC is risky business:
  - Any value lower than that is going to leave a hole on the bit stream when you shift up the sign bit from the second generation.
  - Any value higher than that (e.g. 2^32, which could very well be casted into an `int`), would leave the MSB with a 75% bias towards 1 (assuming a 50% original bias OR'ed with the LSB of the second generation, which also has a 50% bias).
  
  In general, `rand` is so ill-specified that using it on production code is suicidal, and any work-arounds for it are more easily implemented by writing a PRNG from scratch, the features of which we can control and analyze.
- On top of that, `rand()` is not reentrant. At all. And although GLibC's `rand()` is as mind-numbingly simple (stupid?) as this:
  
  ``` c
  int rand_r(unsigned int *seed)
  {
          *seed = *seed * 1103515245 + 12345;
          return (*seed % ((unsigned int)RAND_MAX + 1));
  }
  
  int rand(void)
  {
          return (rand_r(&next));
  }
  ```
  
  ...there's still a pretty big chance of getting races on the internal state, and most significantly, duplicate values, when being called from a highly concurrent library such as ZMQ.
- Last, but not least, `seed_random` is not called anywhere, so `rand` is running with a default seed. I may be missing something (I grep'ed to the extent of my available skills), and I couldn't find it anywhere. This was during my plane flight yesterday, so after finding out that the PRNG was not being seeded, I couldn't fall asleep for the rest of the flight. Awful.
### What I propose

For this PR, I went ahead and dropped `rand()` altogether, replacing it with a threadsafe implementation of a Mersenne Twister. MT is a fan favorite since always, and I very much dig the balance between the amount of code and the quality of the generated randomness.

My initial approach was to add a Mersenne instance with its own internal state for each `zmq::io_thread_t` on the system, but the thread references don't get passed _everywhere_, so that was getting the code base slightly too cluttered.

Instead, I decided to add minimal synchronization on the PRNG and kept a single instance of it available globally, as `zmq::random`. This PRNG is seeded on construction. This may not be the most elegant option, but it does prevent races and minimizes the amount of changes on the PR.

Anyway, I'm pretty happy with this. As stated, it's minimal and non-intrusive, and fixes the issue(s) at hand. I'd love some feedback (specially regarding formatting) from somebody who has read the ZMQ code for more than 3 hours.

Love and randomness,
Vicent
