### PR TITLE
Fix some PGM refactor breakages

### DIFF
--- a/src/pgm_receiver.cpp
+++ b/src/pgm_receiver.cpp
@@ -274,7 +274,7 @@ void zmq::pgm_receiver_t::timer_event (int token)
 void zmq::pgm_receiver_t::drop_subscriptions ()
 {
     msg_t msg;
-    while (session->read (&msg))
+    while (session->pull_msg (&msg))
         msg.close ();
 }
 

--- a/src/pgm_sender.cpp
+++ b/src/pgm_sender.cpp
@@ -109,7 +109,7 @@ void zmq::pgm_sender_t::unplug ()
     rm_fd (uplink_handle);
     rm_fd (rdata_notify_handle);
     rm_fd (pending_notify_handle);
-    encoder.set_session (NULL);
+    encoder.set_msg_source (NULL);
 }
 
 void zmq::pgm_sender_t::terminate ()

--- a/src/pgm_socket.cpp
+++ b/src/pgm_socket.cpp
@@ -65,7 +65,7 @@ zmq::pgm_socket_t::pgm_socket_t (bool receiver_, const options_t &options_) :
 //       link-local;224.250.0.1,224.250.0.2;224.250.0.3:8000
 //       ;[fe80::1%en0]:7500
 int zmq::pgm_socket_t::init_address (const char *network_,
-    struct pgm_addrinfo_t **addr, uint16_t *port_number)
+    struct pgm_addrinfo_t **res, uint16_t *port_number)
 {
     //  Parse port number, start from end for IPv6
     const char *port_delim = strrchr (network_, ':');
@@ -85,11 +85,11 @@ int zmq::pgm_socket_t::init_address (const char *network_,
     memcpy (network, network_, port_delim - network_);
 
     pgm_error_t *pgm_error = NULL;
-    struct pgm_addrinfo_t hints, *res = NULL;
+    struct pgm_addrinfo_t hints;
 
     memset (&hints, 0, sizeof (hints));
     hints.ai_family = AF_UNSPEC;
-    if (!pgm_getaddrinfo (network, NULL, &res, &pgm_error)) {
+    if (!pgm_getaddrinfo (network, NULL, res, &pgm_error)) {
 
         //  Invalid parameters don't set pgm_error_t.
         zmq_assert (pgm_error != NULL);

--- a/tests/test_connect_delay.cpp
+++ b/tests/test_connect_delay.cpp
@@ -112,7 +112,7 @@ static void *worker (void *)
 
     hadone = 0;
     // Not checking RC as some may be -1
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 6; i++) {
         usleep(200000);
         rc = zmq_send (socket, "hi", 2, ZMQ_DONTWAIT);
         if (rc != -1)


### PR DESCRIPTION
Hopefully fixed LIBZMQ-427 - there was a slight typo in the init_address
refactor. The encoder refactoring had also broken pgm_sender and
receiver, but just required updating to use the new functions.
