### PR TITLE
Add pthread.h include to test_connect_delay.cpp

### DIFF
--- a/tests/test_connect_delay.cpp
+++ b/tests/test_connect_delay.cpp
@@ -24,6 +24,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 #include <string.h>
 #include <unistd.h>
 #include <string>
+#include <pthread.h>
 
 #undef NDEBUG
 #include <assert.h>


### PR DESCRIPTION
This test case uses pthreads, but doesn't include the header.
