### PR TITLE
Init msg in pgm_receiver drop subs

### DIFF
--- a/src/pgm_receiver.cpp
+++ b/src/pgm_receiver.cpp
@@ -274,6 +274,7 @@ void zmq::pgm_receiver_t::timer_event (int token)
 void zmq::pgm_receiver_t::drop_subscriptions ()
 {
     msg_t msg;
+    msg.init ();
     while (session->pull_msg (&msg))
         msg.close ();
 }


### PR DESCRIPTION
Fixes reported issue with PGM receiver on 32bit Suse where asserts
were hit due to the msg flags not being zeroed.
