### PR TITLE
Use <stdint.h> shipped with Visual Studio 2010 and later

### DIFF
--- a/src/stdint.hpp
+++ b/src/stdint.hpp
@@ -27,7 +27,7 @@
 
 #include <inttypes.h>
 
-#elif defined _MSC_VER
+#elif defined _MSC_VER && _MSC_VER < 1600
 
 #ifndef int8_t
 typedef __int8 int8_t;


### PR DESCRIPTION
Visual Studio didn’t have <stdint.h> until 2010, therefore we had a bunch of typedefs for int8_t, int16_t and the likes in "stdint.hpp". This patch limits these typedefs to Visual Studio versions older than 2010 and uses compiler-shipped <stdint.h> on 2010 and newer.
