### PR TITLE
Explicit comments

### DIFF
--- a/src/pgm_socket.cpp
+++ b/src/pgm_socket.cpp
@@ -326,7 +326,7 @@ int zmq::pgm_socket_t::init (bool udp_encapsulation_, const char *network_)
 
     //  Set IP level parameters.
     {
-	        // Multicast loopback disabled by default
+		// Multicast loopback disabled by default
 		const int multicast_loop = 0;
 		if (!pgm_setsockopt (sock, IPPROTO_PGM, PGM_MULTICAST_LOOP,
 		      &multicast_loop, sizeof (multicast_loop)))
@@ -338,10 +338,10 @@ int zmq::pgm_socket_t::init (bool udp_encapsulation_, const char *network_)
 		    goto err_abort;
 
 		//  Expedited Forwarding PHB for network elements, no ECN.
-		const int dscp = 0x2e << 2; 
+		const int dscp = 0x2e << 2;
 		if (AF_INET6 != sa_family && !pgm_setsockopt (sock,
 		      IPPROTO_PGM, PGM_TOS, &dscp, sizeof (dscp)))
-		    goto err_abort; 
+		    goto err_abort;
 
 		const int nonblocking = 1;
 		if (!pgm_setsockopt (sock, IPPROTO_PGM, PGM_NOBLOCK,


### PR DESCRIPTION
Explicit comments for multicast loopback disabled in pgm_socket.cpp
