### PR TITLE
Fix Build Regression #449: Move socket_base.hpp and err.hpp after poll.h include

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -21,9 +21,7 @@
 #include <stddef.h>
 #include "platform.hpp"
 #include "proxy.hpp"
-#include "socket_base.hpp"
 #include "likely.hpp"
-#include "err.hpp"
 
 #if defined ZMQ_FORCE_SELECT
 #define ZMQ_POLL_BASED_ON_SELECT
@@ -47,6 +45,11 @@
 #if defined ZMQ_POLL_BASED_ON_POLL
 #include <poll.h>
 #endif
+
+// These headers end up pulling in zmq.h somewhere in their include
+// dependency chain
+#include "socket_base.hpp"
+#include "err.hpp"
 
 // zmq.h must be included *after* poll.h for AIX to build properly
 #include "../include/zmq.h"


### PR DESCRIPTION
Another required change to finish fix for #449:
These two headers also include zmq.h somewhere in their dependency
chain, so must be included after poll.h is included for builds to work
on AIX.
