### PR TITLE
resolve issue 456

### DIFF
--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -95,7 +95,13 @@ int zmq::xsub_t::xsend (msg_t *msg_, int flags_)
 
     // Process the subscription.
     if (*data == 1) {
-        if (subscriptions.add (data + 1, size - 1))
+	// this used to filter out duplicate subscriptions,
+	// however this is alread done on the XPUB side and
+	// doing it here as well breaks ZMQ_XPUB_VERBOSE
+	// when there are forwarding devices involved
+	//
+        //if (subscriptions.add (data + 1, size - 1))
+	subscriptions.add (data + 1, size - 1);
             return dist.send_to_all (msg_, flags_);
     }
     else {


### PR DESCRIPTION
Do not filter out duplicate subscriptions on the XSUB side of
XSUB/XPUB, so that ZMQ_XPUB_VERBOSE doesn't get blocked by forwarding
devices (as long as the devices all use ZMQ_XPUB_VERBOSE)
