### PR TITLE
New socket option (ZMQ_ROUTER_RAW_SOCK) for ZMQ_ROUTER sockets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -77,6 +77,7 @@ Toralf Wittner <toralf.wittner@gmail.com>
 Tore Halvorsen <tore.halvorsen@gmail.com>
 Vitaly Mayatskikh <v.mayatskih@gmail.com>
 Lourens Naudé <lourens@methodmissing.com>
+Hardeep Singh <hshardeesi@gmail.com>
 
 Credits
 =======

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -250,6 +250,7 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_TCP_ACCEPT_FILTER 38
 #define ZMQ_DELAY_ATTACH_ON_CONNECT 39
 #define ZMQ_XPUB_VERBOSE 40
+#define ZMQ_ROUTER_RAW_SOCK 41
 
 
 /*  Message options                                                           */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -146,7 +146,11 @@ libzmq_la_SOURCES = \
     v1_protocol.hpp \
     xsub.cpp \
     zmq.cpp \
-    zmq_utils.cpp
+    zmq_utils.cpp \
+    raw_decoder.hpp \
+    raw_decoder.cpp \
+    raw_encoder.hpp \
+    raw_encoder.cpp
 
 if ON_MINGW
 libzmq_la_LDFLAGS = -no-undefined -avoid-version -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -143,6 +143,11 @@ namespace zmq
             }
         }
 
+        inline bool message_ready_size (size_t msg_sz){
+            zmq_assert(false);
+            return false;
+        }
+
     protected:
 
         //  Prototype of state machine action. Action should return false if

--- a/src/i_decoder.hpp
+++ b/src/i_decoder.hpp
@@ -41,7 +41,8 @@ namespace zmq
         virtual size_t process_buffer (unsigned char *data_, size_t size_) = 0;
 
         virtual bool stalled () const = 0;
-
+        
+        virtual bool message_ready_size (size_t msg_sz) = 0;
     };
 
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -55,6 +55,7 @@ zmq::options_t::options_t () :
     tcp_keepalive_intvl (-1),
     socket_id (0)
 {
+    raw_sock = false;
 }
 
 int zmq::options_t::setsockopt (int option_, const void *optval_,

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -114,6 +114,9 @@ namespace zmq
 
         //  If true, the identity message is forwarded to the socket.
         bool recv_identity;
+    
+        // if true, router socket accepts non-zmq tcp connections
+        bool raw_sock;
 
         //  TCP keep-alive settings.
         //  Defaults to -1 = do not change socket options

--- a/src/raw_decoder.cpp
+++ b/src/raw_decoder.cpp
@@ -1,0 +1,99 @@
+/*
+    Copyright (c) 2009-2011 250bpm s.r.o.
+    Copyright (c) 2007-2009 iMatix Corporation
+    Copyright (c) 2007-2012 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "platform.hpp"
+#ifdef ZMQ_HAVE_WINDOWS
+#include "windows.hpp"
+#endif
+
+#include "raw_decoder.hpp"
+#include "likely.hpp"
+#include "wire.hpp"
+#include "err.hpp"
+
+zmq::raw_decoder_t::raw_decoder_t (size_t bufsize_,
+      int64_t maxmsgsize_, i_msg_sink *msg_sink_) :
+    decoder_base_t <raw_decoder_t> (bufsize_),
+    msg_sink (msg_sink_),
+    maxmsgsize (maxmsgsize_)
+{
+    int rc = in_progress.init ();
+    errno_assert (rc == 0);
+}
+
+zmq::raw_decoder_t::~raw_decoder_t ()
+{
+    int rc = in_progress.close ();
+    errno_assert (rc == 0);
+}
+
+void zmq::raw_decoder_t::set_msg_sink (i_msg_sink *msg_sink_)
+{
+    msg_sink = msg_sink_;
+}
+
+bool zmq::raw_decoder_t::stalled () const
+{
+    return false;
+}
+
+bool zmq::raw_decoder_t::message_ready_size (size_t msg_sz)
+{
+    int rc = in_progress.init_size (msg_sz);
+    if (rc != 0) {
+        errno_assert (errno == ENOMEM);
+        rc = in_progress.init ();
+        errno_assert (rc == 0);
+        decoding_error ();
+        return false;
+    }
+
+    next_step (in_progress.data (), in_progress.size (),
+        &raw_decoder_t::raw_message_ready);
+
+    return true;
+}
+
+bool zmq::raw_decoder_t::raw_message_ready ()
+{
+    zmq_assert (in_progress.size ());
+    //  Message is completely read. Push it further and start reading
+    //  new message. (in_progress is a 0-byte message after this point.)
+    if (unlikely (!msg_sink))
+        return false;
+    int rc = msg_sink->push_msg (&in_progress);
+    if (unlikely (rc != 0)) {
+        if (errno != EAGAIN)
+            decoding_error ();
+        return false;
+    }
+
+    // NOTE: This is just to break out of process_buffer
+    // raw_message_ready should never get called in state machine w/o
+    // message_ready_size from stream_engine.
+    next_step (in_progress.data (), 1,
+    		&raw_decoder_t::raw_message_ready);
+
+    return true;
+}

--- a/src/raw_decoder.hpp
+++ b/src/raw_decoder.hpp
@@ -1,0 +1,69 @@
+/*
+    Copyright (c) 2009-2011 250bpm s.r.o.
+    Copyright (c) 2007-2012 iMatix Corporation
+    Copyright (c) 2007-2012 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __ZMQ_RAW_DECODER_HPP_INCLUDED__
+#define __ZMQ_RAW_DECODER_HPP_INCLUDED__
+
+#include "err.hpp"
+#include "msg.hpp"
+#include "decoder.hpp"
+#include "raw_decoder.hpp"
+#include "i_msg_sink.hpp"
+#include "stdint.hpp"
+
+namespace zmq
+{
+
+    //  Decoder for 0MQ v1 framing protocol. Converts data stream into messages.
+
+    class raw_decoder_t : public decoder_base_t <raw_decoder_t>
+    {
+    public:
+
+    	raw_decoder_t (size_t bufsize_,
+            int64_t maxmsgsize_, i_msg_sink *msg_sink_);
+        virtual ~raw_decoder_t ();
+
+        //  i_decoder interface.
+        virtual void set_msg_sink (i_msg_sink *msg_sink_);
+
+        virtual bool stalled () const;
+
+        virtual bool message_ready_size (size_t msg_sz);
+
+    private:
+
+
+        bool raw_message_ready ();
+
+        i_msg_sink *msg_sink;
+        msg_t in_progress;
+
+        const int64_t maxmsgsize;
+
+        raw_decoder_t (const raw_decoder_t&);
+        void operator = (const raw_decoder_t&);
+    };
+
+}
+
+#endif
+

--- a/src/raw_encoder.cpp
+++ b/src/raw_encoder.cpp
@@ -1,0 +1,87 @@
+/*
+    Copyright (c) 2007-2012 iMatix Corporation
+    Copyright (c) 2009-2011 250bpm s.r.o.
+    Copyright (c) 2011 VMware, Inc.
+    Copyright (c) 2007-2012 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "encoder.hpp"
+#include "raw_encoder.hpp"
+#include "i_msg_source.hpp"
+#include "likely.hpp"
+#include "wire.hpp"
+
+zmq::raw_encoder_t::raw_encoder_t (size_t bufsize_, i_msg_source *msg_source_) :
+    encoder_base_t <raw_encoder_t> (bufsize_),
+    msg_source (msg_source_)
+{
+    int rc = in_progress.init ();
+    errno_assert (rc == 0);
+
+    //  Write 0 bytes to the batch and go to message_ready state.
+    next_step (NULL, 0, &raw_encoder_t::raw_message_ready, true);
+}
+
+zmq::raw_encoder_t::~raw_encoder_t ()
+{
+    int rc = in_progress.close ();
+    errno_assert (rc == 0);
+}
+
+void zmq::raw_encoder_t::set_msg_source (i_msg_source *msg_source_)
+{
+    msg_source = msg_source_;
+}
+
+bool zmq::raw_encoder_t::raw_message_size_ready ()
+{
+    //  Write message body into the buffer.
+    next_step (in_progress.data (), in_progress.size (),
+        &raw_encoder_t::raw_message_ready, !(in_progress.flags () & msg_t::more));
+    return true;
+}
+
+bool zmq::raw_encoder_t::raw_message_ready ()
+{
+
+    //  Destroy content of the old message.
+    int rc = in_progress.close ();
+    errno_assert (rc == 0);
+
+    //  Read new message. If there is none, return false.
+    //  Note that new state is set only if write is successful. That way
+    //  unsuccessful write will cause retry on the next state machine
+    //  invocation.
+    if (unlikely (!msg_source)) {
+        rc = in_progress.init ();
+        errno_assert (rc == 0);
+        return false;
+    }
+    rc = msg_source->pull_msg (&in_progress);
+    if (unlikely (rc != 0)) {
+        errno_assert (errno == EAGAIN);
+        rc = in_progress.init ();
+        errno_assert (rc == 0);
+        return false;
+    }
+
+    in_progress.reset_flags(0xff);
+    next_step (NULL, 0, &raw_encoder_t::raw_message_size_ready, true);
+
+    return true;
+}

--- a/src/raw_encoder.hpp
+++ b/src/raw_encoder.hpp
@@ -1,0 +1,69 @@
+/*
+    Copyright (c) 2009-2011 250bpm s.r.o.
+    Copyright (c) 2007-2009 iMatix Corporation
+    Copyright (c) 2007-2012 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __ZMQ_RAW_ENCODER_HPP_INCLUDED__
+#define __ZMQ_RAW_ENCODER_HPP_INCLUDED__
+
+#if defined(_MSC_VER)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#endif
+
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <algorithm>
+
+#include "err.hpp"
+#include "msg.hpp"
+#include "i_encoder.hpp"
+
+namespace zmq
+{
+
+
+    //  Encoder for 0MQ framing protocol. Converts messages into data batches.
+
+    class raw_encoder_t : public encoder_base_t <raw_encoder_t>
+    {
+    public:
+
+        raw_encoder_t (size_t bufsize_, i_msg_source *msg_source_);
+        ~raw_encoder_t ();
+
+        void set_msg_source (i_msg_source *msg_source_);
+
+    private:
+
+        bool raw_message_ready ();
+        bool raw_message_size_ready ();
+
+        i_msg_source *msg_source;
+        msg_t in_progress;
+        unsigned char tmpbuf [4];
+        raw_encoder_t (const raw_encoder_t&);
+        const raw_encoder_t &operator = (const raw_encoder_t&);
+    };
+}
+
+#endif
+

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -113,6 +113,7 @@ namespace zmq
         // If true, report EAGAIN to the caller instead of silently dropping 
         // the message targeting an unknown peer.
         bool mandatory;
+        bool raw_sock;
 
         router_t (const router_t&);
         const router_t &operator = (const router_t&);

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -120,6 +120,11 @@ zmq::session_base_t::session_base_t (class io_thread_t *io_thread_,
     identity_received (false),
     addr (addr_)
 {
+    // identities are not exchanged for raw sockets
+    if(options.raw_sock){
+        identity_sent  = (true);
+        identity_received = (true);
+    }
 }
 
 zmq::session_base_t::~session_base_t ()
@@ -244,6 +249,15 @@ void zmq::session_base_t::terminated (pipe_t *pipe_)
     else
         // Remove the pipe from the detached pipes set
         terminating_pipes.erase (pipe_);
+
+    if (!is_terminating() && options.raw_sock){
+        if(engine){
+            engine->terminate ();
+            engine = NULL;
+        }
+        terminate();
+    }
+
 
     // If we are waiting for pending messages to be sent, at this point
     // we are sure that there will be no more messages and we can proceed

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,7 +17,8 @@ noinst_PROGRAMS = test_pair_inproc \
                   test_last_endpoint \
                   test_term_endpoint \
                   test_monitor \
-                  test_router_mandatory
+                  test_router_mandatory \
+                  test_raw_sock
 
 if !ON_MINGW
 noinst_PROGRAMS += test_shutdown_stress \
@@ -41,6 +42,7 @@ test_last_endpoint_SOURCES = test_last_endpoint.cpp
 test_term_endpoint_SOURCES = test_term_endpoint.cpp
 test_monitor_SOURCES = test_monitor.cpp
 test_router_mandatory_SOURCES = test_router_mandatory.cpp
+test_raw_sock_SOURCES = test_raw_sock.cpp
 
 if !ON_MINGW
 test_shutdown_stress_SOURCES = test_shutdown_stress.cpp

--- a/tests/test_raw_sock.cpp
+++ b/tests/test_raw_sock.cpp
@@ -1,0 +1,167 @@
+/*
+    Copyright (c) 2007-2012 iMatix Corporation
+    Copyright (c) 2011 250bpm s.r.o.
+    Copyright (c) 2007-2012 Other contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <pthread.h>
+#include <netinet/tcp.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <zmq.h>
+#include<unistd.h> 
+
+//ToDo: Windows?
+const char *test_str = "TEST-STRING";
+
+
+int tcp_client(){
+
+    int sockfd, portno;
+    struct sockaddr_in serv_addr;
+    struct hostent *server;
+
+    portno = 5555;
+
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(sockfd >=0 );
+    server = gethostbyname("localhost");
+    assert(server);
+
+    bzero((char *) &serv_addr, sizeof(serv_addr));
+    serv_addr.sin_family = AF_INET;
+    bcopy((char *)server->h_addr,
+         (char *)&serv_addr.sin_addr.s_addr,
+         server->h_length);
+    serv_addr.sin_port = htons(portno);
+
+    if (connect(sockfd,(struct sockaddr *) &serv_addr,sizeof(serv_addr)) < 0)
+    	assert(0);
+    int nodelay = 1;
+    int rc = setsockopt (sockfd, IPPROTO_TCP, TCP_NODELAY, (char*) &nodelay,
+        sizeof (int));
+    assert(rc == 0);
+
+
+    return sockfd;
+}
+
+void tcp_client_write(int sockfd, const void *buf, int buf_len){
+	assert(buf);
+	int n = write(sockfd, buf, buf_len);
+	assert(n >= 0);
+}
+
+void tcp_client_read(int sockfd){
+    struct timeval tm;
+    tm.tv_sec = 1;
+    tm.tv_usec = 0;
+    fd_set r;
+
+    int  sr;
+    char buffer[16];
+
+    FD_ZERO(&r);
+    FD_SET(sockfd, &r);
+
+    if ((sr = select(sockfd + 1, &r, NULL, NULL, &tm)) <= 0)
+    {
+    	assert(0);
+    }
+
+    int n = read(sockfd, buffer, 16);
+    assert(n>0);
+    assert(memcmp(buffer, test_str, strlen(test_str)) == 0);
+}
+
+
+void tcp_client_close(int sockfd){
+	close(sockfd);
+}
+
+
+int main(){
+    fprintf (stderr, "test_raw_sock running...\n");
+
+    zmq_msg_t message;
+    zmq_msg_t id;
+
+    //===================
+    void *ctx = zmq_init (1);
+    assert (ctx);
+
+    int raw_sock = 1, rc = 0;
+    void *sb = zmq_socket (ctx, ZMQ_ROUTER);
+    assert (sb);
+    rc = zmq_setsockopt( sb, ZMQ_ROUTER_RAW_SOCK, &raw_sock, sizeof(int));
+    assert(rc == 0);
+    rc = zmq_bind (sb, "tcp://127.0.0.1:5555");
+    assert (rc == 0);
+
+    int sock_fd = tcp_client();
+    assert(sock_fd >= 0);
+    // ===================
+
+    zmq_msg_init(&message);
+    zmq_msg_init(&id);
+    assert (rc == 0);
+
+    zmq_pollitem_t items [] = {
+        { sb, 0, ZMQ_POLLIN, 0 },
+    };
+
+    tcp_client_write(sock_fd, test_str, strlen(test_str));
+    zmq_poll (items, 1, 500);
+    if (items [0].revents & ZMQ_POLLIN) {
+        int n = zmq_msg_recv (&id, sb, 0);
+        assert(n > 0);
+        n = zmq_msg_recv (&message, sb, 0);
+        assert(n > 0);
+        assert(memcmp(zmq_msg_data (&message), test_str, strlen(test_str)) == 0);
+    }else{
+        assert(0);
+    }
+
+    zmq_msg_send (&id, sb, ZMQ_SNDMORE);
+    zmq_msg_send (&message, sb, ZMQ_SNDMORE);// SNDMORE option is ignored
+
+    tcp_client_read(sock_fd);
+    tcp_client_close(sock_fd);
+
+    zmq_msg_close(&id);
+    zmq_msg_close(&message);
+
+
+    zmq_close(sb);
+    zmq_term(ctx);
+
+    fprintf (stderr, "test_raw_sock PASSED.\n");
+
+    return 0;
+}
+
+
+
+


### PR DESCRIPTION
Hi,

I had a requirement to support telnet connection to my application for cli. Instead of writing code for tcp server socket, I decided to make few modifications to zmq and use it instead. Sending pull request for inclusion if it would be useful to others.

With my limited experiments with zmq I made the following modifications and they seem to be working fine for my requirement. May be someone more experienced can review the code changes and provide comments.

Thanks
- Hardeep
  P.S. Raised issue - LIBZMQ-457 on zeromq.
# 
- Created a new option ZMQ_ROUTER_RAW_SOCK
  - Added new raw_encoder and raw_decoder to receive and send messages in raw form to remote client
  - Added test case file tests/test_raw_sock.cpp
  
  o To create a raw router sock set the ZMQ_ROUTER_RAW_SOCK option
  o ZMQ_MSGMORE flag is ignored for non-id messages
  o To terminate a remote connection send id message followed by zero length data message
