### PR TITLE
Update builds/msvc/libzmq/libzmq.vcproj

### DIFF
--- a/builds/msvc/libzmq/libzmq.vcproj
+++ b/builds/msvc/libzmq/libzmq.vcproj
@@ -64,6 +64,7 @@
 				OutputFile="../../../lib/libzmq.dll"
 				GenerateDebugInformation="true"
 				TargetMachine="1"
+				LinkDLL="true"
 			/>
 			<Tool
 				Name="VCALinkTool"
@@ -138,6 +139,7 @@
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
 				TargetMachine="1"
+				LinkDLL="true"
 			/>
 			<Tool
 				Name="VCALinkTool"
@@ -215,6 +217,7 @@
 				OptimizeReferences="2"
 				EnableCOMDATFolding="2"
 				TargetMachine="1"
+				LinkDLL="true"
 			/>
 			<Tool
 				Name="VCALinkTool"


### PR DESCRIPTION
Without the LinkDLL statement, command-line compile using vcbuild attempts to compile EXE and complains about entrypoint
The LinkDLL statement forces the linker to produce desired output
