### PR TITLE
Renamed ZMQ_ROUTER_RAW_SOCK to ZMQ_ROUTER_RAW

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -381,6 +381,23 @@ Default value:: 0
 Applicable socket types:: ZMQ_ROUTER
 
 
+ZMQ_ROUTER_RAW: switch ROUTER socket to raw mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sets the raw mode on the 'ROUTER', when set to 1. When the ROUTER socket is in
+raw mode, and when using the tcp:// transport, it will read and write TCP data
+without 0MQ framing. This lets 0MQ applications talk to non-0MQ applications.
+When using raw mode, you cannot set explicit identities, and the ZMQ_MSGMORE
+flag is ignored when sending data messages. In raw mode you can close a specific
+connection by sending it a zero-length message (following the identity frame).
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1
+Default value:: 0
+Applicable socket types:: ZMQ_ROUTER
+
+
 ZMQ_XPUB_VERBOSE: provide all subscription messages on XPUB sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -250,7 +250,7 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_TCP_ACCEPT_FILTER 38
 #define ZMQ_DELAY_ATTACH_ON_CONNECT 39
 #define ZMQ_XPUB_VERBOSE 40
-#define ZMQ_ROUTER_RAW_SOCK 41
+#define ZMQ_ROUTER_RAW 41
 
 
 /*  Message options                                                           */

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -79,7 +79,7 @@ int zmq::router_t::xsetsockopt (int option_, const void *optval_,
     size_t optvallen_)
 {
     if (option_ != ZMQ_ROUTER_MANDATORY
-    &&  option_ != ZMQ_ROUTER_RAW_SOCK) {
+    &&  option_ != ZMQ_ROUTER_RAW) {
         errno = EINVAL;
         return -1;
     }
@@ -87,7 +87,7 @@ int zmq::router_t::xsetsockopt (int option_, const void *optval_,
         errno = EINVAL;
         return -1;
     }
-    if (option_ == ZMQ_ROUTER_RAW_SOCK) {
+    if (option_ == ZMQ_ROUTER_RAW) {
         raw_sock = *static_cast <const int*> (optval_);
         if (raw_sock) {
             options.recv_identity = false;

--- a/tests/test_raw_sock.cpp
+++ b/tests/test_raw_sock.cpp
@@ -110,7 +110,7 @@ int main ()
     assert (sb);
 
     int raw_sock = 1;
-    int rc = zmq_setsockopt (sb, ZMQ_ROUTER_RAW_SOCK, &raw_sock, sizeof raw_sock);
+    int rc = zmq_setsockopt (sb, ZMQ_ROUTER_RAW, &raw_sock, sizeof raw_sock);
     assert (rc == 0);
     rc = zmq_bind (sb, "tcp://127.0.0.1:5555");
     assert (rc == 0);


### PR DESCRIPTION
For consistency and clarity. Since this was not a published API I did not keep the old name.
