### PR TITLE
[LIBZMQ-450] Copy the stream engine endpoint - string reference caused memory corruption

### DIFF
--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -63,7 +63,6 @@ zmq::stream_engine_t::stream_engine_t (fd_t fd_, const options_t &options_, cons
     greeting_bytes_read (0),
     session (NULL),
     options (options_),
-    endpoint (endpoint_),
     plugged (false),
     socket (NULL)
 {
@@ -96,6 +95,8 @@ zmq::stream_engine_t::stream_engine_t (fd_t fd_, const options_t &options_, cons
     int rc = setsockopt (s, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof (int));
     errno_assert (rc == 0);
 #endif
+    endpoint = new char[endpoint_.length() + 1];
+    strcpy (endpoint, endpoint_.c_str());
 }
 
 zmq::stream_engine_t::~stream_engine_t ()
@@ -117,6 +118,7 @@ zmq::stream_engine_t::~stream_engine_t ()
         delete encoder;
     if (decoder != NULL)
         delete decoder;
+    delete [] endpoint;
 }
 
 void zmq::stream_engine_t::plug (io_thread_t *io_thread_,
@@ -484,7 +486,7 @@ int zmq::stream_engine_t::push_msg (msg_t *msg_)
 void zmq::stream_engine_t::error ()
 {
     zmq_assert (session);
-    socket->event_disconnected (endpoint.c_str(), s);
+    socket->event_disconnected (endpoint, s);
     session->detach ();
     unplug ();
     delete this;

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -132,7 +132,7 @@ namespace zmq
         options_t options;
 
         // String representation of endpoint
-        std::string endpoint;
+        char *endpoint;
 
         bool plugged;
 


### PR DESCRIPTION
References https://zeromq.jira.com/browse/LIBZMQ-450 :

"Adrien Kunysz added a comment - 16/Nov/12 11:45 AM
As per previous comment. I am still able to reproduce the issue after applying the patch."
