### PR TITLE
Check decoder's state function for NULL before calling it

### DIFF
--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -148,6 +148,10 @@ namespace zmq
         //  False is returned if the decoder has encountered an error.
         bool stalled ()
         {
+            //  Check whether there was decoding error.
+            if (unlikely (static_cast <T*> (this)->next == NULL))
+                return false;
+
             while (!to_read) {
                 if (!(static_cast <T*> (this)->*next) ()) {
                     if (unlikely (!(static_cast <T*> (this)->next)))


### PR DESCRIPTION
Fixes bug reported by Peter Friend
(http://lists.zeromq.org/pipermail/zeromq-dev/2012-November/019425.html)
