### PR TITLE
Tiny fix

### DIFF
--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -149,7 +149,7 @@ namespace zmq
         bool stalled ()
         {
             //  Check whether there was decoding error.
-            if (unlikely (static_cast <T*> (this)->next == 0))
+            if (unlikely (!(static_cast <T*> (this)->next)))
                 return false;
 
             while (!to_read) {


### PR DESCRIPTION
Compilation fails without that when using arm-linux-androideabi v4.4.3.
