### PR TITLE
fix for LIBZMQ-84: Address already in use (signaler.cpp)

### DIFF
--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -95,7 +95,11 @@ zmq::signaler_t::~signaler_t ()
     int rc = close (r);
     errno_assert (rc == 0);
 #elif defined ZMQ_HAVE_WINDOWS
-    int rc = closesocket (w);
+    struct linger so_linger = { 1, 0 };
+    int rc = setsockopt (w, SOL_SOCKET, SO_LINGER,
+        (char *)&so_linger, sizeof (so_linger));
+    wsa_assert (rc != SOCKET_ERROR);
+    rc = closesocket (w);
     wsa_assert (rc != SOCKET_ERROR);
     rc = closesocket (r);
     wsa_assert (rc != SOCKET_ERROR);


### PR DESCRIPTION
To summarize the problem: 
1) Windows XP has less ephemeral ports than other OSes. 1025 to 5000 versus the 49152 to 65535 in newer versions of Windows and other OSes.
2) On Windows, TCP sockets are used for the mailbox implementation.
3) When creating and destroying lots of zmq_ctx(es) and/or zmq_socket(s), lots more mailboxes are created and destroyed, leaving the TCP sockets used in the TIME_WAIT state. (240 secs by default)
4) The first socket to close goes into TIME_WAIT

What this fix does is to set SO_LINGER to "on" and to "0 secs" on the first socket to close. This causes a RST to be sent to the peer socket when the first socket gets closed. The end result is that neither socket goes into TIME_WAIT.

Normally, this is considered a "bad" thing to do because you are messing up the peer socket. However, in our case, both the local and peer socket are under our control and on the local machine, so this isn't a problem.

(Where do I submit a short program demonstrating what the patch has fixed?)
