### PR TITLE
allow XSUB/XPUB to send/recv messages unrelated to sub/unsub

### DIFF
--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -224,7 +224,8 @@ ZMQ_XPUB
 Same as ZMQ_PUB except that you can receive subscriptions from the peers
 in form of incoming messages. Subscription message is a byte 1 (for
 subscriptions) or byte 0 (for unsubscriptions) followed by the subscription
-body.
+body. Messages without a sub/unsub prefix are also received, but have no
+effect on subscription status.
 
 [horizontal]
 .Summary of ZMQ_XPUB characteristics
@@ -240,7 +241,8 @@ ZMQ_XSUB
 ^^^^^^^^
 Same as ZMQ_SUB except that you subscribe by sending subscription messages to
 the socket. Subscription message is a byte 1 (for subscriptions) or byte 0
-(for unsubscriptions) followed by the subscription body.
+(for unsubscriptions) followed by the subscription body. Messages without a
+sub/unsub prefix may also be sent, but have no effect on subscription status.
 
 [horizontal]
 .Summary of ZMQ_XSUB characteristics

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -74,6 +74,9 @@ void zmq::xpub_t::xread_activated (pipe_t *pipe_)
             if (options.type == ZMQ_XPUB && (unique || (*data && verbose)))
                 pending.push_back (blob_t (data, size));
         }
+	else /*process message unrelated to sub/unsub*/ {
+	    pending.push_back (blob_t (data, size));
+	}
 
         sub.close ();
     }


### PR DESCRIPTION
zmq::xpub_t::xread_activated() – change to process messages without 0
or 1 prefix, but without affecting subscriptions

zmq::xsub_t::xsend() – change to send rather than discard messages
without 0 or 1 prefix, but without affecting subscriptions

Update documentation
