### PR TITLE
Minor autoconf tweaks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_INIT([zeromq],[m4_esyscmd([./version.sh])],[zeromq-dev@lists.zeromq.org])
 
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
-AM_CONFIG_HEADER(src/platform.hpp)
+AC_CONFIG_HEADERS([src/platform.hpp])
 AM_INIT_AUTOMAKE(tar-ustar dist-zip foreign)
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 


### PR DESCRIPTION
- move configure.in -> configure.ac (as recommended by autotools)
- AM_CONFIG_HEADER -> AC_CONFIG_HEADERS
  AM_CONFIG_HEADER raises an 'obsolete error' with automake 1.13.
