### PR TITLE
do not use EPROTO on platforms that do not have it

### DIFF
--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -195,8 +195,13 @@ zmq::fd_t zmq::ipc_listener_t::accept ()
     zmq_assert (s != retired_fd);
     fd_t sock = ::accept (s, NULL, NULL);
     if (sock == -1) {
+#ifdef EPROTO
+#define OR_ERRNO_EQ_EPROTO || errno == EPROTO
+#else
+#define OR_ERRNO_EQ_EPROTO
+#endif
         errno_assert (errno == EAGAIN || errno == EWOULDBLOCK ||
-            errno == EINTR || errno == ECONNABORTED || errno == EPROTO ||
+            errno == EINTR || errno == ECONNABORTED OR_ERRNO_EQ_EPROTO ||
             errno == ENFILE);
         return retired_fd;
     }

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -262,8 +262,13 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
     win_assert (brc);
 #else
     if (sock == -1) {
+#ifdef EPROTO
+#define OR_ERRNO_EQ_EPROTO || errno == EPROTO
+#else
+#define OR_ERRNO_EQ_EPROTO
+#endif
         errno_assert (errno == EAGAIN || errno == EWOULDBLOCK ||
-            errno == EINTR || errno == ECONNABORTED || errno == EPROTO ||
+            errno == EINTR || errno == ECONNABORTED OR_ERRNO_EQ_EPROTO ||
             errno == ENOBUFS || errno == ENOMEM || errno == EMFILE ||
             errno == ENFILE);
         return retired_fd;


### PR DESCRIPTION
Some platforms (only OpenBSD?) do not use EPROTO; this patch fixes compiler errors on such platforms.  This patch is also superior to [this one](https://github.com/PiotrSikora/libxs/commit/7bc7682bce0cf575c2250d0280b51aed14af7636) because embedding CPP directives within macro arguments is not portable, or so said a compiler warning.
##### References:

I first became aware of this issue through reports from the [CPAN testers](http://www.cpantesters.org/cpan/report/43efd072-6342-11e2-a2f1-82091a5d253f).
