### PR TITLE
define a dummy EPROTO for platforms that don't use it

### DIFF
--- a/src/err.hpp
+++ b/src/err.hpp
@@ -44,6 +44,11 @@
 #include <netdb.h>
 #endif
 
+// EPROTO is not used by OpenBSD and maybe other platforms.
+#ifndef EPROTO
+#define EPROTO 0
+#endif
+
 namespace zmq
 {
     const char *errno_to_string (int errno_);

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -195,13 +195,8 @@ zmq::fd_t zmq::ipc_listener_t::accept ()
     zmq_assert (s != retired_fd);
     fd_t sock = ::accept (s, NULL, NULL);
     if (sock == -1) {
-#ifdef EPROTO
-#define OR_ERRNO_EQ_EPROTO || errno == EPROTO
-#else
-#define OR_ERRNO_EQ_EPROTO
-#endif
         errno_assert (errno == EAGAIN || errno == EWOULDBLOCK ||
-            errno == EINTR || errno == ECONNABORTED OR_ERRNO_EQ_EPROTO ||
+            errno == EINTR || errno == ECONNABORTED || errno == EPROTO ||
             errno == ENFILE);
         return retired_fd;
     }

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -262,13 +262,8 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
     win_assert (brc);
 #else
     if (sock == -1) {
-#ifdef EPROTO
-#define OR_ERRNO_EQ_EPROTO || errno == EPROTO
-#else
-#define OR_ERRNO_EQ_EPROTO
-#endif
         errno_assert (errno == EAGAIN || errno == EWOULDBLOCK ||
-            errno == EINTR || errno == ECONNABORTED OR_ERRNO_EQ_EPROTO ||
+            errno == EINTR || errno == ECONNABORTED || errno == EPROTO ||
             errno == ENOBUFS || errno == ENOMEM || errno == EMFILE ||
             errno == ENFILE);
         return retired_fd;


### PR DESCRIPTION
This accomplishes the same thing as 2e2ef7fd in a potentially cleaner way.
