### PR TITLE
 LIBZMQ-498 - Remove heap allocations in zmq_poll for small poll item sets

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -381,6 +381,8 @@ typedef struct
     short revents;
 } zmq_pollitem_t;
 
+#define ZMQ_POLLITEMS_DFLT 16
+
 ZMQ_EXPORT int zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
 
 /*  Built-in message proxy (3-way) */


### PR DESCRIPTION
Until now, zmq_poll always allocates the poll items on the heap.
Now, small item sets, up to ZMQ_POLLITEMS_DFLT, are stack allocated
and only larger sets are allocated on the heap.
