### PR TITLE
Corrected linking error in MSVC build

### DIFF
--- a/builds/msvc/libzmq/libzmq.vcproj
+++ b/builds/msvc/libzmq/libzmq.vcproj
@@ -60,7 +60,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="Ws2_32.lib Rpcrt4.lib"
+				AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib"
 				OutputFile="../../../lib/libzmq.dll"
 				GenerateDebugInformation="true"
 				TargetMachine="1"
@@ -133,7 +133,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="Ws2_32.lib Rpcrt4.lib"
+				AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib"
 				OutputFile="../../../lib/libzmq.dll"
 				GenerateDebugInformation="true"
 				OptimizeReferences="2"
@@ -210,7 +210,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="Ws2_32.lib Rpcrt4.lib libpgm.lib"
+				AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib libpgm.lib"
 				OutputFile="../../../lib/libzmq.dll"
 				AdditionalLibraryDirectories="../../../../OpenPGM/lib"
 				GenerateDebugInformation="true"


### PR DESCRIPTION
MSVC build fails with linking errors for unresolved symbols SetSecurityDescriptorDacl and InitializeSecurityDescriptor in signaler.obj
Adding the relevant link library (Advapi32.lib) to VCLinkerTool fixes this (tested MSVC2010 on XP and Win7)
