### PR TITLE
Windows: Fix rounding error in now_us. [Jira LIBZMQ-514]

### DIFF
--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -66,7 +66,7 @@ uint64_t zmq::clock_t::now_us ()
 
     //  Convert the tick number into the number of seconds
     //  since the system was started.
-    double ticks_div = (double) (ticksPerSecond.QuadPart / 1000000);     
+    double ticks_div = ticksPerSecond.QuadPart / 1000000.0;     
     return (uint64_t) (tick.QuadPart / ticks_div);
 
 #elif defined HAVE_CLOCK_GETTIME && defined CLOCK_MONOTONIC


### PR DESCRIPTION
Improve accuracy of time calculations and avoid division by zero when
ticksPerSecond.QuadPart < 1000000.
