### PR TITLE
Simplified zmq_event_t structure.

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -294,51 +294,11 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
                         ZMQ_EVENT_ACCEPT_FAILED | ZMQ_EVENT_CLOSED | \
                         ZMQ_EVENT_CLOSE_FAILED | ZMQ_EVENT_DISCONNECTED )
 
-/*  Socket event data (union member per event)                                */
+/*  Socket event data  */
 typedef struct {
-    int event;
-    union {
-    struct {
-        char *addr;
-        int fd;
-    } connected;
-    struct {
-        char *addr;
-        int err;
-    } connect_delayed;
-    struct {
-        char *addr;
-        int interval;
-    } connect_retried;
-    struct {
-        char *addr;
-        int fd;
-    } listening;
-    struct {
-        char *addr;
-        int err;
-    } bind_failed;
-    struct {
-        char *addr;
-        int fd;
-    } accepted;
-    struct {
-        char *addr;
-        int err;
-    } accept_failed;
-    struct {
-        char *addr;
-        int fd;
-    } closed;
-    struct {
-        char *addr;
-        int err;
-    } close_failed;
-    struct {
-        char *addr;
-        int fd;
-    } disconnected;
-    } data;
+    unsigned int event;  // id of the event as bitfield
+    char *addr;          // endpoint affected as c string
+    int value ;          // value is either error code, fd or reconnect interval
 } zmq_event_t;
 
 ZMQ_EXPORT void *zmq_socket (void *, int type);

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1091,9 +1091,9 @@ void zmq::socket_base_t::event_connected (std::string &addr_, int fd_)
     if (monitor_events & ZMQ_EVENT_CONNECTED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_CONNECTED;
-        event.data.connected.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.connected.addr, addr_);
-        event.data.connected.fd = fd_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = fd_;
         monitor_event (event);
     }
 }
@@ -1103,9 +1103,9 @@ void zmq::socket_base_t::event_connect_delayed (std::string &addr_, int err_)
     if (monitor_events & ZMQ_EVENT_CONNECT_DELAYED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_CONNECT_DELAYED;
-        event.data.connect_delayed.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.connect_delayed.addr, addr_);
-        event.data.connect_delayed.err = err_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = err_;
         monitor_event (event);
     }
 }
@@ -1115,9 +1115,9 @@ void zmq::socket_base_t::event_connect_retried (std::string &addr_, int interval
     if (monitor_events & ZMQ_EVENT_CONNECT_RETRIED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_CONNECT_RETRIED;
-        event.data.connect_retried.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.connect_retried.addr, addr_);
-        event.data.connect_retried.interval = interval_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = interval_;
         monitor_event (event);
     }
 }
@@ -1127,9 +1127,9 @@ void zmq::socket_base_t::event_listening (std::string &addr_, int fd_)
     if (monitor_events & ZMQ_EVENT_LISTENING) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_LISTENING;
-        event.data.listening.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.listening.addr, addr_);
-        event.data.listening.fd = fd_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = fd_;
         monitor_event (event);
     }
 }
@@ -1139,9 +1139,9 @@ void zmq::socket_base_t::event_bind_failed (std::string &addr_, int err_)
     if (monitor_events & ZMQ_EVENT_BIND_FAILED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_BIND_FAILED;
-        event.data.bind_failed.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.bind_failed.addr, addr_);
-        event.data.bind_failed.err = err_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = err_;
         monitor_event (event);
     }
 }
@@ -1151,9 +1151,9 @@ void zmq::socket_base_t::event_accepted (std::string &addr_, int fd_)
     if (monitor_events & ZMQ_EVENT_ACCEPTED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_ACCEPTED;
-        event.data.accepted.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.accepted.addr, addr_);
-        event.data.accepted.fd = fd_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = fd_;
         monitor_event (event);
     }
 }
@@ -1163,9 +1163,9 @@ void zmq::socket_base_t::event_accept_failed (std::string &addr_, int err_)
     if (monitor_events & ZMQ_EVENT_ACCEPT_FAILED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_ACCEPT_FAILED;
-        event.data.accept_failed.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.accept_failed.addr, addr_);
-        event.data.accept_failed.err= err_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value= err_;
         monitor_event (event);
     }
 }
@@ -1175,9 +1175,9 @@ void zmq::socket_base_t::event_closed (std::string &addr_, int fd_)
     if (monitor_events & ZMQ_EVENT_CLOSED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_CLOSED;
-        event.data.closed.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.closed.addr, addr_);
-        event.data.closed.fd = fd_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = fd_;
         monitor_event (event);
     }
 }
@@ -1187,9 +1187,9 @@ void zmq::socket_base_t::event_close_failed (std::string &addr_, int err_)
     if (monitor_events & ZMQ_EVENT_CLOSE_FAILED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_CLOSE_FAILED;
-        event.data.close_failed.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.close_failed.addr, addr_);
-        event.data.close_failed.err = err_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = err_;
         monitor_event (event);
     }
 }
@@ -1199,9 +1199,9 @@ void zmq::socket_base_t::event_disconnected (std::string &addr_, int fd_)
     if (monitor_events & ZMQ_EVENT_DISCONNECTED) {
         zmq_event_t event;
         event.event = ZMQ_EVENT_DISCONNECTED;
-        event.data.disconnected.addr = (char *) malloc (addr_.size () + 1);
-        copy_monitor_address (event.data.disconnected.addr, addr_);
-        event.data.disconnected.fd = fd_;
+        event.addr = (char *) malloc (addr_.size () + 1);
+        copy_monitor_address (event.addr, addr_);
+        event.value = fd_;
         monitor_event (event);
     }
 }

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1004,39 +1004,8 @@ int zmq_device (int /* type */, void *frontend_, void *backend_)
 
 void zmq_free_event (void *event_data, void * /* hint */)
 {
-    zmq_event_t *event = (zmq_event_t *) event_data;
+    const zmq_event_t *event = (zmq_event_t *) event_data;
 
-    switch (event->event) {
-    case ZMQ_EVENT_CONNECTED:
-        free (event->data.connected.addr);
-        break;
-    case ZMQ_EVENT_CONNECT_DELAYED:
-        free (event->data.connect_delayed.addr);
-        break;
-    case ZMQ_EVENT_CONNECT_RETRIED:
-        free (event->data.connect_retried.addr);
-        break;
-    case ZMQ_EVENT_LISTENING:
-        free (event->data.listening.addr);
-        break;
-    case ZMQ_EVENT_BIND_FAILED:
-        free (event->data.bind_failed.addr);
-        break;
-    case ZMQ_EVENT_ACCEPTED:
-        free (event->data.accepted.addr);
-        break;
-    case ZMQ_EVENT_ACCEPT_FAILED:
-        free (event->data.accept_failed.addr);
-        break;
-    case ZMQ_EVENT_CLOSED:
-        free (event->data.closed.addr);
-        break;
-    case ZMQ_EVENT_CLOSE_FAILED:
-        free (event->data.close_failed.addr);
-        break;
-    case ZMQ_EVENT_DISCONNECTED:
-        free (event->data.disconnected.addr);
-        break;
-    }
+    free (event->addr);
     free (event_data);
 }

--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -53,31 +53,27 @@ static void *req_socket_monitor (void *ctx)
         assert (rc != -1);
 
         memcpy (&event, zmq_msg_data (&msg), sizeof (event));
+	assert (!strcmp (event.addr, addr));
         switch (event.event) {
             case ZMQ_EVENT_CONNECTED:
-                assert (event.data.connected.fd > 0);
-                assert (!strcmp (event.data.connected.addr, addr));
+                assert (event.value > 0);
                 req_socket_events |= ZMQ_EVENT_CONNECTED;
                 req2_socket_events |= ZMQ_EVENT_CONNECTED;
                 break;
             case ZMQ_EVENT_CONNECT_DELAYED:
-                assert (event.data.connect_delayed.err != 0);
-                assert (!strcmp (event.data.connect_delayed.addr, addr));
+                assert (event.value != 0);
                 req_socket_events |= ZMQ_EVENT_CONNECT_DELAYED;
                 break;
             case ZMQ_EVENT_CLOSE_FAILED:
-                assert (event.data.close_failed.err != 0);
-                assert (!strcmp (event.data.close_failed.addr, addr));
+                assert (event.value != 0);
                 req_socket_events |= ZMQ_EVENT_CLOSE_FAILED;
                 break;
             case ZMQ_EVENT_CLOSED:
-                assert (event.data.closed.fd != 0);
-                assert (!strcmp (event.data.closed.addr, addr));
+                assert (event.value != 0);
                 req_socket_events |= ZMQ_EVENT_CLOSED;
                 break;
             case ZMQ_EVENT_DISCONNECTED:
-                assert (event.data.disconnected.fd != 0);
-                assert (!strcmp (event.data.disconnected.addr, addr));
+                assert (event.value != 0);
                 req_socket_events |= ZMQ_EVENT_DISCONNECTED;
                 break;
         }
@@ -106,15 +102,14 @@ static void *req2_socket_monitor (void *ctx)
         assert (rc != -1);
 
         memcpy (&event, zmq_msg_data (&msg), sizeof (event));
+	assert (!strcmp (event.addr, addr));
         switch (event.event) {
             case ZMQ_EVENT_CONNECTED:
-                assert (event.data.connected.fd > 0);
-                assert (!strcmp (event.data.connected.addr, addr));
+                assert (event.value > 0);
                 req2_socket_events |= ZMQ_EVENT_CONNECTED;
                 break;
             case ZMQ_EVENT_CLOSED:
-                assert (event.data.closed.fd != 0);
-                assert (!strcmp (event.data.closed.addr, addr));
+                assert (event.value != 0);
                 req2_socket_events |= ZMQ_EVENT_CLOSED;
                 break;
         }
@@ -143,30 +138,26 @@ static void *rep_socket_monitor (void *ctx)
         assert (rc != -1);
 
         memcpy (&event, zmq_msg_data (&msg), sizeof (event));
+	assert (!strcmp (event.addr, addr));
         switch (event.event) {
             case ZMQ_EVENT_LISTENING:
-                assert (event.data.listening.fd > 0);
-                assert (!strcmp (event.data.listening.addr, addr));
+                assert (event.value > 0);
                 rep_socket_events |= ZMQ_EVENT_LISTENING;
                 break;
             case ZMQ_EVENT_ACCEPTED:
-                assert (event.data.accepted.fd > 0);
-                assert (!strcmp (event.data.accepted.addr, addr));
+                assert (event.value > 0);
                 rep_socket_events |= ZMQ_EVENT_ACCEPTED;
                 break;
             case ZMQ_EVENT_CLOSE_FAILED:
-                assert (event.data.close_failed.err != 0);
-                assert (!strcmp (event.data.close_failed.addr, addr));
+                assert (event.value != 0);
                 rep_socket_events |= ZMQ_EVENT_CLOSE_FAILED;
                 break;
             case ZMQ_EVENT_CLOSED:
-                assert (event.data.closed.fd != 0);
-                assert (!strcmp (event.data.closed.addr, addr));
+                assert (event.value != 0);
                 rep_socket_events |= ZMQ_EVENT_CLOSED;
                 break;
             case ZMQ_EVENT_DISCONNECTED:
-                assert (event.data.disconnected.fd != 0);
-                assert (!strcmp (event.data.disconnected.addr, addr));
+                assert (event.value != 0);
                 rep_socket_events |= ZMQ_EVENT_DISCONNECTED;
                 break;
         }


### PR DESCRIPTION
Makes usage of the events much easier and allows better integration with language bindings.
