### PR TITLE
Optimize atomics implementaiton for the Tile architecture

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Jacob Rideout <jacob.rideout@returnpath.net>
 Joe Thornber <joe.thornber@gmail.com>
 Jon Dyte <jon@totient.co.uk>
 Kamil Shakirov <kamils80@gmail.com>
+Ken Steele <ken@tilera.com>
 Marc Rossi <mrossi19@gmail.com>
 Martin Hurton <hurtonm@gmail.com>
 Martin Lucina <martin@lucina.net>

--- a/src/atomic_counter.hpp
+++ b/src/atomic_counter.hpp
@@ -33,6 +33,8 @@
 #define ZMQ_ATOMIC_COUNTER_WINDOWS
 #elif (defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_NETBSD)
 #define ZMQ_ATOMIC_COUNTER_ATOMIC_H
+#elif defined __tile__
+#define ZMQ_ATOMIC_COUNTER_TILE
 #else
 #define ZMQ_ATOMIC_COUNTER_MUTEX
 #endif
@@ -43,6 +45,8 @@
 #include "windows.hpp"
 #elif defined ZMQ_ATOMIC_COUNTER_ATOMIC_H
 #include <atomic.h>
+#elif defined ZMQ_ATOMIC_COUNTER_TILE
+#include <arch/atomic.h>
 #endif
 
 namespace zmq
@@ -82,6 +86,8 @@ namespace zmq
 #elif defined ZMQ_ATOMIC_COUNTER_ATOMIC_H
             integer_t new_value = atomic_add_32_nv (&value, increment_);
             old_value = new_value - increment_;
+#elif defined ZMQ_ATOMIC_COUNTER_TILE
+	    old_value = arch_atomic_add (&value, increment_);
 #elif defined ZMQ_ATOMIC_COUNTER_X86
             __asm__ volatile (
                 "lock; xadd %0, %1 \n\t"
@@ -122,6 +128,10 @@ namespace zmq
 #elif defined ZMQ_ATOMIC_COUNTER_ATOMIC_H
             int32_t delta = - ((int32_t) decrement);
             integer_t nv = atomic_add_32_nv (&value, delta);
+            return nv != 0;
+#elif defined ZMQ_ATOMIC_COUNTER_TILE
+            int32_t delta = - ((int32_t) decrement);
+            integer_t nv = arch_atomic_add (&value, delta);
             return nv != 0;
 #elif defined ZMQ_ATOMIC_COUNTER_X86
             integer_t oldval = -decrement;

--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -28,6 +28,8 @@
 #define ZMQ_ATOMIC_PTR_X86
 #elif defined __ARM_ARCH_7A__ && defined __GNUC__
 #define ZMQ_ATOMIC_PTR_ARM
+#elif defined __tile__
+#define ZMQ_ATOMIC_PTR_TILE
 #elif defined ZMQ_HAVE_WINDOWS
 #define ZMQ_ATOMIC_PTR_WINDOWS
 #elif (defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_NETBSD)
@@ -42,6 +44,8 @@
 #include "windows.hpp"
 #elif defined ZMQ_ATOMIC_PTR_ATOMIC_H
 #include <atomic.h>
+#elif defined ZMQ_ATOMIC_PTR_TILE
+#include <arch/atomic.h>
 #endif
 
 namespace zmq
@@ -80,6 +84,8 @@ namespace zmq
             return (T*) InterlockedExchangePointer ((PVOID*) &ptr, val_);
 #elif defined ZMQ_ATOMIC_PTR_ATOMIC_H
             return (T*) atomic_swap_ptr (&ptr, val_);
+#elif defined ZMQ_ATOMIC_PTR_TILE
+            return (T*) arch_atomic_exchange (&ptr, val_);
 #elif defined ZMQ_ATOMIC_PTR_X86
             T *old;
             __asm__ volatile (
@@ -123,6 +129,8 @@ namespace zmq
                 (volatile PVOID*) &ptr, val_, cmp_);
 #elif defined ZMQ_ATOMIC_PTR_ATOMIC_H
             return (T*) atomic_cas_ptr (&ptr, cmp_, val_);
+#elif defined ZMQ_ATOMIC_PTR_TILE
+            return (T*) arch_atomic_val_compare_and_exchange (&ptr, cmp_, val_);
 #elif defined ZMQ_ATOMIC_PTR_X86
             T *old;
             __asm__ volatile (


### PR DESCRIPTION
For atomic_counter and atomic_ptr classes, detect the Tile architecture
using #if defined **tile** (matching the style of ARM and Solaris) and then
use the Tile atomic instructions. Without this change, the default Mutex
implementation is used, which is slower.

This only affects compiling on the 'tile' architecture (http://www.tilera.com).

Passes "make check"
