### PR TITLE
Fix return code redeclaration for platforms with SO_NOSIGPIPE

### DIFF
--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -99,7 +99,7 @@ zmq::stream_engine_t::stream_engine_t (fd_t fd_, const options_t &options_, cons
     //  Make sure that SIGPIPE signal is not generated when writing to a
     //  connection that was already closed by the peer.
     int set = 1;
-    int rc = setsockopt (s, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof (int));
+    rc = setsockopt (s, SOL_SOCKET, SO_NOSIGPIPE, &set, sizeof (int));
     errno_assert (rc == 0);
 #endif
 }


### PR DESCRIPTION
Fixes :

stream_engine.cpp: In constructor 'zmq::stream_engine_t::stream_engine_t(zmq::fd_t, const zmq::options_t&, const std::string&)':
stream_engine.cpp:102: error: redeclaration of 'int rc'
stream_engine.cpp:73: error: 'int rc' previously declared here
