### PR TITLE
Fold constant expression into constant.

### DIFF
--- a/src/mechanism.cpp
+++ b/src/mechanism.cpp
@@ -64,7 +64,7 @@ size_t zmq::mechanism_t::add_property (unsigned char *ptr, const char *name,
     *ptr++ = static_cast <unsigned char> (name_len);
     memcpy (ptr, name, name_len);
     ptr += name_len;
-    zmq_assert (value_len <= (2^31) - 1);
+    zmq_assert (value_len <= 0x7FFFFFFF);
     put_uint32 (ptr, static_cast <uint32_t> (value_len));
     ptr += 4;
     memcpy (ptr, value, value_len);


### PR DESCRIPTION
This is clearly wrong. What is the purpose of this assert in the first place? add_property takes a size_t (aka uintptr_t aka uint64_t on most 64 bit systems) as a length, (attempts to) makes sure it fits in an int32_t, then stores it. Is there any reason the function can't just take a uint32_t?
