### PR TITLE
Make "./configure --with-system-pgm" detect the OpenPGM 5.2 system library.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,10 +349,18 @@ fi
 # Build with system openpgm
 if test "x$with_system_pgm_ext" != "xno"; then
     m4_ifdef([PKG_CHECK_MODULES], [
-        PKG_CHECK_MODULES([OpenPGM], [openpgm-5.1 >= 5.1])
-        AC_DEFINE(ZMQ_HAVE_OPENPGM, 1, [Have OpenPGM extension])
-        LIBZMQ_EXTRA_CXXFLAGS="$OpenPGM_CFLAGS $LIBZMQ_EXTRA_CXXFLAGS"
-        LIBS="$OpenPGM_LIBS $LIBS"
+        have_pgm_system_library="no"
+        PKG_CHECK_MODULES([OpenPGM], [openpgm-5.2 >= 5.2],
+            [ have_pgm_system_library="yes" ],
+            [PKG_CHECK_MODULES([OpenPGM], [openpgm-5.1 >= 5.1],
+                [ have_pgm_system_library="yes" ])
+            ]
+        )
+        if test "x$have_pgm_system_library" = "xyes"; then
+            AC_DEFINE(ZMQ_HAVE_OPENPGM, 1, [Have OpenPGM extension])
+            LIBZMQ_EXTRA_CXXFLAGS="$OpenPGM_CFLAGS $LIBZMQ_EXTRA_CXXFLAGS"
+            LIBS="$OpenPGM_LIBS $LIBS"
+        fi
     ],
     [AC_MSG_ERROR([--with-system-pgm requires a working pkg-config installation])])
 fi


### PR DESCRIPTION
This patch fixes  https://zeromq.jira.com/browse/LIBZMQ-531 (packaging problem detected in Fedora when using the OpenPGM 5.2 system library).

Note that OpenPGM installs a versioned pkgconfig file
(openpgm-5.2.pc, openpgm-5.1.pc).
