### PR TITLE
another iteration on ZMQ_PROBE_ROUTER

### DIFF
--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -44,8 +44,8 @@ void zmq::dealer_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
         int rc = probe_msg_.init ();
         errno_assert (rc == 0);
 
-        int ok = pipe_->write (&probe_msg_);
-        zmq_assert (ok);
+        rc = pipe_->write (&probe_msg_);
+        // zmq_assert (rc) is not applicable here, since it is not a bug.
         pipe_->flush ();
 
         rc = probe_msg_.close ();

--- a/tests/test_probe_router.cpp
+++ b/tests/test_probe_router.cpp
@@ -35,9 +35,7 @@ int main (void)
     assert (rc == 0);
 
     //  Create client and connect to server, doing a probe
-    void *client = zmq_socket (ctx, ZMQ_DEALER);
-    //  Trying this results in the first recv waiting forever
-    // void *client = zmq_socket (ctx, ZMQ_ROUTER);
+    void *client = zmq_socket (ctx, ZMQ_ROUTER);
     assert (client);
     rc = zmq_setsockopt (client, ZMQ_IDENTITY, "X", 1);
     assert (rc == 0);


### PR DESCRIPTION
Now it properly works for ROUTER.
Previous place for this code was wrong. router_t::indentify_peer() depend on other party to send us something to activate reading on our end of pipe.

Actually Pieter's Hintjens idea:

> > @shripchenko I had a random idea today; wouldn't it be simpler for the user if a >>ROUTER socket generated an empty message automatically when it got a new peer, >>rather than doing this from the peer end?

is really good. Unfortunately I don't know much how ROUTER socket works, so can't implement it by myself.

Another note on this code - is that I disabled zmq_assert(rc). Failed probe is not really a bug. We can't just ignore the pipe, we could pipe->terminate() the pipe on error, but then we have to modify xpipe_terminated() since current implementation asserts on unknown pipe.
