### PR TITLE
Clean up socket_type_string

### DIFF
--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -58,6 +58,8 @@ namespace zmq
 
     protected:
 
+        //  Only used to identify the socket for the Socket-Type
+        //  property in the wire protocol.
         const char *socket_type_string (int socket_type) const;
 
         size_t add_property (unsigned char *ptr, const char *name,

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -109,8 +109,6 @@ namespace zmq
         size_t add_property (unsigned char *ptr,
             const char *name, const void *value, size_t value_len);
 
-        const char *socket_type_string (int socket_type);
-
         //  Underlying socket.
         fd_t s;
 


### PR DESCRIPTION
Remove old function definition, add comment to clarify mechanism usage. 
