### PR TITLE
Store identity for raw socket

### DIFF
--- a/src/router.cpp
+++ b/src/router.cpp
@@ -372,6 +372,9 @@ bool zmq::router_t::identify_peer (pipe_t *pipe_)
         buf [0] = 0;
         put_uint32 (buf + 1, next_peer_id++);
         identity = blob_t (buf, sizeof buf);
+        unsigned int i = 0;  // Store identity to allow use of raw socket as client
+        for (blob_t::iterator it = identity.begin(); it != identity.end(); it++) options.identity[i++] = *it;
+        options.identity_size = i;
     }
     else {
         msg.init ();


### PR DESCRIPTION
Identity stored during connect procedure. Can be read using
zmq_getsockopt and used as the identity frame when sending messages.
This allows the implementation of a raw socket client.
