### PR TITLE
REQ sockets drop replies from unasked peers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Chia-liang Kao <clkao@clkao.org>
 Chris Rempel <csrl@gmx.com>
 Chris Wong <chris@chriswongstudio.com>
 Christian Gudrian <christian.gudrian@fluidon.com>
+Christian Kamm <kamm@incasoftware.de>
 Chuck Remes <cremes@mac.com>
 Conrad D. Steenberg <conrad.steenberg@caltech.edu>
 Dhammika Pathirana <dhammika@gmail.com>

--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -80,12 +80,12 @@ int zmq::dealer_t::xsetsockopt (int option_, const void *optval_,
 
 int zmq::dealer_t::xsend (msg_t *msg_)
 {
-    return lb.send (msg_);
+    return sendpipe (msg_, NULL);
 }
 
 int zmq::dealer_t::xrecv (msg_t *msg_)
 {
-    return fq.recv (msg_);
+    return recvpipe (msg_, NULL);
 }
 
 bool zmq::dealer_t::xhas_in ()
@@ -112,4 +112,14 @@ void zmq::dealer_t::xpipe_terminated (pipe_t *pipe_)
 {
     fq.pipe_terminated (pipe_);
     lb.pipe_terminated (pipe_);
+}
+
+int zmq::dealer_t::sendpipe (msg_t *msg_, pipe_t **pipe_)
+{
+    return lb.sendpipe (msg_, pipe_);
+}
+
+int zmq::dealer_t::recvpipe (msg_t *msg_, pipe_t **pipe_)
+{
+    return fq.recvpipe (msg_, pipe_);
 }

--- a/src/dealer.hpp
+++ b/src/dealer.hpp
@@ -55,6 +55,10 @@ namespace zmq
         void xwrite_activated (zmq::pipe_t *pipe_);
         void xpipe_terminated (zmq::pipe_t *pipe_);
 
+        //  Send and recv - knowing which pipe was used.
+        int sendpipe (zmq::msg_t *msg_, zmq::pipe_t **pipe_);
+        int recvpipe (zmq::msg_t *msg_, zmq::pipe_t **pipe_);
+
     private:
 
         //  Messages are fair-queued from inbound pipes. And load-balanced to

--- a/src/lb.cpp
+++ b/src/lb.cpp
@@ -70,6 +70,11 @@ void zmq::lb_t::activated (pipe_t *pipe_)
 
 int zmq::lb_t::send (msg_t *msg_)
 {
+    return sendpipe (msg_, NULL);
+}
+
+int zmq::lb_t::sendpipe (msg_t *msg_, pipe_t **pipe_)
+{
     //  Drop the message if required. If we are at the end of the message
     //  switch back to non-dropping mode.
     if (dropping) {
@@ -86,7 +91,11 @@ int zmq::lb_t::send (msg_t *msg_)
 
     while (active > 0) {
         if (pipes [current]->write (msg_))
+        {
+            if (pipe_)
+                *pipe_ = pipes [current];
             break;
+        }
 
         zmq_assert (!more);
         active--;
@@ -139,4 +148,3 @@ bool zmq::lb_t::has_out ()
 
     return false;
 }
-

--- a/src/lb.hpp
+++ b/src/lb.hpp
@@ -41,6 +41,13 @@ namespace zmq
         void pipe_terminated (pipe_t *pipe_);
 
         int send (msg_t *msg_);
+
+        //  Sends a message and stores the pipe that was used in pipe_.
+        //  It is possible for this function to return success but keep pipe_
+        //  unset if the rest of a multipart message to a terminated pipe is
+        //  being dropped. For the first frame, this will never happen.
+        int sendpipe (msg_t *msg_, pipe_t **pipe_);
+
         bool has_out ();
 
     private:

--- a/src/req.hpp
+++ b/src/req.hpp
@@ -44,6 +44,12 @@ namespace zmq
         bool xhas_in ();
         bool xhas_out ();
 
+    protected:
+
+        //  Receive only from the pipe the request was sent to, discarding
+        //  frames from other pipes.
+        int recv_reply_pipe (zmq::msg_t *msg_);
+
     private:
 
         //  If true, request was already sent and reply wasn't received yet or
@@ -53,6 +59,9 @@ namespace zmq
         //  If true, we are starting to send/recv a message. The first part
         //  of the message must be empty message part (backtrace stack bottom).
         bool message_begins;
+
+        //  The pipe the request was sent to and where the reply is expected.
+        zmq::pipe_t *reply_pipe;
 
         req_t (const req_t&);
         const req_t &operator = (const req_t&);

--- a/tests/test_spec_req.cpp
+++ b/tests/test_spec_req.cpp
@@ -234,8 +234,7 @@ int main (void)
         // SHALL accept an incoming message only from the last peer that it sent a
         // request to.
         // SHALL discard silently any messages received from other peers.
-        // *** Test disabled until libzmq does this properly ***
-        // test_req_only_listens_to_current_peer (ctx);
+        test_req_only_listens_to_current_peer (ctx);
     }
 
     int rc = zmq_ctx_term (ctx);


### PR DESCRIPTION
Commit message:
- Add lb_t::sendpipe() that returns the pipe that was used for sending,
  similar to fq_t::recvpipe().
- Add forwarder functions to dealer_t to access these two.
- Add logic to req_t to ignore replies on pipes that are not the one
  where the request was sent.

The test case for this code was in https://github.com/zeromq/libzmq/pull/606 - this change makes test_spec_req pass.
