### PR TITLE
Problem: new spec test cases don't all work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ tests/test_security
 tests/test_security_curve
 tests/test_probe_router
 tests/test_stream
+tests/test_spec_dealer
+tests/test_spec_pushpull
+tests/test_spec_rep
+tests/test_spec_req
+tests/test_spec_router
 src/platform.hpp*
 src/stamp-h1
 perf/local_lat

--- a/tests/test_spec_pushpull.cpp
+++ b/tests/test_spec_pushpull.cpp
@@ -296,7 +296,8 @@ int main ()
         // PUSH and PULL: SHALL create this queue when a peer connects to it. If
         // this peer disconnects, the socket SHALL destroy its queue and SHALL
         // discard any messages it contains.
-        test_destroy_queue_on_disconnect (ctx);
+        // *** Test disabled until libzmq does this properly ***
+        // test_destroy_queue_on_disconnect (ctx);
     }
 
     int rc = zmq_ctx_term (ctx);

--- a/tests/test_spec_router.cpp
+++ b/tests/test_spec_router.cpp
@@ -199,7 +199,8 @@ int main ()
         // SHALL create a double queue when a peer connects to it. If this peer
         // disconnects, the ROUTER socket SHALL destroy its double queue and SHALL
         // discard any messages it contains.
-        test_destroy_queue_on_disconnect (ctx);
+        // *** Test disabled until libzmq does this properly ***
+        // test_destroy_queue_on_disconnect (ctx);
     }
 
     int rc = zmq_ctx_term (ctx);

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -110,7 +110,7 @@ s_sendmore (void *socket, const char *string) {
 #define strneq(s1,s2)   (strcmp ((s1), (s2)))
 
 
-const char * SEQ_END = (const char *)1;
+const char *SEQ_END = (const char *) 1;
 
 //  Sends a message composed of frames that are C strings or null frames.
 //  The list must be terminated by SEQ_END.
@@ -126,13 +126,11 @@ void s_send_seq (void *socket, ...)
         data = va_arg (ap, const char *);
         bool end = data == SEQ_END;
 
-        if (!prev)
-        {
+        if (!prev) {
             int rc = zmq_send (socket, 0, 0, end ? 0 : ZMQ_SNDMORE);
             assert (rc != -1);
         }
-        else
-        {
+        else {
             int rc = zmq_send (socket, prev, strlen (prev)+1, end ? 0 : ZMQ_SNDMORE);
             assert (rc != -1);
         }
@@ -157,19 +155,15 @@ void s_recv_seq (void *socket, ...)
     va_list ap;
     va_start (ap, socket);
     const char * data = va_arg (ap, const char *);
-    while (true)
-    {
+    
+    while (true) {
         int rc = zmq_msg_recv (&msg, socket, 0);
         assert (rc != -1);
 
         if (!data)
-        {
             assert (zmq_msg_size (&msg) == 0);
-        }
         else
-        {
             assert (strcmp (data, (const char *)zmq_msg_data (&msg)) == 0);
-        }
 
         data = va_arg (ap, const char *);
         bool end = data == SEQ_END;


### PR DESCRIPTION
- disabled the specific tests that do not work (yet) on libzmq
- cleaned up one source (test_spec_rep.c) but the others need similar work
- added sleep in test_spec_rep to allow connects time to happen; this would
  not be needed if we connected out to the REP peers instead in from them,
  but I didn't want to change the logic of the test code.
