### PR TITLE
Rename ZMQ_REQ_SEND_RESETS -> ZMQ_REQ_STRICT.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ tests/test_spec_rep
 tests/test_spec_req
 tests/test_spec_router
 tests/test_req_request_ids
-tests/test_req_send_resets
+tests/test_req_strict
 src/platform.hpp*
 src/stamp-h1
 perf/local_lat

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -14,7 +14,8 @@ SYNOPSIS
 
 Caution: All options, with the exception of ZMQ_SUBSCRIBE, ZMQ_UNSUBSCRIBE,
 ZMQ_LINGER, ZMQ_ROUTER_MANDATORY, ZMQ_PROBE_ROUTER, ZMQ_XPUB_VERBOSE,
-ZMQ_REQ_SEND_RESETS only take effect for subsequent socket bind/connects.
+ZMQ_REQ_STRICT, ZMQ_REQ_REQUEST_IDS only take effect for subsequent socket
+bind/connects.
 Specifically, security options take effect for subsequent binds/connects and can be
 changed at any time to affect subsequent binds and/or connects.
 
@@ -476,25 +477,25 @@ Default value:: 0
 Applicable socket types:: ZMQ_REQ
 
 
-ZMQ_REQ_SEND_RESETS: reset request-reply sequence by sending another message
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ZMQ_REQ_STRICT: enforce strict alternation between request and reply
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When set to 0, a REQ socket does not allow initiating a new request with
+When set to 1, a REQ socket does not allow initiating a new request with
 _zmq_send(3)_ until the reply to the previous one has been received. 
-When set to 1, sending another message is allowed and has the effect of
+When set to 0, sending another message is allowed and has the effect of
 disconnecting the underlying connection to the peer from which the reply was
 expected, triggering a reconnection attempt on transports that support it.
 The request-reply state machine is reset and a new request is sent to the
 next available peer.
 
-When this option is enabled, also enable ZMQ_REQ_REQUEST_IDS to ensure correct
+If set to 0, also enable ZMQ_REQ_REQUEST_IDS to ensure correct
 matching of requests and replies. Otherwise a late reply to an aborted request
 can be reported as the reply to the superseding request.
 
 [horizontal]
 Option value type:: int
 Option value unit:: 0, 1
-Default value:: 0
+Default value:: 1
 Applicable socket types:: ZMQ_REQ
 
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -277,7 +277,7 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_CURVE_SERVERKEY 50
 #define ZMQ_PROBE_ROUTER 51
 #define ZMQ_REQ_REQUEST_IDS 52
-#define ZMQ_REQ_SEND_RESETS 53
+#define ZMQ_REQ_STRICT 53
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -31,7 +31,7 @@ zmq::req_t::req_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
     reply_pipe (NULL),
     request_id_frames_enabled (false),
     request_id (generate_random()),
-    send_resets (false)
+    strict (true)
 {
     options.type = ZMQ_REQ;
 }
@@ -43,9 +43,9 @@ zmq::req_t::~req_t ()
 int zmq::req_t::xsend (msg_t *msg_)
 {
     //  If we've sent a request and we still haven't got the reply,
-    //  we can't send another request unless the send_resets option is enabled.
+    //  we can't send another request unless the strict option is disabled.
     if (receiving_reply) {
-        if (!send_resets) {
+        if (strict) {
             errno = EFSM;
             return -1;
         }
@@ -205,9 +205,9 @@ int zmq::req_t::xsetsockopt (int option_, const void *optval_, size_t optvallen_
             }
             break;
 
-        case ZMQ_REQ_SEND_RESETS:
+        case ZMQ_REQ_STRICT:
             if (is_int && value >= 0) {
-                send_resets = value;
+                strict = value;
                 return 0;
             }
             break;

--- a/src/req.hpp
+++ b/src/req.hpp
@@ -72,10 +72,10 @@ namespace zmq
         //  request is sent.
         uint32_t request_id;
 
-        //  If true, send() will reset its internal state and terminate the
+        //  If false, send() will reset its internal state and terminate the
         //  reply_pipe's connection instead of failing if a previous request is
         //  still pending.
-        bool send_resets;
+        bool strict;
 
         req_t (const req_t&);
         const req_t &operator = (const req_t&);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -31,7 +31,7 @@ noinst_PROGRAMS = test_pair_inproc \
                   test_spec_router \
                   test_spec_pushpull \
                   test_req_request_ids \
-                  test_req_send_resets
+                  test_req_strict
 
 if !ON_MINGW
 noinst_PROGRAMS += test_shutdown_stress \
@@ -68,7 +68,7 @@ test_spec_dealer_SOURCES = test_spec_dealer.cpp
 test_spec_router_SOURCES = test_spec_router.cpp
 test_spec_pushpull_SOURCES = test_spec_pushpull.cpp
 test_req_request_ids_SOURCES = test_req_request_ids.cpp
-test_req_send_resets_SOURCES = test_req_send_resets.cpp
+test_req_strict_SOURCES = test_req_strict.cpp
 if !ON_MINGW
 test_shutdown_stress_SOURCES = test_shutdown_stress.cpp
 test_pair_ipc_SOURCES = test_pair_ipc.cpp testutil.hpp

--- a/tests/test_req_strict.cpp
+++ b/tests/test_req_strict.cpp
@@ -30,10 +30,11 @@ int main (void)
     void *req = zmq_socket (ctx, ZMQ_REQ);
     assert (req);
 
-    int enabled = 1;
-    int rc = zmq_setsockopt (req, ZMQ_REQ_SEND_RESETS, &enabled, sizeof (int));
+    int disabled = 0;
+    int rc = zmq_setsockopt (req, ZMQ_REQ_STRICT, &disabled, sizeof (int));
     assert (rc == 0);
 
+    int enabled = 1;
     rc = zmq_setsockopt (req, ZMQ_REQ_REQUEST_IDS, &enabled, sizeof (int));
     assert (rc == 0);
 


### PR DESCRIPTION
It defaults to enabled. Switch it off to be able to send a new message
before the previous reply has been received.
