### PR TITLE
Attempt to fix disconnect not respecting linger

### DIFF
--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -158,10 +158,11 @@ namespace zmq
 
     private:
         //  Creates new endpoint ID and adds the endpoint to the map.
-        void add_endpoint (const char *addr_, own_t *endpoint_);
+        void add_endpoint (const char *addr_, own_t *endpoint_, pipe_t *pipe);
 
         //  Map of open endpoints.
-        typedef std::multimap <std::string, own_t *> endpoints_t;
+        typedef std::pair <own_t *, pipe_t*> endpoint_pipe_t;
+        typedef std::multimap <std::string, endpoint_pipe_t> endpoints_t;
         endpoints_t endpoints;
 
         //  Map of open inproc endpoints.


### PR DESCRIPTION
Looks like linger is honoured properly, but shutting down the session
causes the pipe termination to come from that side - because the local
pipe then shuts down right away it seems to trigger a terminated on the
other end instead of waiting. This way we trigger the termination from
the local end and then terminate the session.
