### PR TITLE
Optimized zmq::msg_t for constant messages

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -75,19 +75,28 @@ int zmq::msg_t::init_size (size_t size_)
 int zmq::msg_t::init_data (void *data_, size_t size_, msg_free_fn *ffn_,
     void *hint_)
 {
-    u.lmsg.type = type_lmsg;
-    u.lmsg.flags = 0;
-    u.lmsg.content = (content_t*) malloc (sizeof (content_t));
-    if (!u.lmsg.content) {
-        errno = ENOMEM;
-        return -1;
+    // Initialize constant message if there's no need to deallocate
+    if(ffn_ == NULL) {
+        u.cmsg.type = type_cmsg;
+        u.cmsg.flags = 0;
+        u.cmsg.data = data_;
+        u.cmsg.size = size_;
     }
+    else {
+        u.lmsg.type = type_lmsg;
+        u.lmsg.flags = 0;
+        u.lmsg.content = (content_t*) malloc (sizeof (content_t));
+        if (!u.lmsg.content) {
+            errno = ENOMEM;
+            return -1;
+        }
 
-    u.lmsg.content->data = data_;
-    u.lmsg.content->size = size_;
-    u.lmsg.content->ffn = ffn_;
-    u.lmsg.content->hint = hint_;
-    new (&u.lmsg.content->refcnt) zmq::atomic_counter_t ();
+        u.lmsg.content->data = data_;
+        u.lmsg.content->size = size_;
+        u.lmsg.content->ffn = ffn_;
+        u.lmsg.content->hint = hint_;
+        new (&u.lmsg.content->refcnt) zmq::atomic_counter_t ();
+    }
     return 0;
 
 }
@@ -193,6 +202,8 @@ void *zmq::msg_t::data ()
         return u.vsm.data;
     case type_lmsg:
         return u.lmsg.content->data;
+    case type_cmsg:
+        return u.cmsg.data;
     default:
         zmq_assert (false);
         return NULL;
@@ -209,6 +220,8 @@ size_t zmq::msg_t::size ()
         return u.vsm.size;
     case type_lmsg:
         return u.lmsg.content->size;
+    case type_cmsg:
+        return u.cmsg.size;
     default:
         zmq_assert (false);
         return 0;
@@ -245,6 +258,11 @@ bool zmq::msg_t::is_vsm ()
     return u.base.type == type_vsm;
 }
 
+bool zmq::msg_t::is_cmsg ()
+{
+    return u.base.type == type_cmsg;
+}
+
 void zmq::msg_t::add_refs (int refs_)
 {
     zmq_assert (refs_ >= 0);
@@ -253,8 +271,8 @@ void zmq::msg_t::add_refs (int refs_)
     if (!refs_)
         return;
 
-    //  VSMs and delimiters can be copied straight away. The only message type
-    //  that needs special care are long messages.
+    //  VSMs, CMSGS and delimiters can be copied straight away. The only
+    //  message type that needs special care are long messages.
     if (u.base.type == type_lmsg) {
         if (u.lmsg.flags & msg_t::shared)
             u.lmsg.content->refcnt.add (refs_);

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -69,6 +69,7 @@ namespace zmq
         bool is_identity () const;
         bool is_delimiter ();
         bool is_vsm ();
+        bool is_cmsg ();
 
         //  After calling this function you can copy the message in POD-style
         //  refs_ times. No need to call copy.
@@ -107,7 +108,9 @@ namespace zmq
             type_vsm = 101,
             type_lmsg = 102,
             type_delimiter = 103,
-            type_max = 103
+            // CMSG messages point to constant data
+            type_cmsg = 104,
+            type_max = 104
         };
 
         //  Note that fields shared between different message types are not
@@ -132,6 +135,14 @@ namespace zmq
                 unsigned char type;
                 unsigned char flags;
             } lmsg;
+            struct {
+                void* data;
+                size_t size;
+                unsigned char unused
+                    [max_vsm_size + 1 - sizeof (void*) - sizeof (size_t)];
+                unsigned char type;
+                unsigned char flags;
+            } cmsg;
             struct {
                 unsigned char unused [max_vsm_size + 1];
                 unsigned char type;


### PR DESCRIPTION
Currently, constant messages are LMSG-types. LMSG initialization causes two mallocs:
- A _content_t_ instance that saves the parameters
- An _atomic_counter_t_ for refcounting

When allocating a large numbers of messages with a NULL _ffn_ argument to _zmq_msg_init_data_, this behaviour could cause memory fragmentation. It will cause poor performance.

This patch adds the new message type CMSG ("Constant"), which saves the data pointer and the data size inline. A message is set to cmsg-type if the _ffn_ arg is NULL.

In a quick benchmark repeatedly init_data'ing and closing the same message with constant data, the performance gained by using cmsgs is +320% !
I think that's worth the minor extra complexity (the user API is not changed at all, existing applications will profit from this patch without recompilation).
