### PR TITLE
Add the Socket Identity info to the ZAP Messages

### DIFF
--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -537,6 +537,14 @@ void zmq::curve_server_t::send_zap_request (const uint8_t *key)
     rc = session->write_zap_msg (&msg);
     errno_assert (rc == 0);
 
+    // identity frame 
+    rc = msg.init_size (options.identity_size);
+    errno_assert(rc == 0);
+    memcpy (msg.data (), options.identity, options.identity_size);
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    errno_assert (rc == 0);
+
     //  Mechanism frame
     rc = msg.init_size (5);
     errno_assert (rc == 0);

--- a/src/plain_mechanism.cpp
+++ b/src/plain_mechanism.cpp
@@ -380,6 +380,14 @@ void zmq::plain_mechanism_t::send_zap_request (const std::string &username,
     rc = session->write_zap_msg (&msg);
     errno_assert (rc == 0);
 
+    // identity frame 
+    rc = msg.init_size (options.identity_size);
+    errno_assert(rc == 0);
+    memcpy (msg.data (), options.identity, options.identity_size);
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    errno_assert (rc == 0);
+
     //  Mechanism frame
     rc = msg.init_size (5);
     errno_assert (rc == 0);

--- a/tests/test_security.cpp
+++ b/tests/test_security.cpp
@@ -28,12 +28,15 @@ static void zap_handler (void *zap)
     char *sequence = s_recv (zap);
     char *domain = s_recv (zap);
     char *address = s_recv (zap);
+    char *identity = s_recv(zap);
     char *mechanism = s_recv (zap);
     char *username = s_recv (zap);
     char *password = s_recv (zap);
     
+    printf("identity: %s\n", identity);
     assert (streq (version, "1.0"));
     assert (streq (mechanism, "PLAIN"));
+    assert (streq (identity, "IDENT"));
 
     s_sendmore (zap, version);
     s_sendmore (zap, sequence);
@@ -55,6 +58,7 @@ static void zap_handler (void *zap)
     free (sequence);
     free (domain);
     free (address);
+    free (identity);
     free (mechanism);
     free (username);
     free (password);
@@ -115,6 +119,7 @@ int main (void)
     //  Check PLAIN security
     server = zmq_socket (ctx, ZMQ_DEALER);
     assert (server);
+    rc = zmq_setsockopt(server, ZMQ_IDENTITY, "IDENT",6);
     client = zmq_socket (ctx, ZMQ_DEALER);
     assert (client);
     

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -29,11 +29,13 @@ static void zap_handler (void *zap)
     char *sequence = s_recv (zap);
     char *domain = s_recv (zap);
     char *address = s_recv (zap);
+    char *identity = s_recv(zap);
     char *mechanism = s_recv (zap);
     char *client_key = s_recv (zap);
     
     assert (streq (version, "1.0"));
     assert (streq (mechanism, "CURVE"));
+    assert (streq (identity, "IDENT"));
 
     s_sendmore (zap, version);
     s_sendmore (zap, sequence);
@@ -46,6 +48,7 @@ static void zap_handler (void *zap)
     free (sequence);
     free (domain);
     free (address);
+    free (identity);
     free (mechanism);
     free (client_key);
     
@@ -86,6 +89,8 @@ int main (void)
     rc = zmq_setsockopt (server, ZMQ_CURVE_SERVER, &as_server, sizeof (int));
     assert (rc == 0);
     rc = zmq_setsockopt (server, ZMQ_CURVE_SECRETKEY, server_secret, 40);
+    assert (rc == 0);
+    rc = zmq_setsockopt(server, ZMQ_IDENTITY, "IDENT",6);
     assert (rc == 0);
 
     rc = zmq_setsockopt (client, ZMQ_CURVE_SERVERKEY, server_public, 40);


### PR DESCRIPTION
This change adds the socket identity information from the socket to the
zap frames.  In doing this the ZAP is able preform different operations
based on different sockets.  This is not compatible with the current ZAP
RFC, but that can be updated.  As the ZAP RFC is currently draft for I
did not change the version number.

Tests also modified and passing.
