### PR TITLE
get to clean compile under vs2012

### DIFF
--- a/builds/msvc/libzmq/libzmq11.vcxproj
+++ b/builds/msvc/libzmq/libzmq11.vcxproj
@@ -223,8 +223,10 @@
     <ClCompile Include="..\..\..\src\kqueue.cpp" />
     <ClCompile Include="..\..\..\src\lb.cpp" />
     <ClCompile Include="..\..\..\src\mailbox.cpp" />
+    <ClCompile Include="..\..\..\src\mechanism.cpp" />
     <ClCompile Include="..\..\..\src\msg.cpp" />
     <ClCompile Include="..\..\..\src\mtrie.cpp" />
+    <ClCompile Include="..\..\..\src\null_mechanism.cpp" />
     <ClCompile Include="..\..\..\src\object.cpp" />
     <ClCompile Include="..\..\..\src\options.cpp" />
     <ClCompile Include="..\..\..\src\own.cpp" />
@@ -233,6 +235,7 @@
     <ClCompile Include="..\..\..\src\pgm_sender.cpp" />
     <ClCompile Include="..\..\..\src\pgm_socket.cpp" />
     <ClCompile Include="..\..\..\src\pipe.cpp" />
+    <ClCompile Include="..\..\..\src\plain_mechanism.cpp" />
     <ClCompile Include="..\..\..\src\poll.cpp" />
     <ClCompile Include="..\..\..\src\poller_base.cpp" />
     <ClCompile Include="..\..\..\src\precompiled.cpp">
@@ -253,6 +256,7 @@
     <ClCompile Include="..\..\..\src\session_base.cpp" />
     <ClCompile Include="..\..\..\src\signaler.cpp" />
     <ClCompile Include="..\..\..\src\socket_base.cpp" />
+    <ClCompile Include="..\..\..\src\stream.cpp" />
     <ClCompile Include="..\..\..\src\stream_engine.cpp" />
     <ClCompile Include="..\..\..\src\sub.cpp" />
     <ClCompile Include="..\..\..\src\tcp.cpp" />

--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -65,7 +65,7 @@ int zmq::dealer_t::xsetsockopt (int option_, const void *optval_,
     switch (option_) {
         case ZMQ_PROBE_ROUTER:
             if (is_int && value >= 0) {
-                probe_router = value;
+                probe_router = (value != 0);
                 return 0;
             }
             break;

--- a/src/mutex.hpp
+++ b/src/mutex.hpp
@@ -52,7 +52,7 @@ namespace zmq
 
         inline bool try_lock ()
         {
-            return (bool) TryEnterCriticalSection (&cs);
+            return (TryEnterCriticalSection (&cs)) ? true : false;
         }
 
         inline void unlock ()

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -200,14 +200,14 @@ int zmq::req_t::xsetsockopt (int option_, const void *optval_, size_t optvallen_
     switch (option_) {
         case ZMQ_REQ_REQUEST_IDS:
             if (is_int && value >= 0) {
-                request_id_frames_enabled = value;
+                request_id_frames_enabled = (value != 0);
                 return 0;
             }
             break;
 
         case ZMQ_REQ_STRICT:
             if (is_int && value >= 0) {
-                strict = value;
+                strict = (value != 0);
                 return 0;
             }
             break;

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -89,7 +89,7 @@ int zmq::router_t::xsetsockopt (int option_, const void *optval_,
     switch (option_) {
         case ZMQ_ROUTER_RAW:
             if (is_int && value >= 0) {
-                raw_sock = value;
+                raw_sock = (value != 0);
                 if (raw_sock) {
                     options.recv_identity = false;
                     options.raw_sock = true;
@@ -100,14 +100,14 @@ int zmq::router_t::xsetsockopt (int option_, const void *optval_,
 
         case ZMQ_ROUTER_MANDATORY:
             if (is_int && value >= 0) {
-                mandatory = value;
+                mandatory = (value != 0);
                 return 0;
             }
             break;
 
         case ZMQ_PROBE_ROUTER:
             if (is_int && value >= 0) {
-                probe_router = value;
+                probe_router = (value != 0);
                 return 0;
             }
             break;


### PR DESCRIPTION
Added some missing (but existing in branch) files to libzmq11 project needed
to compile as static library by VS2012 (at least), and fixed some warnings.
One warning remains in raw_decoder.cpp, which I'm leaving for now because I'm
not sure how project owners would like to fix it.
