### PR TITLE
Fixed markup so documentation can be built.

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -683,7 +683,7 @@ Applicable socket types:: all, when using TCP transport
 
 
 ZMQ_CONFLATE: Keep only last message
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If set, a socket shall keep only one message in its inbound/outbound
 queue, this message being the last message received/the last message


### PR DESCRIPTION
Nothing big, but prevented the generation of the man pages and aborted compile.
