### PR TITLE
Change name of icanhasall to subscribe_to_all

### DIFF
--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -32,10 +32,10 @@ zmq::dealer_t::~dealer_t ()
 {
 }
 
-void zmq::dealer_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::dealer_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // icanhasall_ is unused
-    (void) icanhasall_;
+    // subscribe_to_all_ is unused
+    (void) subscribe_to_all_;
 
     zmq_assert (pipe_);
 

--- a/src/dealer.hpp
+++ b/src/dealer.hpp
@@ -45,7 +45,7 @@ namespace zmq
     protected:
 
         //  Overloads of functions from socket_base_t.
-        void xattach_pipe (zmq::pipe_t *pipe_, bool icanhasall_);
+        void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xsetsockopt (int option_, const void *optval_, size_t optvallen_);
         int xsend (zmq::msg_t *msg_);
         int xrecv (zmq::msg_t *msg_);

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -34,10 +34,10 @@ zmq::pair_t::~pair_t ()
     zmq_assert (!pipe);
 }
 
-void zmq::pair_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::pair_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // icanhasall_ is unused
-    (void)icanhasall_;
+    // subscribe_to_all_ is unused
+    (void)subscribe_to_all_;
 
     zmq_assert (pipe_ != NULL);
 

--- a/src/pair.hpp
+++ b/src/pair.hpp
@@ -40,7 +40,7 @@ namespace zmq
         ~pair_t ();
 
         //  Overloads of functions from socket_base_t.
-        void xattach_pipe (zmq::pipe_t *pipe_, bool icanhasall_);
+        void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xsend (zmq::msg_t *msg_);
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();

--- a/src/pull.cpp
+++ b/src/pull.cpp
@@ -32,10 +32,10 @@ zmq::pull_t::~pull_t ()
 {
 }
 
-void zmq::pull_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::pull_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // icanhasall_ is unused
-    (void)icanhasall_;
+    // subscribe_to_all_ is unused
+    (void)subscribe_to_all_;
 
     zmq_assert (pipe_);
     fq.attach (pipe_);

--- a/src/pull.hpp
+++ b/src/pull.hpp
@@ -43,7 +43,7 @@ namespace zmq
     protected:
 
         //  Overloads of functions from socket_base_t.
-        void xattach_pipe (zmq::pipe_t *pipe_, bool icanhasall_);
+        void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
         void xread_activated (zmq::pipe_t *pipe_);

--- a/src/push.cpp
+++ b/src/push.cpp
@@ -32,10 +32,10 @@ zmq::push_t::~push_t ()
 {
 }
 
-void zmq::push_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::push_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // icanhasall_ is unused
-    (void)icanhasall_;
+    // subscribe_to_all_ is unused
+    (void)subscribe_to_all_;
 
     zmq_assert (pipe_);
     lb.attach (pipe_);

--- a/src/push.hpp
+++ b/src/push.hpp
@@ -43,7 +43,7 @@ namespace zmq
     protected:
 
         //  Overloads of functions from socket_base_t.
-        void xattach_pipe (zmq::pipe_t *pipe_, bool icanhasall_);
+        void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xsend (zmq::msg_t *msg_);
         bool xhas_out ();
         void xwrite_activated (zmq::pipe_t *pipe_);

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -53,10 +53,10 @@ zmq::router_t::~router_t ()
     prefetched_msg.close ();
 }
 
-void zmq::router_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::router_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // icanhasall_ is unused
-    (void)icanhasall_;
+    // subscribe_to_all_ is unused
+    (void)subscribe_to_all_;
 
     zmq_assert (pipe_);
 

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -45,7 +45,7 @@ namespace zmq
         ~router_t ();
 
         //  Overloads of functions from socket_base_t.
-        void xattach_pipe (zmq::pipe_t *pipe_, bool icanhasall_);
+        void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xsetsockopt (int option_, const void *optval_, size_t optvallen_);
         int xsend (zmq::msg_t *msg_);
         int xrecv (zmq::msg_t *msg_);

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -221,14 +221,14 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_)
     return 0;
 }
 
-void zmq::socket_base_t::attach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::socket_base_t::attach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
     //  First, register the pipe so that we can terminate it later on.
     pipe_->set_event_sink (this);
     pipes.push_back (pipe_);
     
     //  Let the derived socket type know about new pipe.
-    xattach_pipe (pipe_, icanhasall_);
+    xattach_pipe (pipe_, subscribe_to_all_);
 
     //  If the socket is already being closed, ask any new pipes to terminate
     //  straight away.
@@ -556,10 +556,10 @@ int zmq::socket_base_t::connect (const char *addr_)
 
     //  PGM does not support subscription forwarding; ask for all data to be
     //  sent to this pipe.
-    bool icanhasall = protocol == "pgm" || protocol == "epgm";
+    bool subscribe_to_all = protocol == "pgm" || protocol == "epgm";
     pipe_t *newpipe = NULL;
 
-    if (options.immediate != 1 || icanhasall) {
+    if (options.immediate != 1 || subscribe_to_all) {
         //  Create a bi-directional pipe.
         object_t *parents [2] = {this, session};
         pipe_t *new_pipes [2] = {NULL, NULL};
@@ -579,7 +579,7 @@ int zmq::socket_base_t::connect (const char *addr_)
         errno_assert (rc == 0);
 
         //  Attach local end of the pipe to the socket object.
-        attach_pipe (new_pipes [0], icanhasall);
+        attach_pipe (new_pipes [0], subscribe_to_all);
         newpipe = new_pipes [0];
 
         //  Attach remote end of the pipe to the session object later on.

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -125,7 +125,7 @@ namespace zmq
         //  Concrete algorithms for the x- methods are to be defined by
         //  individual socket types.
         virtual void xattach_pipe (zmq::pipe_t *pipe_,
-            bool icanhasall_ = false) = 0;
+            bool subscribe_to_all_ = false) = 0;
 
         //  The default implementation assumes there are no specific socket
         //  options for the particular socket type. If not so, overload this
@@ -197,7 +197,7 @@ namespace zmq
         int check_protocol (const std::string &protocol_);
 
         //  Register the pipe with this socket.
-        void attach_pipe (zmq::pipe_t *pipe_, bool icanhasall_ = false);
+        void attach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_ = false);
 
         //  Processes commands sent to this socket (if any). If timeout is -1,
         //  returns only after at least one command was processed.

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -46,10 +46,10 @@ zmq::stream_t::~stream_t ()
     prefetched_msg.close ();
 }
 
-void zmq::stream_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::stream_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // icanhasall_ is unused
-    (void)icanhasall_;
+    // subscribe_to_all_ is unused
+    (void)subscribe_to_all_;
 
     zmq_assert (pipe_);
 

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -39,7 +39,7 @@ namespace zmq
         ~stream_t ();
 
         //  Overloads of functions from socket_base_t.
-        void xattach_pipe (zmq::pipe_t *pipe_, bool icanhasall_);
+        void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xsend (zmq::msg_t *msg_);
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -36,14 +36,14 @@ zmq::xpub_t::~xpub_t ()
 {
 }
 
-void zmq::xpub_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::xpub_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
     zmq_assert (pipe_);
     dist.attach (pipe_);
 
-    //  If icanhasall_ is specified, the caller would like to subscribe
+    //  If subscribe_to_all_ is specified, the caller would like to subscribe
     //  to all data on this pipe, implicitly.
-    if (icanhasall_)
+    if (subscribe_to_all_)
         subscriptions.add (NULL, 0, pipe_);
 
     //  The pipe is active when attached. Let's read the subscriptions from

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -46,7 +46,7 @@ namespace zmq
         ~xpub_t ();
 
         //  Implementations of virtual functions from socket_base_t.
-        void xattach_pipe (zmq::pipe_t *pipe_, bool icanhasall_ = false);
+        void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_ = false);
         int xsend (zmq::msg_t *msg_);
         bool xhas_out ();
         int xrecv (zmq::msg_t *msg_);

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -43,10 +43,10 @@ zmq::xsub_t::~xsub_t ()
     errno_assert (rc == 0);
 }
 
-void zmq::xsub_t::xattach_pipe (pipe_t *pipe_, bool icanhasall_)
+void zmq::xsub_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // icanhasall_ is unused
-    (void) icanhasall_;
+    // subscribe_to_all_ is unused
+    (void) subscribe_to_all_;
 
     zmq_assert (pipe_);
     fq.attach (pipe_);

--- a/src/xsub.hpp
+++ b/src/xsub.hpp
@@ -44,7 +44,7 @@ namespace zmq
     protected:
 
         //  Overloads of functions from socket_base_t.
-        void xattach_pipe (zmq::pipe_t *pipe_, bool icanhasall_);
+        void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xsend (zmq::msg_t *msg_);
         bool xhas_out ();
         int xrecv (zmq::msg_t *msg_);


### PR DESCRIPTION
icanhasall is cute (for now), but the effect of the variable is clear
only after tracking down its origin reading the commit. This change is
intended to make it easier for people to have some intuition about its
effect from its name.
