### PR TITLE
Fixed ZAP authentication

### DIFF
--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -588,24 +588,28 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
 
     //  Address delimiter frame
     if (msg [0].size () > 0) {
+        rc = -1;
         errno = EPROTO;
         goto error;
     }
 
     //  Version frame
     if (msg [1].size () != 3 || memcmp (msg [1].data (), "1.0", 3)) {
+        rc = -1;
         errno = EPROTO;
         goto error;
     }
 
     //  Request id frame
     if (msg [2].size () != 1 || memcmp (msg [2].data (), "1", 1)) {
+        rc = -1;
         errno = EPROTO;
         goto error;
     }
 
     //  Status code frame
     if (msg [3].size () != 3 || memcmp (msg [3].data (), "200", 3)) {
+        rc = -1;
         errno = EACCES;
         goto error;
     }

--- a/src/plain_mechanism.cpp
+++ b/src/plain_mechanism.cpp
@@ -439,24 +439,28 @@ int zmq::plain_mechanism_t::receive_and_process_zap_reply ()
 
     //  Address delimiter frame
     if (msg [0].size () > 0) {
+        rc = -1;
         errno = EPROTO;
         goto error;
     }
 
     //  Version frame
     if (msg [1].size () != 3 || memcmp (msg [1].data (), "1.0", 3)) {
+        rc = -1;
         errno = EPROTO;
         goto error;
     }
 
     //  Request id frame
     if (msg [2].size () != 1 || memcmp (msg [2].data (), "1", 1)) {
+        rc = -1;
         errno = EPROTO;
         goto error;
     }
 
     //  Status code frame
     if (msg [3].size () != 3 || memcmp (msg [3].data (), "200", 3)) {
+        rc = -1;
         errno = EACCES;
         goto error;
     }

--- a/tests/test_security_plain.cpp
+++ b/tests/test_security_plain.cpp
@@ -114,6 +114,18 @@ int main (void)
     rc = zmq_close (client);
     assert (rc == 0);
 
+    //  Check PLAIN security with badly configured client (as_server)
+    //  This will be caught by the plain_server class, not passed to ZAP
+    client = zmq_socket (ctx, ZMQ_DEALER);
+    assert (client);
+    as_server = 1;
+    rc = zmq_setsockopt (client, ZMQ_PLAIN_SERVER, &as_server, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_connect (client, "tcp://localhost:9998");
+    assert (rc == 0);
+    expect_bounce_fail (server, client);
+    close_zero_linger (client);
+    
     //  Check PLAIN security -- failed authentication
     client = zmq_socket (ctx, ZMQ_DEALER);
     assert (client);
@@ -125,22 +137,9 @@ int main (void)
     assert (rc == 0);
     rc = zmq_connect (client, "tcp://localhost:9998");
     assert (rc == 0);
-    //  TODO: this does not fail as it should
-    //     expect_bounce_fail (server, client);
+    expect_bounce_fail (server, client);
     close_zero_linger (client);
 
-    //  Check PLAIN security with badly configured client (as_server)
-    client = zmq_socket (ctx, ZMQ_DEALER);
-    assert (client);
-    as_server = 1;
-    rc = zmq_setsockopt (client, ZMQ_PLAIN_SERVER, &as_server, sizeof (int));
-    assert (rc == 0);
-    rc = zmq_connect (client, "tcp://localhost:9998");
-    assert (rc == 0);
-    //  TODO: this does not fail as it should
-    //     expect_bounce_fail (server, client);
-    close_zero_linger (client);
-    
     //  Shutdown
     rc = zmq_close (server);
     assert (rc == 0);

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -102,21 +102,22 @@ expect_bounce_fail (void *server, void *client)
     int timeout = 150;
     rc = zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
-    rc = zmq_setsockopt (client, ZMQ_RCVTIMEO, &timeout, sizeof (int));
-    assert (rc == 0);
-    
     rc = zmq_recv (server, buffer, 32, 0);
     assert (rc == -1);
-    assert (zmq_errno() == EAGAIN);
+    assert (zmq_errno () == EAGAIN);
 
+    //  Send message from server to client to test other direction
     rc = zmq_send (server, content, 32, ZMQ_SNDMORE);
     assert (rc == 32);
     rc = zmq_send (server, content, 32, 0);
     assert (rc == 32);
 
+    //  Receive message at client side (should not succeed)
+    rc = zmq_setsockopt (client, ZMQ_RCVTIMEO, &timeout, sizeof (int));
+    assert (rc == 0);
     rc = zmq_recv (client, buffer, 32, 0);
     assert (rc == -1);
-    assert (zmq_errno() == EAGAIN);
+    assert (zmq_errno () == EAGAIN);
 }
 
 //  Receive 0MQ string from socket and convert into C string


### PR DESCRIPTION
- if ZAP server returns anything except 200, connection is closed
- all security tests now pass correctly
- test_security_curve now does proper client key authentication using test key
- test_security_plain now does proper password authentication
