### PR TITLE
simplify test_security_curve.cpp with zmq_z85_encode

### DIFF
--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -30,39 +30,6 @@ static char server_secret [] = "JTKVSB%%)wK0E.X)V>+}o?pNmC{O&4W4b!Ni{Lh6";
 //  size * 5 / 4 bytes long plus 1 byte for the null terminator. Returns
 //  dest. Size must be a multiple of 4.
 
-//  Maps base 256 to base 85
-static char encoder [85 + 1] = {
-    "0123456789" "abcdefghij" "klmnopqrst" "uvwxyzABCD"
-    "EFGHIJKLMN" "OPQRSTUVWX" "YZ.-:+=^!/" "*?&<>()[]{" 
-    "}@%$#"
-};
-
-static char *
-Z85_encode (char *dest, uint8_t *data, size_t size)
-{
-    assert (size % 4 == 0);
-    unsigned int char_nbr = 0;
-    unsigned int byte_nbr = 0;
-    uint32_t value = 0;
-    while (byte_nbr < size) {
-        //  Accumulate value in base 256 (binary)
-        value = value * 256 + data [byte_nbr++];
-        if (byte_nbr % 4 == 0) {
-            //  Output value in base 85
-            unsigned int divisor = 85 * 85 * 85 * 85;
-            while (divisor) {
-                dest [char_nbr++] = encoder [value / divisor % 85];
-                divisor /= 85;
-            }
-            value = 0;
-        }
-    }
-    assert (char_nbr == size * 5 / 4);
-    dest [char_nbr] = 0;
-    return dest;
-}
-
-
 static void zap_handler (void *ctx)
 {
     //  Create and bind ZAP socket
@@ -87,7 +54,7 @@ static void zap_handler (void *ctx)
         assert (size == 32);
 
         char client_key_text [41];
-        Z85_encode (client_key_text, client_key, 32);
+        zmq_z85_encode (client_key_text, client_key, 32);
 
         assert (streq (version, "1.0"));
         assert (streq (mechanism, "CURVE"));


### PR DESCRIPTION
Suppress Z85_encode and encoder definitions and make use of zmq_z85_encode instead of Z85_encode
