### PR TITLE
Renamed new socket options to be clearer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,8 @@ tests/test_spec_pushpull
 tests/test_spec_rep
 tests/test_spec_req
 tests/test_spec_router
-tests/test_req_request_ids
-tests/test_req_strict
+tests/test_req_correlate
+tests/test_req_relaxed
 tests/test_fork
 tests/test_conflate
 tests/test_inproc_connect

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,8 +592,8 @@ set(tests
         test_pair_inproc
         test_pair_tcp
         test_probe_router
-        test_req_request_ids
-        test_req_strict
+        test_req_correlate
+        test_req_relaxed
         test_reqrep_device
         test_reqrep_inproc
         test_reqrep_tcp

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -352,8 +352,8 @@ Default value:: 1 (true)
 Applicable socket types:: all, when using TCP transports.
 
 
-ZMQ_DELAY_ATTACH_ON_CONNECT: Retrieve attach-on-connect value
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ZMQ_IMMEDIATE: Retrieve attach-on-connect value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Retrieve the state of the attach on connect value. If set to `1`, will delay the
 attachment of a pipe on connect until the underlying connection has completed.
 This will cause the socket to block if there are no other connections, but will

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 
 Caution: All options, with the exception of ZMQ_SUBSCRIBE, ZMQ_UNSUBSCRIBE,
 ZMQ_LINGER, ZMQ_ROUTER_MANDATORY, ZMQ_PROBE_ROUTER, ZMQ_XPUB_VERBOSE,
-ZMQ_REQ_STRICT, ZMQ_REQ_REQUEST_IDS only take effect for subsequent socket
+ZMQ_REQ_CORRELATE, and ZMQ_REQ_RELAXED, only take effect for subsequent socket
 bind/connects.
 
 Specifically, security options take effect for subsequent bind/connect calls,
@@ -461,11 +461,11 @@ Default value:: 0
 Applicable socket types:: ZMQ_XPUB
 
 
-ZMQ_REQ_REQUEST_IDS: enable extra request identity frames
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ZMQ_REQ_CORRELATE: match replies with requests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The default behavior of REQ sockets is to rely on the ordering of messages
-to match requests and responses and that is usually sufficient. When this option
+The default behavior of REQ sockets is to rely on the ordering of messages to 
+match requests and responses and that is usually sufficient. When this option
 is set to 1, the REQ socket will prefix outgoing messages with an extra frame
 containing a request id. That means the full message is (request id, 0,
 user frames...). The REQ socket will discard all incoming messages that don't
@@ -478,25 +478,25 @@ Default value:: 0
 Applicable socket types:: ZMQ_REQ
 
 
-ZMQ_REQ_STRICT: enforce strict alternation between request and reply
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ZMQ_REQ_RELAXED: relax strict alternation between request and reply
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When set to 1, a REQ socket does not allow initiating a new request with
+By default, a REQ socket does not allow initiating a new request with
 _zmq_send(3)_ until the reply to the previous one has been received.
-When set to 0, sending another message is allowed and has the effect of
+When set to 1, sending another message is allowed and has the effect of
 disconnecting the underlying connection to the peer from which the reply was
 expected, triggering a reconnection attempt on transports that support it.
 The request-reply state machine is reset and a new request is sent to the
 next available peer.
 
-If set to 0, also enable ZMQ_REQ_REQUEST_IDS to ensure correct
-matching of requests and replies. Otherwise a late reply to an aborted request
-can be reported as the reply to the superseding request.
+If set to 1, also enable ZMQ_REQ_CORRELATE to ensure correct matching of
+requests and replies. Otherwise a late reply to an aborted request can be 
+reported as the reply to the superseding request.
 
 [horizontal]
 Option value type:: int
 Option value unit:: 0, 1
-Default value:: 1
+Default value:: 0
 Applicable socket types:: ZMQ_REQ
 
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -277,8 +277,8 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_CURVE_SECRETKEY 49
 #define ZMQ_CURVE_SERVERKEY 50
 #define ZMQ_PROBE_ROUTER 51
-#define ZMQ_REQ_REQUEST_IDS 52
-#define ZMQ_REQ_STRICT 53
+#define ZMQ_REQ_CORRELATE 52
+#define ZMQ_REQ_RELAXED 53
 #define ZMQ_CONFLATE 54
 #define ZMQ_ZAP_DOMAIN 55
 

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -198,16 +198,16 @@ int zmq::req_t::xsetsockopt (int option_, const void *optval_, size_t optvallen_
     bool is_int = (optvallen_ == sizeof (int));
     int value = is_int? *((int *) optval_): 0;
     switch (option_) {
-        case ZMQ_REQ_REQUEST_IDS:
+        case ZMQ_REQ_CORRELATE:
             if (is_int && value >= 0) {
                 request_id_frames_enabled = (value != 0);
                 return 0;
             }
             break;
 
-        case ZMQ_REQ_STRICT:
+        case ZMQ_REQ_RELAXED:
             if (is_int && value >= 0) {
-                strict = (value != 0);
+                strict = (value == 0);
                 return 0;
             }
             break;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,8 +34,8 @@ noinst_PROGRAMS = test_system \
                   test_spec_dealer \
                   test_spec_router \
                   test_spec_pushpull \
-                  test_req_request_ids \
-                  test_req_strict \
+                  test_req_correlate \
+                  test_req_relaxed \
                   test_conflate \
                   test_inproc_connect
 
@@ -78,8 +78,8 @@ test_spec_rep_SOURCES = test_spec_rep.cpp
 test_spec_dealer_SOURCES = test_spec_dealer.cpp
 test_spec_router_SOURCES = test_spec_router.cpp
 test_spec_pushpull_SOURCES = test_spec_pushpull.cpp
-test_req_request_ids_SOURCES = test_req_request_ids.cpp
-test_req_strict_SOURCES = test_req_strict.cpp
+test_req_correlate_SOURCES = test_req_correlate.cpp
+test_req_relaxed_SOURCES = test_req_relaxed.cpp
 test_conflate_SOURCES = test_conflate.cpp
 test_inproc_connect_SOURCES = test_inproc_connect.cpp
 if !ON_MINGW

--- a/tests/test_req_correlate.cpp
+++ b/tests/test_req_correlate.cpp
@@ -32,7 +32,7 @@ int main (void)
     assert (router);
 
     int enabled = 1;
-    int rc = zmq_setsockopt (req, ZMQ_REQ_REQUEST_IDS, &enabled, sizeof (int));
+    int rc = zmq_setsockopt (req, ZMQ_REQ_CORRELATE, &enabled, sizeof (int));
     assert (rc == 0);
 
     int rcvtimeo = 100;

--- a/tests/test_req_relaxed.cpp
+++ b/tests/test_req_relaxed.cpp
@@ -28,12 +28,11 @@ int main (void)
     void *req = zmq_socket (ctx, ZMQ_REQ);
     assert (req);
 
-    int disabled = 0;
-    int rc = zmq_setsockopt (req, ZMQ_REQ_STRICT, &disabled, sizeof (int));
+    int enabled = 1;
+    int rc = zmq_setsockopt (req, ZMQ_REQ_RELAXED, &enabled, sizeof (int));
     assert (rc == 0);
 
-    int enabled = 1;
-    rc = zmq_setsockopt (req, ZMQ_REQ_REQUEST_IDS, &enabled, sizeof (int));
+    rc = zmq_setsockopt (req, ZMQ_REQ_CORRELATE, &enabled, sizeof (int));
     assert (rc == 0);
 
     rc = zmq_bind (req, "tcp://127.0.0.1:5555");


### PR DESCRIPTION
- ZMQ_REQ_STRICT was negative option (default 1) which goes against
  the standard, where defaults are zero. I renamed this to
  ZMQ_REQ_RELAXED.
- ZMQ_REQ_REQUEST_IDS felt clumsy and describes the technical solution
  rather than the problem/requirement. I changed to ZMQ_REQ_CORRELATE
  which seems more explicit.
