### PR TITLE
Revert "Reference platform.h by ../src/platform.h - AIX is ignoring -I flags"

### DIFF
--- a/perf/inproc_lat.cpp
+++ b/perf/inproc_lat.cpp
@@ -24,8 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Just specifying platform.hpp and relying on -I flags doesn't work on AIX */
-#include "../src/platform.hpp"
+#include "platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>

--- a/perf/inproc_thr.cpp
+++ b/perf/inproc_thr.cpp
@@ -26,8 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Just specifying platform.hpp and relying on -I flags doesn't work on AIX */
-#include "../src/platform.hpp"
+#include "platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -22,8 +22,7 @@
 
 #include "../include/zmq.h"
 #include "../include/zmq_utils.h"
-/* Just specifying platform.hpp and relying on -I flags doesn't work on AIX */
-#include "../src/platform.hpp"
+#include "platform.hpp"
 
 #undef NDEBUG
 #include <time.h>


### PR DESCRIPTION
This reverts commit 015d9564ee16959847a30a0ec3b080f718f40678.

Turns out my AIX system  was sick somehow and was having issues with the filesystem I was compiling on.  I copied the source to /tmp/ and it worked just fine without this change.
