### PR TITLE
stdint.h is not available on all platforms

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -62,6 +62,9 @@ typedef __int32 int32_t;
 #   ifndef uint16_t
 typedef unsigned __int16 uint16_t;
 #   endif
+#   ifndef uint8_t
+typedef unsigned __int8 uint8_t;
+#   endif
 #else
 #   include <stdint.h>
 #endif

--- a/include/zmq_utils.h
+++ b/include/zmq_utils.h
@@ -22,7 +22,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <stdint.h>
 #include <stdlib.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes the same issue as https://github.com/zeromq/zeromq4-x/issues/5 in zeromq4-x, but for libzmq.
