### PR TITLE
This pull requests fixes building on SmartOS and possibly other Solaris-like systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,7 @@ case "${host_os}" in
         fi
         # ssp library is required for libsodium on Solaris-like systems
         LDFLAGS="-lssp $LDFLAGS"
+        CPPFLAGS="$CPPFLAGS -Wno-long-long"
         ;;
     *freebsd*)
         # Define on FreeBSD to enable all library features


### PR DESCRIPTION
After these two changes, libzmq compiles with libsodium on SmartOS, with all tests passing.
