### PR TITLE
config for libsodium in alternate path, using CPP flags for both C and C...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ AC_ARG_WITH([libsodium],
 
 if test "x$zmq_search_libsodium" = "xyes"; then
     if test -r "${with_libsodium}/include/sodium.h"; then
-        CXXFLAGS="-I${with_libsodium}/include ${CXXFLAGS}"
+        CPPFLAGS="-I${with_libsodium}/include ${CPPFLAGS}"
         LDFLAGS="-L${with_libsodium}/lib ${LDFLAGS}"
     fi
 fi
@@ -86,7 +86,7 @@ AC_ARG_WITH([libsodium-include-dir],
 
 if test "x$zmq_search_libsodium_include" = "xyes"; then
     if test -r "${with_libsodium_include_dir}/sodium.h"; then
-        CXXFLAGS="-I${with_libsodium_include_dir}/include ${CXXFLAGS}"
+        CPPFLAGS="-I${with_libsodium_include_dir}/include ${CPPFLAGS}"
     fi
 fi
 


### PR DESCRIPTION
...++ sources.

my previous attempt only did the C++ sources, the curve-keygen tool didn't build.
