### PR TITLE
It is safe to "free(NULL)" and "delete NULL"

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -74,14 +74,12 @@ zmq::ctx_t::~ctx_t ()
         delete io_threads [i];
 
     //  Deallocate the reaper thread object.
-    if (reaper)
-        delete reaper;
+    delete reaper;
 
     //  Deallocate the array of mailboxes. No special work is
     //  needed as mailboxes themselves were deallocated with their
     //  corresponding io_thread/socket objects.
-    if (slots)
-        free (slots);
+    free (slots);
 
     //  Remove the tag, so that the object is considered dead.
     tag = ZMQ_CTX_TAG_VALUE_BAD;

--- a/src/mtrie.cpp
+++ b/src/mtrie.cpp
@@ -54,8 +54,7 @@ zmq::mtrie_t::~mtrie_t ()
     else 
     if (count > 1) {
         for (unsigned short i = 0; i != count; ++i)
-            if (next.table [i])
-                delete next.table [i];
+            delete next.table [i];
         free (next.table);
     }
 }

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -96,8 +96,7 @@ zmq::session_base_t::~session_base_t ()
     if (engine)
         engine->terminate ();
 
-    if (addr)
-        delete addr;
+    delete addr;
 }
 
 void zmq::session_base_t::attach_pipe (pipe_t *pipe_)

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -114,12 +114,9 @@ zmq::stream_engine_t::~stream_engine_t ()
     int rc = tx_msg.close ();
     errno_assert (rc == 0);
 
-    if (encoder != NULL)
-        delete encoder;
-    if (decoder != NULL)
-        delete decoder;
-    if (mechanism != NULL)
-        delete mechanism;
+    delete encoder;
+    delete decoder;
+    delete mechanism;
 }
 
 void zmq::stream_engine_t::plug (io_thread_t *io_thread_,

--- a/src/trie.cpp
+++ b/src/trie.cpp
@@ -48,8 +48,7 @@ zmq::trie_t::~trie_t ()
     else
     if (count > 1) {
         for (unsigned short i = 0; i != count; ++i)
-            if (next.table [i])
-                delete next.table [i];
+            delete next.table [i];
         free (next.table);
     }
 }

--- a/src/yqueue.hpp
+++ b/src/yqueue.hpp
@@ -72,8 +72,7 @@ namespace zmq
             }
 
             chunk_t *sc = spare_chunk.xchg (NULL);
-            if (sc)
-                free (sc);
+            free (sc);
         }
 
         //  Returns reference to the front element of the queue.
@@ -156,8 +155,7 @@ namespace zmq
                 //  so for cache reasons we'll get rid of the spare and
                 //  use 'o' as the spare.
                 chunk_t *cs = spare_chunk.xchg (o);
-                if (cs)
-                    free (cs);
+                free (cs);
             }
         }
 


### PR DESCRIPTION
Hi

According to C standard (7.20.3.2/2 from ISO-IEC 9899) and C++ standard ($5.3.5/2 - C++11) it is completely safe to  call "free(NULL)" and "delete NULL" because they check argument for NULL internally (for all compilers and platforms). So we can reduce code size and improve performance a bit by removing useless checks.

More details about why is it safe on Stackoverflow:
http://stackoverflow.com/questions/6084218/is-it-good-practice-to-free-a-null-pointer-in-c
http://stackoverflow.com/questions/4190703/is-it-safe-to-delete-a-null-pointer
