### PR TITLE
Adding source for test_stream_empty

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -71,6 +71,7 @@ test_router_mandatory_SOURCES = test_router_mandatory.cpp
 test_router_raw_empty_SOURCES = test_router_raw_empty.cpp
 test_probe_router_SOURCES = test_probe_router.cpp
 test_stream_SOURCES = test_stream.cpp
+test_stream_empty_SOURCES = test_stream_empty.cpp
 test_disconnect_inproc_SOURCES = test_disconnect_inproc.cpp
 test_ctx_options_SOURCES = test_ctx_options.cpp
 test_iov_SOURCES = test_iov.cpp


### PR DESCRIPTION
Fix compilation on Mac OS X and SmartOS where source file defaults to .c not .cpp.
