### PR TITLE
Fixed LIBZMQ-556: ROUTER socket does not support reconnection from clients with multiple NICs

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -292,6 +292,7 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_REQ_RELAXED 53
 #define ZMQ_CONFLATE 54
 #define ZMQ_ZAP_DOMAIN 55
+#define ZMQ_ROUTER_REASSIGN_IDENTITES 56
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -115,6 +115,11 @@ namespace zmq
         // if true, send an empty message to every connected router peer
         bool probe_router;
 
+        // If true, the router will reassign an identity upon encountering a
+        // name collision. The new pipe will take the identity, the old pipe
+        // will be terminated.
+        bool reassign_identities;
+
         router_t (const router_t&);
         const router_t &operator = (const router_t&);
     };


### PR DESCRIPTION
My proposed fix for LIBZMQ-556, where the router will re-assign the identity when it encounters a name collision (as discussed on zeromq-dev mailing list, in the summer). 

This behaviour is optional, with a new socket option to enable it. 

If this fix looks good, I can submit test cases & documentation update.
