### PR TITLE
zmq: narrow condition to include TIPC in build/test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,36 @@ LIBZMQ_CHECK_ENABLE_DEBUG
 # Check wheter to enable code coverage
 LIBZMQ_WITH_GCOV
 
+AC_MSG_CHECKING([if TIPC is available and supports nonblocking connect])
+AC_RUN_IFELSE([AC_LANG_PROGRAM([[ #include <stdlib.h>
+                                  #include <string.h>
+                                  #include <fcntl.h>
+                                  #include <errno.h>
+                                  #include <sys/socket.h>
+                                  #include <linux/tipc.h>
+			          ]],[[
+                                      struct sockaddr_tipc topsrv;
+                                      int sd = socket(AF_TIPC, SOCK_SEQPACKET, 0);
+                                      if (sd == -EAFNOSUPPORT) {
+                                          return 1;
+                                      }
+                                      memset(&topsrv, 0, sizeof(topsrv));
+                                      topsrv.family = AF_TIPC;
+                                      topsrv.addrtype = TIPC_ADDR_NAME;
+                                      topsrv.addr.name.name.type = TIPC_TOP_SRV;
+                                      topsrv.addr.name.name.instance = TIPC_TOP_SRV;
+                                      fcntl(sd, F_SETFL, O_NONBLOCK);
+                                      if (connect(sd, (struct sockaddr *)&topsrv,
+					          sizeof(topsrv)) != 0) {
+                                          if (errno != EINPROGRESS)
+					  	return -1;
+                                      }]])
+                                  ],
+               [libzmq_tipc_support=yes],
+               [libzmq_tipc_support=no],
+               [libzmq_tipc_support=no])
+AC_MSG_RESULT([$libzmq_tipc_support])
+
 # Allow libsodium to be installed in a custom path:
 
 AC_ARG_WITH([libsodium],
@@ -141,6 +171,9 @@ case "${host_os}" in
         AC_DEFINE(ZMQ_HAVE_LINUX, 1, [Have Linux OS])
         libzmq_on_linux="yes"
 
+        if test "x$libzmq_tipc_support" = "xyes"; then
+            AC_DEFINE(ZMQ_HAVE_TIPC, 1, [Have TIPC support])
+        fi
         case "${host_os}" in
             *android*)
                 AC_DEFINE(ZMQ_HAVE_ANDROID, 1, [Have Android OS])
@@ -436,6 +469,7 @@ if test "x$libzmq_pedantic" = "xyes"; then
 fi
 AC_LANG_POP([C++])
 
+AM_CONDITIONAL(BUILD_TIPC, test "x$libzmq_tipc_support" = "xyes")
 AM_CONDITIONAL(BUILD_PGM, test "x$libzmq_pgm_ext" = "xyes")
 AM_CONDITIONAL(ON_MINGW, test "x$libzmq_on_mingw32" = "xyes")
 AM_CONDITIONAL(ON_ANDROID, test "x$libzmq_on_android" = "xyes")

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -52,7 +52,7 @@ zmq::address_t::~address_t ()
         }
     }
 #endif
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
     else if (protocol == "tipc") {
         if (resolved.tipc_addr) {
             delete resolved.tipc_addr;
@@ -75,7 +75,7 @@ int zmq::address_t::to_string (std::string &addr_) const
             return resolved.ipc_addr->to_string(addr_);
     }
 #endif
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
     else if (protocol == "tipc") {
         if (resolved.tipc_addr) {
             return resolved.tipc_addr->to_string(addr_);

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -501,7 +501,7 @@ void zmq::session_base_t::start_connecting (bool wait_)
         return;
     }
 #endif
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
     if (addr->protocol == "tipc") {
         tipc_connecter_t *connecter = new (std::nothrow) tipc_connecter_t (
             io_thread, this, options, addr, wait_);

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -210,7 +210,7 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_)
 #endif
 
     // TIPC transport is only available on Linux.
-#if !defined ZMQ_HAVE_LINUX
+#if !defined ZMQ_HAVE_TIPC
     if (protocol_ == "tipc") {
         errno = EPROTONOSUPPORT;
         return -1;
@@ -409,7 +409,7 @@ int zmq::socket_base_t::bind (const char *addr_)
         return 0;
     }
 #endif
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
     if (protocol == "tipc") {
          tipc_listener_t *listener = new (std::nothrow) tipc_listener_t (
               io_thread, this, options);
@@ -589,7 +589,7 @@ int zmq::socket_base_t::connect (const char *addr_)
             return -1;
     }
 #endif
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
     else
     if (protocol == "tipc") {
         paddr->resolved.tipc_addr = new (std::nothrow) tipc_address_t ();

--- a/src/tipc_address.cpp
+++ b/src/tipc_address.cpp
@@ -19,7 +19,7 @@
 
 #include "tipc_address.hpp"
 
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
 
 #include "err.hpp"
 

--- a/src/tipc_address.hpp
+++ b/src/tipc_address.hpp
@@ -24,7 +24,7 @@
 
 #include "platform.hpp"
 
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
 
 #include <sys/socket.h>
 #include <linux/tipc.h>

--- a/src/tipc_connecter.cpp
+++ b/src/tipc_connecter.cpp
@@ -19,7 +19,7 @@
 
 #include "tipc_connecter.hpp"
 
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
 
 #include <new>
 #include <string>

--- a/src/tipc_connecter.hpp
+++ b/src/tipc_connecter.hpp
@@ -22,7 +22,7 @@
 
 #include "platform.hpp"
 
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
 
 #include "fd.hpp"
 #include "own.hpp"

--- a/src/tipc_listener.cpp
+++ b/src/tipc_listener.cpp
@@ -19,7 +19,7 @@
 
 #include "tipc_listener.hpp"
 
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
 
 #include <new>
 

--- a/src/tipc_listener.hpp
+++ b/src/tipc_listener.hpp
@@ -22,7 +22,7 @@
 
 #include "platform.hpp"
 
-#if defined ZMQ_HAVE_LINUX
+#if defined ZMQ_HAVE_TIPC
 
 #include <string>
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -51,7 +51,7 @@ noinst_PROGRAMS += test_shutdown_stress \
                    test_fork
 endif
 
-if ON_LINUX
+if BUILD_TIPC
 noinst_PROGRAMS += test_connect_delay_tipc \
                   test_pair_tipc \
                   test_reqrep_device_tipc \
@@ -108,7 +108,7 @@ test_reqrep_ipc_SOURCES = test_reqrep_ipc.cpp testutil.hpp
 test_timeo_SOURCES = test_timeo.cpp
 test_fork_SOURCES = test_fork.cpp
 endif
-if ON_LINUX
+if BUILD_TIPC
 test_connect_delay_tipc_SOURCES = test_connect_delay_tipc.cpp
 test_pair_tipc_SOURCES = test_pair_tipc.cpp
 test_reqrep_device_tipc_SOURCES = test_reqrep_device_tipc.cpp


### PR DESCRIPTION
As TIPC transport for 0MQ will only work on post 3.8
Linux kernels where nonblocking connect was added,
we add AC_RUN test to check for this functionality.
Should the test fail, tipc is excluded from build/test.

The test tries to establish a connection to the TIPC
topology server (that's started immediately when the
module is installed). The test fails if we fail to create
an AF_TIPC socket (module not installed), or if the
nonblocking connection returns an error other than
the expected -EINPROGRESS.
