### PR TITLE
Doc examples with zmq_msg_close usage - parameter is 'zmq_msg_t *'

### DIFF
--- a/doc/zmq_msg_get.txt
+++ b/doc/zmq_msg_get.txt
@@ -40,6 +40,7 @@ EXAMPLE
 -------
 .Receiving a multi-frame message
 ----
+zmq_msg_t frame;
 while (true) {
     //  Create an empty 0MQ message to hold the message frame
     int rc = zmq_msg_init (&frame);
@@ -53,7 +54,7 @@ while (true) {
         fprintf (stderr, "end\n");
         break;
     }
-    zmq_msg_close (frame);
+    zmq_msg_close (&frame);
 }
 ----
 

--- a/doc/zmq_msg_more.txt
+++ b/doc/zmq_msg_more.txt
@@ -45,7 +45,7 @@ while (true) {
         fprintf (stderr, "end\n");
         break;
     }
-    zmq_msg_close (part);
+    zmq_msg_close (&part);
 }
 ----
 


### PR DESCRIPTION
Documentation examples for zmq_msg_get and zmq_msg_more functions have an incorrect call to zmq_msg_close function - with 'zmq_msg_t' as a parameter despite 'zmq_msg_t *' is required, so it is impossible to compile these examples properly.

Also for zmq_msg_get example - declaration of zmq_msg_t variable is added (like it is done in other examples).
