### PR TITLE
zmq: change TIPC default lookup domain when connecting

### DIFF
--- a/src/tipc_address.cpp
+++ b/src/tipc_address.cpp
@@ -60,6 +60,10 @@ int zmq::tipc_address_t::resolve (const char *name)
         address.addrtype = TIPC_ADDR_NAME;
         address.addr.name.name.type = type;
         address.addr.name.name.instance = lower;
+        /* Since we can't specify lookup domain when connecting
+         * (and we're not sure that we want it to be configurable)
+         * Change from 'closest first' approach, to search entire zone */
+        address.addr.name.domain = tipc_addr(1, 0, 0);
         address.scope = 0;
         return 0;
     }


### PR DESCRIPTION
By default, TIPC uses a closest first approach to find
a publication that can satisfy your connection request.
Any publication on the local node will automatically
be chosen for all requests, even if you're trying to
spread it out over multiple machines.
We fix this by widening the default lookup scope.

Signed-off-by: Erik Hugne erik.hugne@ericsson.com
