### PR TITLE
changing zmq_proxy_steerable to not use null terminated strings

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -114,13 +114,13 @@ int zmq::proxy (
                 if (unlikely (rc < 0))
                     return -1;
             }
-            if (msg.size () == 6 && memcmp (msg.data (), "PAUSE", 6) == 0)
+            if (msg.size () == 5 && memcmp (msg.data (), "PAUSE", 5) == 0)
                 state = paused;
             else
-            if (msg.size () == 7 && memcmp (msg.data (), "RESUME", 7) == 0)
+            if (msg.size () == 6 && memcmp (msg.data (), "RESUME", 6) == 0)
                 state = active;
             else
-            if (msg.size () == 10 && memcmp (msg.data (), "TERMINATE", 10) == 0)
+            if (msg.size () == 9 && memcmp (msg.data (), "TERMINATE", 9) == 0)
                 state = terminated;
             else {
                 //  This is an API error, we should assert

--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -87,7 +87,7 @@ client_task (void *ctx)
             if (items [1].revents & ZMQ_POLLIN) {
                 rc = zmq_recv (control, content, CONTENT_SIZE_MAX, 0);
                 if (is_verbose) printf("client receive - identity = %s    command = %s\n", identity, content);
-                if (memcmp (content, "TERMINATE", 10) == 0) {
+                if (memcmp (content, "TERMINATE", 9) == 0) {
                     run = false;
                     break;
                 }
@@ -184,7 +184,7 @@ server_worker (void *ctx)
         if (rc > 0) {
             if (is_verbose)
                 printf("server_worker receives command = %s\n", content);
-            if (memcmp (content, "TERMINATE", 10) == 0)
+            if (memcmp (content, "TERMINATE", 9) == 0)
                 run = false;
         }
         // The DEALER socket gives us the reply envelope and message
@@ -236,8 +236,8 @@ int main (void)
     threads[QT_CLIENTS] = zmq_threadstart  (&server_task, ctx);
     msleep (500); // Run for 500 ms then quit
 
-    rc = zmq_send (control, "TERMINATE", 10, 0);
-    assert (rc == 10);
+    rc = zmq_send (control, "TERMINATE", 9, 0);
+    assert (rc == 9);
 
     rc = zmq_close (control);
     assert (rc == 0);


### PR DESCRIPTION
zmq_proxy_steerable was using null terminated strings for the proxy commands - making it not compatible with zstr_send in czmq.  changed to bring in line with general guidelines for sending strings over zeromq.
