### PR TITLE
New NOP mechanism that allow proxying CURVE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ set(cxx-sources
         mechanism.cpp
         msg.cpp
         mtrie.cpp
+	nop_mechanism.cpp
         object.cpp
         options.cpp
         own.cpp
@@ -604,6 +605,7 @@ set(tests
         test_ctx_options
         test_ctx_destroy
         test_security_null
+	test_security_nop
         test_security_plain
         test_security_curve
         test_iov
@@ -612,6 +614,7 @@ set(tests
         test_spec_dealer
         test_spec_router
         test_spec_pushpull
+	test_surrogate_curve
         test_req_correlate
         test_req_relaxed
         test_conflate

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -290,6 +290,10 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_ZAP_DOMAIN 55
 #define ZMQ_ROUTER_HANDOVER 56
 #define ZMQ_TOS 57
+// 58 to 63 are reserved for PARANO
+#define ZMQ_SURROGATION_MECHANISM 64
+#define ZMQ_USE_SURROGATION_MECHANISM 65
+#define ZMQ_NOP_NODE 66
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
@@ -302,6 +306,8 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_NULL 0
 #define ZMQ_PLAIN 1
 #define ZMQ_CURVE 2
+// 3 is reserved for ZMQ_PARANO
+#define ZMQ_NOP 4
 
 /*  Deprecated options and aliases                                            */
 #define ZMQ_IPV4ONLY                31

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,6 +45,7 @@ libzmq_la_SOURCES = \
     msg.hpp \
     mtrie.hpp \
     mutex.hpp \
+    nop_mechanism.hpp \
     null_mechanism.hpp \
     object.hpp \
     options.hpp \
@@ -112,6 +113,7 @@ libzmq_la_SOURCES = \
     mechanism.cpp \
     msg.cpp \
     mtrie.cpp \
+    nop_mechanism.cpp \
     null_mechanism.cpp \
     object.cpp \
     options.cpp \

--- a/src/nop_mechanism.cpp
+++ b/src/nop_mechanism.cpp
@@ -1,0 +1,94 @@
+/*
+    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "platform.hpp"
+#ifdef ZMQ_HAVE_WINDOWS
+#include "windows.hpp"
+#endif
+
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "err.hpp"
+#include "msg.hpp"
+#include "session_base.hpp"
+#include "wire.hpp"
+#include "nop_mechanism.hpp"
+
+zmq::nop_mechanism_t::nop_mechanism_t (session_base_t *session_,
+                                         const std::string &peer_address_,
+                                         const options_t &options_) :
+    mechanism_t (options_),
+    session (session_),
+    peer_address (peer_address_),
+    ready_command_sent (false),
+    ready_command_received (false),
+    zap_connected (false),
+    zap_request_sent (false),
+    zap_reply_received (false)
+{
+}
+
+zmq::nop_mechanism_t::~nop_mechanism_t ()
+{
+}
+
+int zmq::nop_mechanism_t::next_handshake_command (msg_t *msg_)
+{
+    if (ready_command_sent) {
+        errno = EAGAIN;
+        return -1;
+    }
+
+    ready_command_sent = true;
+
+    return 0;
+}
+
+int zmq::nop_mechanism_t::process_handshake_command (msg_t *msg_)
+{
+    if (ready_command_received) {
+        errno = EPROTO;
+        return -1;
+    }
+
+    ready_command_received = true;
+
+    return 0;
+}
+
+int zmq::nop_mechanism_t::zap_msg_available ()
+{
+    return 0;
+}
+
+bool zmq::nop_mechanism_t::is_handshake_complete () const
+{
+    return ready_command_received && ready_command_sent;
+}
+
+void zmq::nop_mechanism_t::send_zap_request ()
+{
+}
+
+int zmq::nop_mechanism_t::receive_and_process_zap_reply ()
+{
+	return 0;
+}

--- a/src/nop_mechanism.hpp
+++ b/src/nop_mechanism.hpp
@@ -1,0 +1,65 @@
+/*
+    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __ZMQ_NOP_MECHANISM_HPP_INCLUDED__
+#define __ZMQ_NOP_MECHANISM_HPP_INCLUDED__
+
+#include "mechanism.hpp"
+#include "options.hpp"
+
+namespace zmq
+{
+
+    class msg_t;
+    class session_base_t;
+
+    class nop_mechanism_t : public mechanism_t
+    {
+    public:
+
+        nop_mechanism_t (session_base_t *session_,
+                          const std::string &peer_address,
+                          const options_t &options_);
+        virtual ~nop_mechanism_t ();
+
+        // mechanism implementation
+        virtual int next_handshake_command (msg_t *msg_);
+        virtual int process_handshake_command (msg_t *msg_);
+        virtual int zap_msg_available ();
+        virtual bool is_handshake_complete () const;
+
+    private:
+
+        session_base_t * const session;
+
+        const std::string peer_address;
+
+        bool ready_command_sent;
+        bool ready_command_received;
+        bool zap_connected;
+        bool zap_request_sent;
+        bool zap_reply_received;
+
+        void send_zap_request ();
+        int receive_and_process_zap_reply ();
+    };
+
+}
+
+#endif

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -52,6 +52,8 @@ zmq::options_t::options_t () :
     tcp_keepalive_idle (-1),
     tcp_keepalive_intvl (-1),
     mechanism (ZMQ_NULL),
+    surrogation_mechanism (ZMQ_NULL),
+    use_surrogation_mechanism (false),
     as_server (0),
     socket_id (0),
     conflate (false)
@@ -254,6 +256,31 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                     tcp_accept_filters.push_back (mask);
                     return 0;
                 }
+            }
+            break;
+
+        case ZMQ_SURROGATION_MECHANISM:
+            if (is_int) {
+            	surrogation_mechanism = value;
+                return 0;
+            }
+            break;
+
+        case ZMQ_USE_SURROGATION_MECHANISM:
+            if (optvallen_ == sizeof (bool)) {
+            	use_surrogation_mechanism = *((bool *) optval_);
+                return 0;
+            }
+            break;
+
+        case ZMQ_NOP_NODE:
+//			mechanism = ZMQ_NOP;
+//			return 0;
+//            break;
+            if (is_int && (value == 0 || value == 1)) {
+                as_server = value;
+                mechanism = ZMQ_NOP;
+                return 0;
             }
             break;
 
@@ -554,6 +581,27 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_)
         case ZMQ_MECHANISM:
             if (is_int) {
                 *value = mechanism;
+                return 0;
+            }
+            break;
+
+        case ZMQ_SURROGATION_MECHANISM:
+            if (is_int) {
+                *value = surrogation_mechanism;
+                return 0;
+            }
+            break;
+
+        case ZMQ_USE_SURROGATION_MECHANISM:
+            if (*optvallen_ == sizeof (bool)) {
+                *((bool *) optval_) = use_surrogation_mechanism;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NOP_NODE:
+            if (is_int) {
+                *value = mechanism == ZMQ_NOP;
                 return 0;
             }
             break;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -122,6 +122,8 @@ namespace zmq
 
         //  Security mechanism for all connections on this socket
         int mechanism;
+        int surrogation_mechanism; // the mechanism sent in the greeting may be different (i.e. to NULL-proxy CURVE-peers)
+        bool use_surrogation_mechanism; // default is false to conform to ZMTP 3.0
 
         //  If peer is acting as server for PLAIN or CURVE mechanisms
         int as_server;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,8 +27,10 @@ noinst_PROGRAMS = test_system \
                   test_ctx_options \
                   test_ctx_destroy \
                   test_security_null \
+                  test_security_nop \
                   test_security_plain \
                   test_security_curve \
+                  test_surrogate_curve \
                   test_iov \
                   test_spec_req \
                   test_spec_rep \
@@ -89,8 +91,10 @@ test_ctx_options_SOURCES = test_ctx_options.cpp
 test_iov_SOURCES = test_iov.cpp
 test_ctx_destroy_SOURCES = test_ctx_destroy.cpp
 test_security_null_SOURCES = test_security_null.cpp
+test_security_nop_SOURCES = test_security_nop.cpp
 test_security_plain_SOURCES = test_security_plain.cpp
 test_security_curve_SOURCES = test_security_curve.cpp
+test_surrogate_curve_SOURCES = test_surrogate_curve.cpp
 test_spec_req_SOURCES = test_spec_req.cpp
 test_spec_rep_SOURCES = test_spec_rep.cpp
 test_spec_dealer_SOURCES = test_spec_dealer.cpp

--- a/tests/test_security_nop.cpp
+++ b/tests/test_security_nop.cpp
@@ -1,0 +1,58 @@
+/*
+    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+
+int main (void)
+{
+    setup_test_environment();
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    //  We bounce between a binding server and a connecting client
+    void *server = zmq_socket (ctx, ZMQ_DEALER);
+    assert (server);
+    int is_server = 1;
+    int rc = zmq_setsockopt (server, ZMQ_NOP_NODE, &is_server, sizeof (int));
+    assert (rc == 0);
+    void *client = zmq_socket (ctx, ZMQ_DEALER);
+    assert (client);
+    is_server = 0;
+    rc = zmq_setsockopt (client, ZMQ_NOP_NODE, &is_server, sizeof (int));
+    assert (rc == 0);
+    
+    //  We first test client/server with no ZAP domain
+    //  Libzmq does not call our ZAP handler, the connect must succeed
+    rc = zmq_bind (server, "tcp://127.0.0.1:9998");
+    assert (rc == 0);
+    rc = zmq_connect (client, "tcp://127.0.0.1:9998");
+    assert (rc == 0);
+    bounce (server, client);
+    zmq_unbind (server, "tcp://127.0.0.1:9998");
+    zmq_disconnect (client, "tcp://127.0.0.1:9998");
+    
+    
+    //  Shutdown
+    close_zero_linger (client);
+    close_zero_linger (server);
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+
+    return 0;
+}

--- a/tests/test_surrogate_curve.cpp
+++ b/tests/test_surrogate_curve.cpp
@@ -1,0 +1,203 @@
+/*
+    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+
+//  We'll generate random test keys at startup
+static char client_public [41];
+static char client_secret [41];
+static char server_public [41];
+static char server_secret [41];
+
+//  --------------------------------------------------------------------------
+//  Encode a binary frame as a string; destination string MUST be at least
+//  size * 5 / 4 bytes long plus 1 byte for the null terminator. Returns
+//  dest. Size must be a multiple of 4.
+
+static void zap_handler (void *handler)
+{
+    //  Process ZAP requests forever
+    while (true) {
+        char *version = s_recv (handler);
+        if (!version)
+            break;          //  Terminating
+
+        char *sequence = s_recv (handler);
+        char *domain = s_recv (handler);
+        char *address = s_recv (handler);
+        char *identity = s_recv (handler);
+        char *mechanism = s_recv (handler);
+        uint8_t client_key [32];
+        int size = zmq_recv (handler, client_key, 32, 0);
+        assert (size == 32);
+
+        char client_key_text [41];
+        zmq_z85_encode (client_key_text, client_key, 32);
+
+        assert (streq (version, "1.0"));
+        assert (streq (mechanism, "CURVE"));
+        assert (streq (identity, "IDENT"));
+
+        s_sendmore (handler, version);
+        s_sendmore (handler, sequence);
+
+        if (streq (client_key_text, client_public)) {
+            s_sendmore (handler, "200");
+            s_sendmore (handler, "OK");
+            s_sendmore (handler, "anonymous");
+            s_send     (handler, "");
+        }
+        else {
+            s_sendmore (handler, "400");
+            s_sendmore (handler, "Invalid client public key");
+            s_sendmore (handler, "");
+            s_send     (handler, "");
+        }
+        free (version);
+        free (sequence);
+        free (domain);
+        free (address);
+        free (identity);
+        free (mechanism);
+    }
+    zmq_close (handler);
+}
+
+void
+nop_proxy (void *ctx)
+{
+    // Frontend socket talks to clients over TCP
+    void *frontend = zmq_socket (ctx, ZMQ_ROUTER);
+    assert (frontend);
+    int as_server = 1;
+    int rc = zmq_setsockopt (frontend, ZMQ_NOP_NODE, &as_server, sizeof (int));
+    assert (rc == 0);
+    bool surrogate_curve = true;
+	rc = zmq_setsockopt (frontend, ZMQ_USE_SURROGATION_MECHANISM, &surrogate_curve, sizeof (bool));
+	assert (rc == 0);
+	int surrogation_mechanism = ZMQ_NULL;
+	rc = zmq_setsockopt (frontend, ZMQ_SURROGATION_MECHANISM, &surrogation_mechanism, sizeof (int));
+	assert (rc == 0);
+    rc = zmq_bind (frontend, "tcp://127.0.0.1:9999");
+    assert (rc == 0);
+
+    // Backend socket talks to workers over inproc
+    void *backend = zmq_socket (ctx, ZMQ_DEALER);
+    assert (backend);
+    rc = zmq_setsockopt (backend, ZMQ_NOP_NODE, &as_server, sizeof (int));
+    assert (rc == 0);
+	rc = zmq_setsockopt (backend, ZMQ_USE_SURROGATION_MECHANISM, &surrogate_curve, sizeof (bool));
+	assert (rc == 0);
+	rc = zmq_setsockopt (backend, ZMQ_SURROGATION_MECHANISM, &surrogation_mechanism, sizeof (int));
+	assert (rc == 0);
+    rc = zmq_bind (backend, "tcp://127.0.0.1:9998");
+    assert (rc == 0);
+
+    // Connect backend to frontend via a proxy
+    zmq_proxy (frontend, backend, NULL);
+
+    rc = zmq_close (frontend);
+    assert (rc == 0);
+    rc = zmq_close (backend);
+    assert (rc == 0);
+}
+
+int main (void)
+{
+#ifndef HAVE_LIBSODIUM
+    printf ("libsodium not installed, skipping CURVE test\n");
+    return 0;
+#endif
+
+    //  Generate new keypairs for this test
+    int rc = zmq_curve_keypair (client_public, client_secret);
+    assert (rc == 0);
+    rc = zmq_curve_keypair (server_public, server_secret);
+    assert (rc == 0);
+
+    setup_test_environment ();
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    //  Spawn ZAP handler
+    //  We create and bind ZAP socket in main thread to avoid case
+    //  where child thread does not start up fast enough.
+    void *handler = zmq_socket (ctx, ZMQ_REP);
+    assert (handler);
+    rc = zmq_bind (handler, "inproc://zeromq.zap.01");
+    assert (rc == 0);
+    void *zap_thread = zmq_threadstart (&zap_handler, handler);
+
+    //  Server socket will accept connections
+    void *server = zmq_socket (ctx, ZMQ_DEALER);
+    assert (server);
+    int as_server = 1;
+    rc = zmq_setsockopt (server, ZMQ_CURVE_SERVER, &as_server, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_setsockopt (server, ZMQ_CURVE_SECRETKEY, server_secret, 40);
+    assert (rc == 0);
+    bool surrogate_curve = true;
+    rc = zmq_setsockopt (server, ZMQ_USE_SURROGATION_MECHANISM, &surrogate_curve, sizeof (bool));
+    assert (rc == 0);
+    int surrogation_mechanism = ZMQ_NULL;
+    rc = zmq_setsockopt (server, ZMQ_SURROGATION_MECHANISM, &surrogation_mechanism, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_setsockopt (server, ZMQ_IDENTITY, "IDENT", 6);
+    assert (rc == 0);
+    rc = zmq_connect (server, "tcp://127.0.0.1:9998");
+    assert (rc == 0);
+
+    //  Check CURVE security with valid credentials
+    void *client = zmq_socket (ctx, ZMQ_DEALER);
+    assert (client);
+    rc = zmq_setsockopt (client, ZMQ_CURVE_SERVERKEY, server_public, 40);
+    assert (rc == 0);
+    rc = zmq_setsockopt (client, ZMQ_CURVE_PUBLICKEY, client_public, 40);
+    assert (rc == 0);
+    rc = zmq_setsockopt (client, ZMQ_CURVE_SECRETKEY, client_secret, 40);
+    assert (rc == 0);
+    rc = zmq_setsockopt (client, ZMQ_USE_SURROGATION_MECHANISM, &surrogate_curve, sizeof (bool));
+    assert (rc == 0);
+    rc = zmq_setsockopt (client, ZMQ_SURROGATION_MECHANISM, &surrogation_mechanism, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_connect (client, "tcp://127.0.0.1:9999");
+    assert (rc == 0);
+
+    // Launch the NULL proxy in a thread, to connect backend to frontend - as we have one single worker (server here), we don't have to mind the one-to-one client/worker relationship required by CURVE
+    void* proxy_thread = zmq_threadstart (&nop_proxy, ctx);
+
+    // Perform some exchanges
+    bounce (server, client);
+
+
+    //  Shutdown
+    rc = zmq_close (client);
+    assert (rc == 0);
+    rc = zmq_close (server);
+    assert (rc == 0);
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+
+    //  Wait until ZAP handler terminates
+    zmq_threadclose (zap_thread);
+    // Wait until the proxy terminates
+    zmq_threadclose (proxy_thread);
+
+    return 0;
+}


### PR DESCRIPTION
Here is what it permits to do:

Client (DEALER, CURVE) --------- (NOP, ROUTER) Proxy (ROUTER, NOP) ------------ (CURVE, DEALER) Worker
Surrogate_______NULL________NULL________________________NULL_________NULL
___________________________<---------------------------------------------- Server ----------------------------------------------------->

The rational is to be able to proxy heavy security mechanisms. Actually, I am preparing PARANO. Here, tests are performed with CURVE. With surrogation, the apparent mechanism can be anything. I could try successfuly with PLAIN while the client and the worker use CURVE. By "apparent", I mean only the greetings.

I have still to update the doc, what I will do soon.
I think I can simplify a little the code: in option.cpp, NOP does not need the is_server value.
