### PR TITLE
use enum retired_fd instead of -1

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -121,7 +121,7 @@ zmq::socket_base_t *zmq::socket_base_t::create (int type_, class ctx_t *parent_,
             errno = EINVAL;
             return NULL;
     }
-    if (s->mailbox.get_fd () == -1)
+    if (s->mailbox.get_fd () == retired_fd)
         return NULL;
 
     alloc_assert (s);


### PR DESCRIPTION
using -1 causes a warning on Windows platform because SOCKET is unsigned.

In particular, compilation with MinGW will fail because of -Werror
