### PR TITLE
add failing test for binding to resources

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,6 +18,7 @@ noinst_PROGRAMS = test_system \
                   test_last_endpoint \
                   test_term_endpoint \
                   test_monitor \
+                  test_resource \
                   test_router_mandatory \
                   test_router_handover \
                   test_probe_router \
@@ -81,6 +82,7 @@ test_immediate_SOURCES = test_immediate.cpp
 test_last_endpoint_SOURCES = test_last_endpoint.cpp
 test_term_endpoint_SOURCES = test_term_endpoint.cpp
 test_monitor_SOURCES = test_monitor.cpp
+test_resource_SOURCES = test_resource.cpp
 test_router_mandatory_SOURCES = test_router_mandatory.cpp
 test_router_handover_SOURCES = test_router_handover.cpp
 test_probe_router_SOURCES = test_probe_router.cpp
@@ -129,7 +131,7 @@ endif
 
 #  Run the test cases
 TESTS = $(noinst_PROGRAMS)
-XFAIL_TESTS =
+XFAIL_TESTS = test_resource
 
 if !ON_LINUX
 XFAIL_TESTS += test_abstract_ipc

--- a/tests/test_resource.cpp
+++ b/tests/test_resource.cpp
@@ -1,0 +1,56 @@
+/*
+    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+
+int main (int argc, char *argv [])
+{
+    const char *bind_1 = "tcp://127.0.0.1:5555/resource/1";
+    const char *bind_2 = "tcp://127.0.0.1:5555/resource/2";
+
+    int rc;
+
+    void* ctx = zmq_init (1);
+    assert (ctx);
+
+    void* p1 = zmq_socket (ctx, ZMQ_PUSH);
+    assert (p1);
+
+    rc = zmq_bind(p1, bind_1);
+    assert (rc == 0);
+
+    void* p2 = zmq_socket (ctx, ZMQ_PUSH);
+    assert (p2);
+    
+    // should be able to bind a second socket to the same ip/port
+    // but with different resource
+    rc = zmq_bind(p2, bind_2);
+    assert (rc == 0);
+
+    rc = zmq_close (p1);
+    assert (rc == 0);
+
+    rc = zmq_close (p2);
+    assert (rc == 0);
+
+    rc = zmq_term (ctx);
+    assert (rc == 0);
+
+    return 0;
+}


### PR DESCRIPTION
As I understand ZMTP/3.0, one should be able to bind multiple sockets to the same interface, as long as they don't share a resource.

But the code does not reflect this.
