### PR TITLE
Fixed setting TCP keepalive parameters on Windows

### DIFF
--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -94,44 +94,37 @@ void zmq::tune_tcp_keepalives (fd_t s_, int keepalive_, int keepalive_cnt_, int 
 
     //  Tuning TCP keep-alives if platform allows it
     //  All values = -1 means skip and leave it for OS
+#ifdef ZMQ_HAVE_WINDOWS
+	tcp_keepalive keepalive_opts;
+	keepalive_opts.onoff = keepalive_;
+	keepalive_opts.keepalivetime = keepalive_idle_ != -1 ? keepalive_idle_ * 1000 : 7200000;
+	keepalive_opts.keepaliveinterval = keepalive_intvl_ != -1 ? keepalive_intvl_ * 1000 : 1000;
+	DWORD num_bytes_returned;
+	int rc = WSAIoctl(s_, SIO_KEEPALIVE_VALS, &keepalive_opts, sizeof(keepalive_opts), NULL, 0, &num_bytes_returned, NULL, NULL);
+	wsa_assert (rc != SOCKET_ERROR);
+#else
 #ifdef ZMQ_HAVE_SO_KEEPALIVE
     if (keepalive_ != -1) {
         int rc = setsockopt (s_, SOL_SOCKET, SO_KEEPALIVE, (char*) &keepalive_, sizeof (int));
-#ifdef ZMQ_HAVE_WINDOWS
-        wsa_assert (rc != SOCKET_ERROR);
-#else
         errno_assert (rc == 0);
-#endif
 
 #ifdef ZMQ_HAVE_TCP_KEEPCNT
         if (keepalive_cnt_ != -1) {
             int rc = setsockopt (s_, IPPROTO_TCP, TCP_KEEPCNT, &keepalive_cnt_, sizeof (int));
-#ifdef ZMQ_HAVE_WINDOWS
-            wsa_assert (rc != SOCKET_ERROR);
-#else
             errno_assert (rc == 0);
-#endif
         }
 #endif // ZMQ_HAVE_TCP_KEEPCNT
 
 #ifdef ZMQ_HAVE_TCP_KEEPIDLE
         if (keepalive_idle_ != -1) {
             int rc = setsockopt (s_, IPPROTO_TCP, TCP_KEEPIDLE, &keepalive_idle_, sizeof (int));
-#ifdef ZMQ_HAVE_WINDOWS
-            wsa_assert (rc != SOCKET_ERROR);
-#else
             errno_assert (rc == 0);
-#endif
         }
 #else // ZMQ_HAVE_TCP_KEEPIDLE
 #ifdef ZMQ_HAVE_TCP_KEEPALIVE
         if (keepalive_idle_ != -1) {
             int rc = setsockopt (s_, IPPROTO_TCP, TCP_KEEPALIVE, &keepalive_idle_, sizeof (int));
-#ifdef ZMQ_HAVE_WINDOWS
-            wsa_assert (rc != SOCKET_ERROR);
-#else
             errno_assert (rc == 0);
-#endif
         }
 #endif // ZMQ_HAVE_TCP_KEEPALIVE
 #endif // ZMQ_HAVE_TCP_KEEPIDLE
@@ -139,13 +132,10 @@ void zmq::tune_tcp_keepalives (fd_t s_, int keepalive_, int keepalive_cnt_, int 
 #ifdef ZMQ_HAVE_TCP_KEEPINTVL
         if (keepalive_intvl_ != -1) {
             int rc = setsockopt (s_, IPPROTO_TCP, TCP_KEEPINTVL, &keepalive_intvl_, sizeof (int));
-#ifdef ZMQ_HAVE_WINDOWS
-            wsa_assert (rc != SOCKET_ERROR);
-#else
             errno_assert (rc == 0);
-#endif
         }
 #endif // ZMQ_HAVE_TCP_KEEPINTVL
     }
 #endif // ZMQ_HAVE_SO_KEEPALIVE
+#endif // ZMQ_HAVE_WINDOWS
 }

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -165,6 +165,7 @@
  
 #include <winsock2.h>
 #include <mswsock.h>
+#include <Mstcpip.h>
 
 #include <ws2tcpip.h>
 #include <ipexport.h>


### PR DESCRIPTION
I've never done any C/C++ coding on Windows but this seemed easy enough.
I have tested this and verified with Wireshark that it works as intended.
