### PR TITLE
Fix LIBZMQ-576 - Revert "Merge pull request #510 from miniway/master"

### DIFF
--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -127,11 +127,6 @@ namespace zmq
             (static_cast <T*> (this)->*next) ();
         }
 
-        inline bool has_data ()
-        {
-            return to_write > 0;
-        }
-
     protected:
 
         //  Prototype of state machine action.

--- a/src/i_encoder.hpp
+++ b/src/i_encoder.hpp
@@ -43,7 +43,6 @@ namespace zmq
         //  Load a new message into encoder.
         virtual void load_msg (msg_t *msg_) = 0;
 
-        virtual bool has_data () = 0;
     };
 
 }

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -69,7 +69,6 @@ zmq::stream_engine_t::stream_engine_t (fd_t fd_, const options_t &options_,
     options (options_),
     endpoint (endpoint_),
     plugged (false),
-    terminating (false),
     read_msg (&stream_engine_t::read_identity),
     write_msg (&stream_engine_t::write_identity),
     io_error (false),
@@ -212,11 +211,6 @@ void zmq::stream_engine_t::unplug ()
 
 void zmq::stream_engine_t::terminate ()
 {
-    if (!terminating && encoder && encoder->has_data ()) {
-        //  Give io_thread a chance to send in the buffer
-        terminating = true;
-        return;
-    }
     unplug ();
     delete this;
 }
@@ -343,8 +337,6 @@ void zmq::stream_engine_t::out_event ()
     //  this is necessary to prevent losing incoming messages.
     if (nbytes == -1) {
         reset_pollout (handle);
-        if (unlikely (terminating))
-            terminate ();
         return;
     }
 
@@ -356,10 +348,6 @@ void zmq::stream_engine_t::out_event ()
     if (unlikely (handshaking))
         if (outsize == 0)
             reset_pollout (handle);
-
-    if (unlikely (terminating))
-        if (outsize == 0)
-            terminate ();
 }
 
 void zmq::stream_engine_t::restart_output ()

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -162,7 +162,6 @@ namespace zmq
         std::string endpoint;
 
         bool plugged;
-        bool terminating;
 
         int (stream_engine_t::*read_msg) (msg_t *msg_);
 


### PR DESCRIPTION
This reverts commit f27eb67e1abb0484c41050e454404cce30647b63, reversing
changes made to a3ae0d4c16c892a4e6c96d626a7c8b7068450336.

https://zeromq.jira.com/browse/LIBZMQ-576

Conflicts:
    src/stream_engine.cpp

Conflicts were around additional defaults to the constructor after the
'terminating' default.  The additional defaults were left alone, and
the 'terminating' default was removed.
