### PR TITLE
Update test_filter_ipc to not use abstract socket.

### DIFF
--- a/tests/test_abstract_ipc.cpp
+++ b/tests/test_abstract_ipc.cpp
@@ -25,7 +25,7 @@ int main (void)
     void *ctx = zmq_ctx_new ();
     assert (ctx);
 
-    void *sb = zmq_socket (ctx, ZMQ_PAIR);
+    void *sb = zmq_socket (ctx, ZMQ_DEALER);
     assert (sb);
     int rc = zmq_bind (sb, "ipc://@/tmp/tester");
     assert (rc == 0);
@@ -37,7 +37,7 @@ int main (void)
     rc = strncmp(endpoint, "ipc://@/tmp/tester", size);
     assert (rc == 0);
 
-    void *sc = zmq_socket (ctx, ZMQ_PAIR);
+    void *sc = zmq_socket (ctx, ZMQ_DEALER);
     assert (sc);
     rc = zmq_connect (sc, "ipc://@/tmp/tester");
     assert (rc == 0);

--- a/tests/test_filter_ipc.cpp
+++ b/tests/test_filter_ipc.cpp
@@ -60,7 +60,7 @@ static void run_test (int opt, T optval, int expected_error, int bounce_test)
     void *ctx = zmq_ctx_new ();
     assert (ctx);
 
-    void *sb = zmq_socket (ctx, ZMQ_PAIR);
+    void *sb = zmq_socket (ctx, ZMQ_DEALER);
     assert (sb);
 
     if (opt) {
@@ -73,7 +73,7 @@ static void run_test (int opt, T optval, int expected_error, int bounce_test)
         }
     }
 
-    void *sc = zmq_socket (ctx, ZMQ_PAIR);
+    void *sc = zmq_socket (ctx, ZMQ_DEALER);
     assert (sc);
 
     // If a test fails, don't hang for too long
@@ -91,10 +91,11 @@ static void run_test (int opt, T optval, int expected_error, int bounce_test)
     assert (rc == 0);
 
     if (bounce_test) {
-        int rc = zmq_bind (sb, "ipc://@/tmp/test");
+        const char* endpoint = "ipc://test_filter_ipc.sock";
+        int rc = zmq_bind (sb, endpoint);
         assert (rc == 0);
 
-        rc = zmq_connect (sc, "ipc://@/tmp/test");
+        rc = zmq_connect (sc, endpoint);
         assert (rc == 0);
         
         if (bounce_test > 0)


### PR DESCRIPTION
This fixes the test on Mac OS X and SmartOS (probably other Solarises).
Also updates the sockets using ipc: to use DEALER sockets instead
of PAIR sockets.
