### PR TITLE
cmake: fixed error 'install TARGETS given no ARCHIVE DESTINATION'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -674,6 +674,7 @@ if(MSVC)
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     install(TARGETS libzmq libzmq-static
             RUNTIME DESTINATION bin
+            ARCHIVE DESTINATION lib
             PUBLIC_HEADER DESTINATION include
             COMPONENT SDK)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/libzmq${_zmq_COMPILER}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}.pdb DESTINATION lib


### PR DESCRIPTION
using cmake with nmake gives error 

<pre>
CMake Error at CMakeLists.txt:675 (install):
  install TARGETS given no ARCHIVE DESTINATION for static library target
  "libzmq-static".


-- Configuring incomplete, errors occurred!
</pre>


Added missed line for debug target
