### PR TITLE
windows: changed tcp port from glrpc assigned to unassigned one

### DIFF
--- a/tests/test_stream.cpp
+++ b/tests/test_stream.cpp
@@ -171,12 +171,12 @@ test_stream_to_stream (void)
     
     void *server = zmq_socket (ctx, ZMQ_STREAM);
     assert (server);
-    rc = zmq_bind (server, "tcp://127.0.0.1:9080");
+    rc = zmq_bind (server, "tcp://127.0.0.1:9070");
     assert (rc == 0);
 
     void *client = zmq_socket (ctx, ZMQ_STREAM);
     assert (client);
-    rc = zmq_connect (client, "tcp://localhost:9080");
+    rc = zmq_connect (client, "tcp://localhost:9070");
     assert (rc == 0);
     //  It would be less surprising to get an empty message instead
     //  of having to fetch the identity like this [PH 2013/06/27]


### PR DESCRIPTION
On Windows 7 with MS Sharepoint Workspace installed test_stream failed with 10048 - WSAEADDRINUSE
Tcp port 9080 is occupied with glrpc service and can't be binded with SO_EXCLUSIVEADDRUSE option.

<pre>
test 17
      Start 17: test_stream

17: Test command: C:\WORK\GITHUB\0MQ\dev\b\bin\test_stream.exe
17: Test timeout computed to be: 9.99988e+006
17: Assertion failed: rc == 0, file C:\WORK\GITHUB\0MQ\dev\libzmq\tests\test_stream.cpp, line 175
</pre>


Here the list of IANA assigned ports http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?&page=110

With this pull request I've changed 9080 to unassigned 9070.
