### PR TITLE
Only export zmq_* symbols

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -180,7 +180,7 @@ else
 if ON_ANDROID
 libzmq_la_LDFLAGS = -avoid-version -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@
 else
-libzmq_la_LDFLAGS = -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@
+libzmq_la_LDFLAGS = -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@ -Wl,--version-script=libzmq.vers
 endif
 endif
 

--- a/src/libzmq.vers
+++ b/src/libzmq.vers
@@ -1,0 +1,4 @@
+{
+  global: zmq_*;
+  local: *;
+};


### PR DESCRIPTION
Right now the libzmq library exports a bunch of C++ symbols additionally to the usual `zmq_*` ones.

```
std::basic_string<unsigned char, std::char_traits<unsigned char>, std::allocator<unsigned char> >::_M_leak_hard()@Base
unsigned char* std::basic_string<unsigned char, std::char_traits<unsigned char>, std::allocator<unsigned char> >::_S_construct<unsigned char const*>(unsigned char const*, unsigned char const*, std::allocator<unsigned char> const&, std::forward_iterator_tag)@Base
std::basic_string<unsigned char, std::char_traits<unsigned char>, std::allocator<unsigned char> >::_Rep::_S_empty_rep_storage@Base
std::basic_string<unsigned char, std::char_traits<unsigned char>, std::allocator<unsigned char> >::assign(std::basic_string<unsigned char, std::char_traits<unsigned char>, std::allocator<unsigned char> > const&)@Base
char* std::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_construct<char*>(char*, char*, std::allocator<char> const&, std::forward_iterator_tag)@Base
std::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::~basic_stringbuf()@Base
std::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::~basic_stringbuf()@Base
std::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::~basic_stringbuf()@Base
std::deque<std::basic_string<unsigned char, std::char_traits<unsigned char>, std::allocator<unsigned char> >, std::allocator<std::basic_string<unsigned char, std::char_traits<unsigned char>, std::allocator<unsigned char> > > >::_M_push_back_aux(std::basic_string<unsigned char, std::char_traits<unsigned char>, std::allocator<unsigned char> > const&)@Base
std::vector<unsigned int, std::allocator<unsigned int> >::_M_insert_aux(__gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int, std::allocator<unsigned int> > >, unsigned int const&)@Base
```

(this is the demangled version)

This causes problems to tools that track library symbols (e.g. the ones we use in Debian to calculate dependencies), because C++ symbols have the funny habit of changing across architectures.

This patch basically forces ld to only export `zmq_*` symbols.
