### PR TITLE
Fix compilation on Windows (MinGW-w64)

### DIFF
--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -20,139 +20,14 @@
 #ifndef __ZMQ_WINDOWS_HPP_INCLUDED__
 #define __ZMQ_WINDOWS_HPP_INCLUDED__
 
-//  The purpose of this header file is to turn on only the items actually
-//  needed on the windows platform.
-
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
-#endif
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOGDICAPMASKS
-#define NOGDICAPMASKS     // CC_*, LC_*, PC_*, CP_*, TC_*, RC_
-#endif
-#ifndef NOVIRTUALKEYCODES
-#define NOVIRTUALKEYCODES // VK_*
-#endif
-#ifndef NOWINMESSAGES
-#define NOWINMESSAGES     // WM_*, EM_*, LB_*, CB_*
-#endif
-#ifndef NOWINSTYLES
-#define NOWINSTYLES       // WS_*, CS_*, ES_*, LBS_*, SBS_*, CBS_*
-#endif
-#ifndef NOSYSMETRICS
-#define NOSYSMETRICS      // SM_*
-#endif
-#ifndef NOMENUS
-#define NOMENUS           // MF_*
-#endif
-#ifndef NOICONS
-#define NOICONS           // IDI_*
-#endif
-#ifndef NOKEYSTATES
-#define NOKEYSTATES       // MK_*
-#endif
-#ifndef NOSYSCOMMANDS
-#define NOSYSCOMMANDS     // SC_*
-#endif
-#ifndef NORASTEROPS
-#define NORASTEROPS       // Binary and Tertiary raster ops
-#endif
-#ifndef NOSHOWWINDOW
-#define NOSHOWWINDOW      // SW_*
-#endif
-#ifndef OEMRESOURCE
-#define OEMRESOURCE       // OEM Resource values
-#endif
-#ifndef NOATOM
-#define NOATOM            // Atom Manager routines
-#endif
-#ifndef NOCLIPBOARD
-#define NOCLIPBOARD       // Clipboard routines
-#endif
-#ifndef NOCOLOR
-#define NOCOLOR           // Screen colors
-#endif
-#ifndef NOCTLMGR
-#define NOCTLMGR          // Control and Dialog routines
-#endif
-#ifndef NODRAWTEXT
-#define NODRAWTEXT        // DrawText() and DT_*
-#endif
-#ifndef NOGDI
-#define NOGDI             // All GDI defines and routines
-#endif
-#ifndef NOKERNEL
-#define NOKERNEL          // All KERNEL defines and routines
-#endif
-#ifndef NOUSER
-#define NOUSER            // All USER defines and routines
-#endif
-#ifndef NONLS
-#define NONLS             // All NLS defines and routines
-#endif
-#ifndef NOMB
-#define NOMB              // MB_* and MessageBox()
-#endif
-#ifndef NOMEMMGR
-#define NOMEMMGR          // GMEM_*, LMEM_*, GHND, LHND, associated routines
-#endif
-#ifndef NOMETAFILE
-#define NOMETAFILE        // typedef METAFILEPICT
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX          // Macros min(a,b) and max(a,b)
-#endif
-#ifndef NOMSG
-#define NOMSG             // typedef MSG and associated routines
-#endif
-#ifndef NOOPENFILE
-#define NOOPENFILE        // OpenFile(), OemToAnsi, AnsiToOem, and OF_*
-#endif
-#ifndef NOSCROLL
-#define NOSCROLL          // SB_* and scrolling routines
-#endif
-#ifndef NOSERVICE
-#define NOSERVICE         // All Service Controller routines, SERVICE_ equates, etc.
-#endif
-#ifndef NOSOUND
-#define NOSOUND           // Sound driver routines
-#endif
-#ifndef NOTEXTMETRIC
-#define NOTEXTMETRIC      // typedef TEXTMETRIC and associated routines
-#endif
-#ifndef NOWH
-#define NOWH              // SetWindowsHook and WH_*
-#endif
-#ifndef NOWINOFFSETS
-#define NOWINOFFSETS      // GWL_*, GCL_*, associated routines
-#endif
-#ifndef NOCOMM
-#define NOCOMM            // COMM driver routines
-#endif
-#ifndef NOKANJI
-#define NOKANJI           // Kanji support stuff.
-#endif
-#ifndef NOHELP
-#define NOHELP            // Help engine interface.
-#endif
-#ifndef NOPROFILER
-#define NOPROFILER        // Profiler interface.
-#endif
-#ifndef NODEFERWINDOWPOS
-#define NODEFERWINDOWPOS  // DeferWindowPos routines
-#endif
-#ifndef NOMCX
-#define NOMCX             // Modem Configuration ExtensionsA
 #endif
 
 //  Set target version to Windows Server 2003, Windows XP/SP1 or higher.
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0501
 #endif
-
-#include <windows.h>
 
 #ifdef __MINGW32__
 //  Require Windows XP or higher with MinGW for getaddrinfo().
@@ -164,8 +39,12 @@
 #endif
  
 #include <winsock2.h>
+#include <windows.h>
 #include <mswsock.h>
+
+#if !defined __MINGW64_VERSION_MAJOR && !defined __MINGW64_VERSION_MINOR
 #include <Mstcpip.h>
+#endif
 
 #include <ws2tcpip.h>
 #include <ipexport.h>

--- a/tests/test_srcfd.cpp
+++ b/tests/test_srcfd.cpp
@@ -24,6 +24,7 @@
 #ifdef _WIN32
 #include <Winsock2.h>
 #include <Ws2tcpip.h>
+#define usleep(a) Sleep((a) / 1000)
 #else
 #include <sys/types.h>
 #include <sys/socket.h>


### PR DESCRIPTION
Windows.hpp did some funky stuff about conditionally including components from Windows.h. To be honest, this is completely unnecessary (e.g see [here](http://blogs.msdn.com/b/oldnewthing/archive/2009/11/30/9929944.aspx)), and causes more issues than what's saved in compilation time.

For example, it complained that `CCHFORMNAME` was missing because of those conditionals.

Additionally, it appears that including mstcpip.h on MinGW-w64 does not work, with it complaining that `'IN6_ADDR' does not name a type`. It doesn't appear to be a required header though, since it compiles fine without including mstcpip.h.

Finally, Winsock2.h must be included before Windows.h, to avoid a warning (-Werror?) that stops compilation.
