### PR TITLE
use version-script only for ELF linux

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -180,7 +180,11 @@ else
 if ON_ANDROID
 libzmq_la_LDFLAGS = -avoid-version -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@
 else
+if ON_LINUX
 libzmq_la_LDFLAGS = -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@ -Wl,--version-script=libzmq.vers
+else
+libzmq_la_LDFLAGS = -version-info @LTVER@ @LIBZMQ_EXTRA_LDFLAGS@ -Wl
+endif
 endif
 endif
 


### PR DESCRIPTION
version-script breaks Mac build. According to the ld man page, the version-script only applies to ELF, so I assume it's safe to use the OS_LINUX macro
