### PR TITLE
Fixes CMake build after ZAP test file was deleted.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -635,7 +635,6 @@ list(APPEND tests
         test_abstract_ipc
         test_proxy
         test_filter_ipc
-        test_zap_ipc_creds
 )
 endif()
 


### PR DESCRIPTION
File was removed in 5bf96f64b07ff74548495fdf38198a9cc8edb662 a few days ago.
