### PR TITLE
Adds support for detecting ZMQ_STREAM disconnections.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,6 +98,7 @@ Trevor Bernard <trevor.bernard@gmail.com>
 Vitaly Mayatskikh <v.mayatskih@gmail.com>
 Lourens Naudé <lourens@methodmissing.com>
 Hardeep Singh <hshardeesi@gmail.com>
+André Caron <andre.l.caron@gmail.com>
 
 Credits
 =======

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,6 +604,7 @@ set(tests
         test_probe_router
         test_stream
         test_stream_empty
+        test_stream_disconnect_notifications
         test_disconnect_inproc
         test_ctx_options
         test_ctx_destroy

--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -352,7 +352,9 @@ To open a connection to a server, use the zmq_connect call, and then fetch the
 socket identity using the ZMQ_IDENTITY zmq_getsockopt call.
 
 To close a specific client connection, as a server, send the identity frame
-followed by a zero-length message (see EXAMPLE section).
+followed by a zero-length message (see EXAMPLE section).  Similarly, when the
+peer disconnects (or the connection is lost), a zero-length message will be
+received by the application.
 
 The ZMQ_SNDMORE flag is ignored on data frames. You must send one identity frame
 followed by one data frame.

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -780,6 +780,14 @@ int zmq::stream_engine_t::write_subscription_msg (msg_t *msg_)
 
 void zmq::stream_engine_t::error ()
 {
+    if (options.raw_sock) {
+        //  For raw sockets, send a final 0-length message to the application
+        //  so that it knows the peer has been disconnected.
+        msg_t terminator;
+        terminator.init();
+        (this->*write_msg) (&terminator);
+        terminator.close();
+    }
     zmq_assert (session);
     socket->event_disconnected (endpoint, s);
     session->flush ();

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -25,6 +25,7 @@ noinst_PROGRAMS = test_system \
                   test_probe_router \
                   test_stream \
                   test_stream_empty \
+                  test_stream_disconnect_notifications \
                   test_disconnect_inproc \
                   test_ctx_options \
                   test_ctx_destroy \
@@ -90,6 +91,7 @@ test_router_handover_SOURCES = test_router_handover.cpp
 test_probe_router_SOURCES = test_probe_router.cpp
 test_stream_SOURCES = test_stream.cpp
 test_stream_empty_SOURCES = test_stream_empty.cpp
+test_stream_disconnect_notifications_SOURCES = test_stream_disconnect_notifications.cpp
 test_disconnect_inproc_SOURCES = test_disconnect_inproc.cpp
 test_ctx_options_SOURCES = test_ctx_options.cpp
 test_iov_SOURCES = test_iov.cpp


### PR DESCRIPTION
When a ZMQ_STREAM socket connection is broken (intentionally, via `shutdown()`
or accidentally via client crash or network failure), there is no way for the
application to dertermine that it should drop per-connection data (such as
buffers).

This contribution makes sure the application receives a 0-length message to
notify it that the connection has been broken.  This is symmetric with the
process of closing the connection from within the application (where the
application sends a 0-length message to tell ZeroMQ to close the connection).

Conflicts:
    CMakeLists.txt
