### PR TITLE
Corrects ypipe initialization when conflate is NOT enabled.

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -481,10 +481,10 @@ void zmq::pipe_t::hiccup ()
     //  Create new inpipe.
     if (conflate)
         inpipe = new (std::nothrow)
-            ypipe_conflate_t <msg_t, message_pipe_granularity> ();
+            ypipe_conflate_t <msg_t> ();
     else
         inpipe = new (std::nothrow)
-            ypipe_t <msg_t> ();
+            ypipe_t <msg_t, message_pipe_granularity> ();
 
     alloc_assert (inpipe);
     in_active = true;


### PR DESCRIPTION
Tracked down an issue with subscription filters not being properly applied when more than one is used and the connection is broken and re-established. Conflate outbound pipe was being used when conflate is not enabled.

This change should be backported to zeromq4-x as it exists there as well.

Fixes LIBZMQ-584
