### PR TITLE
Store socket FD after connect

### DIFF
--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -124,6 +124,9 @@ void zmq::tcp_connecter_t::out_event ()
     tune_tcp_socket (fd);
     tune_tcp_keepalives (fd, options.tcp_keepalive, options.tcp_keepalive_cnt, options.tcp_keepalive_idle, options.tcp_keepalive_intvl);
 
+    // remember our fd for ZMQ_SRCFD in messages
+    socket->set_fd(fd);
+
     //  Create the engine object for this connection.
     stream_engine_t *engine = new (std::nothrow)
         stream_engine_t (fd, options, endpoint);


### PR DESCRIPTION
The tcp_connector forgets to set the FD after connect() unlike the tcp_listener who sets it after accept().
