### PR TITLE
Fix unused variable error.

### DIFF
--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -183,6 +183,7 @@ void zmq::stream_engine_t::plug (io_thread_t *io_thread_,
         msg_t connector;
         connector.init();
         int rc = (this->*write_msg) (&connector);
+        zmq_assert(rc == 0);
         connector.close();
         session->flush ();
     }


### PR DESCRIPTION
  CXX    libzmq_la-stream_engine.lo
stream_engine.cpp: In member function 'virtual void zmq::stream_engine_t::plug(zmq::io_thread_t_, zmq::session_base_t_)':
stream_engine.cpp:185:9: error: 'rc' was not declared in this scope
make[3]: **\* [libzmq_la-stream_engine.lo] Error 1
