### PR TITLE
Fixed compile issue with missing member of socket_base.  Changed ZMQ_NEX...

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -293,7 +293,7 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_IPC_FILTER_PID 58
 #define ZMQ_IPC_FILTER_UID 59
 #define ZMQ_IPC_FILTER_GID 60
-#define ZMQ_NEXT_IDENTITY 61 
+#define ZMQ_NEXT_CONNECT_PEER_ID 61 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
 #define ZMQ_SRCFD 2

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -164,7 +164,8 @@ namespace zmq
 
         // Monitor socket cleanup
         void stop_monitor ();
-
+        // Next assigned name on a zmq_connect() call used by ROUTER and STREAM socket types
+        std::string next_identity;
     private:
         //  Creates new endpoint ID and adds the endpoint to the map.
         void add_endpoint (const char *addr_, own_t *endpoint_, pipe_t *pipe);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -170,7 +170,7 @@ int zmq::stream_t::xsetsockopt (int option_, const void *optval_,
     int value = is_int? *((int *) optval_): 0;
 
     switch (option_) {
-        case ZMQ_NEXT_IDENTITY:
+		case ZMQ_NEXT_CONNECT_PEER_ID:
             if(optval_ && optvallen_) {
                 next_identity.assign((char*)optval_,optvallen_);
                 return 0;


### PR DESCRIPTION
...T_IDENTITY to ZMQ_NEXT_CONNECT_PEER_ID.

Fixed case where ZMQ_NEXT_CONNECT_PEER_ID is used in ROUTER, and ROUTER does not read the identity message from the connected pipe.

This should fix the compile issue.  I will be submitting a test case tomorrow (likely). 
