### PR TITLE
Cleaned up option to force identity on outgoing connection

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -293,7 +293,8 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_IPC_FILTER_PID 58
 #define ZMQ_IPC_FILTER_UID 59
 #define ZMQ_IPC_FILTER_GID 60
-#define ZMQ_NEXT_CONNECT_PEER_ID 61 
+#define ZMQ_CONNECT_RID 61 
+
 /*  Message options                                                           */
 #define ZMQ_MORE 1
 #define ZMQ_SRCFD 2

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -104,9 +104,9 @@ namespace zmq
         //  If true, more outgoing message parts are expected.
         bool more_out;
 
-        //  Peer ID are generated. It's a simple increment and wrap-over
+        //  Routing IDs are generated. It's a simple increment and wrap-over
         //  algorithm. This value is the next ID to use (if not used already).
-        uint32_t next_peer_id;
+        uint32_t next_rid;
 
         // If true, report EAGAIN to the caller instead of silently dropping 
         // the message targeting an unknown peer.

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -164,8 +164,10 @@ namespace zmq
 
         // Monitor socket cleanup
         void stop_monitor ();
+        
         // Next assigned name on a zmq_connect() call used by ROUTER and STREAM socket types
-        std::string next_identity;
+        std::string connect_rid;
+
     private:
         //  Creates new endpoint ID and adds the endpoint to the map.
         void add_endpoint (const char *addr_, own_t *endpoint_, pipe_t *pipe);

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -84,9 +84,9 @@ namespace zmq
         //  If true, more outgoing message parts are expected.
         bool more_out;
 
-        //  Peer ID are generated. It's a simple increment and wrap-over
+        //  Routing IDs are generated. It's a simple increment and wrap-over
         //  algorithm. This value is the next ID to use (if not used already).
-        uint32_t next_peer_id;
+        uint32_t next_rid;
 
         stream_t (const stream_t&);
         const stream_t &operator = (const stream_t&);


### PR DESCRIPTION
- renamed to ZMQ_CONNECT_RID
- fixed whitespace malformating around previous patch
- renamamed next_peer_id to next_rid in preparation for
  larger rename of IDENTITY to ROUTING_ID

Note: ZMQ_CONNECT_RID has no test case and no entry in the man
page, as yet.
