### PR TITLE
Fix potential segfault/memleak

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -123,8 +123,10 @@ zmq::socket_base_t *zmq::socket_base_t::create (int type_, class ctx_t *parent_,
     }
 
     alloc_assert (s);
-    if (s->mailbox.get_fd () == retired_fd)
+    if (s->mailbox.get_fd () == retired_fd) {
+        delete s;
         return NULL;
+    }
 
     return s;
 }


### PR DESCRIPTION
This set of patches fixes a potential segfault/memleak in file socket_base.cpp. The conditions under which they are triggered are easy to see:
- Allocation assertion after a dereference.
- No deletion of allocated object in case of an error.

The proposed patch should counter these bugs.
