### PR TITLE
Revert "Fix potential memory leak"

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -123,10 +123,8 @@ zmq::socket_base_t *zmq::socket_base_t::create (int type_, class ctx_t *parent_,
     }
 
     alloc_assert (s);
-    if (s->mailbox.get_fd () == retired_fd) {
-        delete s;
+    if (s->mailbox.get_fd () == retired_fd)
         return NULL;
-    }
 
     return s;
 }


### PR DESCRIPTION
This reverts commit 50d34e5653ade4f3f1623c86f1426aeb746ae564.
- patch was breaking regression tests (test_many_sockets).
