### PR TITLE
Add ZMQ_MAX_SOCKETS_MAX to zmq_ctx_get()

### DIFF
--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -31,6 +31,11 @@ ZMQ_MAX_SOCKETS: Get maximum number of sockets
 The 'ZMQ_MAX_SOCKETS' argument returns the maximum number of sockets
 allowed for this context.
 
+ZMQ_MAX_SOCKETS_MAX: Get largest configurable number of sockets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_MAX_SOCKETS_MAX' argument returns the largest number of sockets
+that linkzmq:zmq_ctx_set[3] will accept.
+
 ZMQ_IPV6: Set IPv6 option
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_IPV6' argument returns the IPv6 option for the context.

--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -35,7 +35,8 @@ Default value:: 1
 ZMQ_MAX_SOCKETS: Set maximum number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_MAX_SOCKETS' argument sets the maximum number of sockets allowed
-on the context.
+on the context. You can query the maximal allowed value with
+linkzmq:zmq_ctx_get[3] using 'option_name' set to 'ZMQ_MAX_SOCKETS_MAX'.
 
 [horizontal]
 Default value:: 1024

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -178,6 +178,7 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 /*  Context options                                                           */
 #define ZMQ_IO_THREADS  1
 #define ZMQ_MAX_SOCKETS 2
+#define ZMQ_MAX_SOCKETS_MAX 3
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT  1

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #endif
 
+#include <limits>
 #include <new>
 #include <string.h>
 
@@ -203,6 +204,9 @@ int zmq::ctx_t::get (int option_)
     int rc = 0;
     if (option_ == ZMQ_MAX_SOCKETS)
         rc = max_sockets;
+    else
+    if (option_ == ZMQ_MAX_SOCKETS_MAX)
+        rc = clipped_maxsocket (std::numeric_limits<int>::max());
     else
     if (option_ == ZMQ_IO_THREADS)
         rc = io_thread_count;

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -17,6 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <limits>
 #include "testutil.hpp"
 
 int main (void)
@@ -29,6 +30,13 @@ int main (void)
     assert (ctx);
     
     assert (zmq_ctx_get (ctx, ZMQ_MAX_SOCKETS) == ZMQ_MAX_SOCKETS_DFLT);
+#if defined(ZMQ_USE_SELECT)
+    assert (zmq_ctx_get (ctx, ZMQ_MAX_SOCKETS_MAX) == ZMQ_MAX_SOCKETS_DFLT);
+#elif    defined(ZMQ_USE_POLL) || defined(ZMQ_USE_EPOLL)     \
+      || defined(ZMQ_USE_DEVPOLL) || defined(ZMQ_USE_KQUEUE)
+    assert (zmq_ctx_get (ctx, ZMQ_MAX_SOCKETS_MAX)
+                              == std::numeric_limits<int>::max());
+#endif
     assert (zmq_ctx_get (ctx, ZMQ_IO_THREADS) == ZMQ_IO_THREADS_DFLT);
     assert (zmq_ctx_get (ctx, ZMQ_IPV6) == 0);
     


### PR DESCRIPTION
When calling zmq_ctx_set(ZMQ_MAX_SOCKETS) it is not clear what the range of allowed socket numbers is. This can be either tested (try different socket numbers until the call succeeds) or one can use the knowledge that only select_t has a limited number of sockets and that that is only used under Windows. But this approach seems cleaner to me:

The new options allows querying the maximum allowed number of sockets. This is system dependent and cannot be encoded in the include file as a preprocessor macro: for ZMQ_USE_SELECT, this depends on the FD_SETSIZE macro at time of library compilation, not at time of include file use.
