### PR TITLE
Fix a strict-aliasing with type-punning

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -145,7 +145,14 @@ int zmq::get_peer_ip_address (fd_t sockfd_, std::string &ip_addr_)
         return 0;
 
     ip_addr_ = host;
-    return (int) ((struct sockaddr *) &ss)->sa_family;
+
+    union {
+        struct sockaddr sa;
+        struct sockaddr_storage sa_stor;
+    } u;
+
+    u.sa_stor = ss;
+    return (int) u.sa.sa_family;
 }
 
 void zmq::set_ip_type_of_service (fd_t s_, int iptos)


### PR DESCRIPTION
Fixes #880

See :
https://stackoverflow.com/questions/1429645/how-to-cast-sockaddr-storage-and-avoid-breaking-strict-aliasing-rules/1432959#1432959
