### PR TITLE
Rename ZMQ_MAX_SOCKETS_MAX to ZMQ_SOCKET_LIMIT

### DIFF
--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -31,10 +31,10 @@ ZMQ_MAX_SOCKETS: Get maximum number of sockets
 The 'ZMQ_MAX_SOCKETS' argument returns the maximum number of sockets
 allowed for this context.
 
-ZMQ_MAX_SOCKETS_MAX: Get largest configurable number of sockets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_MAX_SOCKETS_MAX' argument returns the largest number of sockets
-that linkzmq:zmq_ctx_set[3] will accept.
+ZMQ_SOCKET_LIMIT: Get largest configurable number of sockets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_SOCKET_LIMIT' argument returns the largest number of sockets that
+linkzmq:zmq_ctx_set[3] will accept.
 
 ZMQ_IPV6: Set IPv6 option
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -36,7 +36,7 @@ ZMQ_MAX_SOCKETS: Set maximum number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_MAX_SOCKETS' argument sets the maximum number of sockets allowed
 on the context. You can query the maximal allowed value with
-linkzmq:zmq_ctx_get[3] using 'option_name' set to 'ZMQ_MAX_SOCKETS_MAX'.
+linkzmq:zmq_ctx_get[3] using the 'ZMQ_SOCKET_LIMIT' option.
 
 [horizontal]
 Default value:: 1024

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -178,7 +178,7 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 /*  Context options                                                           */
 #define ZMQ_IO_THREADS  1
 #define ZMQ_MAX_SOCKETS 2
-#define ZMQ_MAX_SOCKETS_MAX 3
+#define ZMQ_SOCKET_LIMIT 3
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT  1

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -205,7 +205,7 @@ int zmq::ctx_t::get (int option_)
     if (option_ == ZMQ_MAX_SOCKETS)
         rc = max_sockets;
     else
-    if (option_ == ZMQ_MAX_SOCKETS_MAX)
+    if (option_ == ZMQ_SOCKET_LIMIT)
         rc = clipped_maxsocket (std::numeric_limits<int>::max());
     else
     if (option_ == ZMQ_IO_THREADS)

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -31,10 +31,10 @@ int main (void)
     
     assert (zmq_ctx_get (ctx, ZMQ_MAX_SOCKETS) == ZMQ_MAX_SOCKETS_DFLT);
 #if defined(ZMQ_USE_SELECT)
-    assert (zmq_ctx_get (ctx, ZMQ_MAX_SOCKETS_MAX) == ZMQ_MAX_SOCKETS_DFLT);
+    assert (zmq_ctx_get (ctx, ZMQ_SOCKET_LIMIT) == ZMQ_MAX_SOCKETS_DFLT);
 #elif    defined(ZMQ_USE_POLL) || defined(ZMQ_USE_EPOLL)     \
       || defined(ZMQ_USE_DEVPOLL) || defined(ZMQ_USE_KQUEUE)
-    assert (zmq_ctx_get (ctx, ZMQ_MAX_SOCKETS_MAX)
+    assert (zmq_ctx_get (ctx, ZMQ_SOCKET_LIMIT)
                               == std::numeric_limits<int>::max());
 #endif
     assert (zmq_ctx_get (ctx, ZMQ_IO_THREADS) == ZMQ_IO_THREADS_DFLT);


### PR DESCRIPTION
As per suggestion by Pieter Hintjens. Also update wording in
zmq_ctx_set manual a bit.
