### PR TITLE
Added temporary CURVE debugging support

### DIFF
--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -70,7 +70,8 @@ namespace zmq
             expect_initiate,
             expect_zap_reply,
             send_ready,
-            connected
+            connected,
+            errored
         };
 
         session_base_t * const session;


### PR DESCRIPTION
- just prints server-side failures to console
- can be improved over time, e.g. enabled at build time or
  sent to inproc debug channel
