### PR TITLE
Remove duplicate poller decision making

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,56 @@ if(APPLE)
 endif()
 
 
-set(POLLER "" CACHE STRING "Choose polling system manually. valid values are
+set(POLLER "" CACHE STRING "Choose polling system. valid values are
                             kqueue, epoll, devpoll, poll or select [default=autodetect]")
 
-if(     NOT POLLER STREQUAL ""
-    AND NOT POLLER STREQUAL "kqueue"
+include(CheckFunctionExists)
+include(CheckTypeSize)
+if(POLLER STREQUAL "")
+    set(CMAKE_REQUIRED_INCLUDES sys/event.h)
+    check_function_exists(kqueue HAVE_KQUEUE)
+    set(CMAKE_REQUIRED_INCLUDES )
+    if(HAVE_KQUEUE)
+        set(POLLER "kqueue")
+    else()
+        set(CMAKE_REQUIRED_INCLUDES sys/epoll.h)
+        check_function_exists(epoll_create HAVE_EPOLL)
+        set(CMAKE_REQUIRED_INCLUDES )
+        if(HAVE_EPOLL)
+            set(POLLER "epoll")
+        else()
+            set(CMAKE_REQUIRED_INCLUDES sys/devpoll.h)
+            check_type_size("struct pollfd" DEVPOLL)
+            set(CMAKE_REQUIRED_INCLUDES )
+            if(HAVE_DEVPOLL)
+                set(POLLER "devpoll")
+            else()
+                set(CMAKE_REQUIRED_INCLUDES poll.h)
+                check_function_exists(poll HAVE_POLL)
+                set(CMAKE_REQUIRED_INCLUDES )
+                if(HAVE_POLL)
+                    set(POLLER "poll")
+                else()
+                    if(CMAKE_HOST_WIN32)
+                        set(CMAKE_REQUIRED_INCLUDES winsock2.h)
+                    else()
+                        set(CMAKE_REQUIRED_INCLUDES sys/select.h)
+                    endif()
+                    check_function_exists(select HAVE_SELECT)
+                    set(CMAKE_REQUIRED_INCLUDES )
+                    if(HAVE_SELECT)
+                        set(POLLER "select")
+                    else()
+                        message(FATAL_ERROR
+                            "Could not autodetect polling method")
+                    endif()
+                endif()
+            endif()
+        endif()
+    endif()
+endif()
+
+if(     NOT POLLER STREQUAL "kqueue"
     AND NOT POLLER STREQUAL "epoll"
     AND NOT POLLER STREQUAL "devpoll"
     AND NOT POLLER STREQUAL "poll"
@@ -24,7 +69,7 @@ endif()
 
 if(NOT ${POLLER} STREQUAL "")
   string(TOUPPER ${POLLER} UPPER_POLLER)
-  set(ZMQ_FORCE_${UPPER_POLLER} 1)
+  set(ZMQ_USE_${UPPER_POLLER} 1)
 endif()
 
 set(ZMQ_CMAKE_MODULES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/Modules)
@@ -34,7 +79,6 @@ include(TestZMQVersion)
 include(ZMQSourceRunChecks)
 include(CheckIncludeFiles)
 include(CheckLibraryExists)
-include(CheckFunctionExists)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 include(CheckCSourceCompiles)

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -922,7 +922,7 @@ AC_DEFUN([LIBZMQ_CHECK_POLLER], [{
       ;;
     esac
 
-    libzmq_cv_poller_flag=`echo "ZMQ_FORCE_${libzmq_cv_poller}" | tr a-z A-Z`
+    libzmq_cv_poller_flag=`echo "ZMQ_USE_${libzmq_cv_poller}" | tr a-z A-Z`
 
     AS_IF([test "x${libzmq_cv_poller}" != "x"],
           [AC_MSG_RESULT([using $libzmq_cv_poller]) ; $1], [AC_MSG_RESULT(no suitable polling system found) ; $2])

--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -1,13 +1,11 @@
 #ifndef __ZMQ_PLATFORM_HPP_INCLUDED__
 #define __ZMQ_PLATFORM_HPP_INCLUDED__
 
-#cmakedefine ZMQ_FORCE_SELECT
-#cmakedefine ZMQ_FORCE_POLL
-#cmakedefine ZMQ_FORCE_EPOLL
-#cmakedefine ZMQ_FORCE_DEVPOLL
-#cmakedefine ZMQ_FORCE_KQUEUE
-#cmakedefine ZMQ_FORCE_SELECT
-#cmakedefine ZMQ_FORCE_POLL
+#cmakedefine ZMQ_USE_KQUEUE
+#cmakedefine ZMQ_USE_EPOLL
+#cmakedefine ZMQ_USE_DEVPOLL
+#cmakedefine ZMQ_USE_POLL
+#cmakedefine ZMQ_USE_SELECT
 
 #cmakedefine ZMQ_FORCE_MUTEXES
 

--- a/builds/mingw32/Makefile.mingw32
+++ b/builds/mingw32/Makefile.mingw32
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Wall -Os -g -DDLL_EXPORT -DFD_SETSIZE=1024 -I.
+CFLAGS=-Wall -Os -g -DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -I.
 LIBS=-lws2_32
 
 OBJS = ctx.o reaper.o dist.o err.o \

--- a/builds/msvc/libzmq/libzmq.vcproj
+++ b/builds/msvc/libzmq/libzmq.vcproj
@@ -40,7 +40,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="0"
 				PreprocessorDefinitions="NOMINMAX"
 				MinimalRebuild="true"
@@ -114,7 +114,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
 				RuntimeLibrary="2"
@@ -188,7 +188,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="0"
 				PreprocessorDefinitions="NOMINMAX"
 				MinimalRebuild="true"
@@ -254,7 +254,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
 				RuntimeLibrary="2"
@@ -319,7 +319,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
 				AdditionalIncludeDirectories="../../../../OpenPGM/include"

--- a/builds/msvc/properties/ZeroMQ.props
+++ b/builds/msvc/properties/ZeroMQ.props
@@ -13,7 +13,7 @@
       <Command>copy ..\platform.hpp ..\..\..\src</Command>
     </PreBuildEvent>
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DLL_EXPORT;FD_SETSIZE=1024;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DLL_EXPORT;FD_SETSIZE=1024;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/builds/msvc/properties/ZeroMQ_Static.props
+++ b/builds/msvc/properties/ZeroMQ_Static.props
@@ -13,7 +13,7 @@
       <Command>copy ..\platform.hpp ..\..\..\src</Command>
     </PreBuildEvent>
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ZMQ_STATIC;FD_SETSIZE=1024;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;ZMQ_STATIC;FD_SETSIZE=1024;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>Ws2_32.lib;Rpcrt4.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/poller.hpp
+++ b/src/poller.hpp
@@ -22,59 +22,30 @@
 
 #include "platform.hpp"
 
-#if defined ZMQ_FORCE_SELECT
-#define ZMQ_USE_SELECT
-#include "select.hpp"
-#elif defined ZMQ_FORCE_POLL
-#define ZMQ_USE_POLL
-#include "poll.hpp"
-#elif defined ZMQ_FORCE_EPOLL
-#define ZMQ_USE_EPOLL
+#if   defined ZMQ_USE_KQUEUE  + defined ZMQ_USE_EPOLL \
+    + defined ZMQ_USE_DEVPOLL + defined ZMQ_USE_POLL  \
+    + defined ZMQ_USE_SELECT > 1
+#error More than one of the ZMQ_USE_* macros defined
+#endif
+
+#if defined ZMQ_USE_KQUEUE
+#include "kqueue.hpp"
+#elif defined ZMQ_USE_EPOLL
 #include "epoll.hpp"
-#elif defined ZMQ_FORCE_DEVPOLL
-#define ZMQ_USE_DEVPOLL
+#elif defined ZMQ_USE_DEVPOLL
 #include "devpoll.hpp"
-#elif defined ZMQ_FORCE_KQUEUE
-#define ZMQ_USE_KQUEUE
-#include "kqueue.hpp"
-#elif defined ZMQ_HAVE_LINUX
-#define ZMQ_USE_EPOLL
-#include "epoll.hpp"
-#elif defined ZMQ_HAVE_WINDOWS
-#define ZMQ_USE_SELECT
-#include "select.hpp"
-#elif defined ZMQ_HAVE_FREEBSD
-#define ZMQ_USE_KQUEUE
-#include "kqueue.hpp"
-#elif defined ZMQ_HAVE_OPENBSD
-#define ZMQ_USE_KQUEUE
-#include "kqueue.hpp"
-#elif defined ZMQ_HAVE_NETBSD
-#define ZMQ_USE_KQUEUE
-#include "kqueue.hpp"
-#elif defined ZMQ_HAVE_SOLARIS
-#define ZMQ_USE_DEVPOLL
-#include "devpoll.hpp"
-#elif defined ZMQ_HAVE_OSX
-#define ZMQ_USE_KQUEUE
-#include "kqueue.hpp"
-#elif defined ZMQ_HAVE_QNXNTO
-#define ZMQ_USE_POLL
+#elif defined ZMQ_USE_POLL
 #include "poll.hpp"
-#elif defined ZMQ_HAVE_AIX
-#define ZMQ_USE_POLL
-#include "poll.hpp"
-#elif defined ZMQ_HAVE_HPUX
-#define ZMQ_USE_DEVPOLL
-#include "devpoll.hpp"
-#elif defined ZMQ_HAVE_OPENVMS
-#define ZMQ_USE_SELECT
-#include "select.hpp"
-#elif defined ZMQ_HAVE_CYGWIN
-#define ZMQ_USE_SELECT
+#elif defined ZMQ_USE_SELECT
 #include "select.hpp"
 #else
-#error Unsupported platform
+#error None of the ZMQ_USE_* macros defined
+#endif
+
+#if defined ZMQ_USE_SELECT
+#define ZMQ_POLL_BASED_ON_SELECT
+#else
+#define ZMQ_POLL_BASED_ON_POLL
 #endif
 
 #endif

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -18,24 +18,9 @@
 */
 
 #include <stddef.h>
-#include "platform.hpp"
+#include "poller.hpp"
 #include "proxy.hpp"
 #include "likely.hpp"
-
-#if defined ZMQ_FORCE_SELECT
-#define ZMQ_POLL_BASED_ON_SELECT
-#elif defined ZMQ_FORCE_POLL
-#define ZMQ_POLL_BASED_ON_POLL
-#elif defined ZMQ_HAVE_LINUX || defined ZMQ_HAVE_FREEBSD ||\
-    defined ZMQ_HAVE_OPENBSD || defined ZMQ_HAVE_SOLARIS ||\
-    defined ZMQ_HAVE_OSX || defined ZMQ_HAVE_QNXNTO ||\
-    defined ZMQ_HAVE_HPUX || defined ZMQ_HAVE_AIX ||\
-    defined ZMQ_HAVE_NETBSD
-#define ZMQ_POLL_BASED_ON_POLL
-#elif defined ZMQ_HAVE_WINDOWS || defined ZMQ_HAVE_OPENVMS ||\
-     defined ZMQ_HAVE_CYGWIN
-#define ZMQ_POLL_BASED_ON_SELECT
-#endif
 
 //  On AIX platform, poll.h has to be included first to get consistent
 //  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -17,30 +17,15 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "platform.hpp"
-
-#if defined ZMQ_FORCE_SELECT
-#define ZMQ_SIGNALER_WAIT_BASED_ON_SELECT
-#elif defined ZMQ_FORCE_POLL
-#define ZMQ_SIGNALER_WAIT_BASED_ON_POLL
-#elif defined ZMQ_HAVE_LINUX || defined ZMQ_HAVE_FREEBSD ||\
-    defined ZMQ_HAVE_OPENBSD || defined ZMQ_HAVE_SOLARIS ||\
-    defined ZMQ_HAVE_OSX || defined ZMQ_HAVE_QNXNTO ||\
-    defined ZMQ_HAVE_HPUX || defined ZMQ_HAVE_AIX ||\
-    defined ZMQ_HAVE_NETBSD
-#define ZMQ_SIGNALER_WAIT_BASED_ON_POLL
-#elif defined ZMQ_HAVE_WINDOWS || defined ZMQ_HAVE_OPENVMS ||\
-	defined ZMQ_HAVE_CYGWIN
-#define ZMQ_SIGNALER_WAIT_BASED_ON_SELECT
-#endif
+#include "poller.hpp"
 
 //  On AIX, poll.h has to be included before zmq.h to get consistent
 //  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'
 //  instead of 'events' and 'revents' and defines macros to map from POSIX-y
 //  names to AIX-specific names).
-#if defined ZMQ_SIGNALER_WAIT_BASED_ON_POLL
+#if defined ZMQ_POLL_BASED_ON_POLL
 #include <poll.h>
-#elif defined ZMQ_SIGNALER_WAIT_BASED_ON_SELECT
+#elif defined ZMQ_POLL_BASED_ON_SELECT
 #if defined ZMQ_HAVE_WINDOWS
 #include "windows.hpp"
 #elif defined ZMQ_HAVE_HPUX
@@ -166,7 +151,7 @@ int zmq::signaler_t::wait (int timeout_)
     }
 #endif
 
-#ifdef ZMQ_SIGNALER_WAIT_BASED_ON_POLL
+#ifdef ZMQ_POLL_BASED_ON_POLL
 
     struct pollfd pfd;
     pfd.fd = r;
@@ -194,7 +179,7 @@ int zmq::signaler_t::wait (int timeout_)
     zmq_assert (pfd.revents & POLLIN);
     return 0;
 
-#elif defined ZMQ_SIGNALER_WAIT_BASED_ON_SELECT
+#elif defined ZMQ_POLL_BASED_ON_SELECT
 
     fd_set fds;
     FD_ZERO (&fds);
@@ -516,11 +501,3 @@ int zmq::signaler_t::make_fdpair (fd_t *r_, fd_t *w_)
     }
 #endif
 }
-
-#if defined ZMQ_SIGNALER_WAIT_BASED_ON_SELECT
-#undef ZMQ_SIGNALER_WAIT_BASED_ON_SELECT
-#endif
-#if defined ZMQ_SIGNALER_WAIT_BASED_ON_POLL
-#undef ZMQ_SIGNALER_WAIT_BASED_ON_POLL
-#endif
-

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -18,22 +18,7 @@
 */
 #define ZMQ_TYPE_UNSAFE
 
-#include "platform.hpp"
-
-#if defined ZMQ_FORCE_SELECT
-#define ZMQ_POLL_BASED_ON_SELECT
-#elif defined ZMQ_FORCE_POLL
-#define ZMQ_POLL_BASED_ON_POLL
-#elif defined ZMQ_HAVE_LINUX || defined ZMQ_HAVE_FREEBSD ||\
-    defined ZMQ_HAVE_OPENBSD || defined ZMQ_HAVE_SOLARIS ||\
-    defined ZMQ_HAVE_OSX || defined ZMQ_HAVE_QNXNTO ||\
-    defined ZMQ_HAVE_HPUX || defined ZMQ_HAVE_AIX ||\
-    defined ZMQ_HAVE_NETBSD
-#define ZMQ_POLL_BASED_ON_POLL
-#elif defined ZMQ_HAVE_WINDOWS || defined ZMQ_HAVE_OPENVMS ||\
-     defined ZMQ_HAVE_CYGWIN
-#define ZMQ_POLL_BASED_ON_SELECT
-#endif
+#include "poller.hpp"
 
 //  On AIX platform, poll.h has to be included first to get consistent
 //  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'
@@ -1008,13 +993,6 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
     return -1;
 #endif
 }
-
-#if defined ZMQ_POLL_BASED_ON_SELECT
-#undef ZMQ_POLL_BASED_ON_SELECT
-#endif
-#if defined ZMQ_POLL_BASED_ON_POLL
-#undef ZMQ_POLL_BASED_ON_POLL
-#endif
 
 //  The proxy functionality
 


### PR DESCRIPTION
The decision about the poller mechanism to use (select, poll, ...)
was done twice: once by the build system and once by the code in
poller.hpp. As the build-system can actually detect the mechanisms
available, prefer that result to the hard coded defaults in
poller.hpp.

At the same time, remove the duplicate detection of select() vs.
poll()-variant from proxy.cpp, signaler.cpp and zmq.cpp.

This patch has not been tested on many build platforms: especially
the cmake build needs testing / patching. For the other builds,
hard code the result as these these are all Windows platforms.
