### PR TITLE
Fix build with ZMQ_HAVE_WINDOWS (typedef UINT_PTR fd_t; -> unsigned type...

### DIFF
--- a/src/select.hpp
+++ b/src/select.hpp
@@ -30,7 +30,7 @@
 #include <vector>
 
 #ifdef ZMQ_HAVE_WINDOWS
-#include "winsock2.h"
+#include <winsock2.h>
 #elif defined ZMQ_HAVE_OPENVMS
 #include <sys/types.h>
 #include <sys/time.h>

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -842,7 +842,7 @@ int zmq::socket_base_t::recv (msg_t *msg_, int flags_)
 
     //  If we have the message, return immediately.
     if (rc == 0) {
-        if (file_desc >= 0)
+        if (file_desc != retired_fd)
             msg_->set_fd(file_desc);
         extract_flags (msg_);
         return 0;
@@ -860,7 +860,7 @@ int zmq::socket_base_t::recv (msg_t *msg_, int flags_)
         rc = xrecv (msg_);
         if (rc < 0)
             return rc;
-        if (file_desc >= 0)
+        if (file_desc != retired_fd)
             msg_->set_fd(file_desc);
         extract_flags (msg_);
         return 0;
@@ -894,7 +894,7 @@ int zmq::socket_base_t::recv (msg_t *msg_, int flags_)
         }
     }
 
-    if (file_desc >= 0)
+    if (file_desc != retired_fd)
         msg_->set_fd(file_desc);
     extract_flags (msg_);
     return 0;


### PR DESCRIPTION
...)

  V547 Expression 'file_desc >= 0' is always true. Unsigned type value is always >= 0. socket_base.cpp 845
  V547 Expression 'file_desc >= 0' is always true. Unsigned type value is always >= 0. socket_base.cpp 863
  V547 Expression 'file_desc >= 0' is always true. Unsigned type value is always >= 0. socket_base.cpp 897
  http://www.viva64.com/en/d/0137/print/
