### PR TITLE
Fix zmq_socket example in documentation

### DIFF
--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -404,10 +404,17 @@ assert (rc == 0);
 /* Data structure to hold the ZMQ_STREAM ID */
 uint8_t id [256];
 size_t id_size = 256;
+/* Data structure to hold the ZMQ_STREAM received data */
+uint8_t raw [256];
+size_t raw_size = 256;
 while (1) {
 	/*  Get HTTP request; ID frame and then request */
-	id_size = zmq_recv (server, id, 256, 0);
+	id_size = zmq_recv (socket, id, 256, 0);
 	assert (id_size > 0);
+	do {
+		raw_size = zmq_recv (socket, raw, 256, 0);
+		assert (raw_size >= 0);
+	} while (raw_size == 256);
 	/* Prepares the response */
 	char http_response [] =
 		"HTTP/1.0 200 OK\r\n"


### PR DESCRIPTION
Issues adressed:
- The actual data was never read from the socket, causing all even
  numbered loop iterations to fail
- The socket variable was called server once
