### PR TITLE
add linking to librt under cmake build - fixes missing symbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,6 +591,10 @@ if(HAVE_IPHLAPI)
   target_link_libraries(libzmq iphlpapi)
 endif()
 
+if(RT_LIBRARY)
+  target_link_libraries(libzmq ${RT_LIBRARY})
+endif()
+
 set(perf-tools local_lat
                remote_lat
                local_thr


### PR DESCRIPTION
The libzmq library itself uses clock_gettime and should link w/ -lrt on linux.
Caught this issue on on Ubuntu 12.04 LTS.
