### PR TITLE
Fix MSVC8 build

### DIFF
--- a/builds/msvc/libzmq/libzmq.vcproj
+++ b/builds/msvc/libzmq/libzmq.vcproj
@@ -40,7 +40,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="0"
 				PreprocessorDefinitions="NOMINMAX"
 				MinimalRebuild="true"
@@ -114,7 +114,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
 				RuntimeLibrary="2"
@@ -188,7 +188,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="0"
 				PreprocessorDefinitions="NOMINMAX"
 				MinimalRebuild="true"
@@ -254,7 +254,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
 				RuntimeLibrary="2"
@@ -319,7 +319,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT; -D_CRT_SECURE_NO_WARNINGS"
+				AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
 				AdditionalIncludeDirectories="../../../../OpenPGM/include"


### PR DESCRIPTION
The extra semicolons were introduced in 48b50ce together with the
defintion of the ZMQ_USE_SELECT macros.
