### PR TITLE
Minor change to zmq_curve_keypair doc

### DIFF
--- a/doc/zmq_curve_keypair.txt
+++ b/doc/zmq_curve_keypair.txt
@@ -38,7 +38,7 @@ EXAMPLE
 ----
 char public_key [41];
 char secret_key [41];
-int rc = crypto_box_keypair (public_key, secret_key);
+int rc = zmq_curve_keypair (public_key, secret_key);
 assert (rc == 0);
 ----
 


### PR DESCRIPTION
It looks like this doc uses the libsodium call for curve keypair generation in the example rather than the zmq_curve_keypair function described in the documentation
