### PR TITLE
Libsodium is now required if and only if --with-libsodium is used

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Dhammika Pathirana <dhammika@gmail.com>
 Dhruva Krishnamurthy <dhruva@ymail.com>
 Dirk O. Kaar <dok@dok-net.net>
 Douglas Creager <douglas.creager@redjack.com>
+Drew Crawford <drew@sealedabstract.com>
 Erich Heine <sophacles@gmail.com>
 Erik Hugne <erik.hugne@ericsson.com>
 Erik Rigtorp <erik@rigtorp.com>

--- a/configure.ac
+++ b/configure.ac
@@ -299,7 +299,12 @@ esac
 # Checks for libraries
 AC_CHECK_LIB([pthread], [pthread_create])
 AC_CHECK_LIB([rt], [clock_gettime])
-AC_CHECK_LIB([sodium], [sodium_init],,AC_MSG_WARN(libsodium is needed for CURVE security))
+if test "x$zmq_search_libsodium" = "xyes"; then
+    AC_CHECK_LIB([sodium], [sodium_init],,AC_MSG_ERROR(libsodium is not installed.  Install it or don't pass --with-libsodium to configure script))
+else
+    AC_CHECK_LIB([sodium], [sodium_init],,AC_MSG_WARN(libsodium is needed for CURVE security))
+fi
+
 
 #
 # Check if the compiler supports -fvisibility=hidden flag. MinGW32 uses __declspec


### PR DESCRIPTION
This patch is proposed for https://github.com/zeromq/libzmq/issues/912.  If a user specifies that they want libzmq built with libsodium, and the requirement cannot be satisfied, we should error at the user so they can either A) install libsodium to a reasonable location or B) relax their requirement for libsodium support.

Previously a warning was issued in this case, causing users who wanted libsodium support not to get it, which may be discovered at a much later time when their programs didn't work as expected.

I release this patch under the LGPL v3 or any later version.
