### PR TITLE
Revert "Fixed potential SEGFAULT."

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -121,13 +121,10 @@ zmq::socket_base_t *zmq::socket_base_t::create (int type_, class ctx_t *parent_,
             errno = EINVAL;
             return NULL;
     }
-    alloc_assert (s);
 
-    if (s->mailbox.get_fd () == -1)
-    {
-        delete s;
+    alloc_assert (s);
+    if (s->mailbox.get_fd () == retired_fd)
         return NULL;
-    }
 
     return s;
 }


### PR DESCRIPTION
This reverts commit 79b81f48402c1276d4cfd3bf0cbfb4084952b36b.
Was causing:

Assertion failed: destroyed (socket_base.cpp:154)
/bin/bash: line 5: 31344 Aborted                 ${dir}$tst
FAIL: test_many_sockets

On TravisCI.
