### PR TITLE
fixed another missed norm_engine issue for non-norm build

### DIFF
--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -1,8 +1,6 @@
 
 #include "platform.hpp"
 
-#define ZMQ_HAVE_NORM 1
-
 #if defined ZMQ_HAVE_NORM
 
 #include "norm_engine.hpp"


### PR DESCRIPTION
Found one last issue where "#define ZMQ_HAVE_NORM 1" was hard coded into "src/norm_engine.cpp" from prior to integration with GitHub repository. Sorry again!  This should be the last issue that affects non-NORM builds.
