### PR TITLE
Fixed wrong assert in zmq_recv

### DIFF
--- a/doc/zmq_msg_init.txt
+++ b/doc/zmq_msg_init.txt
@@ -44,8 +44,8 @@ EXAMPLE
 zmq_msg_t msg;
 rc = zmq_msg_init (&msg);
 assert (rc == 0);
-rc = zmq_recv (socket, &msg, 0);
-assert (rc == 0);
+int nbytes = zmq_recv (socket, &msg, 0);
+assert (nbytes != -1);
 ----
 
 


### PR DESCRIPTION
zmq_recv returns bytes count, not error code, so 'assert (rc==0)' behaved completely wrong
