### PR TITLE
cmake // fixed msvc dll output path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,7 +548,8 @@ if(MSVC)
   set_target_properties(libzmq PROPERTIES
     PUBLIC_HEADER "${public_headers}"
     RELEASE_POSTFIX "${_zmq_COMPILER}-mt-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
-    DEBUG_POSTFIX "${_zmq_COMPILER}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}")
+    DEBUG_POSTFIX "${_zmq_COMPILER}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
   add_library(libzmq-static STATIC ${sources})
   set_target_properties(libzmq-static PROPERTIES
     PUBLIC_HEADER "${public_headers}"


### PR DESCRIPTION
Unable to run test from console (cmd) or msvc ide

<pre>
cmake  &lt; path to libzmq clone &gt;
cmake --build . --config Debug
ctest -VV -C Debug
</pre>

Test execution will fail because dll file is placed into 'lib' folder instead of 'bin'

Fix it by adding target property to place zeromq dll with test binaries.
