### PR TITLE
Fix building on MinGW64 Windows

### DIFF
--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -49,8 +49,8 @@
 #include <Mstcpip.h>
 #endif
 
-//  Workaround missing Mstcpip.h in mingw32
-#if defined __MINGW32__ && !defined SIO_KEEPALIVE_VALS
+//  Workaround missing Mstcpip.h in mingw32 (MinGW64 provides this)
+#if defined __MINGW32__ && !defined SIO_KEEPALIVE_VALS && !defined __MINGW64__
 struct tcp_keepalive {
     u_long onoff;
     u_long keepalivetime;


### PR DESCRIPTION
Mingw64 provides mstcpip.h and the build fails (redefinition) if the struct tcp_keepalive is redefined. Do not define the struct if **MINGW64** is defined. Note that I had to manually pass the compile definition to cmake: -D__MINGW64__=1
