### PR TITLE
Include zmq.h after platform.hpp

### DIFF
--- a/src/err.hpp
+++ b/src/err.hpp
@@ -20,9 +20,6 @@
 #ifndef __ZMQ_ERR_HPP_INCLUDED__
 #define __ZMQ_ERR_HPP_INCLUDED__
 
-//  0MQ-specific error codes are defined in zmq.h
-#include "../include/zmq.h"
-
 #include <assert.h>
 #if defined _WIN32_WCE
 #include "..\builds\msvc\errno.hpp"
@@ -35,6 +32,9 @@
 
 #include "platform.hpp"
 #include "likely.hpp"
+
+//  0MQ-specific error codes are defined in zmq.h
+#include "../include/zmq.h"
 
 #ifdef ZMQ_HAVE_WINDOWS
 #include "windows.hpp"


### PR DESCRIPTION
zmq.h requires definitions from platform.hpp so include platform.hpp before zmq.h. This is only an intermediate fix though. zmq.h should not require definitions from platform.hpp because platform.hpp is not installed. So, when zmq.h wants to include <inttypes.h> on ZMQ_HAVE_SOLARIS || ZMQ_HAVE_OPENVMS, it will not and fall back to #include <stdint.h> which will fail when building something like pyzmq on Solaris 8, 9/SPARC which do not have <stdint.h>
