### PR TITLE
Allow iov_base as char * on Solaris 8/9/10.

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -533,7 +533,7 @@ int zmq_recviov (void *s_, iovec *a_, size_t *count_, int flags_)
         }
 
         a_[i].iov_len = zmq_msg_size (&msg);
-        a_[i].iov_base = malloc(a_[i].iov_len);
+        a_[i].iov_base = static_cast<char *> (malloc(a_[i].iov_len));
         if (unlikely (!a_[i].iov_base)) {
             errno = ENOMEM;
             return -1;


### PR DESCRIPTION
On Solaris 8, 9, 10/SPARC, iov_base is of type caddr_t which is char _. The Sun C++ compiler errors with "Cannot assign void_ to char*". Using a static case to override this. On Solaris 11, HP-UX, AIX, and RHEL, iov_base is void \* so no issues there. This seems a rather hackish solution so open to something better.
