### PR TITLE
sockets created by accept are leaked to child processes (ticket #956)

### DIFF
--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -280,6 +280,13 @@ zmq::fd_t zmq::ipc_listener_t::accept ()
         return retired_fd;
     }
 
+    //  Race condition can cause socket not to be closed (if fork happens
+    //  between accept and this point).
+#ifdef FD_CLOEXEC
+    int rc = fcntl (sock, F_SETFD, FD_CLOEXEC);
+    errno_assert (rc != -1);
+#endif
+
     // IPC accept() filters
 #if defined ZMQ_HAVE_SO_PEERCRED || defined ZMQ_HAVE_LOCAL_PEERCRED
     if (!filter (sock)) {

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -288,6 +288,13 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
     }
 #endif
 
+    //  Race condition can cause socket not to be closed (if fork happens
+    //  between accept and this point).
+#ifdef FD_CLOEXEC
+    int rc = fcntl (sock, F_SETFD, FD_CLOEXEC);
+    errno_assert (rc != -1);
+#endif
+
     if (!options.tcp_accept_filters.empty ()) {
         bool matched = false;
         for (options_t::tcp_accept_filters_t::size_type i = 0; i != options.tcp_accept_filters.size (); ++i) {


### PR DESCRIPTION
I have tested the fix only on Solaris where it seems to work fine. It's quite simple so I don't expect that it would break anything on other platforms (though I don't know libzmq well enough to know for sure)
