### PR TITLE
Update function prototype for zmq_msg_gets ()

### DIFF
--- a/doc/zmq_msg_gets.txt
+++ b/doc/zmq_msg_gets.txt
@@ -9,7 +9,7 @@ zmq_msg_gets - get message metadata property
 
 SYNOPSIS
 --------
-*char *zmq_msg_gets (zmq_msg_t '*message', char *'property');*
+*const char *zmq_msg_gets (zmq_msg_t '*message', const char *'property');*
 
 
 DESCRIPTION

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -218,7 +218,7 @@ ZMQ_EXPORT size_t zmq_msg_size (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_more (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_get (zmq_msg_t *msg, int property);
 ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int property, int optval);
-ZMQ_EXPORT char *zmq_msg_gets (zmq_msg_t *msg, char *property);
+ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 
 
 /******************************************************************************/

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -644,7 +644,7 @@ int zmq_msg_set (zmq_msg_t *, int, int)
 
 //  Get message metadata string
 
-char *zmq_msg_gets (zmq_msg_t *msg_, char *property_)
+const char *zmq_msg_gets (zmq_msg_t *msg_, const char *property_)
 {
     //  All unknown properties return NULL
     return NULL;


### PR DESCRIPTION
Added modifiers reflect the following properties:
- zmq_msg_gets () does not mutate property parameter
- zmq_msg_gets () returns a pointer to memory the caller should not modify
