### PR TITLE
Define i_properties interface

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,6 +32,7 @@ libzmq_la_SOURCES = \
     i_decoder.hpp \
     i_engine.hpp \
     i_poll_events.hpp \
+    i_properties.hpp \
     io_object.hpp \
     io_thread.hpp \
     ip.hpp \

--- a/src/i_properties.hpp
+++ b/src/i_properties.hpp
@@ -1,0 +1,45 @@
+/*
+    Copyright (c) 2007-2014 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __ZMQ_I_PROPERTIES_HPP_INCLUDED__
+#define __ZMQ_I_PROPERTIES_HPP_INCLUDED__
+
+namespace zmq
+{
+    //  Interface for accessing message properties.
+    //  Implementers are supposed to use reference counting to
+    //  manage object's lifetime.
+
+    struct i_properties
+    {
+        virtual ~i_properties () {}
+
+        //  Returns pointer to property value or NULL if
+        //  property not found.
+        virtual const char *get (const char *property) const = 0;
+
+        virtual void add_ref () = 0;
+
+        //  Drop reference. Returns true iff the reference
+        //  counter drops to zero.
+        virtual bool drop_ref () = 0;
+    };
+}
+
+#endif

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -25,6 +25,7 @@
 
 #include "config.hpp"
 #include "atomic_counter.hpp"
+#include "i_properties.hpp"
 
 //  Signature for free function to deallocate the message content.
 //  Note that it has to be declared as "C" so that it is the same as
@@ -70,6 +71,8 @@ namespace zmq
         void reset_flags (unsigned char flags_);
         int64_t fd ();
         void set_fd (int64_t fd_);
+        i_properties *properties () const;
+        void set_properties (i_properties *properties_);
         bool is_identity () const;
         bool is_credential () const;
         bool is_delimiter () const;
@@ -85,8 +88,6 @@ namespace zmq
         bool rm_refs (int refs_);
 
     private:
-
-        class i_properties;
 
         //  Size in bytes of the largest message that is still copied around
         //  rather than being reference-counted.

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -63,6 +63,7 @@ struct iovec {
 #include "err.hpp"
 #include "msg.hpp"
 #include "fd.hpp"
+#include "i_properties.hpp"
 
 #if !defined ZMQ_HAVE_WINDOWS
 #include <unistd.h>
@@ -646,8 +647,11 @@ int zmq_msg_set (zmq_msg_t *, int, int)
 
 const char *zmq_msg_gets (zmq_msg_t *msg_, const char *property_)
 {
-    //  All unknown properties return NULL
-    return NULL;
+    zmq::i_properties *properties = ((zmq::msg_t*) msg_)->properties ();
+    if (properties)
+        return properties->get (property_);
+    else
+        return NULL;
 }
 
 // Polling.


### PR DESCRIPTION
- copy and move message operations are updated to maintain proper
  reference count of properties object
- zmq_msg_gets updated to use i_properties interface to fetch property
  value
- setter/getter added to msg_t class
