### PR TITLE
Include ZMTP properties in message metadata

### DIFF
--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -65,7 +65,13 @@ namespace zmq
 
         blob_t get_user_id () const;
 
-        metadata_t *get_metadata () { return metadata; }
+        const metadata_t::dict_t& get_zmtp_properties () {
+            return zmtp_properties;
+        }
+
+        const metadata_t::dict_t& get_zap_properties () {
+            return zap_properties;
+        }
 
     protected:
 
@@ -93,9 +99,11 @@ namespace zmq
         virtual int property (const std::string& name_,
                               const void *value_, size_t length_);
 
-        //  Metadada as returned by ZAP protocol.
-        //  NULL if no metadata received.
-        metadata_t *metadata;
+        //  Properties received from ZMTP peer.
+        metadata_t::dict_t zmtp_properties;
+
+        //  Properties received from ZAP server.
+        metadata_t::dict_t zap_properties;
 
         options_t options;
 

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -19,7 +19,7 @@
 
 #include "metadata.hpp"
 
-zmq::metadata_t::metadata_t (dict_t &dict) :
+zmq::metadata_t::metadata_t (const dict_t &dict) :
     ref_cnt (1),
     dict (dict)
 {

--- a/src/metadata.hpp
+++ b/src/metadata.hpp
@@ -31,7 +31,9 @@ namespace zmq
     {
         public:
 
-            metadata_t (std::map <const std::string, const std::string> &dict);
+            typedef std::map <const std::string, const std::string> dict_t;
+
+            metadata_t (const dict_t &dict);
             virtual ~metadata_t ();
 
             //  Returns pointer to property value or NULL if
@@ -50,7 +52,6 @@ namespace zmq
             atomic_counter_t ref_cnt;
 
             //  Dictionary holding metadata.
-            typedef std::map <const std::string, const std::string> dict_t;
             const dict_t dict;
     };
 

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -30,6 +30,7 @@
 #include "options.hpp"
 #include "socket_base.hpp"
 #include "../include/zmq.h"
+#include "metadata.hpp"
 
 namespace zmq
 {
@@ -130,6 +131,9 @@ namespace zmq
         unsigned char *outpos;
         size_t outsize;
         i_encoder *encoder;
+
+        //  Metadata to be attached to received messages. May be NULL.
+        metadata_t *metadata;
 
         //  When true, we are still trying to determine whether
         //  the peer is using versioned protocol, and if so, which


### PR DESCRIPTION
Metadata are built in stream_engine now.
This makes it easy to extend metadata with user-defined properties.
