### PR TITLE
gssapi: RFC 2744 mandates GSS_C_NT_HOSTBASED_SERVICE

### DIFF
--- a/src/gssapi_client.cpp
+++ b/src/gssapi_client.cpp
@@ -165,7 +165,8 @@ int zmq::gssapi_client_t::initialize_context ()
         send_tok.value = service_name;
         send_tok.length = strlen(service_name);
         OM_uint32 maj = gss_import_name(&min_stat, &send_tok,
-                                        gss_nt_service_name, &target_name);
+                                        GSS_C_NT_HOSTBASED_SERVICE,
+                                        &target_name);
 
         if (maj != GSS_S_COMPLETE)
             return -1;

--- a/src/gssapi_mechanism_base.cpp
+++ b/src/gssapi_mechanism_base.cpp
@@ -317,7 +317,7 @@ int zmq::gssapi_mechanism_base_t::acquire_credentials (char * service_name_, gss
     name_buf.length = strlen ((char *) name_buf.value) + 1;
 
     maj_stat = gss_import_name (&min_stat, &name_buf,
-                                gss_nt_service_name, &server_name);
+                                GSS_C_NT_HOSTBASED_SERVICE, &server_name);
 
     if (maj_stat != GSS_S_COMPLETE)
         return -1;

--- a/src/gssapi_mechanism_base.hpp
+++ b/src/gssapi_mechanism_base.hpp
@@ -24,7 +24,9 @@
 
 #ifdef HAVE_LIBGSSAPI_KRB5
 
+#ifndef ZMQ_HAVE_FREEBSD
 #include <gssapi/gssapi_generic.h>
+#endif
 #include <gssapi/gssapi_krb5.h>
 
 #include "mechanism.hpp"


### PR DESCRIPTION
Tested on FreeBSD 10. Fixes the build and looks reasonable for other OSes, but testing on non-FreeBSD would be welcome. I know you like to pull without testing Pieter. :D
