### PR TITLE
tests: fix abstract ipc test by omitting slashes

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -146,5 +146,5 @@ TESTS = $(noinst_PROGRAMS)
 XFAIL_TESTS =
 
 if !ON_LINUX
-XFAIL_TESTS += test_abstract_ipc
+XFAIL_TESTS +=
 endif

--- a/tests/test_abstract_ipc.cpp
+++ b/tests/test_abstract_ipc.cpp
@@ -27,19 +27,19 @@ int main (void)
 
     void *sb = zmq_socket (ctx, ZMQ_DEALER);
     assert (sb);
-    int rc = zmq_bind (sb, "ipc://@/tmp/tester");
+    int rc = zmq_bind (sb, "ipc://@tmp-tester");
     assert (rc == 0);
 
     char endpoint[200];
     size_t size = sizeof(endpoint);
     rc = zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, endpoint, &size);
     assert (rc == 0);
-    rc = strncmp(endpoint, "ipc://@/tmp/tester", size);
+    rc = strncmp(endpoint, "ipc://@tmp-tester", size);
     assert (rc == 0);
 
     void *sc = zmq_socket (ctx, ZMQ_DEALER);
     assert (sc);
-    rc = zmq_connect (sc, "ipc://@/tmp/tester");
+    rc = zmq_connect (sc, "ipc://@tmp-tester");
     assert (rc == 0);
     
     bounce (sb, sc);


### PR DESCRIPTION
https://zeromq.jira.com/browse/LIBZMQ-567 says slashes are bad for NO_LINUX so there's no reason to use them in the test. Does that sound reasonable? Tests run fine on FreeBSD now...
