### PR TITLE
ipc: fail harder for abstract ipc on non-Linux

### DIFF
--- a/src/ipc_address.cpp
+++ b/src/ipc_address.cpp
@@ -51,20 +51,16 @@ int zmq::ipc_address_t::resolve (const char *path_)
         errno = ENAMETOOLONG;
         return -1;
     }
-#if defined ZMQ_HAVE_LINUX
     if (path_[0] == '@' && !path_[1]) {
         errno = EINVAL;
         return -1;
     }
-#endif
 
     address.sun_family = AF_UNIX;
     strcpy (address.sun_path, path_);
-#if defined ZMQ_HAVE_LINUX
-    /* Abstract sockets on Linux start with '\0' */
+    /* Abstract sockets start with '\0' */
     if (path_[0] == '@')
         *address.sun_path = '\0';
-#endif
     return 0;
 }
 
@@ -76,15 +72,11 @@ int zmq::ipc_address_t::to_string (std::string &addr_)
     }
 
     std::stringstream s;
-#if !defined ZMQ_HAVE_LINUX
-    s << "ipc://" << address.sun_path;
-#else
     s << "ipc://";
     if (!address.sun_path[0] && address.sun_path[1])
        s << "@" << address.sun_path + 1;
     else
        s << address.sun_path;
-#endif
     addr_ = s.str ();
     return 0;
 }
@@ -96,10 +88,8 @@ const sockaddr *zmq::ipc_address_t::addr () const
 
 socklen_t zmq::ipc_address_t::addrlen () const
 {
-#if defined ZMQ_HAVE_LINUX
     if (!address.sun_path[0] && address.sun_path[1])
         return (socklen_t) strlen(address.sun_path + 1) + sizeof (sa_family_t) + 1;
-#endif
     return (socklen_t) sizeof (address);
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -146,5 +146,5 @@ TESTS = $(noinst_PROGRAMS)
 XFAIL_TESTS =
 
 if !ON_LINUX
-XFAIL_TESTS +=
+XFAIL_TESTS += test_abstract_ipc
 endif


### PR DESCRIPTION
Using 'ipc://@abstract-socket' on non-Linux platforms yields inconsistent
behaviour.  Abstract sockets don't exist, so the literal file is created.
The test previously failed, but for a different reason: this is not the
directory you are looking for.  Now, zmq_bind() will fail for the right
reason: the socket can't be created.  Put the XFAIL back.
