### PR TITLE
add untracked test_stream_timeout into .gitignore and tests/Makefile.am

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tools/curve_keygen
 tests/test_resource
 tests/test_ipc_wildcard
 tests/test_stream_empty
+tests/test_stream_timeout
 tests/test_issue_566
 tests/test_ctx_destroy
 tests/test_term_endpoint

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -95,6 +95,7 @@ test_router_handover_SOURCES = test_router_handover.cpp
 test_probe_router_SOURCES = test_probe_router.cpp
 test_stream_SOURCES = test_stream.cpp
 test_stream_empty_SOURCES = test_stream_empty.cpp
+test_stream_timeout_SOURCES = test_stream_timeout.cpp
 test_stream_disconnect_SOURCES = test_stream_disconnect.cpp
 test_disconnect_inproc_SOURCES = test_disconnect_inproc.cpp
 test_ctx_options_SOURCES = test_ctx_options.cpp


### PR DESCRIPTION
fix the error while make (after ./autogen.sh and ./configure):

~$ make
  CXX      test_stream.o
  CXXLD    test_stream
  CXX      test_stream_empty.o
  CXXLD    test_stream_empty
  CXX      test_stream_disconnect.o
  CXXLD    test_stream_disconnect
make[1]: **\* No rule to make target `test_stream_timeout.c', needed by`test_stream_timeout.o'.  Stop.
make: **\* [all-recursive] Error 1
