### PR TITLE
Don't reconnect on protocol errors

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -376,10 +376,22 @@ void zmq::session_base_t::engine_error (
     if (pipe)
         clean_pipes ();
 
-    if (active)
-        reconnect ();
-    else
-        terminate ();
+    zmq_assert (reason == stream_engine_t::connection_error
+             || reason == stream_engine_t::timeout_error
+             || reason == stream_engine_t::protocol_error);
+
+    switch (reason) {
+        case stream_engine_t::timeout_error:
+        case stream_engine_t::connection_error:
+            if (active)
+                reconnect ();
+            else
+                terminate ();
+            break;
+        case stream_engine_t::protocol_error:
+            terminate ();
+            break;
+    }
 
     //  Just in case there's only a delimiter in the pipe.
     if (pipe)


### PR DESCRIPTION
Note that this patch makes test_security_null, test_security_plain and test_security_curve tests block.
