### PR TITLE
Added ProgramDataBaseFile directive

### DIFF
--- a/builds/msvc/properties/Debug.props
+++ b/builds/msvc/properties/Debug.props
@@ -17,6 +17,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(TargetDir)$(TargetName).pdb</ProgramDataBaseFileName>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
Debug builds create a ProgramDataBaseFile (PDB) which is used when linking to projects to provide debug symbol information.  At present this is being placed in the default 'intermediate files' folder, but it should be in the same places as the .lib file, the TargetDir.

This PR adds the necessary directive to the Debug.props file.
