### PR TITLE
Added ignore for perf/platform.hpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ perf/remote_lat
 perf/remote_thr
 perf/inproc_lat
 perf/inproc_thr
+perf/platform.hpp
 doc/*.1
 doc/*.3
 doc/*.7


### PR DESCRIPTION
`perf/platform.hpp` is generated by a Windows MSVC build and therefore does not need to be a tracked file.  Added to .gitignore so that it doesn't think there are untracked changes.
