### PR TITLE
Fix for perf/platform.hpp not being cleaned up by distclean

### DIFF
--- a/builds/msvc/vs2008/inproc_lat/inproc_lat.vcproj
+++ b/builds/msvc/vs2008/inproc_lat/inproc_lat.vcproj
@@ -6,7 +6,7 @@
   <ToolFiles />
   <Configurations>
     <Configuration Name="Debug|Win32" OutputDirectory="$(SolutionDir)$(ConfigurationName)" IntermediateDirectory="$(ConfigurationName)" ConfigurationType="1" CharacterSet="2">
-      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\perf" />
+      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\src" />
       <Tool Name="VCCustomBuildTool" />
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCMIDLTool" />
@@ -24,7 +24,7 @@
       <Tool Name="VCPostBuildEventTool" />
     </Configuration>
     <Configuration Name="Release|Win32" OutputDirectory="$(SolutionDir)$(ConfigurationName)" IntermediateDirectory="$(ConfigurationName)" ConfigurationType="1" CharacterSet="2" WholeProgramOptimization="1">
-      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\perf" />
+      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\src" />
       <Tool Name="VCCustomBuildTool" />
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCMIDLTool" />

--- a/builds/msvc/vs2008/inproc_thr/inproc_thr.vcproj
+++ b/builds/msvc/vs2008/inproc_thr/inproc_thr.vcproj
@@ -6,7 +6,7 @@
   <ToolFiles />
   <Configurations>
     <Configuration Name="Debug|Win32" OutputDirectory="$(SolutionDir)$(ConfigurationName)" IntermediateDirectory="$(ConfigurationName)" ConfigurationType="1" CharacterSet="2">
-      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\perf" />
+      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\src" />
       <Tool Name="VCCustomBuildTool" />
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCMIDLTool" />
@@ -24,7 +24,7 @@
       <Tool Name="VCPostBuildEventTool" />
     </Configuration>
     <Configuration Name="Release|Win32" OutputDirectory="$(SolutionDir)$(ConfigurationName)" IntermediateDirectory="$(ConfigurationName)" ConfigurationType="1" CharacterSet="2" WholeProgramOptimization="1">
-      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\perf" />
+      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\src" />
       <Tool Name="VCCustomBuildTool" />
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCMIDLTool" />

--- a/builds/msvc/vs2008/local_thr/local_thr.vcproj
+++ b/builds/msvc/vs2008/local_thr/local_thr.vcproj
@@ -6,7 +6,7 @@
   <ToolFiles />
   <Configurations>
     <Configuration Name="Debug|Win32" OutputDirectory="$(SolutionDir)$(ConfigurationName)" IntermediateDirectory="$(ConfigurationName)" ConfigurationType="1" CharacterSet="2">
-      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\perf" />
+      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\src" />
       <Tool Name="VCCustomBuildTool" />
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCMIDLTool" />
@@ -24,7 +24,7 @@
       <Tool Name="VCPostBuildEventTool" />
     </Configuration>
     <Configuration Name="Release|Win32" OutputDirectory="$(SolutionDir)$(ConfigurationName)" IntermediateDirectory="$(ConfigurationName)" ConfigurationType="1" CharacterSet="2" WholeProgramOptimization="1">
-      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\perf" />
+      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\src" />
       <Tool Name="VCCustomBuildTool" />
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCMIDLTool" />

--- a/builds/msvc/vs2008/remote_thr/remote_thr.vcproj
+++ b/builds/msvc/vs2008/remote_thr/remote_thr.vcproj
@@ -6,7 +6,7 @@
   <ToolFiles />
   <Configurations>
     <Configuration Name="Debug|Win32" OutputDirectory="$(SolutionDir)$(ConfigurationName)" IntermediateDirectory="$(ConfigurationName)" ConfigurationType="1" CharacterSet="2">
-      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\perf" />
+      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\src" />
       <Tool Name="VCCustomBuildTool" />
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCMIDLTool" />
@@ -24,7 +24,7 @@
       <Tool Name="VCPostBuildEventTool" />
     </Configuration>
     <Configuration Name="Release|Win32" OutputDirectory="$(SolutionDir)$(ConfigurationName)" IntermediateDirectory="$(ConfigurationName)" ConfigurationType="1" CharacterSet="2" WholeProgramOptimization="1">
-      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\perf" />
+      <Tool Name="VCPreBuildEventTool" CommandLine="copy ..\..\platform.hpp ..\..\..\..\src" />
       <Tool Name="VCCustomBuildTool" />
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCMIDLTool" />

--- a/builds/msvc/vs2010/inproc_lat/inproc_lat.props
+++ b/builds/msvc/vs2010/inproc_lat/inproc_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2010/inproc_lat/inproc_lat.vcxproj
+++ b/builds/msvc/vs2010/inproc_lat/inproc_lat.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\inproc_lat.cpp" />

--- a/builds/msvc/vs2010/inproc_thr/inproc_thr.props
+++ b/builds/msvc/vs2010/inproc_thr/inproc_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2010/inproc_thr/inproc_thr.vcxproj
+++ b/builds/msvc/vs2010/inproc_thr/inproc_thr.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\inproc_thr.cpp" />

--- a/builds/msvc/vs2010/local_lat/local_lat.props
+++ b/builds/msvc/vs2010/local_lat/local_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2010/local_lat/local_lat.vcxproj
+++ b/builds/msvc/vs2010/local_lat/local_lat.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup> 
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\local_lat.cpp" />

--- a/builds/msvc/vs2010/local_thr/local_thr.props
+++ b/builds/msvc/vs2010/local_thr/local_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2010/local_thr/local_thr.vcxproj
+++ b/builds/msvc/vs2010/local_thr/local_thr.vcxproj
@@ -68,7 +68,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\local_thr.cpp" />

--- a/builds/msvc/vs2010/remote_lat/remote_lat.props
+++ b/builds/msvc/vs2010/remote_lat/remote_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2010/remote_lat/remote_lat.vcxproj
+++ b/builds/msvc/vs2010/remote_lat/remote_lat.vcxproj
@@ -68,7 +68,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup> 
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\remote_lat.cpp" />

--- a/builds/msvc/vs2010/remote_thr/remote_thr.props
+++ b/builds/msvc/vs2010/remote_thr/remote_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2010/remote_thr/remote_thr.vcxproj
+++ b/builds/msvc/vs2010/remote_thr/remote_thr.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>  
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\remote_thr.cpp" />

--- a/builds/msvc/vs2012/inproc_lat/inproc_lat.props
+++ b/builds/msvc/vs2012/inproc_lat/inproc_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2012/inproc_lat/inproc_lat.vcxproj
+++ b/builds/msvc/vs2012/inproc_lat/inproc_lat.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\inproc_lat.cpp" />

--- a/builds/msvc/vs2012/inproc_thr/inproc_thr.props
+++ b/builds/msvc/vs2012/inproc_thr/inproc_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2012/inproc_thr/inproc_thr.vcxproj
+++ b/builds/msvc/vs2012/inproc_thr/inproc_thr.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\inproc_thr.cpp" />

--- a/builds/msvc/vs2012/local_lat/local_lat.props
+++ b/builds/msvc/vs2012/local_lat/local_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2012/local_lat/local_lat.vcxproj
+++ b/builds/msvc/vs2012/local_lat/local_lat.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup> 
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\local_lat.cpp" />

--- a/builds/msvc/vs2012/local_thr/local_thr.props
+++ b/builds/msvc/vs2012/local_thr/local_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2012/local_thr/local_thr.vcxproj
+++ b/builds/msvc/vs2012/local_thr/local_thr.vcxproj
@@ -68,7 +68,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\local_thr.cpp" />

--- a/builds/msvc/vs2012/remote_lat/remote_lat.props
+++ b/builds/msvc/vs2012/remote_lat/remote_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2012/remote_lat/remote_lat.vcxproj
+++ b/builds/msvc/vs2012/remote_lat/remote_lat.vcxproj
@@ -68,7 +68,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup> 
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\remote_lat.cpp" />

--- a/builds/msvc/vs2012/remote_thr/remote_thr.props
+++ b/builds/msvc/vs2012/remote_thr/remote_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2012/remote_thr/remote_thr.vcxproj
+++ b/builds/msvc/vs2012/remote_thr/remote_thr.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>  
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\remote_thr.cpp" />

--- a/builds/msvc/vs2013/inproc_lat/inproc_lat.props
+++ b/builds/msvc/vs2013/inproc_lat/inproc_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2013/inproc_lat/inproc_lat.vcxproj
+++ b/builds/msvc/vs2013/inproc_lat/inproc_lat.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\inproc_lat.cpp" />

--- a/builds/msvc/vs2013/inproc_thr/inproc_thr.props
+++ b/builds/msvc/vs2013/inproc_thr/inproc_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2013/inproc_thr/inproc_thr.vcxproj
+++ b/builds/msvc/vs2013/inproc_thr/inproc_thr.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\inproc_thr.cpp" />

--- a/builds/msvc/vs2013/local_lat/local_lat.props
+++ b/builds/msvc/vs2013/local_lat/local_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2013/local_lat/local_lat.vcxproj
+++ b/builds/msvc/vs2013/local_lat/local_lat.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup> 
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\local_lat.cpp" />

--- a/builds/msvc/vs2013/local_thr/local_thr.props
+++ b/builds/msvc/vs2013/local_thr/local_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2013/local_thr/local_thr.vcxproj
+++ b/builds/msvc/vs2013/local_thr/local_thr.vcxproj
@@ -68,7 +68,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\local_thr.cpp" />

--- a/builds/msvc/vs2013/remote_lat/remote_lat.props
+++ b/builds/msvc/vs2013/remote_lat/remote_lat.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2013/remote_lat/remote_lat.vcxproj
+++ b/builds/msvc/vs2013/remote_lat/remote_lat.vcxproj
@@ -68,7 +68,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup> 
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\remote_lat.cpp" />

--- a/builds/msvc/vs2013/remote_thr/remote_thr.props
+++ b/builds/msvc/vs2013/remote_thr/remote_thr.props
@@ -11,7 +11,7 @@
 
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)perf\</Command>
+      <Command>xcopy /c /y $(BuildRoot)platform.hpp $(RepoRoot)src\</Command>
     </PreBuildEvent>
     <Link>
       <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -41,7 +41,7 @@
   <!-- Messages -->
 
   <Target Name="CustomInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)perf\platform.hpp" Importance="high"/>
+    <Message Text="Will copy $(BuildRoot)platform.hpp -&gt; $(RepoRoot)src\platform.hpp" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2013/remote_thr/remote_thr.vcxproj
+++ b/builds/msvc/vs2013/remote_thr/remote_thr.vcxproj
@@ -64,7 +64,7 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>  
   <ItemGroup>
-    <ClInclude Include="..\..\..\..\perf\platform.hpp" />
+    <ClInclude Include="..\..\..\..\src\platform.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\..\perf\remote_thr.cpp" />

--- a/perf/inproc_lat.cpp
+++ b/perf/inproc_lat.cpp
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "platform.hpp"
+#include "../src/platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>

--- a/perf/inproc_thr.cpp
+++ b/perf/inproc_thr.cpp
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "platform.hpp"
+#include "../src/platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>


### PR DESCRIPTION
`platform.hpp` was being copied to `/perf` by the msvc projects.  This was not cleaned up by `make distclean` when preparing for another platform build.  The file was already being copied to `/src` as part of the libzmq core project build, so revised the projects to copy to `/src` as well, and changed `#include` statements in affected `/perf` modules to reference the new location.
