### PR TITLE
Exclude MSVC temp files regardless of where they are in builds/msvc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,11 +113,11 @@ src/libzmq.pc
 bin/
 lib/
 obj/
-builds/msvc/*.suo
-builds/msvc/*.sdf
-builds/msvc/*/*.user
-builds/msvc/*/*Debug
-builds/msvc/*/*Release
+builds/msvc/**/*.suo
+builds/msvc/**/*.sdf
+builds/msvc/**/*.user
+builds/msvc/**/*Debug
+builds/msvc/**/*Release
 builds/redhat/zeromq.spec
 foreign/openpgm/*
 !foreign/openpgm/*.tar.bz2


### PR DESCRIPTION
gitignore was for specific temporaries in the builds/msvc folder but these can appear in any subfolder depending on where the build was instigated.
