### PR TITLE
Restore unpathed references to platform.hpp for cmake builds

### DIFF
--- a/perf/inproc_lat.cpp
+++ b/perf/inproc_lat.cpp
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../src/platform.hpp"
+#include "platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>

--- a/perf/inproc_thr.cpp
+++ b/perf/inproc_thr.cpp
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../src/platform.hpp"
+#include "platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>


### PR DESCRIPTION
Previous commit fixed distclean for msvc but broke it for cmake.  This restores includes suitable for cmake, msvc fixes to come.
