### PR TITLE
handle WSAEADDRINUSE in tcp_connecter_t::connect

### DIFF
--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -319,7 +319,7 @@ zmq::fd_t zmq::tcp_connecter_t::connect ()
             err == WSAENETDOWN ||
             err == WSAEACCES ||
             err == WSAEINVAL ||
-            err == WSAEADDRINUSE )
+            err == WSAEADDRINUSE)
             return retired_fd;
         wsa_assert_no (err);
     }


### PR DESCRIPTION
As [mentioned on the mailing list](http://lists.zeromq.org/pipermail/zeromq-dev/2014-June/026279.html), Windows may return WSAEADDRINUSE when binding (reconnecting) to a port. Added this to the handled error codes as Pieter suggested.
