### PR TITLE
Corrected installer source path for VS pdb debug symbols file.  Removed ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,7 +766,7 @@ if(MSVC)
             ARCHIVE DESTINATION lib
             PUBLIC_HEADER DESTINATION include
             COMPONENT SDK)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/libzmq${_zmq_COMPILER}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}.pdb DESTINATION lib
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/libzmq${_zmq_COMPILER}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}.pdb DESTINATION lib
             COMPONENT SDK)
   else()
     install(TARGETS libzmq

--- a/perf/inproc_lat.cpp
+++ b/perf/inproc_lat.cpp
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../src/platform.hpp"
+#include "platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>

--- a/perf/inproc_thr.cpp
+++ b/perf/inproc_thr.cpp
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../src/platform.hpp"
+#include "platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>


### PR DESCRIPTION
Based upon the current CMake files, platform.hpp gets created in the binary directory, not the source directory.  This leads to issues when specifying relative paths for the inclusion of headers, which are based upon the source directory.

The Microsoft pdb (debug symbols file) gets created in the bin directory rather than lib.  This leads to a failure at installation time.
