### PR TITLE
Fix failed assertion for WSAENOTSOCK

### DIFF
--- a/src/err.cpp
+++ b/src/err.cpp
@@ -245,7 +245,7 @@ int zmq::wsa_error_to_errno (int errcode)
         return EAGAIN;
 //  10038 - Socket operation on non-socket.
     case WSAENOTSOCK:
-        return EFAULT;
+        return ENOTSOCK;
 //  10039 - Destination address required.
     case WSAEDESTADDRREQ:
         return EFAULT;


### PR DESCRIPTION
In de9eef306, the error number assigned to WSAENOTSOCK was EFAULT, but
zmq.cpp:919 expects an ENOTSOCK in this case.

BTW: This patch should apply to zeromq4-x cleanly, as well.
