### PR TITLE
Problem: zmq_msg_gets did not set errno on unknown properties

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -648,10 +648,15 @@ int zmq_msg_set (zmq_msg_t *, int, int)
 const char *zmq_msg_gets (zmq_msg_t *msg_, const char *property_)
 {
     zmq::metadata_t *metadata = ((zmq::msg_t*) msg_)->metadata ();
+    const char *value = NULL;
     if (metadata)
-        return metadata->get (std::string (property_));
-    else
+        value = metadata->get (std::string (property_));
+    if (value)
+        return value;
+    else {
+        errno = EINVAL;
         return NULL;
+    }
 }
 
 // Polling.

--- a/tests/test_metadata.cpp
+++ b/tests/test_metadata.cpp
@@ -100,6 +100,8 @@ int main (void)
     assert (streq (zmq_msg_gets (&msg, "Hello"), "World"));
     assert (streq (zmq_msg_gets (&msg, "Socket-Type"), "DEALER"));
     assert (streq (zmq_msg_gets (&msg, "User-Id"), "anonymous"));
+    assert (zmq_msg_gets (&msg, "No Such") == NULL);
+    assert (zmq_errno () == EINVAL);
     zmq_msg_close (&msg);
 
     close_zero_linger (client);


### PR DESCRIPTION
Solution: set errno to EINVAL when a property does not exist.
