### PR TITLE
socks: fix build on FreeBSD

### DIFF
--- a/src/socks.cpp
+++ b/src/socks.cpp
@@ -26,6 +26,7 @@
 
 #ifndef ZMQ_HAVE_WINDOWS
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netdb.h>
 #endif
 


### PR DESCRIPTION
The fix should be sane on all UNIX-like systems, so there's
no ZMQ_HAVE_FREEBSD involved.  It's likely that other BSDs
stumble across this problem too.

**_Please test this on Linux before merging.**_
