### PR TITLE
Add missing socks files

### DIFF
--- a/builds/msvc/vs2013/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2013/libzmq/libzmq.vcxproj
@@ -113,6 +113,8 @@
     <ClInclude Include="..\..\..\..\src\pgm_sender.hpp" />
     <ClInclude Include="..\..\..\..\src\pgm_socket.hpp" />
     <ClInclude Include="..\..\..\..\src\pipe.hpp" />
+    <ClInclude Include="..\..\..\..\src\socks.hpp" />
+    <ClInclude Include="..\..\..\..\src\socks_connecter.hpp" />
     <ClInclude Include="..\..\platform.hpp" />
     <ClInclude Include="..\..\..\..\src\poll.hpp" />
     <ClInclude Include="..\..\..\..\src\poller.hpp" />
@@ -211,6 +213,8 @@
     <ClCompile Include="..\..\..\..\src\session_base.cpp" />
     <ClCompile Include="..\..\..\..\src\signaler.cpp" />
     <ClCompile Include="..\..\..\..\src\socket_base.cpp" />
+    <ClCompile Include="..\..\..\..\src\socks.cpp" />
+    <ClCompile Include="..\..\..\..\src\socks_connecter.cpp" />
     <ClCompile Include="..\..\..\..\src\stream.cpp" />
     <ClCompile Include="..\..\..\..\src\stream_engine.cpp" />
     <ClCompile Include="..\..\..\..\src\sub.cpp" />


### PR DESCRIPTION
Two files were missing from the vs2013 vcxproj file, I've added them both so that visual studio can correctly build libzmq
