### PR TITLE
define encoding for message metadata to be UTF8

### DIFF
--- a/doc/zmq_msg_gets.txt
+++ b/doc/zmq_msg_gets.txt
@@ -16,9 +16,10 @@ DESCRIPTION
 -----------
 The _zmq_msg_gets()_ function shall return the string value for the metadata
 property specified by the 'property' argument for the message pointed to by
-the 'message' argument.
+the 'message' argument. Both the 'property' argument and the 'value'
+shall be NULL-terminated UTF8-encoded strings.
 
-The following properties can be retrieved with the _zmq_msg_get()_ function:
+The following properties can be retrieved with the _zmq_msg_gets()_ function:
 
 
 RETURN VALUE
@@ -26,7 +27,8 @@ RETURN VALUE
 The _zmq_msg_gets()_ function shall return the string value for the property
 if successful. Otherwise it shall return NULL and set 'errno' to one of the
 values defined below. The caller shall not modify or free the returned value,
-which shall be owned by the message.
+which shall be owned by the message. The encoding of the property and value
+shall be UTF8.
 
 
 ERRORS


### PR DESCRIPTION
Clarifies that these are text fields, and removes ambiguity about how to create proper text object from stored bytes.

If message metadata should be allowed to be arbitrary non-null binary data, then obviously this PR shouldn't be merged.
