### PR TITLE
Bugfix wrong CMakeLists.txt after rename of file

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,7 @@ set(tests
         test_many_sockets
         test_diffserv
         test_connect_rid
-        test_xpub_wait_inproc
+        test_xpub_nodrop
 )
 if(NOT WIN32)
   list(APPEND tests


### PR DESCRIPTION
On my last pull request there seemed to be an error in Makefile.am and CMakeLists.txt due to rename of file.
Makefile.am was already fixed, but not CMakeLists.txt

Please integrate it into libzmq to avoid cmake configuration errors.
