### PR TITLE
fix #1058 pipe_t needs to take ownership of metadata

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -199,6 +199,14 @@ bool zmq::pipe_t::write (msg_t *msg_)
     if (unlikely (!check_write ()))
         return false;
 
+    // call will close9) msg_, we need to take ownership of any metadata
+    // while in pipe
+    if (msg_->is_vsm()) {
+        zmq::metadata_t* metadata = msg_->metadata();
+        if (unlikely(metadata != 0))
+            metadata->add_ref();
+    }
+
     bool more = msg_->flags () & msg_t::more ? true : false;
     const bool is_identity = msg_->is_identity ();
     outpipe->write (*msg_, more);


### PR DESCRIPTION
The issue boils down to - 
- the sending side will call close() on a message after placing it in the pipe (and before returning form zmq_msg_send()), causing any associated metadata to have a reference decremented.
- the receiving side will also call close() on a message after delivering it, without having taken ownership of the metadata.

I am not entirely happy with this fix, but I don't know a better way of fixing it without significantly altering the implementation of msg_t to properly support copy/move construction (and likely breaking other assumptions).
