### PR TITLE
Add const qualifier to source parameters for z85 encode/decode

### DIFF
--- a/doc/zmq_z85_decode.txt
+++ b/doc/zmq_z85_decode.txt
@@ -9,7 +9,7 @@ zmq_z85_decode - decode a binary key from Z85 printable text
 
 SYNOPSIS
 --------
-*uint8_t *zmq_z85_decode (uint8_t *dest, char *string);*
+*uint8_t *zmq_z85_decode (uint8_t *dest, const char *string);*
 
 
 DESCRIPTION
@@ -31,7 +31,7 @@ EXAMPLE
 -------
 .Decoding a CURVE key
 ----
-char decoded [] = "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7";
+const char decoded [] = "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7";
 uint8_t public_key [32];
 zmq_z85_decode (public_key, decoded);
 ----

--- a/doc/zmq_z85_encode.txt
+++ b/doc/zmq_z85_encode.txt
@@ -9,7 +9,7 @@ zmq_z85_encode - encode a binary key as Z85 printable text
 
 SYNOPSIS
 --------
-*char *zmq_z85_encode (char *dest, uint8_t *data, size_t size);*
+*char *zmq_z85_encode (char *dest, const uint8_t *data, size_t size);*
 
 
 DESCRIPTION

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -420,10 +420,10 @@ ZMQ_EXPORT int zmq_recvmsg (void *s, zmq_msg_t *msg, int flags);
 /******************************************************************************/
 
 /*  Encode data with Z85 encoding. Returns encoded data                       */
-ZMQ_EXPORT char *zmq_z85_encode (char *dest, uint8_t *data, size_t size);
+ZMQ_EXPORT char *zmq_z85_encode (char *dest, const uint8_t *data, size_t size);
 
 /*  Decode data with Z85 encoding. Returns decoded data                       */
-ZMQ_EXPORT uint8_t *zmq_z85_decode (uint8_t *dest, char *string);
+ZMQ_EXPORT uint8_t *zmq_z85_decode (uint8_t *dest, const char *string);
 
 /*  Generate z85-encoded public and private keypair with libsodium.           */
 /*  Returns 0 on success.                                                     */

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -111,7 +111,7 @@ static uint8_t decoder [96] = {
 //  dest. Size must be a multiple of 4.
 //  Returns NULL and sets errno = EINVAL for invalid input.
 
-char *zmq_z85_encode (char *dest, uint8_t *data, size_t size)
+char *zmq_z85_encode (char *dest, const uint8_t *data, size_t size)
 {
     if (size % 4 != 0) {
         errno = EINVAL;
@@ -145,7 +145,7 @@ char *zmq_z85_encode (char *dest, uint8_t *data, size_t size)
 //  must be a multiple of 5.
 //  Returns NULL and sets errno = EINVAL for invalid input.
 
-uint8_t *zmq_z85_decode (uint8_t *dest, char *string)
+uint8_t *zmq_z85_decode (uint8_t *dest, const char *string)
 {
     if (strlen (string) % 5 != 0) {
         errno = EINVAL;


### PR DESCRIPTION
Hello,

This simply adds the `const` qualifier to read only parameters for `zmq_z85_encode` and `zmq_z85_decode` functions.
