### PR TITLE
Problem: FD_SETSIZE 1024 is too restrictive under Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ if(MSVC)
     -DWIN32
     -DDLL_EXPORT
     # NB: May require tweaking for highly connected applications.
-    -DFD_SETSIZE=1024
+    -DFD_SETSIZE=4096
     -D_CRT_SECURE_NO_WARNINGS)
 
   # Parallel make.

--- a/builds/mingw32/Makefile.mingw32
+++ b/builds/mingw32/Makefile.mingw32
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Wall -Os -g -DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -I.
+CFLAGS=-Wall -Os -g -DDLL_EXPORT -DFD_SETSIZE=4096 -DZMQ_USE_SELECT -I.
 LIBS=-lws2_32
 
 OBJS = ctx.o reaper.o dist.o err.o \

--- a/builds/msvc/vs2008/libzmq/libzmq.vcproj
+++ b/builds/msvc/vs2008/libzmq/libzmq.vcproj
@@ -11,7 +11,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" />
-      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="0" PreprocessorDefinitions="NOMINMAX" MinimalRebuild="true" BasicRuntimeChecks="3" RuntimeLibrary="3" WarningLevel="3" DebugInformationFormat="4" />
+      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=4096 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="0" PreprocessorDefinitions="NOMINMAX" MinimalRebuild="true" BasicRuntimeChecks="3" RuntimeLibrary="3" WarningLevel="3" DebugInformationFormat="4" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
@@ -30,7 +30,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" />
-      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="2" EnableIntrinsicFunctions="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" WarningLevel="3" DebugInformationFormat="3" />
+      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=4096 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="2" EnableIntrinsicFunctions="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" WarningLevel="3" DebugInformationFormat="3" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
@@ -49,7 +49,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" />
-      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="0" PreprocessorDefinitions="NOMINMAX" MinimalRebuild="true" BasicRuntimeChecks="3" RuntimeLibrary="3" WarningLevel="3" DebugInformationFormat="4" />
+      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=4096 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="0" PreprocessorDefinitions="NOMINMAX" MinimalRebuild="true" BasicRuntimeChecks="3" RuntimeLibrary="3" WarningLevel="3" DebugInformationFormat="4" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
@@ -66,7 +66,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" />
-      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="2" EnableIntrinsicFunctions="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" WarningLevel="3" DebugInformationFormat="3" />
+      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DZMQ_STATIC -DFD_SETSIZE=4096 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="2" EnableIntrinsicFunctions="true" RuntimeLibrary="2" EnableFunctionLevelLinking="true" WarningLevel="3" DebugInformationFormat="3" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
@@ -83,7 +83,7 @@
       <Tool Name="VCXMLDataGeneratorTool" />
       <Tool Name="VCWebServiceProxyGeneratorTool" />
       <Tool Name="VCMIDLTool" />
-      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=1024 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="2" EnableIntrinsicFunctions="true" AdditionalIncludeDirectories="../../../../OpenPGM/include" PreprocessorDefinitions="ZMQ_HAVE_OPENPGM" RuntimeLibrary="2" EnableFunctionLevelLinking="true" WarningLevel="3" DebugInformationFormat="3" />
+      <Tool Name="VCCLCompilerTool" AdditionalOptions="-DDLL_EXPORT -DFD_SETSIZE=4096 -DZMQ_USE_SELECT -D_CRT_SECURE_NO_WARNINGS" Optimization="2" EnableIntrinsicFunctions="true" AdditionalIncludeDirectories="../../../../OpenPGM/include" PreprocessorDefinitions="ZMQ_HAVE_OPENPGM" RuntimeLibrary="2" EnableFunctionLevelLinking="true" WarningLevel="3" DebugInformationFormat="3" />
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />

--- a/builds/msvc/vs2010/libzmq/libzmq.props
+++ b/builds/msvc/vs2010/libzmq/libzmq.props
@@ -23,7 +23,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;$(ProjectDir)..\..\..\..\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <EnablePREfast>false</EnablePREfast>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;FD_SETSIZE=1024;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;FD_SETSIZE=4096;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-openpgm)' == 'true'">ZMQ_HAVE_OPENPGM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-sodium)' == 'true'">HAVE_LIBSODIUM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-gssapi)' == 'true'">HAVE_LIBGSSAPI_KRB5;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/builds/msvc/vs2012/libzmq/libzmq.props
+++ b/builds/msvc/vs2012/libzmq/libzmq.props
@@ -23,7 +23,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;$(ProjectDir)..\..\..\..\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <EnablePREfast>false</EnablePREfast>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;FD_SETSIZE=1024;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;FD_SETSIZE=4096;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-openpgm)' == 'true'">ZMQ_HAVE_OPENPGM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-sodium)' == 'true'">HAVE_LIBSODIUM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-gssapi)' == 'true'">HAVE_LIBGSSAPI_KRB5;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/builds/msvc/vs2013/libzmq/libzmq.props
+++ b/builds/msvc/vs2013/libzmq/libzmq.props
@@ -23,7 +23,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;$(ProjectDir)..\..\..\..\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <EnablePREfast>false</EnablePREfast>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;FD_SETSIZE=1024;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;FD_SETSIZE=4096;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-openpgm)' == 'true'">ZMQ_HAVE_OPENPGM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-sodium)' == 'true'">HAVE_LIBSODIUM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-gssapi)' == 'true'">HAVE_LIBGSSAPI_KRB5;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
Solution: increased to 4096 by default for all MSVC builds, for MinGW,
and for CMake.

Note: this is a speculative change, it needs confirmation before we
can keep it. Particularly, there is some doubt that changing this in
libzmq will affect upstream applications using libzmq.dll.

Fixes #1165 
