### PR TITLE
Clean up after using randombytes from libsodium

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -36,6 +36,14 @@
 #include "err.hpp"
 #include "msg.hpp"
 
+#ifdef HAVE_LIBSODIUM
+#ifdef HAVE_TWEETNACL
+#include "randombytes.h"
+#else
+#include "sodium.h"
+#endif
+#endif
+
 #define ZMQ_CTX_TAG_VALUE_GOOD 0xabadcafe
 #define ZMQ_CTX_TAG_VALUE_BAD  0xdeadbeef
 
@@ -92,6 +100,12 @@ zmq::ctx_t::~ctx_t ()
     //  needed as mailboxes themselves were deallocated with their
     //  corresponding io_thread/socket objects.
     free (slots);
+
+    //  If we've done any Curve encryption, we may have a file handle
+    //  to /dev/urandom open that needs to be cleaned up.
+#ifdef HAVE_LIBSODIUM
+    randombytes_close();
+#endif
 
     //  Remove the tag, so that the object is considered dead.
     tag = ZMQ_CTX_TAG_VALUE_BAD;

--- a/tweetnacl/contrib/randombytes/devurandom.c
+++ b/tweetnacl/contrib/randombytes/devurandom.c
@@ -32,3 +32,13 @@ void randombytes(unsigned char *x,unsigned long long xlen)
     xlen -= i;
   }
 }
+
+int randombytes_close(void)
+{
+  int rc = -1;
+  if(fd != -1 && close(fd) == 0) {
+    fd = -1;
+    rc = 0;
+  }
+  return rc;
+}

--- a/tweetnacl/contrib/randombytes/devurandom.h
+++ b/tweetnacl/contrib/randombytes/devurandom.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 extern void randombytes(unsigned char *,unsigned long long);
+extern int randombytes_close(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When Curve authentication is used, libsodium opens a file
descriptor to /dev/urandom to generate random bytes. When
the ZMQ context terminates, it should ensure that file gets
closed.
