### PR TITLE
Problem: undocumented limit on IPC paths in Linux is 107 chars

### DIFF
--- a/doc/zmq_ipc.txt
+++ b/doc/zmq_ipc.txt
@@ -53,6 +53,10 @@ namespace shall be used.  The abstract namespace is independent of the
 filesystem and if a process attempts to bind an endpoint already bound by a
 process, it will fail.  See unix(7) for details.
 
+NOTE: IPC pathnames have a maximum size that depends on the operating system.
+On Linux, the maximum is 113 characters including the "ipc://" prefix (107
+characters for the real path name).
+
 Connecting a socket
 ~~~~~~~~~~~~~~~~~~~
 When connecting a 'socket' to a peer address using _zmq_connect()_ with the


### PR DESCRIPTION
Solution: document the limit of 113 chars including ipc://. We might
fix this in libzmq by shortening an over-long IPC pathname into a
unique string; so long as this is done consistently in bind and in
connect, it will save applications from weird failures when they
use external data to generate IPC pathnames.
