### PR TITLE
Fix non-constant-expression narrowing

### DIFF
--- a/src/select.cpp
+++ b/src/select.cpp
@@ -163,8 +163,12 @@ void zmq::select_t::loop ()
         memcpy (&exceptfds, &source_set_err, sizeof source_set_err);
 
         //  Wait for events.
+#ifdef ZMQ_HAVE_OSX
+        struct timeval tv = {(long) (timeout / 1000), timeout % 1000 * 1000};
+#else
         struct timeval tv = {(long) (timeout / 1000),
             (long) (timeout % 1000 * 1000)};
+#endif
 #ifdef ZMQ_HAVE_WINDOWS
         int rc = select (0, &readfds, &writefds, &exceptfds,
             timeout ? &tv : NULL);


### PR DESCRIPTION
For OS X, the microseconds field is implemented as an int type. The implicit narrowing in the initializer list throws a compiler error for some compilers with C++11 support turned on. The specific error message is: "error: non-constant-expression cannot be narrowed from type 'long' to '__darwin_suseconds_t' (aka 'int') in initializer list [-Wc++11-narrowing]".

Tested on Clang 5.1.0 and Mac OS X 10.9.4.
