### PR TITLE
Fix hang terminating PGM ZMQ_SUB (#822).

### DIFF
--- a/src/pgm_receiver.cpp
+++ b/src/pgm_receiver.cpp
@@ -288,7 +288,7 @@ void zmq::pgm_receiver_t::drop_subscriptions ()
 {
     msg_t msg;
     msg.init ();
-    while (session->pull_msg (&msg))
+    while (session->pull_msg (&msg) == 0)
         msg.close ();
 }
 


### PR DESCRIPTION
Looks like the return value from `session_base_t::pull_msg()` tripped someone up.
