### PR TITLE
Remove build and runtime dependencies on uuid and uuid-devel.

### DIFF
--- a/builds/redhat/zeromq.spec.in
+++ b/builds/redhat/zeromq.spec.in
@@ -11,15 +11,9 @@ Buildroot:     %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: gcc, make, gcc-c++, libstdc++-devel, asciidoc, xmlto
 Requires:      libstdc++
 
-%if %{?rhel}%{!?rhel:0} >= 6
-BuildRequires: libuuid-devel
-Requires:      libuuid
-%elseif %{?rhel}%{!?rhel:0} >= 5
+%if %{?rhel}%{!?rhel:0} >= 5
 BuildRequires: e2fsprogs-devel
 Requires:      e2fsprogs
-%else
-BuildRequires: uuid-devel
-Requires:      uuid
 %endif
 
 # Build pgm only on supported archs


### PR DESCRIPTION
Dependency on liquid was removed on Jul 15th, 2011 in commit c8e8f2a24... This change removes the corresponding rpm build and runtime dependencies.
