### PR TITLE
Add support for POLLPRI flag.

### DIFF
--- a/doc/zmq_poll.txt
+++ b/doc/zmq_poll.txt
@@ -69,6 +69,13 @@ condition is present on the socket specified by 'fd'. For 0MQ sockets this flag
 has no effect if set in 'events', and shall never be returned in 'revents' by
 _zmq_poll()_.
 
+*ZMQ_POLLPRI*::
+For 0MQ sockets this flags is of no use. For standard sockets this means there
+is urgent data to read. Refer to the POLLPRI flag for more informations.
+For file descriptor, refer to your use case: as an example, GPIO interrupts
+are signaled through a POLLPRI event.
+This flag has no effect on Windows.
+
 NOTE: The _zmq_poll()_ function may be implemented or emulated using operating
 system interfaces other than _poll()_, and as such may be subject to the limits
 of those interfaces in ways not defined in this documentation.

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -373,6 +373,7 @@ ZMQ_EXPORT int zmq_socket_monitor (void *s, const char *addr, int events);
 #define ZMQ_POLLIN 1
 #define ZMQ_POLLOUT 2
 #define ZMQ_POLLERR 4
+#define ZMQ_POLLPRI 8
 
 typedef struct zmq_pollitem_t
 {

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -722,7 +722,8 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
             pollfds [i].fd = items_ [i].fd;
             pollfds [i].events =
                 (items_ [i].events & ZMQ_POLLIN ? POLLIN : 0) |
-                (items_ [i].events & ZMQ_POLLOUT ? POLLOUT : 0);
+                (items_ [i].events & ZMQ_POLLOUT ? POLLOUT : 0) |
+                (items_ [i].events & ZMQ_POLLPRI ? POLLPRI : 0);
         }
     }
 
@@ -781,7 +782,9 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
                     items_ [i].revents |= ZMQ_POLLIN;
                 if (pollfds [i].revents & POLLOUT)
                     items_ [i].revents |= ZMQ_POLLOUT;
-                if (pollfds [i].revents & ~(POLLIN | POLLOUT))
+                if (pollfds [i].revents & POLLPRI)
+                   items_ [i].revents |= ZMQ_POLLPRI;
+                if (pollfds [i].revents & ~(POLLIN | POLLOUT | POLLPRI))
                     items_ [i].revents |= ZMQ_POLLERR;
             }
 


### PR DESCRIPTION
This commit adds a ZMQ_POLLPRI flag that maps to poll()'s POLLPRI
flag.
This flags does nothing for OMQ sockets. It's only useful for raw
file descriptor (be it socket or file).

I tested only on Linux. I think this does nothing on Windows because `poll()` is not the underlying polling function. I don't know if there is an windows equivalent for this, I therefore stated that this flags does nothing on Windows.
