### PR TITLE
Append to libzmq_la_CPPFLAGS and libzmq_la_LIBADD.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -228,16 +228,18 @@ endif
 endif
 endif
 
+libzmq_la_CPPFLAGS =
 libzmq_la_CXXFLAGS = @LIBZMQ_EXTRA_CXXFLAGS@
+libzmq_la_LIBADD =
 
 if HAVE_SODIUM
-libzmq_la_CPPFLAGS = ${sodium_CFLAGS}
-libzmq_la_LIBADD = ${sodium_LIBS}
+libzmq_la_CPPFLAGS += ${sodium_CFLAGS}
+libzmq_la_LIBADD += ${sodium_LIBS}
 endif
 
 if HAVE_PGM
-libzmq_la_CPPFLAGS = ${pgm_CFLAGS}
-libzmq_la_LIBADD = ${pgm_LIBS}
+libzmq_la_CPPFLAGS += ${pgm_CFLAGS}
+libzmq_la_LIBADD += ${pgm_LIBS}
 endif
 
 noinst_PROGRAMS = \


### PR DESCRIPTION
If both --with-sodium and --with-pgm are defined, the latter overrides the former's CFLAGS and LIBS because libzmq_la_CPPFLAGS and libzmq_La_LIBADD are assigned to instead of appended to.

Note that we need to assign both macros to empty values (lines 231 and 233), because automake does not support += unless the variable has already been defined.
