### PR TITLE
Unbind socket with real endpoint when binding by wild-card * address

### DIFF
--- a/doc/zmq_ipc.txt
+++ b/doc/zmq_ipc.txt
@@ -35,7 +35,7 @@ operating system namespace used by the 'ipc' implementation, and must fulfill
 any restrictions placed by the operating system on the format and length of a
 'pathname'.
 
-When the address is `*`, _zmq_bind()_ shall generate a unique temporary
+When the address is wild-card `*`, _zmq_bind()_ shall generate a unique temporary
 pathname. The caller should retrieve this pathname using the ZMQ_LAST_ENDPOINT
 socket option. See linkzmq:zmq_getsockopt[3] for details.
 
@@ -56,6 +56,12 @@ process, it will fail.  See unix(7) for details.
 NOTE: IPC pathnames have a maximum size that depends on the operating system.
 On Linux, the maximum is 113 characters including the "ipc://" prefix (107
 characters for the real path name).
+
+Unbinding wild-card address from a socket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When wild-card `*` 'endpoint' was used in _zmq_bind()_, the caller should use
+real 'endpoind' obtained from the ZMQ_LAST_ENDPOINT socket option to unbind
+this 'endpoint' from a socket using _zmq_unbind()_.
 
 Connecting a socket
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/zmq_tcp.txt
+++ b/doc/zmq_tcp.txt
@@ -46,6 +46,11 @@ When using ephemeral ports, the caller should retrieve the actual assigned
 port using the ZMQ_LAST_ENDPOINT socket option. See linkzmq:zmq_getsockopt[3]
 for details.
 
+Unbinding wild-card addres from a socket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When wild-card `*` 'endpoint' was used in _zmq_bind()_, the caller should use
+real 'endpoind' obtained from the ZMQ_LAST_ENDPOINT socket option to unbind 
+this 'endpoint' from a socket using _zmq_unbind()_.
 
 Connecting a socket
 ~~~~~~~~~~~~~~~~~~~

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -401,7 +401,7 @@ int zmq::socket_base_t::bind (const char *addr_)
         // Save last endpoint URI
         listener->get_address (last_endpoint);
 
-        add_endpoint (addr_, (own_t *) listener, NULL);
+        add_endpoint (last_endpoint.c_str (), (own_t *) listener, NULL);
         return 0;
     }
 
@@ -420,7 +420,7 @@ int zmq::socket_base_t::bind (const char *addr_)
         // Save last endpoint URI
         listener->get_address (last_endpoint);
 
-        add_endpoint (addr_, (own_t *) listener, NULL);
+        add_endpoint (last_endpoint.c_str (), (own_t *) listener, NULL);
         return 0;
     }
 #endif


### PR DESCRIPTION
When we bind socket with wild-card \* address (e.g. tcp://127.0.0.1:\* or ipc://*),
and try to unbind with real endpoint then it fails with error "No such file or directory".
Example code:

```
#include <zmq.h>
#include <stdio.h>
#include <unistd.h>
#include <string.h>
#include <assert.h>
int main (void) {
    int rc;
    size_t buf_size=100;
    char buffer[buf_size];
    void *context = zmq_ctx_new ();
    void *socket = zmq_socket (context, ZMQ_SUB);
    rc = zmq_bind (socket, "tcp://127.0.0.1:*");
    assert (rc == 0);
    rc = zmq_getsockopt (socket, ZMQ_LAST_ENDPOINT, buffer, &buf_size);
    assert (rc == 0);
    printf("%s\n", buffer);
    rc = zmq_unbind (socket, buffer);
    if (rc == -1)
        printf ("ERROR: %s\n", strerror (errno));
}
```

The output of executing above is:

tcp://127.0.0.1:39969
ERROR: No such file or directory

When we try to unbind with endpoint tcp://127.0.0.1:\* it unbinds clearly.
This behaviour is ok, when we have one binding per socket.
BUT when we bind socket to several endpoints with wild-card we have no
control over exact unbinding our endpoints. I think we REALLY SHOULD be able to unbind
socket by real endpoint returned via getsockopt(ZMQ_LAST_ENDPOINT).
The same behaviour with ipc transport (ipc://*).

This proposition introduces backward incompatible changes with previous versions. Unbinding with wild-card address will be no more possible.
