### PR TITLE
Pass --with/--without-libgssapi_krb5 to configure.

### DIFF
--- a/builds/redhat/zeromq.spec.in
+++ b/builds/redhat/zeromq.spec.in
@@ -29,8 +29,8 @@ Requires:      libstdc++
 %{?_with_libsodium: %{?_without_libsodium: %{error: both _with_libsodium and _without_libsodium}}}
 %{?_with_pgm: %{?_without_pgm: %{error: both _with_pgm and _without_pgm}}}
 
-%{?_with_libgssapi_krb5:BuildRequires: libgssapi_krb5_2}
-%{?_with_libgssapi_krb5:Requires: libgssapi_krb5}
+%{?_with_libgssapi_krb5:BuildRequires: krb5-devel}
+%{?_with_libgssapi_krb5:Requires: krb5-libs}
 
 %{?_with_libsodium:BuildRequires: libsodium-devel}
 %{?_with_libsodium:Requires: libsodium}


### PR DESCRIPTION
Need to pass options to configure if they're to take any effect.
