### PR TITLE
Problem: default LINGER value is insane

### DIFF
--- a/doc/zmq_ctx_term.txt
+++ b/doc/zmq_ctx_term.txt
@@ -39,15 +39,6 @@ option in linkzmq:zmq_setsockopt[3].
 This function replaces the deprecated function linkzmq:zmq_term[3].
 
 
-WARNING
--------
-
-As _ZMQ_LINGER_ defaults to "infinite", by default this function will block
-indefinitely if there are any pending connects or sends. We strongly
-recommend to (a) set _ZMQ_LINGER_ to zero on all sockets and (b) close all
-sockets, before calling this function.
-
-
 RETURN VALUE
 ------------
 The _zmq_ctx_term()_ function shall return zero if successful. Otherwise

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -306,7 +306,7 @@ linkzmq:zmq_disconnect[3] or closed with linkzmq:zmq_close[3], and further
 affects the termination of the socket's context with linkzmq:zmq_term[3]. The
 following outlines the different behaviours:
 
-* The default value of '-1' specifies an infinite linger period. Pending
+* A value of '-1' specifies an infinite linger period. Pending
   messages shall not be discarded after a call to _zmq_disconnect()_ or
   _zmq_close()_; attempting to terminate the socket's context with _zmq_term()_
   shall block until all pending messages have been sent to a peer.
@@ -323,7 +323,7 @@ following outlines the different behaviours:
 [horizontal]
 Option value type:: int
 Option value unit:: milliseconds
-Default value:: -1 (infinite)
+Default value:: 2000 (two seconds)
 Applicable socket types:: all
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -35,7 +35,7 @@ zmq::options_t::options_t () :
     rcvbuf (0),
     tos (0),
     type (-1),
-    linger (-1),
+    linger (2000),
     reconnect_ivl (100),
     reconnect_ivl_max (0),
     backlog (100),


### PR DESCRIPTION
Solution: use a sane value, e.g. 2 seconds

Fixes #1247
