### PR TITLE
use more conservative 30 second default timeout for LINGER

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -323,7 +323,7 @@ following outlines the different behaviours:
 [horizontal]
 Option value type:: int
 Option value unit:: milliseconds
-Default value:: 2000 (two seconds)
+Default value:: 30000 (thirty seconds)
 Applicable socket types:: all
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -35,7 +35,7 @@ zmq::options_t::options_t () :
     rcvbuf (0),
     tos (0),
     type (-1),
-    linger (2000),
+    linger (30000),
     reconnect_ivl (100),
     reconnect_ivl_max (0),
     backlog (100),


### PR DESCRIPTION
Regression in #1248 can cause lost messages for fire & forget-style services.

It is logical for users who actively want messages to be discarded to need to state this explicitly by setting small values for LINGER.
