### PR TITLE
Fix #1274

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -395,7 +395,7 @@ have_sodium_library="no"
 AC_ARG_WITH([libsodium], [AS_HELP_STRING([--with-libsodium],
     [require libzmq build with libsodium. Requires pkg-config [default=no]])],
     [require_libsodium_ext=$withval],
-    [require_libsodium_ext=no])
+    [require_libsodium_ext=yes])
 
 # conditionally require libsodium package
 if test "x$require_libsodium_ext" != "xno"; then


### PR DESCRIPTION
Alter default --with-libsodium requiring libsodium when not explicitly requested --without-libsodium.
