### PR TITLE
Problem: very hard to debug security mechanism mismatch

### DIFF
--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -660,6 +660,18 @@ bool zmq::stream_engine_t::handshake ()
         }
 #endif
         else {
+            //  Temporary support for security debugging
+            char mechanism [21];
+            memcpy (mechanism, greeting_recv + 12, 20);
+            mechanism [20] = 0;
+            printf ("LIBZMQ I: security failure, self=%s peer=%s\n",
+                options.mechanism == ZMQ_NULL? "NULL":
+                options.mechanism == ZMQ_PLAIN? "PLAIN":
+                options.mechanism == ZMQ_CURVE? "CURVE":
+                options.mechanism == ZMQ_GSSAPI? "GSSAPI":
+                "OTHER",
+                mechanism);
+            
             error (protocol_error);
             return false;
         }


### PR DESCRIPTION
E.g. when server is not configured, and client tries PLAIN security,
there is no hint of why this does not work.

Solution: add debugging output for this case. Note that the various
debugging outputs for security failures should probably be sent to
an inproc monitor of some kind.
