### PR TITLE
Implement a definitive cygwin target for libzmq.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -208,6 +208,13 @@ src_libzmq_la_LDFLAGS = \
 	-version-info @LTVER@ \
 	@LIBZMQ_EXTRA_LDFLAGS@
 else
+if ON_CYGWIN
+src_libzmq_la_LDFLAGS = \
+	-no-undefined \
+	-avoid-version \
+	-version-info @LTVER@ \
+	@LIBZMQ_EXTRA_LDFLAGS@
+else
 if ON_ANDROID
 src_libzmq_la_LDFLAGS = \
 	-avoid-version \
@@ -224,6 +231,7 @@ src_libzmq_la_LDFLAGS = \
 	-version-info @LTVER@ \
 	@LIBZMQ_EXTRA_LDFLAGS@ \
 	-Wl
+endif
 endif
 endif
 endif
@@ -507,6 +515,7 @@ tests_test_atomics_SOURCES = tests/test_atomics.cpp
 tests_test_atomics_LDADD = src/libzmq.la
 
 if !ON_MINGW
+if !ON_CYGWIN
 test_apps += \
 	tests/test_shutdown_stress \
 	tests/test_pair_ipc \
@@ -539,6 +548,7 @@ test_apps += tests/test_fork
 tests_test_fork_SOURCES = tests/test_fork.cpp
 tests_test_fork_LDADD = src/libzmq.la
 
+endif
 endif
 endif
 

--- a/README.cygwin.md
+++ b/README.cygwin.md
@@ -1,0 +1,15 @@
+libzmq-cygwin
+=============
+
+Definitive build fixes for cygwin  (See https://github.com/zeromq/pyzmq/issues/113 for partial solution)
+
+What's changed:
+  ./Makefile.am                       Add cygwin-specific target mostly the same as mingw
+  ./configure.ac                      Add cygwin-specific target mostly the same as mingw
+  ./tests/testutil.hpp                Lengthen socket timeout to 121 seconds
+  
+What's new:
+  ./README.cygwin.md                  This file
+  ./builds/cygwin                     Folder for cygwin-specific build files
+  ./builds/cygwin/Makefile.cygwin     Makefile for cygwin targets
+  

--- a/builds/cygwin/Makefile.cygwin
+++ b/builds/cygwin/Makefile.cygwin
@@ -1,0 +1,47 @@
+CC=gcc
+CFLAGS=-Wall -Os -g -DDLL_EXPORT -DFD_SETSIZE=4096 -DZMQ_USE_SELECT -I.
+LIBS=-lws2_32
+
+OBJS = ctx.o reaper.o dist.o err.o \
+	clock.o metadata.o random.o \
+	object.o own.o \
+	io_object.o io_thread.o \
+	lb.o fq.o \
+	address.o tcp_address.o ipc_address.o \
+	ipc_connecter.o ipc_listener.o \
+	tcp_connecter.o tcp_listener.o \
+	mailbox.o msg.o mtrie.o \
+	pipe.o precompiled.o proxy.o \
+	signaler.o stream_engine.o \
+	thread.o trie.o \
+	ip.o tcp.o \
+	pgm_socket.o pgm_receiver.o pgm_sender.o \
+	raw_decoder.o raw_encoder.o \
+	v1_decoder.o v1_encoder.o v2_decoder.o v2_encoder.o \
+	socket_base.o session_base.o options.o \
+	req.o rep.o push.o pull.o pub.o sub.o pair.o \
+	dealer.o router.o xpub.o xsub.o stream.o \
+	poller_base.o select.o poll.o epoll.o kqueue.o devpoll.o \
+	curve_client.o curve_server.o \
+	mechanism.o null_mechanism.o plain_client.o plain_server.o \
+	zmq.o zmq_utils.o
+
+%.o: ../../src/%.cpp
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+%.o: ../../perf/%.cpp
+	$(CC) -c -o $@ $< $(CFLAGS)
+
+all: libzmq.dll
+
+perf: inproc_lat.exe inproc_thr.exe local_lat.exe local_thr.exe remote_lat.exe remote_thr.exe
+
+libzmq.dll: $(OBJS)
+	g++ -shared -o $@ $^ -Wl,--out-implib,-Wl,--export-all-symbols -Wl,--enable-auto-import -Wl,--whole-archive $@.a -Wl,--no-whole-archive $(LIBS)
+
+%.exe: %.o libzmq.dll
+	g++ -o $@ $^
+
+clean:
+	del *.o *.a *.dll *.exe
+	

--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,7 @@ libzmq_dso_visibility="yes"
 
 # Platform specific checks
 libzmq_on_mingw32="no"
+libzmq_on_cygwin="no"
 libzmq_on_android="no"
 libzmq_on_linux="no"
 
@@ -269,6 +270,8 @@ case "${host_os}" in
         # Define on Cygwin to enable all library features
         CPPFLAGS="-D_GNU_SOURCE $CPPFLAGS"
         AC_DEFINE(ZMQ_HAVE_CYGWIN, 1, [Have Cygwin])
+        libzmq_on_cygwin="yes"
+        libzmq_dso_visibility="no"        
         if test "x$enable_static" = "xyes"; then
             AC_MSG_ERROR([Building static libraries is not supported under Cygwin])
         fi
@@ -472,6 +475,7 @@ AC_LANG_POP([C++])
 
 AM_CONDITIONAL(BUILD_TIPC, test "x$libzmq_tipc_support" = "xyes")
 AM_CONDITIONAL(ON_MINGW, test "x$libzmq_on_mingw32" = "xyes")
+AM_CONDITIONAL(ON_CYGWIN, test "x$libzmq_on_cygwin" = "xyes")
 AM_CONDITIONAL(ON_ANDROID, test "x$libzmq_on_android" = "xyes")
 AM_CONDITIONAL(ON_LINUX, test "x$libzmq_on_linux" = "xyes")
 

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -268,8 +268,13 @@ void setup_test_environment()
     _CrtSetReportFile( _CRT_ASSERT, _CRTDBG_FILE_STDERR );
 #   endif
 #else
+#if defined ZMQ_HAVE_CYGWIN
+    // abort test after 121 seconds
+    alarm(121);
+#else
     // abort test after 60 seconds
     alarm(60);
+#endif
 #endif
 #if defined __MVS__
     // z/OS UNIX System Services: Ignore SIGPIPE during test runs, as a


### PR DESCRIPTION
Hi folks!

Like the original poster here:

https://github.com/zeromq/pyzmq/issues/113

I couldn't get a shared library built on cygwin with existing and past releases. The solution offered there worked but was really inelegant. I thought maybe a few hours work could correct that (some friends of mine are using 0mq for an emulator project and I'm helping ensure a Windows port exists).

The changes I offer create a working shared library for the cygwin environment, tested only on Cygwin64, but should work in Cygwin32 as well. They should not affect builds on any other targets.

All tests pass except for test_ipc_wildcard, which fails in bounce() trying to receive the message it sent itself. One other observation from extensive debugging through test_term_endpoint showed all the IPC stuff is working but the program hands trying to return(0); substituting exit(0) briefly fixed it, and my guess is that something is corrupting the stack, making it impossible for the program to return control to the caller. I do not include the modified test_term_endpoint, exit(0) is not a proper fix for a corrupted stack.

I'll be submitting parallel changes to czmq and zyre as well, and I'd appreciate any and all feedback on these proposed changes.

Thanks in advance!