### PR TITLE
Problem: incomplete definition of integer types

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -71,18 +71,18 @@ extern "C" {
 #endif
 
 /*  Define integer types needed for event interface                          */
+#define ZMQ_DEFINED_STDINT 1
 #if defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_OPENVMS
 #   include <inttypes.h>
-#elif defined _MSC_VER && _MSC_VER < 1600
-#   ifndef int32_t
+#elif defined _MSC_VER
+typedef __int8 int8_t;
+typedef __int16 int16_t;
 typedef __int32 int32_t;
-#   endif
-#   ifndef uint16_t
-typedef unsigned __int16 uint16_t;
-#   endif
-#   ifndef uint8_t
+typedef __int64 int64_t;
 typedef unsigned __int8 uint8_t;
-#   endif
+typedef unsigned __int16 uint16_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
 #else
 #   include <stdint.h>
 #endif


### PR DESCRIPTION
Firstly, only a few types are defined, leaving it hard for higher layers
to complete the set. Secondly, the code incorrectly tries to use ifndef
to avoid re-defining typedefs, which does not work in C.

Solution: define all types, unconditionally for all MSVC compilers.
Additionally, define ZMQ_DEFINED_STDINT that tells higher layers that we
already defined these integer types.
