### PR TITLE
resolve #1292 ZMQ_IDENTITY_FD does not validate option_len

### DIFF
--- a/src/router.cpp
+++ b/src/router.cpp
@@ -34,7 +34,7 @@ zmq::router_t::router_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
     next_rid (generate_random ()),
     mandatory (false),
     //  raw_sock functionality in ROUTER is deprecated
-    raw_sock (false),       
+    raw_sock (false),
     probe_router (false),
     handover (false)
 {
@@ -118,8 +118,8 @@ int zmq::router_t::xsetsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
-            
-        case ZMQ_ROUTER_HANDOVER: 
+
+        case ZMQ_ROUTER_HANDOVER:
             if (is_int && value >= 0) {
                 handover = (value != 0);
                 return 0;
@@ -142,7 +142,13 @@ int zmq::router_t::xgetsockopt (int option_, const void *optval_,
                 *optvallen_=sizeof(fd_t);
                 return 0;
             }
+
             if (optval_ && optvallen_ && *optvallen_) {
+                if (*optvallen_ < sizeof(fd_t)) {
+                    *optvallen_=sizeof(fd_t);
+                    return EINVAL;
+                }
+
                 blob_t identity= blob_t((unsigned char*)optval_,*optvallen_);
                 outpipes_t::iterator it = outpipes.find (identity);
                 if (it == outpipes.end() ){
@@ -420,10 +426,10 @@ bool zmq::router_t::identify_peer (pipe_t *pipe_)
             connect_rid.length());
         connect_rid.clear ();
         outpipes_t::iterator it = outpipes.find (identity);
-        if (it != outpipes.end ()) 
+        if (it != outpipes.end ())
             zmq_assert(false); //  Not allowed to duplicate an existing rid
     }
-    else 
+    else
     if (options.raw_sock) { //  Always assign identity for raw-socket
         unsigned char buf [5];
         buf [0] = 0;
@@ -431,7 +437,7 @@ bool zmq::router_t::identify_peer (pipe_t *pipe_)
         identity = blob_t (buf, sizeof buf);
     }
     else
-    if (!options.raw_sock) { 
+    if (!options.raw_sock) {
         //  Pick up handshake cases and also case where next identity is set
         msg.init ();
         ok = pipe_->read (&msg);
@@ -457,7 +463,7 @@ bool zmq::router_t::identify_peer (pipe_t *pipe_)
                     return false;
                 else {
                     //  We will allow the new connection to take over this
-                    //  identity. Temporarily assign a new identity to the 
+                    //  identity. Temporarily assign a new identity to the
                     //  existing pipe so we can terminate it asynchronously.
                     unsigned char buf [5];
                     buf [0] = 0;
@@ -465,13 +471,13 @@ bool zmq::router_t::identify_peer (pipe_t *pipe_)
                     blob_t new_identity = blob_t (buf, sizeof buf);
 
                     it->second.pipe->set_identity (new_identity);
-                    outpipe_t existing_outpipe = 
+                    outpipe_t existing_outpipe =
                         {it->second.pipe, it->second.active};
-                
+
                     ok = outpipes.insert (outpipes_t::value_type (
                         new_identity, existing_outpipe)).second;
                     zmq_assert (ok);
-                
+
                     //  Remove the existing identity entry to allow the new
                     //  connection to take the identity.
                     outpipes.erase (it);


### PR DESCRIPTION
Apologies for the extraneous white space only changes (editor automatically strips trailing white space), relevant change is router.cpp lines 147-150 and corresponding change test_id2fd.cpp