### PR TITLE
Increase size of zmq_msg_t to 64 bytes

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -195,7 +195,7 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
 /*  0MQ message definition.                                                   */
 /******************************************************************************/
 
-typedef struct zmq_msg_t {unsigned char _ [48];} zmq_msg_t;
+typedef struct zmq_msg_t {unsigned char _ [64];} zmq_msg_t;
 
 typedef void (zmq_free_fn) (void *data, void *hint);
 

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -92,7 +92,7 @@ namespace zmq
 
         //  Size in bytes of the largest message that is still copied around
         //  rather than being reference-counted.
-        enum { msg_t_size = 48 };
+        enum { msg_t_size = 64 };
         enum { max_vsm_size = msg_t_size - (8 + sizeof (metadata_t *) + 3) };
 
         //  Shared message buffer. Message data are either allocated in one


### PR DESCRIPTION
Increasing it would have at least two benefits -

* More messages would be 'VSM' messages, so it would reduce allocation
overhead a bit.
* Remove any chance of false sharing of things that are, by design (except
on IBM Power, which has 128 byte cache line), pushed by value onto a
ypipe_t<msg_t> which is shared between two threads.

The only downside I see is slightly increased memory consumption on memory
constrained applications.

- Full discussion of this rationale is part of issue #1295