### PR TITLE
Fix. Use C++03 compatible way to align struct. (Build on MSVC)

### DIFF
--- a/src/command.hpp
+++ b/src/command.hpp
@@ -59,7 +59,8 @@ namespace zmq
             done
         } type;
 
-        union {
+        union args_t
+        {
 
             //  Sent to I/O thread to let it know that it should
             //  terminate itself.
@@ -147,7 +148,7 @@ namespace zmq
 
         } args;
 
-        enum { pad_size = 64 - (sizeof(destination) + sizeof(args)) };
+        enum { pad_size = 64 - (sizeof(zmq::object_t*) + sizeof(args_t) + sizeof(type_t)) };
         unsigned char unused[ pad_size ];
 
     };


### PR DESCRIPTION
But is it correct way to align?
`offsetof(zmq::command_t, args) + sizeof(args_t)` is not same as `(sizeof(zmq::object_t*) + sizeof(args_t))`
And still `unused` array also could be aligned.
Also you forget to add `sizeof(type_t)`
On my WinXP and MSVC 2010 `sizeof(zmq::command_t)` with my patch is 72.
May be you need use `pragma pack` or `align` directive?

To make `sizeof(zmq::command_t)==64` on my MSVC I make

``` C
#pragma pack(push, 1)
    struct command_t
    {
        …
        enum { pad_size = 64 - (sizeof(zmq::object_t*) + sizeof(args_t) + sizeof(type_t)) };
        unsigned char unused[ pad_size ];

    };
#pragma pack(pop)
}
static_assert(sizeof(zmq::command_t) == 64, "Invalid align");
```
But I do not know how do this crosspaltrom.