### PR TITLE
Add 'Peer-Address' property to connection metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ zeromq-*.tar.gz
 zeromq-*.zip
 core
 build
+test-suite.log

--- a/doc/zmq_msg_gets.txt
+++ b/doc/zmq_msg_gets.txt
@@ -28,7 +28,10 @@ function:
     Socket-Type
     Identity
     Resource
-    Peer-Address
+
+Additionally, when available for the underlying transport, the *Peer-Address*
+property will return the IP address of the remote endpoint as returned by
+getnameinfo(2).
 
 Other properties may be defined based on the underlying security, see ZAP
 auththenticated connection sample below.

--- a/doc/zmq_msg_gets.txt
+++ b/doc/zmq_msg_gets.txt
@@ -28,6 +28,7 @@ function:
     Socket-Type
     Identity
     Resource
+    Peer-Address
 
 Other properties may be defined based on the underlying security, see ZAP
 auththenticated connection sample below.

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -813,19 +813,11 @@ void zmq::stream_engine_t::mechanism_ready ()
 
     //  Add ZAP properties.
     const properties_t& zap_properties = mechanism->get_zap_properties ();
-    it = zap_properties.begin ();
-    while (it != zap_properties.end ()) {
-        properties.insert (properties_t::value_type (it->first, it->second));
-        ++it;
-    }
+    properties.insert(zap_properties.begin(), zap_properties.end());
 
     //  Add ZMTP properties.
     const properties_t& zmtp_properties = mechanism->get_zmtp_properties ();
-    it = zmtp_properties.begin ();
-    while (it != zmtp_properties.end ()) {
-        properties.insert (properties_t::value_type (it->first, it->second));
-        ++it;
-    }
+    properties.insert(zmtp_properties.begin(), zmtp_properties.end ());
 
     zmq_assert (metadata == NULL);
     if (!properties.empty ())

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -671,7 +671,7 @@ bool zmq::stream_engine_t::handshake ()
                 options.mechanism == ZMQ_GSSAPI? "GSSAPI":
                 "OTHER",
                 mechanism);
-            
+
             error (protocol_error);
             return false;
         }
@@ -805,6 +805,11 @@ void zmq::stream_engine_t::mechanism_ready ()
     typedef metadata_t::dict_t properties_t;
     properties_t properties;
     properties_t::const_iterator it;
+
+    //  If we have a peer_address, add it to metadata
+    if (!peer_address.empty()) {
+        properties.insert(std::make_pair("Peer-Address", peer_address));
+    }
 
     //  Add ZAP properties.
     const properties_t& zap_properties = mechanism->get_zap_properties ();

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -813,11 +813,11 @@ void zmq::stream_engine_t::mechanism_ready ()
 
     //  Add ZAP properties.
     const properties_t& zap_properties = mechanism->get_zap_properties ();
-    properties.insert(zap_properties.begin(), zap_properties.end());
+    properties.insert(zap_properties.begin (), zap_properties.end ());
 
     //  Add ZMTP properties.
     const properties_t& zmtp_properties = mechanism->get_zmtp_properties ();
-    properties.insert(zmtp_properties.begin(), zmtp_properties.end ());
+    properties.insert(zmtp_properties.begin (), zmtp_properties.end ());
 
     zmq_assert (metadata == NULL);
     if (!properties.empty ())

--- a/tests/test_metadata.cpp
+++ b/tests/test_metadata.cpp
@@ -41,7 +41,7 @@ zap_handler (void *handler)
 
         assert (streq (version, "1.0"));
         assert (streq (mechanism, "NULL"));
-        
+
         s_sendmore (handler, version);
         s_sendmore (handler, sequence);
         if (streq (domain, "DOMAIN")) {
@@ -100,6 +100,8 @@ int main (void)
     assert (streq (zmq_msg_gets (&msg, "Hello"), "World"));
     assert (streq (zmq_msg_gets (&msg, "Socket-Type"), "DEALER"));
     assert (streq (zmq_msg_gets (&msg, "User-Id"), "anonymous"));
+    assert (streq (zmq_msg_gets (&msg, "Peer-Address"), "127.0.0.1"));
+
     assert (zmq_msg_gets (&msg, "No Such") == NULL);
     assert (zmq_errno () == EINVAL);
     zmq_msg_close (&msg);


### PR DESCRIPTION
Allows non-C/C++ based clients easy access to the peer's IP address via
zmq_msg_gets(&msg, "Peer-Address") instead of zmq_msg_get(&msg, ZMQ_SRCFD)
followed by calls to getpeername and getnameinfo