### PR TITLE
Close messages that failed to send

### DIFF
--- a/src/router.cpp
+++ b/src/router.cpp
@@ -246,12 +246,16 @@ int zmq::router_t::xsend (msg_t *msg_)
         }
 
         bool ok = current_out->write (msg_);
-        if (unlikely (!ok))
+        if (unlikely (!ok)) {
+            // Message failed to send - we must close it ourselves.
+            int rc = msg_->close ();
+            errno_assert (rc == 0);
             current_out = NULL;
-        else
-        if (!more_out) {
-            current_out->flush ();
-            current_out = NULL;
+        } else {
+          if (!more_out) {
+              current_out->flush ();
+              current_out = NULL;
+          }
         }
     }
     else {


### PR DESCRIPTION
pipe_t.write only takes control of the underlying message memory when it
succeeds. When it returns failure, we must close the message ourselves to
clean up that memory.

This patch is sponsored by FarSounder, Inc (farsounder.com)