### PR TITLE
documentation clarification on pipe::write failure

### DIFF
--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -86,12 +86,14 @@ namespace zmq
         //  Reads a message to the underlying pipe.
         bool read (msg_t *msg_);
 
-        //  Checks whether messages can be written to the pipe. If writing
-        //  the message would cause high watermark the function returns false.
+        //  Checks whether messages can be written to the pipe. If the pipe is
+        //  closed or if writing the message would cause high watermark the
+        //  function returns false.
         bool check_write ();
 
         //  Writes a message to the underlying pipe. Returns false if the
-        //  message cannot be written because high watermark was reached.
+        //  message does not pass check_write. If false, the message object
+        //  retains ownership of its message buffer.
         bool write (msg_t *msg_);
 
         //  Remove unfinished parts of the outbound message from the pipe.


### PR DESCRIPTION
When pipe::write succeeds, it takes control of the message's data buffer.
When it fails, it has not taken control. The caller should clean up the
message appropriately (msg::close).