### PR TITLE
Clean up of metadata_t

### DIFF
--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -25,10 +25,6 @@ zmq::metadata_t::metadata_t (const dict_t &dict) :
 {
 }
 
-zmq::metadata_t::~metadata_t ()
-{
-}
-
 const char *zmq::metadata_t::get (const std::string &property) const
 {
     dict_t::const_iterator it = dict.find (property);

--- a/src/metadata.hpp
+++ b/src/metadata.hpp
@@ -30,29 +30,29 @@ namespace zmq
     class metadata_t
     {
         public:
-
-            typedef std::map <std::string, const std::string> dict_t;
+            typedef std::map <std::string, std::string> dict_t;
 
             metadata_t (const dict_t &dict);
-            virtual ~metadata_t ();
 
             //  Returns pointer to property value or NULL if
             //  property is not found.
-            virtual const char *get (const std::string &property) const;
+            const char *get (const std::string &property) const;
 
-            virtual void add_ref ();
+            void add_ref ();
 
             //  Drop reference. Returns true iff the reference
             //  counter drops to zero.
-            virtual bool drop_ref ();
+            bool drop_ref ();
 
         private:
+            metadata_t(const metadata_t&);
+            metadata_t & operator=(const metadata_t&);
 
             //  Reference counter.
             atomic_counter_t ref_cnt;
 
             //  Dictionary holding metadata.
-            const dict_t dict;
+            dict_t dict;
     };
 
 }


### PR DESCRIPTION
* There is no clear reason why the map should hold const std::strings
* This class is never derived, there doesn't seem to be a compelling
  reason to ever do so, so no need to make virtual members
* In general const member data is an anti-pattern, the *only* reason
  is to prevent assignability, and the accepted idiom for that is to
  to declare the assigment operator private. This change does so, and
  also prevents copy construction.