### PR TITLE
Use GCC/Clang compiler intrinsics for atomic operations

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -604,6 +604,26 @@ int main (int argc, char *argv [])
 }])
 
 dnl ################################################################################
+dnl # LIBZMQ_CHECK_ATOMIC_INSTRINSICS([action-if-found], [action-if-not-found])    #
+dnl # Check if compiler supoorts __atomic_Xxx intrinsics                           #
+dnl ################################################################################
+AC_DEFUN([LIBZMQ_CHECK_ATOMIC_INTRINSICS], [{
+    AC_MSG_CHECKING(whether compiler supports __atomic_Xxx intrinsics)
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+/* atomic intrinsics test */
+int v = 0;
+int main (int, char **)
+{
+    int t = __atomic_add_fetch (&v, 1, __ATOMIC_ACQ_REL);
+    return t;
+}
+    ])],
+    [AC_MSG_RESULT(yes) ; libzmq_cv_has_atomic_instrisics="yes" ; $1],
+    [AC_MSG_RESULT(no)  ; libzmq_cv_has_atomic_instrisics="no"  ; $2]
+    )
+}])
+
+dnl ################################################################################
 dnl # LIBZMQ_CHECK_SO_KEEPALIVE([action-if-found], [action-if-not-found])          #
 dnl # Check if SO_KEEPALIVE is supported                                           #
 dnl ################################################################################
@@ -764,7 +784,7 @@ kqueue();
 dnl ################################################################################
 dnl # LIBZMQ_CHECK_POLLER_EPOLL_RUN([action-if-found], [action-if-not-found])      #
 dnl # Checks epoll polling system can actually run #
-dnl # For cross-compile, only requires that epoll can link # 
+dnl # For cross-compile, only requires that epoll can link #
 dnl ################################################################################
 AC_DEFUN([LIBZMQ_CHECK_POLLER_EPOLL], [{
     AC_RUN_IFELSE(
@@ -794,7 +814,7 @@ return(r < 0);
               )],
               [libzmq_cv_have_poller_epoll="yes" ; $1],
               [libzmq_cv_have_poller_epoll="no" ; $2])
-        
+
         ])
 }])
 

--- a/configure.ac
+++ b/configure.ac
@@ -479,6 +479,15 @@ AM_CONDITIONAL(ON_CYGWIN, test "x$libzmq_on_cygwin" = "xyes")
 AM_CONDITIONAL(ON_ANDROID, test "x$libzmq_on_android" = "xyes")
 AM_CONDITIONAL(ON_LINUX, test "x$libzmq_on_linux" = "xyes")
 
+# Check for __atomic_Xxx compiler intrinsics
+AC_LANG_PUSH([C++])
+LIBZMQ_CHECK_ATOMIC_INTRINSICS([
+    AC_DEFINE([ZMQ_HAVE_ATOMIC_INTRINSICS],
+              [1],
+              [Whether compiler has __atomic_Xxx intrinsics.])
+    ])
+AC_LANG_POP([C++])
+
 # Checks for library functions.
 AC_TYPE_SIGNAL
 AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs fork posix_memalign)

--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -133,7 +133,7 @@ namespace zmq
                 (volatile PVOID*) &ptr, val_, cmp_);
 #elif defined ZMQ_ATOMIC_PTR_INTRINSIC
             T *old = cmp_;
-            __atomic_compare_exchange_n (&ptr, &old, val_, false,
+            __atomic_compare_exchange_n (&ptr, (volatile T**) &old, val_, false,
                     __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
             return old;
 #elif defined ZMQ_ATOMIC_PTR_ATOMIC_H


### PR DESCRIPTION
These intrinsics are the basis of C11 and C++11 atomics in GCC and Clang. So, on Power/PowerPC for example (or any architecture for which the compiler supports these operations), this enables proper atomic operations rather than downgrading to a mutex as is currently the case in libzmq.