### PR TITLE
Problem: Cross compile for iOS isn't working for auxiliary tools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -282,10 +282,12 @@ perf_inproc_thr_LDADD = src/libzmq.la
 perf_inproc_thr_SOURCES = perf/inproc_thr.cpp
 endif
 
+if ENABLE_CURVE_KEYGEN
 bin_PROGRAMS = tools/curve_keygen
 
 tools_curve_keygen_LDADD = src/libzmq.la
 tools_curve_keygen_SOURCES = tools/curve_keygen.cpp
+endif
 
 #
 # tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -254,6 +254,7 @@ src_libzmq_la_CPPFLAGS += ${pgm_CFLAGS}
 src_libzmq_la_LIBADD += ${pgm_LIBS}
 endif
 
+if ENABLE_PERF
 noinst_PROGRAMS = \
 	perf/local_lat \
 	perf/remote_lat \
@@ -279,6 +280,7 @@ perf_inproc_lat_SOURCES = perf/inproc_lat.cpp
 
 perf_inproc_thr_LDADD = src/libzmq.la
 perf_inproc_thr_SOURCES = perf/inproc_thr.cpp
+endif
 
 bin_PROGRAMS = tools/curve_keygen
 

--- a/configure.ac
+++ b/configure.ac
@@ -354,6 +354,14 @@ AC_ARG_ENABLE([perf],
 
 AM_CONDITIONAL(ENABLE_PERF, test "x$zmq_enable_perf" = "xyes")
 
+# Conditionally build curve key generation tool
+AC_ARG_ENABLE([curve-keygen],
+    [AS_HELP_STRING([--enable-curve-keygen], [Build curve key-generation tool [default=yes].])],
+    [zmq_enable_curve_keygen=$enableval],
+    [zmq_enable_curve_keygen=yes])
+
+AM_CONDITIONAL(ENABLE_CURVE_KEYGEN, test "x$zmq_enable_curve_keygen" = "xyes")
+
 # Use c++ in subsequent tests
 AC_LANG_PUSH(C++)
 

--- a/configure.ac
+++ b/configure.ac
@@ -346,6 +346,14 @@ if test "x$zmq_enable_eventfd" = "xyes"; then
         [AC_DEFINE(ZMQ_HAVE_EVENTFD, 1, [Have eventfd extension.])])
 fi
 
+# Conditionally build performance measurement tools
+AC_ARG_ENABLE([perf],
+    [AS_HELP_STRING([--enable-perf], [Build performance measurement tools [default=yes].])],
+    [zmq_enable_perf=$enableval],
+    [zmq_enable_perf=yes])
+
+AM_CONDITIONAL(ENABLE_PERF, test "x$zmq_enable_perf" = "xyes")
+
 # Use c++ in subsequent tests
 AC_LANG_PUSH(C++)
 


### PR DESCRIPTION
Building tools like performance tests (`local_lat`, etc.) and curve-keygen isn't working for iOS. It's also unnecessary, as command line tools can't be executed on this platform.

This change introduces two new flags to the configure script to disable these features, `--enable-perf` and `--enable--curve-keygen` so that building is conditional. Both are on by default.
