### PR TITLE
Adjust number of sent messages on hiccups

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -267,6 +267,8 @@ void zmq::pipe_t::process_hiccup (void *pipe_)
     outpipe->flush ();
     msg_t msg;
     while (outpipe->read (&msg)) {
+       if (!(msg.flags () & msg_t::more))
+            msgs_written--;
        int rc = msg.close ();
        errno_assert (rc == 0);
     }


### PR DESCRIPTION
Not adjusting the sent message count may lead to situation when SUB
socket does not forward its subscriptions.