### PR TITLE
doc: zmq_msg_init does not set errno

### DIFF
--- a/doc/zmq_msg_init.txt
+++ b/doc/zmq_msg_init.txt
@@ -28,8 +28,7 @@ _zmq_msg_init_size()_ are mutually exclusive. Never initialise the same
 
 RETURN VALUE
 ------------
-The _zmq_msg_init()_ function shall return zero if successful. Otherwise it
-shall return `-1` and set 'errno' to one of the values defined below.
+The _zmq_msg_init()_ function always returns zero.
 
 
 ERRORS


### PR DESCRIPTION
In fact it always returns zero.


Relevant source: https://github.com/zeromq/libzmq/blob/eb3453372868a583bfff7e83e4dd197806e97ca3/src/msg.cpp#L51

This is also an issue in the stable repos.  If this commit looks good I can submit pull requests for those repos as well.