### PR TITLE
update zmq_ctx_term description for consistency

### DIFF
--- a/doc/zmq_ctx_term.txt
+++ b/doc/zmq_ctx_term.txt
@@ -4,7 +4,7 @@ zmq_ctx_term(3)
 
 NAME
 ----
-zmq_ctx_term - destroy a 0MQ context
+zmq_ctx_term - terminate a 0MQ context
 
 
 SYNOPSIS
@@ -36,7 +36,8 @@ Context termination is performed in the following steps:
 For further details regarding socket linger behaviour refer to the _ZMQ_LINGER_
 option in linkzmq:zmq_setsockopt[3].
 
-This function replaces the deprecated function linkzmq:zmq_term[3].
+This function replaces the deprecated functions linkzmq:zmq_term[3] and
+linkzmq:zmq_ctx_destroy[3].
 
 
 RETURN VALUE


### PR DESCRIPTION
zmq_term and zmq_ctx_destroy are just aliases for zmq_ctx_term. that
being the case use 'terminate' in the description for all three so there
isn't any confusion about behavior.

also update the deprecates list in zmq_ctx_term to include
zmq_ctx_destroy.

References:
http://thread.gmane.org/gmane.network.zeromq.devel/23925/focus=23935
https://github.com/zeromq/libzmq/blob/4820d493b039eeca8ac017590dcc4c5d635158c5/src/zmq.cpp#L220
