### PR TITLE
doc: add ENOENT to list of zmq_unbind error codes

### DIFF
--- a/doc/zmq_unbind.txt
+++ b/doc/zmq_unbind.txt
@@ -40,6 +40,8 @@ The endpoint supplied is invalid.
 The 0MQ 'context' associated with the specified 'socket' was terminated.
 *ENOTSOCK*::
 The provided 'socket' was invalid.
+*ENOENT*::
+The endpoint supplied was not previously bound.
 
 
 EXAMPLES


### PR DESCRIPTION
Resolves zeromq/libzmq#1353