### PR TITLE
Add Bitrig to OS detection in configure.ac.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -225,7 +225,7 @@ case "${host_os}" in
             AC_DEFINE(ZMQ_FORCE_MUTEXES, 1, [Force to use mutexes])
         fi
         ;;
-    *openbsd*)
+    *openbsd*|*bitrig*)
         # Define on OpenBSD to enable all library features
         CPPFLAGS="-D_BSD_SOURCE $CPPFLAGS"
         AC_DEFINE(ZMQ_HAVE_OPENBSD, 1, [Have OpenBSD OS])


### PR DESCRIPTION
This pull-request adds Bitrig to the OS detection in configure.ac. Without this it is not possible to compile libzmq on Bitrig.