### PR TITLE
Allow configure to support mingw64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,7 @@ case "${host_os}" in
         LIBZMQ_CHECK_LANG_FLAG_PREPEND([-Ae])
         AC_CHECK_FUNCS(gethrtime)
         ;;
-    *mingw32*)
+    *mingw*)
         AC_DEFINE(ZMQ_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(ZMQ_HAVE_MINGW32, 1, [Have MinGW32])
         AC_CHECK_HEADERS(windows.h)

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -808,6 +808,21 @@ Option value unit:: 0, 1
 Default value:: 0
 Applicable socket types:: ZMQ_XPUB
 
+ZMQ_XPUB_NODROP: do not silently drop messages if SENDHWM is reached
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the 'XPUB' socket behaviour to return error EAGAIN if SENDHWM is
+reached and the message could not be send. 
+
+A value of `0` is the default and drops the message silently when the peers
+SNDHWM is reached.  A value of `1` returns an 'EAGAIN' error code if the
+SNDHWM is reached and ZMQ_DONTWAIT was used.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1
+Default value:: 0
+Applicable socket types:: ZMQ_XPUB, ZMQ_PUB
+
 ZMQ_WELCOME_MSG: set welcome message that will be received by subscriber when connecting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
changes the search pattern for mingw inside configure from \*mingw32\* to \*mingw\* to allow mingw64 matching.