### PR TITLE
Problem: integer narrowing issues.

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -96,7 +96,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
         case ZMQ_IDENTITY:
             //  Identity is any binary string from 1 to 255 octets
             if (optvallen_ > 0 && optvallen_ < 256) {
-                identity_size = optvallen_;
+                identity_size = (unsigned char) optvallen_;
                 memcpy (identity, optval_, identity_size);
                 return 0;
             }

--- a/src/plain_server.cpp
+++ b/src/plain_server.cpp
@@ -265,7 +265,7 @@ int zmq::plain_server_t::produce_error (msg_t *msg_) const
     zmq_assert (rc == 0);
     char *msg_data = static_cast <char *> (msg_->data ());
     memcpy (msg_data, "\5ERROR", 6);
-    msg_data [6] = status_code.length ();
+    msg_data [6] = (char) status_code.length ();
     memcpy (msg_data + 7, status_code.c_str (), status_code.length ());
     return 0;
 }

--- a/src/socks.cpp
+++ b/src/socks.cpp
@@ -37,12 +37,10 @@ zmq::socks_greeting_t::socks_greeting_t (uint8_t method_) :
 }
 
 zmq::socks_greeting_t::socks_greeting_t (
-        uint8_t *methods_, size_t num_methods_)
+    uint8_t *methods_, uint8_t num_methods_)
     : num_methods (num_methods_)
 {
-    zmq_assert (num_methods_ <= 255);
-
-    for (size_t i = 0; i < num_methods_; i++)
+    for (uint8_t i = 0; i < num_methods_; i++)
         methods [i] = methods_ [i];
 }
 
@@ -55,8 +53,8 @@ void zmq::socks_greeting_encoder_t::encode (const socks_greeting_t &greeting_)
     uint8_t *ptr = buf;
 
     *ptr++ = 0x05;
-    *ptr++ = greeting_.num_methods;
-    for (size_t i = 0; i < greeting_.num_methods; i++)
+    *ptr++ = (uint8_t) greeting_.num_methods;
+    for (uint8_t i = 0; i < greeting_.num_methods; i++)
         *ptr++ = greeting_.methods [i];
 
     bytes_encoded = 2 + greeting_.num_methods;
@@ -118,10 +116,13 @@ void zmq::socks_choice_decoder_t::reset ()
     bytes_read = 0;
 }
 
+
 zmq::socks_request_t::socks_request_t (
         uint8_t command_, std::string hostname_, uint16_t port_)
     : command (command_), hostname (hostname_), port (port_)
-{}
+{
+    zmq_assert (hostname_.size () <= UINT8_MAX);
+}
 
 zmq::socks_request_encoder_t::socks_request_encoder_t ()
     : bytes_encoded (0), bytes_written (0)
@@ -129,6 +130,8 @@ zmq::socks_request_encoder_t::socks_request_encoder_t ()
 
 void zmq::socks_request_encoder_t::encode (const socks_request_t &req)
 {
+    zmq_assert (req.hostname.size() <= UINT8_MAX);
+
     unsigned char *ptr = buf;
     *ptr++ = 0x05;
     *ptr++ = req.command;
@@ -163,7 +166,7 @@ void zmq::socks_request_encoder_t::encode (const socks_request_t &req)
     }
     else {
         *ptr++ = 0x03;
-        *ptr++ = req.hostname.size ();
+        *ptr++ = (unsigned char) req.hostname.size ();
         memcpy (ptr, req.hostname.c_str (), req.hostname.size ());
         ptr += req.hostname.size ();
     }

--- a/src/socks.hpp
+++ b/src/socks.hpp
@@ -30,9 +30,9 @@ namespace zmq
     struct socks_greeting_t
     {
         socks_greeting_t (uint8_t method);
-        socks_greeting_t (uint8_t *methods_, size_t num_methods_);
+        socks_greeting_t (uint8_t *methods_, uint8_t num_methods_);
 
-        uint8_t methods [255];
+        uint8_t methods [UINT8_MAX];
         const size_t num_methods;
     };
 
@@ -48,7 +48,7 @@ namespace zmq
         private:
             size_t bytes_encoded;
             size_t bytes_written;
-            uint8_t buf [2 + 255];
+            uint8_t buf [2 + UINT8_MAX];
     };
 
     struct socks_choice_t
@@ -94,7 +94,7 @@ namespace zmq
         private:
             size_t bytes_encoded;
             size_t bytes_written;
-            uint8_t buf [4 + 256 + 2];
+            uint8_t buf [4 + UINT8_MAX + 1 + 2];
     };
 
     struct socks_response_t
@@ -116,7 +116,7 @@ namespace zmq
             void reset ();
 
         private:
-            uint8_t buf [4 + 256 + 2];
+            int8_t buf [4 + UINT8_MAX + 1 + 2];
             size_t bytes_read;
     };
 

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -148,7 +148,7 @@ void zmq::socks_connecter_t::in_event ()
                 //  Attach the engine to the corresponding session object.
                 send_attach (session, engine);
 
-                socket->event_connected (endpoint, s);
+                socket->event_connected (endpoint, (int) s);
 
                 rm_fd (handle);
                 s = -1;
@@ -170,7 +170,7 @@ void zmq::socks_connecter_t::out_event ()
              || status == sending_request);
 
     if (status == waiting_for_proxy_connection) {
-        const int rc = check_proxy_connection ();
+        const int rc = (int) check_proxy_connection ();
         if (rc == -1)
             error ();
         else {
@@ -436,7 +436,7 @@ void zmq::socks_connecter_t::close ()
     const int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (endpoint, s);
+    socket->event_closed (endpoint, (int) s);
     s = retired_fd;
 }
 

--- a/src/stdint.hpp
+++ b/src/stdint.hpp
@@ -59,4 +59,8 @@ typedef unsigned __int64 uint64_t;
 
 #endif
 
+#ifndef UINT8_MAX
+#define UINT8_MAX 0xFF
+#endif
+
 #endif

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -289,14 +289,13 @@ void zmq::stream_t::identify_peer (pipe_t *pipe_)
             connect_rid.length ());
         connect_rid.clear ();
         outpipes_t::iterator it = outpipes.find (identity);
-        if (it != outpipes.end ())
-            zmq_assert(false);
+        zmq_assert (it == outpipes.end ());
     }
     else {
         put_uint32 (buffer + 1, next_rid++);
         identity = blob_t (buffer, sizeof buffer);
         memcpy (options.identity, identity.data (), identity.size ());
-        options.identity_size = identity.size ();
+        options.identity_size = (unsigned char) identity.size ();
     }
     pipe_->set_identity (identity);
     //  Add the record into output pipes lookup table

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -928,7 +928,7 @@ void zmq::stream_engine_t::error (error_reason_t reason)
         terminator.close();
     }
     zmq_assert (session);
-    socket->event_disconnected (endpoint, s);
+    socket->event_disconnected (endpoint, (int) s);
     session->flush ();
     session->engine_error (reason);
     unplug ();

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -138,7 +138,7 @@ void zmq::tcp_connecter_t::out_event ()
     //  Shut the connecter down.
     terminate ();
 
-    socket->event_connected (endpoint, fd);
+    socket->event_connected (endpoint, (int) fd);
 }
 
 void zmq::tcp_connecter_t::timer_event (int id_)
@@ -352,6 +352,6 @@ void zmq::tcp_connecter_t::close ()
     const int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (endpoint, s);
+    socket->event_closed (endpoint, (int) s);
     s = retired_fd;
 }

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -111,7 +111,7 @@ void zmq::tcp_listener_t::in_event ()
     session->inc_seqnum ();
     launch_child (session);
     send_attach (session, engine, false);
-    socket->event_accepted (endpoint, fd);
+    socket->event_accepted (endpoint, (int) fd);
 }
 
 void zmq::tcp_listener_t::close ()
@@ -124,7 +124,7 @@ void zmq::tcp_listener_t::close ()
     int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (endpoint, s);
+    socket->event_closed (endpoint, (int) s);
     s = retired_fd;
 }
 
@@ -239,7 +239,7 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
         goto error;
 #endif
 
-    socket->event_listening (endpoint, s);
+    socket->event_listening (endpoint, (int) s);
     return 0;
 
 error:

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -155,7 +155,7 @@ uint8_t *zmq_z85_decode (uint8_t *dest, const char *string)
     }
     unsigned int byte_nbr = 0;
     unsigned int char_nbr = 0;
-    unsigned int string_len = strlen (string);
+    size_t string_len = strlen (string);
     uint32_t value = 0;
     while (char_nbr < string_len) {
         //  Accumulate value in base 85


### PR DESCRIPTION
This resolves all 64 bit integer narrowing warnings and a couple related safety issues.
* An unsafe cast from `strlen` to `unsigned int` is rectified in z85.
* The assumption remains that it is always safe to cast `fd_t` to `int`.
* An assertion guard against `num_methods` overflow has been moved to a parameter constraint. This strengthens the guard in that it will be visible to callers at compile time (via a narrowing warning).
* There remains an unsafe situation where `socks_request_t::hostname` can overflow a buffer, but this is now mitigated by a pair of assertions