### PR TITLE
change minimum version to windows vista 

### DIFF
--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -86,14 +86,4 @@
 
 #cmakedefine ZMQ_HAVE_WINDOWS
 
-#ifdef ZMQ_HAVE_WINDOWS
-  #if defined _WIN32_WINNT && _WIN32_WINNT < 0x0600
-    #undef _WIN32_WINNT	
-  #endif
-
-  #ifndef _WIN32_WINNT 
-    #define _WIN32_WINNT 0x0600
-  #endif
-#endif
-
 #endif

--- a/builds/mingw32/platform.hpp
+++ b/builds/mingw32/platform.hpp
@@ -29,13 +29,4 @@
 
 #define ZMQ_HAVE_WINDOWS
 
-#if defined _WIN32_WINNT && _WIN32_WINNT < 0x0600
-  #undef _WIN32_WINNT	
-#endif
-
-#ifndef _WIN32_WINNT 
-  #define _WIN32_WINNT 0x0600
-#endif
-
-
 #endif

--- a/builds/msvc/platform.hpp
+++ b/builds/msvc/platform.hpp
@@ -29,12 +29,4 @@
 
 #define ZMQ_HAVE_WINDOWS
 
-#if defined _WIN32_WINNT && _WIN32_WINNT < 0x0600
-  #undef _WIN32_WINNT	
-#endif
-
-#ifndef _WIN32_WINNT 
-  #define _WIN32_WINNT 0x0600
-#endif
-
 #endif

--- a/src/condition_variable.hpp
+++ b/src/condition_variable.hpp
@@ -31,6 +31,47 @@
 
 #include "windows.hpp"
 
+// Condition variable is supported from Windows Vista only, to use condition variable define _WIN32_WINNT to 0x0600
+#if _WIN32_WINNT < 0x0600
+
+namespace zmq
+{
+
+	class condition_variable_t
+	{
+	public:
+		inline condition_variable_t ()
+		{
+			zmq_assert(false);
+		}
+
+		inline ~condition_variable_t ()
+		{
+
+		}
+
+		inline int wait (mutex_t* mutex_, int timeout_ )
+		{
+			zmq_assert(false);
+			return -1;
+		}
+
+		inline void broadcast ()
+		{
+			zmq_assert(false);
+		}
+
+	private:		
+
+		//  Disable copy construction and assignment.
+		condition_variable_t (const condition_variable_t&);
+		void operator = (const condition_variable_t&);
+	};
+
+}
+
+#else
+
 namespace zmq
 {
 
@@ -78,6 +119,8 @@ namespace zmq
     };
 
 }
+
+#endif
 
 #else
 

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -27,9 +27,9 @@
 #define NOMINMAX          // Macros min(a,b) and max(a,b)
 #endif
 
-//  Set target version to Windows Server 2003, Windows XP/SP1 or higher.
+//  Set target version to Windows Server 2008, Windows Vista or higher. Windows XP (0x0501) is also supported but without client & server socket types.
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x0600
 #endif
 
 #ifdef __MINGW32__


### PR DESCRIPTION
also implement dummy condition variable for lower versions of windows if _WIN32_WINNT is changed.

This worth discussion as new socket types (client and server) use condition variable which is only supported from windows vista. This pull request suggest changing the minimum version to windows vista, if one want to compile to windows XP that will be possible with changing the _WIN32_WINNT back to windows xp (0x0501) but using the new socket types will not be possible.

Fix to #1381


