### PR TITLE
Add CMake option for perf-tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -648,6 +648,12 @@ set(perf-tools local_lat
                inproc_thr)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug") # Why?
+option(WITH_PERF_TOOL "Build with perf-tools" ON)
+else()
+option(WITH_PERF_TOOL "Build with perf-tools" OFF)
+endif()
+
+if(WITH_PERF_TOOL)
   foreach(perf-tool ${perf-tools})
     add_executable(${perf-tool} perf/${perf-tool}.cpp)
     target_link_libraries(${perf-tool} libzmq)


### PR DESCRIPTION
This allows disable making perf-tools in Release build type

Signed-off-by: Anton Sergeev <Anton.Sergeev@elecard.ru>