### PR TITLE
Some test fail to build targeting less that Windows Vista

### DIFF
--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -235,7 +235,11 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons (9998);
-    inet_pton (AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#if (_WIN32_WINNT < 0x0600)
+    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
+#else
+    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#endif
 
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     rc = connect (s, (struct sockaddr*) &ip4addr, sizeof (ip4addr));

--- a/tests/test_security_null.cpp
+++ b/tests/test_security_null.cpp
@@ -148,7 +148,11 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons(9003);
+#if (_WIN32_WINNT < 0x0600)
+    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
+#else
     inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#endif
 
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     rc = connect (s, (struct sockaddr*) &ip4addr, sizeof ip4addr);

--- a/tests/test_security_plain.cpp
+++ b/tests/test_security_plain.cpp
@@ -154,7 +154,11 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons (9998);
-    inet_pton (AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#if (_WIN32_WINNT < 0x0600)
+    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
+#else
+    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#endif
 
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     rc = connect (s, (struct sockaddr*) &ip4addr, sizeof (ip4addr));


### PR DESCRIPTION
When targeting a version of Windows less than Windows Vista, the
security tests fail to build. Added a check for Windows version
and substituted inet_pton for inet_addr. Fixes libzmq issue #1396.