### PR TITLE
libzmq: Fix pkg-config files for static linking

### DIFF
--- a/src/libzmq.pc.cmake.in
+++ b/src/libzmq.pc.cmake.in
@@ -7,4 +7,5 @@ Name: libzmq
 Description: 0MQ c++ library
 Version: @ZMQ_VERSION_MAJOR@.@ZMQ_VERSION_MINOR@.@ZMQ_VERSION_PATCH@
 Libs: -L${libdir} -lzmq
+Libs.private: -lstdc++
 Cflags: -I${includedir}

--- a/src/libzmq.pc.in
+++ b/src/libzmq.pc.in
@@ -7,4 +7,5 @@ Name: libzmq
 Description: 0MQ c++ library
 Version: @VERSION@
 Libs: -L${libdir} -lzmq
+Libs.private: -lstdc++
 Cflags: -I${includedir}


### PR DESCRIPTION
Libzmq uses C++ standard library features, so users of it should link
against that as well when statically linking.

Add it to Libs.private so users using pkg-config automatically gets the
correct linker flags.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>