### PR TITLE
Fix degradation from #1382, POLLOUT was tested but not requested

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -108,8 +108,8 @@ int zmq::proxy (
     int more;
     size_t moresz;
     zmq_pollitem_t items [] = {
-        { frontend_, 0, ZMQ_POLLIN, 0 },
-        { backend_, 0, ZMQ_POLLIN, 0 },
+        { frontend_, 0, ZMQ_POLLIN | ZMQ_POLLOUT, 0 },
+        { backend_, 0, ZMQ_POLLIN | ZMQ_POLLOUT, 0 },
         { control_, 0, ZMQ_POLLIN, 0 }
     };
     int qt_poll_items = (control_ ? 3 : 2);


### PR DESCRIPTION
In zeromq/libzmq#1382 I've fixed an issue, but now ZMQ_POLLOUT is never set on revents because it was not requested at first. I think it is kind of odd that the existing tests did not catch it.