### PR TITLE
Fixed out-of-bounds access when releasing socket handles.

### DIFF
--- a/tests/test_system.cpp
+++ b/tests/test_system.cpp
@@ -84,6 +84,7 @@ int main (void)
         }
     }
     //  Release the socket handles
-    while (count)
-        close (handle [count--]);
+    for (count = 0; count < 1000; count++) {
+        close(handle[count]);
+    }
 }


### PR DESCRIPTION
Running make check with address sanitizer revealed little problem in cleanup code in test_system.cpp.