### PR TITLE
Introduce a failing test against zmq_setsockpt().

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -355,7 +355,8 @@ test_apps = \
 	tests/test_client_server \
 	tests/test_server_drop_more \
 	tests/test_client_drop_more \
-	tests/test_thread_safe
+	tests/test_thread_safe \
+	tests/test_socketopt_hwm
 
 tests_test_system_SOURCES = tests/test_system.cpp
 tests_test_system_LDADD = src/libzmq.la
@@ -541,6 +542,9 @@ tests_test_client_drop_more_LDADD = src/libzmq.la
 
 tests_test_thread_safe_SOURCES = tests/test_thread_safe.cpp
 tests_test_thread_safe_LDADD = src/libzmq.la
+
+tests_test_socketopt_hwm_SOURCES = tests/test_sockopt_hwm.cpp
+tests_test_socketopt_hwm_LDADD = src/libzmq.la
 
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ set(tests
         test_pub_invert_matching
         test_thread_safe
         test_client_server
+	test_sockopt_hwm
 )
 if(NOT WIN32)
   list(APPEND tests

--- a/tests/test_sockopt_hwm.cpp
+++ b/tests/test_sockopt_hwm.cpp
@@ -1,0 +1,52 @@
+#include "testutil.hpp"
+
+void test_valid_hwm_change()
+{
+  void *ctx = zmq_ctx_new ();
+  assert (ctx);
+  int rc;
+
+  void *bind_socket = zmq_socket (ctx, ZMQ_SUB);
+  assert (bind_socket);
+
+  int val = 500;
+  rc = zmq_setsockopt(bind_socket, ZMQ_RCVHWM, &val, sizeof(val));
+  assert (rc == 0);
+
+  rc = zmq_bind (bind_socket, "inproc://a");
+  assert (rc == 0);
+
+  size_t placeholder = sizeof(val);
+  val = 0;
+  rc = zmq_getsockopt(bind_socket, ZMQ_RCVHWM, &val, &placeholder);
+  assert (rc == 0);
+  assert(val == 500);
+}
+
+
+/**
+ * Test that zmq_setsockopt() fails to change the RCVHWM when called
+ * after a call to zmq_bind().
+ */
+void test_invalid_hwm_change()
+{
+  void *ctx = zmq_ctx_new ();
+  assert (ctx);
+  int rc;
+
+  void *bind_socket = zmq_socket (ctx, ZMQ_SUB);
+  assert (bind_socket);
+
+  rc = zmq_bind (bind_socket, "inproc://a");
+  assert (rc == 0);
+
+  int val = 500;
+  rc = zmq_setsockopt(bind_socket, ZMQ_RCVHWM, &val, sizeof(val));
+  assert (rc == -1);
+}
+
+int main()
+{
+  test_valid_hwm_change();
+  test_invalid_hwm_change();
+}


### PR DESCRIPTION
Problem: zmq_setsockpt() returns success when changing the
HWM after a bind or connect() even though the call has no effect.

Solution: Introduce a failing test a reminder we need to patch it.

See #1416 