### PR TITLE
Enable install of man pages when BUILD_DOC is not set by shifting INS…

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -32,12 +32,12 @@ MAINTAINERCLEANFILES = $(MAN_DOC) $(MAN_HTML)
 
 EXTRA_DIST = asciidoc.conf $(MAN_TXT)
 
-if BUILD_DOC
-EXTRA_DIST += $(MAN_HTML)
-
 if INSTALL_MAN
 dist_man_MANS = $(MAN_DOC)
 endif
+
+if BUILD_DOC
+EXTRA_DIST += $(MAN_HTML)
 
 SUFFIXES=.html .txt .xml .3 .7
 


### PR DESCRIPTION
…TALL_MAN outside of BUILD_DOC's if/endif

This resolves #1429 and allows installing man pages when the documentation build is not set.  This is relevant to the current ZeroMQ 4.1.1 release tarball and zeromq/zeromq4-1.