### PR TITLE
Rebase3

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -643,7 +643,7 @@ check_PROGRAMS = ${test_apps}
 
 #  Run the test cases
 TESTS = $(test_apps)
-XFAIL_TESTS = tests/test_msg_ffn
+XFAIL_TESTS = 
 
 if !ON_LINUX
 XFAIL_TESTS += tests/test_abstract_ipc

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -73,6 +73,10 @@ namespace zmq
             return bufsize;
         }
 
+        void resize(size_t new_size)
+        {
+            bufsize = new_size;
+        }
     private:
         size_t bufsize;
         unsigned char* buf;
@@ -188,6 +192,11 @@ namespace zmq
             }
 
             return 0;
+        }
+
+        virtual void resize_buffer(size_t new_size)
+        {
+            allocator->resize(new_size);
         }
 
     protected:

--- a/src/i_decoder.hpp
+++ b/src/i_decoder.hpp
@@ -46,6 +46,7 @@ namespace zmq
 
         virtual void get_buffer (unsigned char **data_, size_t *size_) = 0;
 
+        virtual void resize_buffer(size_t) = 0;
         //  Decodes data pointed to by data_.
         //  When a message is decoded, 1 is returned.
         //  When the decoder needs more data, 0 is returnd.
@@ -54,6 +55,8 @@ namespace zmq
                             size_t &processed) = 0;
 
         virtual msg_t *msg () = 0;
+
+
     };
 
 }

--- a/src/raw_decoder.hpp
+++ b/src/raw_decoder.hpp
@@ -56,7 +56,7 @@ namespace zmq
 
         virtual msg_t *msg () { return &in_progress; }
 
-
+        virtual void resize_buffer(size_t) {}
     private:
 
 

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -295,6 +295,7 @@ void zmq::stream_engine_t::in_event ()
         decoder->get_buffer (&inpos, &bufsize);
 
         const int rc = tcp_read (s, inpos, bufsize);
+
         if (rc == 0) {
             error (connection_error);
             return;
@@ -307,6 +308,8 @@ void zmq::stream_engine_t::in_event ()
 
         //  Adjust input size
         insize = static_cast <size_t> (rc);
+        // Adjust buffer size to received bytes
+        decoder->resize_buffer(insize);
     }
 
     int rc = 0;

--- a/src/v2_decoder.cpp
+++ b/src/v2_decoder.cpp
@@ -43,7 +43,8 @@
 
 zmq::shared_message_memory_allocator::shared_message_memory_allocator(size_t bufsize_):
     buf(NULL),
-    bufsize( bufsize_ )
+    bufsize( 0 ),
+    maxsize( bufsize_ )
 {
 
 }
@@ -71,6 +72,7 @@ unsigned char* zmq::shared_message_memory_allocator::allocate()
         new(buf) atomic_counter_t(1);
     }
 
+    bufsize = maxsize;
     return buf + sizeof( zmq::atomic_counter_t);
 }
 
@@ -78,12 +80,15 @@ void zmq::shared_message_memory_allocator::deallocate()
 {
     free(buf);
     buf = NULL;
+    bufsize = 0;
 }
 
 unsigned char* zmq::shared_message_memory_allocator::release()
 {
     unsigned char* b = buf;
     buf = NULL;
+    bufsize = 0;
+
     return b;
 }
 

--- a/src/v2_decoder.hpp
+++ b/src/v2_decoder.hpp
@@ -92,7 +92,7 @@ namespace zmq
     private:
         unsigned char* buf;
         size_t bufsize;
-        size_t maxsize;
+        size_t max_size;
         zmq::atomic_counter_t* msg_refcnt;
     };
 

--- a/src/v2_decoder.hpp
+++ b/src/v2_decoder.hpp
@@ -80,9 +80,16 @@ namespace zmq
             return buf;
         }
 
+        void resize(size_t new_size)
+        {
+            bufsize = new_size;
+        }
+
     private:
         unsigned char* buf;
         size_t bufsize;
+        size_t maxsize;
+        zmq::atomic_counter_t* msg_refcnt;
     };
 
     //  Decoder for ZMTP/2.x framing protocol. Converts data stream into messages.

--- a/src/v2_decoder.hpp
+++ b/src/v2_decoder.hpp
@@ -63,8 +63,6 @@ namespace zmq
         // the messages constructed on top of it.
         unsigned char* release();
 
-        void reset(unsigned char* b);
-
         void inc_ref();
 
         static void call_dec_ref(void*, void* buffer);
@@ -83,6 +81,12 @@ namespace zmq
         void resize(size_t new_size)
         {
             bufsize = new_size;
+        }
+
+        //
+        zmq::atomic_counter_t* create_refcnt()
+        {
+            return msg_refcnt++;
         }
 
     private:


### PR DESCRIPTION
This fixes two bugs introduced in the original commit for zero-copy receive:
- Detection of messages which are not fully contained in the receive buffer and thus have to be copied
- Reference-counting in msg_t for lmsg objects

Additionally, a small optimization has been implemented which only allocates a new buffer when messages depend on it. This improve performance for small messages because no additional allocations are needed.