### PR TITLE
Problem: zmq::socket_base_t::connect fails on tcp ipv6 address

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -717,11 +717,12 @@ int zmq::socket_base_t::connect (const char *addr_)
         //  Following code is quick and dirty check to catch obvious errors,
         //  without trying to be fully accurate.
         const char *check = address.c_str ();
-        if (isalnum (*check) || isxdigit (*check)) {
+        if (isalnum (*check) || isxdigit (*check) || *check == '[') {
             check++;
             while (isalnum  (*check)
                 || isxdigit (*check)
-                || *check == '.' || *check == '-' || *check == ':'|| *check == ';')
+                || *check == '.' || *check == '-' || *check == ':'|| *check == ';'
+                || *check == ']')
                 check++;
         }
         //  Assume the worst, now look for success

--- a/tests/test_connect_resolve.cpp
+++ b/tests/test_connect_resolve.cpp
@@ -40,7 +40,10 @@ int main (void)
 
     int rc = zmq_connect (sock, "tcp://localhost:1234");
     assert (rc == 0);
-    
+
+    rc = zmq_connect (sock, "tcp://[::1]:1234");
+    assert (rc == 0);
+
     rc = zmq_connect (sock, "tcp://localhost:invalid");
     assert (rc == -1);
 


### PR DESCRIPTION
See https://github.com/zeromq/zeromq4-1/issues/43 and https://github.com/saltstack/salt/issues/24712