### PR TITLE
Fix units and default values for heartbeats options

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -278,11 +278,13 @@ ZMQ_HEARTBEAT_TTL: Set the TTL value for ZMTP heartbeats
 The 'ZMQ_HEARTBEAT_TTL' option shall set the timeout on the remote peer for ZMTP
 heartbeats. If this option is greater than 0, the remote side shall time out the
 connection if it does not receive any more traffic within the TTL period. This option
-does not have any effect if 'ZMQ_HEARTBEAT_IVL' is not set or is 0.
+does not have any effect if 'ZMQ_HEARTBEAT_IVL' is not set or is 0. Internally, this
+value is rounded down to the nearest decisecond, any value less than 100 will have
+no effect.
 
 [horizontal]
-Option value type:: uint16_t
-Option value unit:: deciseconds (1/10th of a second)
+Option value type:: int
+Option value unit:: milliseconds
 Default value:: 0
 Applicable socket types:: all, when using connection-oriented transports
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -72,7 +72,7 @@ zmq::options_t::options_t () :
     connected (false),
     heartbeat_ttl (0),
     heartbeat_interval (0),
-    heartbeat_timeout (0)
+    heartbeat_timeout (-1)
 {
 }
 
@@ -530,7 +530,9 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             break;
 
         case ZMQ_HEARTBEAT_TTL:
-            if (is_int && value >= 0 && value < 0xffff) {
+            // Convert this to deciseconds from milliseconds
+            value = value / 100;
+            if (is_int && value >= 0 && value <= 6553) {
                 heartbeat_ttl = (uint16_t)value;
                 return 0;
             }
@@ -905,7 +907,8 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
 
         case ZMQ_HEARTBEAT_TTL:
             if (is_int) {
-                *(uint16_t*)value = heartbeat_ttl;
+                // Convert the internal deciseconds value to milliseconds
+                *value = heartbeat_ttl * 100;
                 return 0;
             }
             break;

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -219,6 +219,7 @@ namespace zmq
         bool has_ttl_timer;
         bool has_timeout_timer;
         bool has_heartbeat_timer;
+        int heartbeat_timeout;
 
         // Socket
         zmq::socket_base_t *socket;


### PR DESCRIPTION
This patch fixes some feedback from the last heartbeats PR and from the zeromq-devel mailing list.

Set the ZMQ_HEARTBEAT_TIMEOUT to default to the value of
ZMQ_HEARTBEAT_IVL if it's not explicitly set.
Change the units of ZMQ_HEARTBEAT_TTL to milliseconds in the API
and round down to the nearest decisecond so that all the options
are using the same units.
Make the maximum heartbeat TTL match the spec (6553 seconds)