### PR TITLE
Add support for <atomic> in C++11

### DIFF
--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -36,6 +36,8 @@
 #define ZMQ_ATOMIC_PTR_MUTEX
 #elif defined ZMQ_HAVE_ATOMIC_INTRINSICS
 #define ZMQ_ATOMIC_PTR_INTRINSIC
+#elif (defined ZMQ_CXX11 && defined __cplusplus && __cplusplus >= 201103L)
+#define ZMQ_ATOMIC_CXX11
 #elif (defined __i386__ || defined __x86_64__) && defined __GNUC__
 #define ZMQ_ATOMIC_PTR_X86
 #elif defined __ARM_ARCH_7A__ && defined __GNUC__
@@ -52,6 +54,8 @@
 
 #if defined ZMQ_ATOMIC_PTR_MUTEX
 #include "mutex.hpp"
+#elif defined ZMQ_ATOMIC_CXX11
+#include <atomic>
 #elif defined ZMQ_ATOMIC_PTR_WINDOWS
 #include "windows.hpp"
 #elif defined ZMQ_ATOMIC_PTR_ATOMIC_H
@@ -96,6 +100,8 @@ namespace zmq
             return (T*) InterlockedExchangePointer ((PVOID*) &ptr, val_);
 #elif defined ZMQ_ATOMIC_PTR_INTRINSIC
             return (T*) __atomic_exchange_n (&ptr, val_, __ATOMIC_ACQ_REL);
+#elif defined ZMQ_ATOMIC_CXX11
+            return ptr.exchange(val_, std::memory_order_acq_rel);
 #elif defined ZMQ_ATOMIC_PTR_ATOMIC_H
             return (T*) atomic_swap_ptr (&ptr, val_);
 #elif defined ZMQ_ATOMIC_PTR_TILE
@@ -146,6 +152,9 @@ namespace zmq
             __atomic_compare_exchange_n (&ptr, (volatile T**) &old, val_, false,
                     __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
             return old;
+#elif defined ZMQ_ATOMIC_CXX11
+            ptr.compare_exchange_strong(cmp_, val_);
+            return cmp_;
 #elif defined ZMQ_ATOMIC_PTR_ATOMIC_H
             return (T*) atomic_cas_ptr (&ptr, cmp_, val_);
 #elif defined ZMQ_ATOMIC_PTR_TILE
@@ -189,13 +198,20 @@ namespace zmq
 
     private:
 
+#if defined ZMQ_ATOMIC_CXX11
+        std::atomic<T*> ptr;
+#else
         volatile T *ptr;
+#endif
+
 #if defined ZMQ_ATOMIC_PTR_MUTEX
         mutex_t sync;
 #endif
 
+#if ! defined ZMQ_ATOMIC_CXX11
         atomic_ptr_t (const atomic_ptr_t&);
         const atomic_ptr_t &operator = (const atomic_ptr_t&);
+#endif
     };
 
 }


### PR DESCRIPTION
Adding atomic support seems surprisingly easy. After the change, TSAN runs cleanly:

    cd /data/libzmqbuild

    CC=clang-3.5 CXX=clang++-3.5 \
    CXXFLAGS="-std=c++11 -fsanitize=thread -DZMQ_CXX11" \
    cmake ../libzmq

    make

Running the above with and without `-DZMQ_CXX11` will show the difference.