### PR TITLE
Add missing relaxed memory ordering.

### DIFF
--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -153,7 +153,7 @@ namespace zmq
                     __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
             return old;
 #elif defined ZMQ_ATOMIC_CXX11
-            ptr.compare_exchange_strong(cmp_, val_);
+            ptr.compare_exchange_strong(cmp_, val_, std::memory_order_acq_rel);
             return cmp_;
 #elif defined ZMQ_ATOMIC_PTR_ATOMIC_H
             return (T*) atomic_cas_ptr (&ptr, cmp_, val_);


### PR DESCRIPTION
The memory ordering was forgotten in the previous pull request. I had added it to the wrong local copy of the file and didn't notice. It was always meant to be acquire-release ordering on both `xchg` and `cas` (just like in the other implementations).

(The omission is not an error; the default is the stronger "sequentially consistent" memory order.)