### PR TITLE
atomic_ptr.h: clean up the clean-up

### DIFF
--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -217,21 +217,13 @@ namespace zmq
 }
 
 //  Remove macros local to this file.
-#if defined ZMQ_ATOMIC_PTR_WINDOWS
-#undef ZMQ_ATOMIC_PTR_WINDOWS
-#endif
-#if defined ZMQ_ATOMIC_PTR_ATOMIC_H
-#undef ZMQ_ATOMIC_PTR_ATOMIC_H
-#endif
-#if defined ZMQ_ATOMIC_PTR_X86
-#undef ZMQ_ATOMIC_PTR_X86
-#endif
-#if defined ZMQ_ATOMIC_PTR_ARM
-#undef ZMQ_ATOMIC_PTR_ARM
-#endif
-#if defined ZMQ_ATOMIC_PTR_MUTEX
 #undef ZMQ_ATOMIC_PTR_MUTEX
-#endif
+#undef ZMQ_ATOMIC_PTR_INTRINSIC
+#undef ZMQ_ATOMIC_CXX11
+#undef ZMQ_ATOMIC_PTR_X86
+#undef ZMQ_ATOMIC_PTR_ARM
+#undef ZMQ_ATOMIC_PTR_TILE
+#undef ZMQ_ATOMIC_PTR_WINDOWS
+#undef ZMQ_ATOMIC_PTR_ATOMIC_H
 
 #endif
-


### PR DESCRIPTION
Clean-up:

* `#undef` has no effect if the following token is not a macro name, so we don't need the `#if defined` checks.
* Undefine a few macros that were missing.
* Order macros in the same way in which they were defined, to make it easier to keep them in sync in the future.
* Remove trailing blank line. Some editors remove those automatically, making it harder to keep diffs minimal. Let's rip off that bandaid.