### PR TITLE
[decoder*] Style fixes for consistency

### DIFF
--- a/src/decoder_allocators.cpp
+++ b/src/decoder_allocators.cpp
@@ -33,79 +33,76 @@
 
 #include "msg.hpp"
 
-zmq::shared_message_memory_allocator::shared_message_memory_allocator(size_t bufsize_):
-        buf(NULL),
-        bufsize( 0 ),
-        max_size( bufsize_ ),
-        msg_refcnt( NULL ),
-        maxCounters( std::ceil( static_cast<double>(max_size) / static_cast<double>(msg_t::max_vsm_size)) )
+zmq::shared_message_memory_allocator::shared_message_memory_allocator (std::size_t bufsize_) :
+    buf(NULL),
+    bufsize(0),
+    max_size(bufsize_),
+    msg_refcnt(NULL),
+    maxCounters (std::ceil (static_cast <double> (max_size) / static_cast <double> (msg_t::max_vsm_size)))
 {
-
 }
 
-zmq::shared_message_memory_allocator::shared_message_memory_allocator(size_t bufsize_, size_t maxMessages):
-        buf(NULL),
-        bufsize( 0 ),
-        max_size( bufsize_ ),
-        msg_refcnt( NULL ),
-        maxCounters( maxMessages )
+zmq::shared_message_memory_allocator::shared_message_memory_allocator (std::size_t bufsize_, std::size_t maxMessages) :
+    buf(NULL),
+    bufsize(0),
+    max_size(bufsize_),
+    msg_refcnt(NULL),
+    maxCounters(maxMessages)
 {
-
 }
 
-zmq::shared_message_memory_allocator::~shared_message_memory_allocator()
+zmq::shared_message_memory_allocator::~shared_message_memory_allocator ()
 {
     deallocate();
 }
 
-unsigned char* zmq::shared_message_memory_allocator::allocate()
+unsigned char* zmq::shared_message_memory_allocator::allocate ()
 {
-    if (buf)
-    {
+    if (buf) {
         // release reference count to couple lifetime to messages
-        zmq::atomic_counter_t *c = reinterpret_cast<zmq::atomic_counter_t *>(buf);
+        zmq::atomic_counter_t* c = reinterpret_cast<zmq::atomic_counter_t* >(buf);
 
         // if refcnt drops to 0, there are no message using the buffer
         // because either all messages have been closed or only vsm-messages
         // were created
-        if (c->sub(1)) {
+        if (c->sub (1)) {
             // buffer is still in use as message data. "Release" it and create a new one
             // release pointer because we are going to create a new buffer
-            release();
+            release ();
         }
     }
 
     // if buf != NULL it is not used by any message so we can re-use it for the next run
     if (!buf) {
         // allocate memory for reference counters together with reception buffer
-        size_t const allocationsize = max_size + sizeof(zmq::atomic_counter_t) + maxCounters * sizeof(zmq::atomic_counter_t);
+        std::size_t const allocationsize =
+              max_size + sizeof (zmq::atomic_counter_t) +
+              maxCounters * sizeof (zmq::atomic_counter_t);
 
-        buf = static_cast<unsigned char *>( malloc(allocationsize) );
+        buf = static_cast <unsigned char *> (std::malloc (allocationsize));
         alloc_assert (buf);
 
-        new(buf) atomic_counter_t(1);
-    }
-    else
-    {
+        new (buf) atomic_counter_t (1);
+    } else {
         // release reference count to couple lifetime to messages
-        zmq::atomic_counter_t *c = reinterpret_cast<zmq::atomic_counter_t *>(buf);
-        c->set(1);
+        zmq::atomic_counter_t *c = reinterpret_cast <zmq::atomic_counter_t *> (buf);
+        c->set (1);
     }
 
     bufsize = max_size;
-    msg_refcnt = reinterpret_cast<zmq::atomic_counter_t*>( buf + sizeof(atomic_counter_t) + max_size );
-    return buf + sizeof( zmq::atomic_counter_t);
+    msg_refcnt = reinterpret_cast <zmq::atomic_counter_t*> (buf + sizeof (atomic_counter_t) + max_size);
+    return buf + sizeof (zmq::atomic_counter_t);
 }
 
-void zmq::shared_message_memory_allocator::deallocate()
+void zmq::shared_message_memory_allocator::deallocate ()
 {
-    std::free(buf);
+    std::free (buf);
     buf = NULL;
     bufsize = 0;
     msg_refcnt = NULL;
 }
 
-unsigned char* zmq::shared_message_memory_allocator::release()
+unsigned char* zmq::shared_message_memory_allocator::release ()
 {
     unsigned char* b = buf;
     buf = NULL;
@@ -115,30 +112,31 @@ unsigned char* zmq::shared_message_memory_allocator::release()
     return b;
 }
 
-void zmq::shared_message_memory_allocator::inc_ref()
+void zmq::shared_message_memory_allocator::inc_ref ()
 {
-    (reinterpret_cast<zmq::atomic_counter_t*>(buf))->add(1);
+    (reinterpret_cast <zmq::atomic_counter_t*> (buf))->add (1);
 }
 
-void zmq::shared_message_memory_allocator::call_dec_ref(void*, void* hint) {
-    zmq_assert( hint );
-    unsigned char* buf = static_cast<unsigned char*>(hint);
-    zmq::atomic_counter_t *c = reinterpret_cast<zmq::atomic_counter_t *>(buf);
+void zmq::shared_message_memory_allocator::call_dec_ref(void*, void* hint)
+{
+    zmq_assert (hint);
+    unsigned char* buf = static_cast <unsigned char*> (hint);
+    zmq::atomic_counter_t* c = reinterpret_cast <zmq::atomic_counter_t*> (buf);
 
-    if (!c->sub(1)) {
-        c->~atomic_counter_t();
-        free(buf);
+    if (!c->sub (1)) {
+        c->~atomic_counter_t ();
+        std::free (buf);
         buf = NULL;
     }
 }
 
 
-size_t zmq::shared_message_memory_allocator::size() const
+std::size_t zmq::shared_message_memory_allocator::size () const
 {
     return bufsize;
 }
 
-unsigned char* zmq::shared_message_memory_allocator::data()
+unsigned char* zmq::shared_message_memory_allocator::data ()
 {
-    return buf + sizeof(zmq::atomic_counter_t);
+    return buf + sizeof (zmq::atomic_counter_t);
 }

--- a/src/decoder_allocators.hpp
+++ b/src/decoder_allocators.hpp
@@ -27,13 +27,14 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef ZEROMQ_DECODER_ALLOCATORS_HPP
-#define ZEROMQ_DECODER_ALLOCATORS_HPP
+#ifndef __ZMQ_DECODER_ALLOCATORS_HPP_INCLUDED__
+#define __ZMQ_DECODER_ALLOCATORS_HPP_INCLUDED__
 
+#include <cstddef>
 #include <cstdlib>
 
-#include "err.hpp"
 #include "atomic_counter.hpp"
+#include "err.hpp"
 
 namespace zmq
 {
@@ -41,43 +42,42 @@ namespace zmq
     class c_single_allocator
     {
     public:
-        explicit c_single_allocator(size_t bufsize_):
+        explicit c_single_allocator (std::size_t bufsize_) :
                 bufsize(bufsize_),
-                buf(static_cast<unsigned char*>( malloc (bufsize) ))
+                buf(static_cast <unsigned char*> (std::malloc (bufsize)))
         {
             alloc_assert (buf);
         }
 
-        ~c_single_allocator()
+        ~c_single_allocator ()
         {
-            std::free(buf);
+            std::free (buf);
         }
 
-        unsigned char* allocate()
+        unsigned char* allocate ()
         {
             return buf;
         }
 
-        void deallocate()
+        void deallocate ()
         {
-
         }
 
-        size_t size() const
+        std::size_t size () const
         {
             return bufsize;
         }
 
-        void resize(size_t new_size)
+        void resize (std::size_t new_size)
         {
             bufsize = new_size;
         }
     private:
-        size_t bufsize;
+        std::size_t bufsize;
         unsigned char* buf;
 
-        c_single_allocator( c_single_allocator const& );
-        c_single_allocator& operator=(c_single_allocator const&);
+        c_single_allocator (c_single_allocator const&);
+        c_single_allocator& operator = (c_single_allocator const&);
     };
 
     // This allocater allocates a reference counted buffer which is used by v2_decoder_t
@@ -92,58 +92,58 @@ namespace zmq
     class shared_message_memory_allocator
     {
     public:
-        explicit shared_message_memory_allocator(size_t bufsize_);
+        explicit shared_message_memory_allocator (std::size_t bufsize_);
 
         // Create an allocator for a maximum number of messages
-        shared_message_memory_allocator(size_t bufsize_, size_t maxMessages);
+        shared_message_memory_allocator (std::size_t bufsize_, std::size_t maxMessages);
 
-        ~shared_message_memory_allocator();
+        ~shared_message_memory_allocator ();
 
         // Allocate a new buffer
         //
         // This releases the current buffer to be bound to the lifetime of the messages
         // created on this bufer.
-        unsigned char* allocate();
+        unsigned char* allocate ();
 
         // force deallocation of buffer.
-        void deallocate();
+        void deallocate ();
 
         // Give up ownership of the buffer. The buffer's lifetime is now coupled to
         // the messages constructed on top of it.
-        unsigned char* release();
+        unsigned char* release ();
 
-        void inc_ref();
+        void inc_ref ();
 
-        static void call_dec_ref(void*, void* buffer);
+        static void call_dec_ref (void*, void* buffer);
 
-        size_t size() const;
+        std::size_t size () const;
 
         // Return pointer to the first message data byte.
-        unsigned char* data();
+        unsigned char* data ();
 
         // Return pointer to the first byte of the buffer.
-        unsigned char* buffer()
+        unsigned char* buffer ()
         {
             return buf;
         }
 
-        void resize(size_t new_size)
+        void resize (std::size_t new_size)
         {
             bufsize = new_size;
         }
 
-        //
-        zmq::atomic_counter_t* create_refcnt()
+        zmq::atomic_counter_t* create_refcnt ()
         {
             return msg_refcnt++;
         }
 
     private:
         unsigned char* buf;
-        size_t bufsize;
-        size_t max_size;
+        std::size_t bufsize;
+        std::size_t max_size;
         zmq::atomic_counter_t* msg_refcnt;
-        size_t maxCounters;
+        std::size_t maxCounters;
     };
 }
-#endif //ZEROMQ_DECODER_ALLOCATORS_HPP
+
+#endif


### PR DESCRIPTION
Apart from applying the style rules a bit more consistently (mostly regarding spaces), this change makes a few more "invasive" changes which I hope will become mandatory in the future:

* No deprecated headers. `<foo.h>` => `<cfoo>`, and qualify all standard library names.

* No redundant `inline`; class member functions that are defined inline are implicitly defined as `inline`.

* One-parameter constructors are `explicit` unless implicit conversions are explicitly desired.

* No extraneous newlines at the end of the file; include guards separated from the file body by one newline.