### PR TITLE
add message type sanity check in msg_t::rm_refs

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -467,7 +467,7 @@ bool zmq::msg_t::rm_refs (int refs_)
     }
 
     //  The only message type that needs special care are long and zcopy messages.
-    if (!u.lmsg.content->refcnt.sub (refs_)) {
+    if (u.base.type == type_lmsg && !u.lmsg.content->refcnt.sub(refs_)) {
         //  We used "placement new" operator to initialize the reference
         //  counter so we call the destructor explicitly now.
         u.lmsg.content->refcnt.~atomic_counter_t ();
@@ -479,7 +479,7 @@ bool zmq::msg_t::rm_refs (int refs_)
         return false;
     }
 
-    if (!u.zclmsg.refcnt->sub (refs_)) {
+    if (is_zcmsg() && !u.zclmsg.refcnt->sub(refs_)) {
         // storage for rfcnt is provided externally
         if (u.zclmsg.ffn) {
             u.zclmsg.ffn(u.zclmsg.data, u.zclmsg.hint);


### PR DESCRIPTION
... in order to avoid invalid memory access with u.zclmsg.refcnt.

I was experiencing sporadic crashes, which I was eventually able to trace down to this. I think I really needed the latter change only, but for symmetry I added the former, too. (I think it may be useful in other cases.)

Note that I am not at all familiar with the internals of ZeroMQ... so I cannot really tell how this should have been fixed. But what I can say for sure is that in my case u.zclmsg.refcnt wasn't a valid pointer (for example, it was equal to 1; I think the message was really a long message, i.e. not a zc message), so the call to sub made the program crash.