### PR TITLE
on Windows, handle WSAENOBUFS like WSAEWOULDBLOCK

### DIFF
--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -173,6 +173,11 @@ int zmq::tcp_write (fd_t s_, const void *data_, size_t size_)
           WSAGetLastError () == WSAECONNRESET))
         return -1;
 
+    //  Circumvent a Windows bug; see https://support.microsoft.com/en-us/kb/201213
+    //  and https://zeromq.jira.com/browse/LIBZMQ-195
+    if (nbytes == SOCKET_ERROR && WSAGetLastError() == WSAENOBUFS)
+        return 0;
+
     wsa_assert (nbytes != SOCKET_ERROR);
     return nbytes;
 


### PR DESCRIPTION
I have been facing an issue similar to https://zeromq.jira.com/browse/LIBZMQ-195, but on Win7 x64, and also on Windows Server 2008 R2 x64.

The messages I am sending are some 5-7 MB in size, and I send about 5 messages per second (for the time being inside localhost only). Sometimes WSAENOBUFS is returned within 24 hours, sometimes within a week.

So far, it looks like the change at hand has fixed the issue for me.

At any rate, wsa_assert crashing the whole program is really bad, at least in my situation.