### PR TITLE
THREAD PRIORITY option documentation

### DIFF
--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -47,6 +47,28 @@ context.
 [horizontal]
 Default value:: 1
 
+ZMQ_THREAD_SCHED_POLICY: Set scheduling policy for I/O threads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_THREAD_SCHED_POLICY' argument sets the scheduling policy for
+internal context's thread pool. This option is not available on windows.
+Supported values for this option can be found in sched.h file,
+or at http://man7.org/linux/man-pages/man2/sched_setscheduler.2.html.
+This option only applies before creating any sockets on the context.
+
+[horizontal]
+Default value:: -1
+
+ZMQ_THREAD_PRIORITY: Set scheduling priority for I/O threads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_THREAD_PRIORITY' argument sets scheduling priority for
+internal context's thread pool. This option is not available on windows.
+Supported values for this option depend on chosen scheduling policy.
+Details can be found in sched.h file, or at http://man7.org/linux/man-pages/man2/sched_setscheduler.2.html.
+This option only applies before creating any sockets on the context.
+
+[horizontal]
+Default value:: -1
+
 ZMQ_MAX_SOCKETS: Set maximum number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_MAX_SOCKETS' argument sets the maximum number of sockets allowed


### PR DESCRIPTION
Added documentation about context's options ZMQ_THREAD_SCHED_POLICY and ZMQ_THREAD_PRIORITY. Already done in 4.1 branch. I don't know if there is a way to do a pull request linked with the one in 4.1 branch. Meanwhile this is a new request.