### PR TITLE
Fix compilation on mac.

### DIFF
--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -161,7 +161,7 @@ zmq::signaler_t::~signaler_t ()
         errno_assert (rc == 0);
     }
     if (r != retired_fd) {
-        rc = close_wait_ms (r);
+        int rc = close_wait_ms (r);
         errno_assert (rc == 0);
     }
 #endif


### PR DESCRIPTION
When compiling on mac with:

```
cd $SOURCEDIR
./autogen.sh
cd $BUILDDIR
$SOURCEDIR/configure --prefix=$INSTALLROOT \
                     --disable-dependency-tracking \
                     sodium_CFLAGS="-I$SODIUM_ROOT/include" \
                     sodium_LIBS="-L$SODIUM_ROOT/lib -lsodium"

make ${JOBS+-j $JOBS}
make install
```

I get:

```
DEBUG:zeromq:5fead473: /Users/ktf/work/active/sw/SOURCES/zeromq/master/5fead473a4/src/signaler.cpp:164:9: error: use of undeclared identifier 'rc'
DEBUG:zeromq:5fead473:         rc = close_wait_ms (r);
DEBUG:zeromq:5fead473:         ^
DEBUG:zeromq:5fead473: /Users/ktf/work/active/sw/SOURCES/zeromq/master/5fead473a4/src/signaler.cpp:165:23: error: use of undeclared identifier 'rc'
DEBUG:zeromq:5fead473:         errno_assert (rc == 0);
DEBUG:zeromq:5fead473:                       ^
DEBUG:zeromq:5fead473: /Users/ktf/work/active/sw/SOURCES/zeromq/master/5fead473a4/src/err.hpp:129:25: note: expanded from macro 'errno_assert'
DEBUG:zeromq:5fead473:         if (unlikely (!(x))) {\
DEBUG:zeromq:5fead473:                         ^
DEBUG:zeromq:5fead473: /Users/ktf/work/active/sw/SOURCES/zeromq/master/5fead473a4/src/likely.hpp:35:40: note: expanded from macro 'unlikely'
DEBUG:zeromq:5fead473: #define unlikely(x) __builtin_expect ((x), 0)
DEBUG:zeromq:5fead473:                                        ^
DEBUG:zeromq:5fead473: 2 errors generated.
```

this fixes the problem.