### PR TITLE
fix #1447 Segfault or Abort after PR #1441

### DIFF
--- a/src/decoder_allocators.hpp
+++ b/src/decoder_allocators.hpp
@@ -132,9 +132,14 @@ namespace zmq
             bufsize = new_size;
         }
 
-        zmq::atomic_counter_t* create_refcnt ()
+        zmq::atomic_counter_t* provide_refcnt ()
         {
-            return msg_refcnt++;
+            return msg_refcnt;
+        }
+
+        void advance_refcnt ()
+        {
+            msg_refcnt++;
         }
 
     private:

--- a/src/raw_decoder.cpp
+++ b/src/raw_decoder.cpp
@@ -63,11 +63,12 @@ int zmq::raw_decoder_t::decode (const uint8_t *data_, size_t size_,
     int rc = in_progress.init ((unsigned char*)data_, size_,
                                shared_message_memory_allocator::call_dec_ref,
                                allocator.buffer(),
-                               allocator.create_refcnt() );
+                               allocator.provide_refcnt() );
 
     // if the buffer serves as memory for a zero-copy message, release it
     // and allocate a new buffer in get_buffer for the next decode
     if (in_progress.is_zcmsg()) {
+        allocator.advance_refcnt();
         allocator.release();
     }
 

--- a/src/v2_decoder.cpp
+++ b/src/v2_decoder.cpp
@@ -129,11 +129,12 @@ int zmq::v2_decoder_t::size_ready(uint64_t msg_size, unsigned char const* read_p
         // if the message will be a large message, pass a valid refcnt memory location as well
         rc = in_progress.init( (unsigned char*)read_pos, msg_size,
                                shared_message_memory_allocator::call_dec_ref, buffer(),
-                               create_refcnt() );
+                               provide_refcnt() );
 
         // For small messages, data has been copied and refcount does not have to be increased
         if (in_progress.is_zcmsg())
         {
+            advance_refcnt();
             inc_ref();
         }
     }


### PR DESCRIPTION
The pointer to refcnt was incremented even if it was not used by a message not qualifying for zerocopy.
As a result, a pattern of many small messages received could cause a write beyond bounds of the allocated buffer.