### PR TITLE
Fix 1478: receive unsubscriptions in XPUB when verbose

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -14,8 +14,9 @@ SYNOPSIS
 
 Caution: All options, with the exception of ZMQ_SUBSCRIBE, ZMQ_UNSUBSCRIBE,
 ZMQ_LINGER, ZMQ_ROUTER_HANDOVER, ZMQ_ROUTER_MANDATORY, ZMQ_PROBE_ROUTER,
-ZMQ_XPUB_VERBOSE, ZMQ_REQ_CORRELATE, ZMQ_REQ_RELAXED, ZMQ_SNDHWM
-and ZMQ_RCVHWM, only take effect for subsequent socket bind/connects.
+ZMQ_XPUB_VERBOSE, ZMQ_XPUB_VERBOSE_UNSUBSCRIBE, ZMQ_REQ_CORRELATE,
+ZMQ_REQ_RELAXED, ZMQ_SNDHWM and ZMQ_RCVHWM, only take effect for
+subsequent socket bind/connects.
 
 Specifically, security options take effect for subsequent bind/connect calls,
 and can be changed at any time to affect subsequent binds and/or connects.
@@ -831,6 +832,25 @@ ZMQ_XPUB_VERBOSE: provide all subscription messages on XPUB sockets
 Sets the 'XPUB' socket behaviour on new subscriptions and unsubscriptions.
 A value of '0' is the default and passes only new subscription messages to
 upstream. A value of '1' passes all subscription messages upstream.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1
+Default value:: 0
+Applicable socket types:: ZMQ_XPUB
+
+
+ZMQ_XPUB_VERBOSE_UNSUBSCRIBE: provide all unsubscription messages on XPUB sockets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the 'XPUB' socket behaviour on new subscriptions and unsubscriptions.
+A value of '0' is the default and passes only the last unsubscription message to
+upstream. A value of '1' passes all unsubscription messages upstream.
+
+This behaviour should be enabled in all the intermediary XPUB sockets if
+ZMQ_XPUB_VERBOSE is also being used in order to allow the correct forwarding
+of all the unsubscription messages.
+
+NOTE: This behaviour only takes effect when ZMQ_XPUB_VERBOSE is also enabled.
 
 [horizontal]
 Option value type:: int

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -319,6 +319,7 @@ ZMQ_EXPORT uint32_t zmq_msg_get_routing_id(zmq_msg_t *msg);
 #define ZMQ_HEARTBEAT_IVL 75
 #define ZMQ_HEARTBEAT_TTL 76
 #define ZMQ_HEARTBEAT_TIMEOUT 77
+#define ZMQ_XPUB_VERBOSE_UNSUBSCRIBE 78
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1

--- a/src/mtrie.hpp
+++ b/src/mtrie.hpp
@@ -54,11 +54,12 @@ namespace zmq
         bool add (unsigned char *prefix_, size_t size_, zmq::pipe_t *pipe_);
 
         //  Remove all subscriptions for a specific peer from the trie.
-        //  If there are no subscriptions left on some topics, invoke the
-        //  supplied callback function.
+        //  The call_on_uniq_ flag controls if the callback is invoked
+        //  when there are no subscriptions left on some topics or on
+        //  every removal.
         void rm (zmq::pipe_t *pipe_,
             void (*func_) (unsigned char *data_, size_t size_, void *arg_),
-            void *arg_);
+            void *arg_, bool call_on_uniq_);
 
         //  Remove specific subscription from the trie. Return true is it was
         //  actually removed rather than de-duplicated.
@@ -75,7 +76,7 @@ namespace zmq
         void rm_helper (zmq::pipe_t *pipe_, unsigned char **buff_,
             size_t buffsize_, size_t maxbuffsize_,
             void (*func_) (unsigned char *data_, size_t size_, void *arg_),
-            void *arg_);
+            void *arg_, bool call_on_uniq_);
         bool rm_helper (unsigned char *prefix_, size_t size_,
             zmq::pipe_t *pipe_);
         bool is_redundant () const;

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -84,7 +84,11 @@ namespace zmq
 
         // If true, send all subscription messages upstream, not just
         // unique ones
-        bool verbose;
+        bool verbose_subs;
+
+        // If true, send all unsubscription messages upstream, not just
+        // unique ones
+        bool verbose_unsubs;
 
         //  True if we are in the middle of sending a multi-part message.
         bool more;


### PR DESCRIPTION
*As I discussed in the mailing list, this fix doesn't break any contract from the current API and only extends it adding a new flag:*

Fixes not receiving unsubscription messages in XPUB socket with
ZMQ_XPUB_VERBOSE and using a XSUB-XPUB proxy in front.

This adds two modifications:

- It adds a new flag, ZMQ_XPUB_VERBOSE_UNSUBSCRIBE, to enable verbose
  unsubscription messages, necessary when using a XSUB/XPUB proxy.

- It adds a boolean switch to zmq::mtrie_t::rm () to control if the
  callback is invoked every time or only in the last removal. Necessary
  when a pipe is terminated and the verbose mode for unsubscriptions is
  enabled.