### PR TITLE
don't break STREAM socket ABI from 4.1.x to 4.2.0

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -716,11 +716,11 @@ Default value:: -1 (infinite)
 Applicable socket types:: all
 
 
-ZMQ_STREAM_NOTIFY: send connect notifications
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Enables connect notifications on a STREAM socket, when set to 1. By default a
-STREAM socket does not notify new connections. When notifications are enabled,
-it delivers a zero-length message to signal new client connections.
+ZMQ_STREAM_NOTIFY: send connect and disconnect notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Enables connect and disconnect notifications on a STREAM socket, when set
+to 1. When notifications are enabled, the socket delivers a zero-length
+message when a peer connects or disconnects.
 
 [horizontal]
 Option value type:: int

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -725,7 +725,7 @@ message when a peer connects or disconnects.
 [horizontal]
 Option value type:: int
 Option value unit:: 0, 1
-Default value:: 0
+Default value:: 1
 Applicable socket types:: ZMQ_STREAM
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -58,7 +58,7 @@ zmq::options_t::options_t () :
     invert_matching(false),
     recv_identity (false),
     raw_socket (false),
-    raw_notify (false),
+    raw_notify (true),
     tcp_keepalive (-1),
     tcp_keepalive_cnt (-1),
     tcp_keepalive_idle (-1),

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -965,7 +965,7 @@ int zmq::stream_engine_t::write_subscription_msg (msg_t *msg_)
 
 void zmq::stream_engine_t::error (error_reason_t reason)
 {
-    if (options.raw_socket) {
+    if (options.raw_socket && options.raw_notify) {
         //  For raw sockets, send a final 0-length message to the application
         //  so that it knows the peer has been disconnected.
         msg_t terminator;

--- a/tests/test_connect_rid.cpp
+++ b/tests/test_connect_rid.cpp
@@ -36,12 +36,15 @@ void test_stream_2_stream(){
     char buff[256];
     char msg[] = "hi 1";
     const char *bindip = "tcp://127.0.0.1:5556";
+    int disabled = 0;
     int zero = 0;
     void *ctx = zmq_ctx_new ();
 
     //  Set up listener STREAM.
     rbind = zmq_socket (ctx, ZMQ_STREAM);
     assert (rbind);
+    ret = zmq_setsockopt (rbind, ZMQ_STREAM_NOTIFY, &disabled, sizeof (disabled));
+    assert (ret == 0);
     ret = zmq_setsockopt (rbind, ZMQ_LINGER, &zero, sizeof (zero));
     assert (0 == ret);
     ret = zmq_bind (rbind, bindip);


### PR DESCRIPTION
The current state of STREAM sockets connect/disconnect notifications behavior is as follows.

notification | 4.0.x | 4.1.x | 4.2.0 (master)
-------------- | ------| -------| ------
connect | no | yes | sockopt (default no)
disconnect | no | yes | yes

Notice that the ABI was broken from 4.0.x to 4.1.x and yet once more from 4.1.x to 4.2.0.
This PR changes the behavior to the following such that no ABI breakage occurs from 4.1.x to 4.2.0. (since 4.2.0 has not been released yet)

notification | 4.0.x | 4.1.x | 4.2.0 (master)
-------------- | ------| -------| ------
connect | no | yes | sockopt (default yes)
disconnect | no | yes | sockopt (default yes)

Use case for connect/disconnect notifications:
1) connect notifications are needed for the server socket when the protocol is such that the server socket is the one that sends the first message upon the connection of a client (added in #832)
2) disconnect notifications are needed so that the application is able to discard any connection state when its peer has disconnected. (added in #825)

See also discussion in #1316
