### PR TITLE
Add a way to disable libzmq's internal test timeout.

### DIFF
--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -282,8 +282,10 @@ void setup_test_environment()
     // abort test after 121 seconds
     alarm(121);
 #else
+#   if !defined ZMQ_DISABLE_TEST_TIMEOUT
     // abort test after 60 seconds
     alarm(60);
+#   endif
 #endif
 #endif
 #if defined __MVS__


### PR DESCRIPTION
It's nice to be able to disable libzmq's internal timeout when there's
another timeout in the test runner being used which gives nicer error
messages.