### PR TITLE
Check for libtoolize instead of libtool on Linux

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -20,10 +20,14 @@
 
 # Script to generate all required files from fresh git checkout.
 
-command -v libtool >/dev/null 2>&1
+# Debian and Ubuntu do not shipt libtool anymore, but OSX does not ship libtoolize.
+command -v libtoolize >/dev/null 2>&1
 if  [ $? -ne 0 ]; then
-    echo "autogen.sh: error: could not find libtool.  libtool is required to run autogen.sh." 1>&2
-    exit 1
+    command -v libtool >/dev/null 2>&1
+    if  [ $? -ne 0 ]; then
+        echo "autogen.sh: error: could not find libtool.  libtool is required to run autogen.sh." 1>&2
+        exit 1
+    fi
 fi
 
 command -v autoreconf >/dev/null 2>&1


### PR DESCRIPTION
Same fix has been merged into Zproject in https://github.com/zeromq/zproject/pull/197 and https://github.com/zeromq/zproject/pull/198

The problem is the same:

autogen.sh has a check for the libtool binary as a mean to
check if libtool is available. But distributions like Debian and
Ubuntu are splitting the libtool package, and the libtool binary is now
in a separate package. What autoconf actually need is not the libtool
binary, but libtoolize and other macro files. So check for libtoolize
instead. On the other hand, OSX only ships libtool, not libtoolize,
and uses a pre-generated libtool script to build. So check for
libtoolize first and then for libtool, and fail if neither can be
found.