### PR TITLE
Travis ci osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 language: c
 
+os:
+- linux
+- osx
+
 env:
 - BUILD_TYPE=default
 - BUILD_TYPE=qt-android

--- a/builds/qt-android/android_build_helper.sh
+++ b/builds/qt-android/android_build_helper.sh
@@ -282,7 +282,16 @@ function android_build_verify_so {
     fi
     android_build_check_fail
     
-    local elfoutput=$(readelf -d ${sofile})
+    if command -v readelf >/dev/null 2>&1 ; then
+        local readelf_bin="readelf"
+    elif command -v greadelf >/dev/null 2>&1 ; then
+        local readelf_bin="greadelf"
+    else
+        ANDROID_BUILD_FAIL+=("Could not find [g]readelf")
+    fi
+    android_build_check_fail
+
+    local elfoutput=$($readelf_bin -d ${sofile})
     
     local soname_regexp='soname: \[([[:alnum:]\.]+)\]'
     if [[ $elfoutput =~ $soname_regexp ]]; then

--- a/builds/qt-android/ci_build.sh
+++ b/builds/qt-android/ci_build.sh
@@ -1,12 +1,28 @@
 #!/usr/bin/env bash
 
-(cd '/tmp' \
-    && wget http://dl.google.com/android/ndk/android-ndk-r9-linux-x86_64.tar.bz2 \
-    && tar -xf android-ndk-r9-linux-x86_64.tar.bz2 \
-    && mv android-ndk-r9 android-ndk)
+NDK_VER=android-ndk-r10e
 
-export ANDROID_NDK_ROOT="/tmp/android-ndk"
-export TOOLCHAIN_PATH="/tmp/android-ndk/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/bin"
+if [ $TRAVIS_OS_NAME == "linux" ]
+then
+    NDK_PLATFORM=linux-x86_64
+elif [ $TRAVIS_OS_NAME == "osx" ]
+then
+    NDK_PLATFORM=darwin-x86_64
+else
+    echo "Unsupported platform $TRAVIS_OS_NAME"
+    exit 1
+fi
+
+export FILENAME=$NDK_VER-$NDK_PLATFORM.bin
+
+(cd '/tmp' \
+    && wget http://dl.google.com/android/ndk/$FILENAME \
+    && chmod a+x $FILENAME \
+    && ./$FILENAME &> /dev/null ) || exit 1
+unset FILENAME
+
+export ANDROID_NDK_ROOT="/tmp/$NDK_VER"
+export TOOLCHAIN_PATH="$ANDROID_NDK_ROOT/toolchains/arm-linux-androideabi-4.8/prebuilt/$NDK_PLATFORM/bin"
 export TOOLCHAIN_NAME="arm-linux-androideabi-4.8"
 export TOOLCHAIN_HOST="arm-linux-androideabi"
 export TOOLCHAIN_ARCH="arm"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -5,7 +5,8 @@ if [ $BUILD_TYPE == "default" ]; then
 
     #   libsodium
     git clone git://github.com/jedisct1/libsodium.git
-    ( cd libsodium; ./autogen.sh; ./configure; make check; sudo make install; sudo ldconfig )
+    ( cd libsodium; ./autogen.sh; ./configure; make check; sudo make install;
+        if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi )
 
     #   Build and check this project
     ./autogen.sh && ./configure --with-libsodium=yes && make && make check


### PR DESCRIPTION
This PR makes the CI build scripts compatible with OSX on Travis. Fixes #1502. Note that until OSX build is enabled on a project by emailing support@travis-ci.com, the option in travis.yml will have no effect.