### PR TITLE
Increase file limit in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,11 @@ env:
 - BUILD_TYPE=default
 - BUILD_TYPE=qt-android
 
+before_script:
+# ZMQ stress tests need more open socket (files) than the usual default
+# On OSX, it seems the way to set the max files limit is constantly changing, so
+# try to use all known knobs to ensure compatibility across various versions
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then sudo sysctl -w kern.maxfiles=64000 ; sudo sysctl -w kern.maxfilesperproc=64000 ; sudo launchctl limit maxfiles 64000 64000 ; fi ; ulimit -n 64000
+
 # Build and check this project according to the BUILD_TYPE
 script: ./ci_build.sh


### PR DESCRIPTION
Test cases occasionally fail, especially on OSX, due to socket limit.
Part of fix for #1502