### PR TITLE
Avoid terminating connections prematurely

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -460,7 +460,8 @@ void zmq::session_base_t::process_term (int linger_)
         //  TODO: Should this go into pipe_t::terminate ?
         //  In case there's no engine and there's only delimiter in the
         //  pipe it wouldn't be ever read. Thus we check for it explicitly.
-        pipe->check_read ();
+        if (!engine)
+            pipe->check_read ();
     }
 
     if (zap_pipe != NULL)


### PR DESCRIPTION
While sending very large messages (far beyond what fits in a the tcp
buffer, so it takes multiple sendto system calls for it to finish),
zmq_close will close the connection regardless of ZMQ_LINGER.

In case no engine is attached, a pipe->check_read() is needed to look
for the delimiter in the pipe and ultimately trigger the pipe
termination.

However, if there *is* an engine attached, the check_read() looks ahead
and finds the delimiter and terminates the connection even though the
engine might actually still be in the middle of sending a message.

This happens because while the io_thread is still busy sending the data,
the pipe can get terminated and the io thread ends up being terminated.