### PR TITLE
Merge fix for zeromq/zeromq4-1#52, getsockopt ZMQ_RCVMORE now resets all bits

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -348,6 +348,7 @@ test_apps = \
 	tests/test_proxy \
 	tests/test_proxy_single_socket \
 	tests/test_proxy_terminate \
+	tests/test_getsockopt_memset \
 	tests/test_many_sockets \
 	tests/test_ipc_wildcard \
 	tests/test_diffserv \
@@ -518,6 +519,9 @@ tests_test_proxy_single_socket_LDADD = src/libzmq.la
 
 tests_test_proxy_terminate_SOURCES = tests/test_proxy_terminate.cpp
 tests_test_proxy_terminate_LDADD = src/libzmq.la
+
+tests_test_getsockopt_memset_SOURCES = tests/test_getsockopt_memset.cpp
+tests_test_getsockopt_memset_LDADD = libzmq.la
 
 tests_test_many_sockets_SOURCES = tests/test_many_sockets.cpp
 tests_test_many_sockets_LDADD = src/libzmq.la

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -361,6 +361,7 @@ int zmq::socket_base_t::getsockopt (int option_, void *optval_,
             EXIT_MUTEX();
             return -1;
         }
+        memset(optval_, 0, *optvallen_);
         *((int*) optval_) = rcvmore ? 1 : 0;
         *optvallen_ = sizeof (int);
         EXIT_MUTEX();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ if(NOT WIN32)
           test_proxy
           test_proxy_single_socket
           test_proxy_terminate
+          test_getsockopt_memset
           test_filter_ipc
   )
   if(HAVE_FORK)

--- a/tests/test_getsockopt_memset.cpp
+++ b/tests/test_getsockopt_memset.cpp
@@ -1,0 +1,64 @@
+/*
+    Copyright (c) 2007-2015 Contributors as noted in the AUTHORS file
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+
+int main (void)
+{
+    int64_t more;
+    size_t more_size = sizeof(more);
+
+    setup_test_environment();
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    void *sb = zmq_socket (ctx, ZMQ_PUB);
+    assert (sb);
+    int rc = zmq_bind (sb, "inproc://a");
+    assert (rc == 0);
+
+    void *sc = zmq_socket (ctx, ZMQ_SUB);
+    assert (sc);
+    rc = zmq_connect (sc, "inproc://a");
+    assert (rc == 0);
+
+    memset(&more, 0xFF, sizeof(int64_t));
+    zmq_getsockopt(sc, ZMQ_RCVMORE, &more, &more_size);
+    assert (more_size == sizeof(int));
+    assert (more == 0);
+
+
+    // Cleanup
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+
+    return 0 ;
+}


### PR DESCRIPTION
see zeromq/zeromq4-1#52 and zeromq/zeromq4-1#53 for PR.