### PR TITLE
Check proxy return values in tests

### DIFF
--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -165,7 +165,8 @@ server_task (void *ctx)
         threads[thread_nbr] = zmq_threadstart (&server_worker, ctx);
 
     // Connect backend to frontend via a proxy
-    zmq_proxy_steerable (frontend, backend, NULL, control);
+    rc = zmq_proxy_steerable (frontend, backend, NULL, control);
+    assert (rc == 0);
 
     for (thread_nbr = 0; thread_nbr < QT_WORKERS; thread_nbr++)
         zmq_threadclose (threads[thread_nbr]);

--- a/tests/test_proxy_single_socket.cpp
+++ b/tests/test_proxy_single_socket.cpp
@@ -52,7 +52,8 @@ server_task (void *ctx)
     assert (rc == 0);
 
     // Use rep as both frontend and backend
-    zmq_proxy_steerable (rep, rep, NULL, control);
+    rc = zmq_proxy_steerable (rep, rep, NULL, control);
+    assert (rc == 0);
 
     rc = zmq_close (rep);
     assert (rc == 0);

--- a/tests/test_proxy_terminate.cpp
+++ b/tests/test_proxy_terminate.cpp
@@ -61,7 +61,8 @@ server_task (void *ctx)
     assert (rc == 0);
 
     // Connect backend to frontend via a proxy
-    zmq_proxy_steerable (frontend, backend, NULL, control);
+    rc = zmq_proxy_steerable (frontend, backend, NULL, control);
+    assert (rc == 0);
 
     rc = zmq_close (frontend);
     assert (rc == 0);


### PR DESCRIPTION
According the docs it should return 0 when a terminate is requested. It does, but let's test it to make sure it does.

See http://api.zeromq.org/4-1:zmq-proxy-steerable

Greetings,

Rik