### PR TITLE
place a ZMQ_UNUSED macro and replace all unused variables with ZMQ_UNUSED macro

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -493,6 +493,12 @@ ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn* func, void* arg);
 ZMQ_EXPORT void zmq_threadclose (void* thread);
 
 
+/******************************************************************************/
+/*  0MQ General                                                               */
+/******************************************************************************/
+
+#define ZMQ_UNUSED(object) (void)object
+
 #undef ZMQ_EXPORT
 
 #ifdef __cplusplus

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -43,8 +43,7 @@ zmq::client_t::~client_t ()
 
 void zmq::client_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void) subscribe_to_all_;
+	ZMQ_UNUSED(subscribe_to_all_);
 
     zmq_assert (pipe_);    
 

--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -44,8 +44,7 @@ zmq::dealer_t::~dealer_t ()
 
 void zmq::dealer_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void) subscribe_to_all_;
+	ZMQ_UNUSED(subscribe_to_all_);
 
     zmq_assert (pipe_);
 

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -47,8 +47,7 @@ zmq::pair_t::~pair_t ()
 
 void zmq::pair_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void)subscribe_to_all_;
+	ZMQ_UNUSED(subscribe_to_all_);
 
     zmq_assert (pipe_ != NULL);
 

--- a/src/pull.cpp
+++ b/src/pull.cpp
@@ -44,8 +44,7 @@ zmq::pull_t::~pull_t ()
 
 void zmq::pull_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void)subscribe_to_all_;
+	ZMQ_UNUSED(subscribe_to_all_);
 
     zmq_assert (pipe_);
     fq.attach (pipe_);

--- a/src/push.cpp
+++ b/src/push.cpp
@@ -44,8 +44,8 @@ zmq::push_t::~push_t ()
 
 void zmq::push_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void)subscribe_to_all_;
+	ZMQ_UNUSED(subscribe_to_all_);
+
     //  Don't delay pipe termination as there is no one
     //  to receive the delimiter.
     pipe_->set_nodelay ();

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -66,8 +66,7 @@ zmq::router_t::~router_t ()
 
 void zmq::router_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void)subscribe_to_all_;
+	ZMQ_UNUSED(subscribe_to_all_);
 
     zmq_assert (pipe_);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -48,8 +48,7 @@ zmq::server_t::~server_t ()
 
 void zmq::server_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void)subscribe_to_all_;
+	ZMQ_UNUSED(subscribe_to_all_);
 
     zmq_assert (pipe_);    
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -58,8 +58,7 @@ zmq::stream_t::~stream_t ()
 
 void zmq::stream_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void)subscribe_to_all_;
+	ZMQ_UNUSED(subscribe_to_all_);
 
     zmq_assert (pipe_);
 

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -94,13 +94,13 @@ void zmq::set_tcp_receive_buffer (fd_t sockfd_, int bufsize_)
 void zmq::tune_tcp_keepalives (fd_t s_, int keepalive_, int keepalive_cnt_, int keepalive_idle_, int keepalive_intvl_)
 {
     // These options are used only under certain #ifdefs below.
-    (void)keepalive_;
-    (void)keepalive_cnt_;
-    (void)keepalive_idle_;
-    (void)keepalive_intvl_;
+    ZMQ_UNUSED(keepalive_);
+    ZMQ_UNUSED(keepalive_cnt_);
+    ZMQ_UNUSED(keepalive_idle_);
+    ZMQ_UNUSED(keepalive_intvl_);
 
     // If none of the #ifdefs apply, then s_ is unused.
-    (void)s_;
+	ZMQ_UNUSED(s_);
 
     //  Tuning TCP keep-alives if platform allows it
     //  All values = -1 means skip and leave it for OS

--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -56,7 +56,7 @@
 int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_src_)
 {
     //  TODO: Unused parameter, IPv6 support not implemented for Solaris.
-    (void) ipv6_;
+	ZMQ_UNUSED(ipv6_);
 
     //  Create a socket.
     const int fd = open_socket (AF_INET, SOCK_DGRAM, 0);
@@ -123,7 +123,7 @@ int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_
 int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_src_)
 {
     //  TODO: Unused parameter, IPv6 support not implemented for AIX or HP/UX.
-    (void) ipv6_;
+    ZMQ_UNUSED(ipv6_);
 
     //  Create a socket.
     const int sd = open_socket (AF_INET, SOCK_DGRAM, 0);
@@ -209,9 +209,8 @@ int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_
 //  This is true especially of Windows.
 int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_src_)
 {
-    //  All unused parameters.
-    (void) nic_;
-    (void) ipv6_;
+	ZMQ_UNUSED(nic_);
+	ZMQ_UNUSED(ipv6_);
 
     errno = ENODEV;
     return -1;

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -55,8 +55,7 @@ zmq::xsub_t::~xsub_t ()
 
 void zmq::xsub_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 {
-    // subscribe_to_all_ is unused
-    (void) subscribe_to_all_;
+    ZMQ_UNUSED(subscribe_to_all_);
 
     zmq_assert (pipe_);
     fq.attach (pipe_);


### PR DESCRIPTION
place a ZMQ_UNUSED macro and replace all unused variables with ZMQ_UNUSED macro