### PR TITLE
remove unnecessary multiple WSAGetLastError() calls

### DIFF
--- a/src/err.cpp
+++ b/src/err.cpp
@@ -89,12 +89,12 @@ void zmq::zmq_abort(const char *errmsg_)
 
 const char *zmq::wsa_error()
 {
-    int no = WSAGetLastError ();
+    const int lastError = WSAGetLastError();
     //  TODO: This is not a generic way to handle this...
-    if (no == WSAEWOULDBLOCK)
+    if (lastError == WSAEWOULDBLOCK)
         return NULL;
 
-    return wsa_error_no (no);
+    return wsa_error_no (lastError);
 }
 
 const char *zmq::wsa_error_no (int no_)

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -132,10 +132,11 @@ int zmq::get_peer_ip_address (fd_t sockfd_, std::string &ip_addr_)
     rc = getpeername (sockfd_, (struct sockaddr*) &ss, &addrlen);
 #ifdef ZMQ_HAVE_WINDOWS
     if (rc == SOCKET_ERROR) {
-        wsa_assert (WSAGetLastError () != WSANOTINITIALISED &&
-                    WSAGetLastError () != WSAEFAULT &&
-                    WSAGetLastError () != WSAEINPROGRESS &&
-                    WSAGetLastError () != WSAENOTSOCK);
+		const int lastError = WSAGetLastError();
+        wsa_assert (lastError != WSANOTINITIALISED &&
+                    lastError != WSAEFAULT &&
+                    lastError != WSAEINPROGRESS &&
+                    lastError != WSAENOTSOCK);
         return 0;
     }
 #else

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -368,11 +368,11 @@ int zmq::socks_connecter_t::connect_to_proxy ()
     //  Translate error codes indicating asynchronous connect has been
     //  launched to a uniform EINPROGRESS.
 #ifdef ZMQ_HAVE_WINDOWS
-    const int error_code = WSAGetLastError ();
-    if (error_code == WSAEINPROGRESS || error_code == WSAEWOULDBLOCK)
+    const int lastError = WSAGetLastError();
+    if (lastError == WSAEINPROGRESS || lastError == WSAEWOULDBLOCK)
         errno = EINPROGRESS;
     else {
-        errno = wsa_error_to_errno (error_code);
+        errno = wsa_error_to_errno (lastError);
         close ();
     }
 #else

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -178,22 +178,24 @@ void zmq::tune_tcp_retransmit_timeout (fd_t sockfd_, int timeout_)
 
     //  If not a single byte can be written to the socket in non-blocking mode
     //  we'll get an error (this may happen during the speculative write).
-    if (nbytes == SOCKET_ERROR && WSAGetLastError () == WSAEWOULDBLOCK)
+	const int lastError = WSAGetLastError();
+    if (nbytes == SOCKET_ERROR && lastError == WSAEWOULDBLOCK)
         return 0;
 
     //  Signalise peer failure.
     if (nbytes == SOCKET_ERROR && (
-          WSAGetLastError () == WSAENETDOWN ||
-          WSAGetLastError () == WSAENETRESET ||
-          WSAGetLastError () == WSAEHOSTUNREACH ||
-          WSAGetLastError () == WSAECONNABORTED ||
-          WSAGetLastError () == WSAETIMEDOUT ||
-          WSAGetLastError () == WSAECONNRESET))
+          lastError == WSAENETDOWN     ||
+          lastError == WSAENETRESET    ||
+          lastError == WSAEHOSTUNREACH ||
+          lastError == WSAECONNABORTED ||
+          lastError == WSAETIMEDOUT    ||
+          lastError == WSAECONNRESET
+		  ))
         return -1;
 
     //  Circumvent a Windows bug; see https://support.microsoft.com/en-us/kb/201213
     //  and https://zeromq.jira.com/browse/LIBZMQ-195
-    if (nbytes == SOCKET_ERROR && WSAGetLastError() == WSAENOBUFS)
+    if (nbytes == SOCKET_ERROR && lastError == WSAENOBUFS)
         return 0;
 
     wsa_assert (nbytes != SOCKET_ERROR);
@@ -237,22 +239,24 @@ int zmq::tcp_read (fd_t s_, void *data_, size_t size_)
 
     //  If not a single byte can be read from the socket in non-blocking mode
     //  we'll get an error (this may happen during the speculative read).
-    if (rc == SOCKET_ERROR) {
-        if (WSAGetLastError () == WSAEWOULDBLOCK)
-            errno = EAGAIN;
-        else {
-            wsa_assert (WSAGetLastError () == WSAENETDOWN
-                     || WSAGetLastError () == WSAENETRESET
-                     || WSAGetLastError () == WSAECONNABORTED
-                     || WSAGetLastError () == WSAETIMEDOUT
-                     || WSAGetLastError () == WSAECONNRESET
-                     || WSAGetLastError () == WSAECONNREFUSED
-                     || WSAGetLastError () == WSAENOTCONN);
-            errno = wsa_error_to_errno (WSAGetLastError ());
-        }
+	if (rc == SOCKET_ERROR) {
+		const int lastError = WSAGetLastError();
+		if (lastError == WSAEWOULDBLOCK) {
+			errno = EAGAIN;
+		}
+		else {
+			wsa_assert (lastError == WSAENETDOWN   ||
+				lastError == WSAENETRESET	   ||
+				lastError == WSAECONNABORTED ||
+				lastError == WSAETIMEDOUT	   ||
+				lastError == WSAECONNRESET   ||
+				lastError == WSAECONNREFUSED ||
+				lastError == WSAENOTCONN);
+			errno = wsa_error_to_errno (lastError);
+		}
     }
 
-    return rc == SOCKET_ERROR? -1: rc;
+    return rc == SOCKET_ERROR ? -1 : rc;
 
 #else
 

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -319,11 +319,11 @@ int zmq::tcp_connecter_t::open ()
     //  Translate error codes indicating asynchronous connect has been
     //  launched to a uniform EINPROGRESS.
 #ifdef ZMQ_HAVE_WINDOWS
-    const int error_code = WSAGetLastError ();
-    if (error_code == WSAEINPROGRESS || error_code == WSAEWOULDBLOCK)
+    const int lastError = WSAGetLastError();
+    if (lastError == WSAEINPROGRESS || lastError == WSAEWOULDBLOCK)
         errno = EINPROGRESS;
     else
-        errno = wsa_error_to_errno (error_code);
+        errno = wsa_error_to_errno (lastError);
 #else
     if (errno == EINTR)
         errno = EINPROGRESS;

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -278,10 +278,11 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
 
 #ifdef ZMQ_HAVE_WINDOWS
     if (sock == INVALID_SOCKET) {
-        wsa_assert (WSAGetLastError () == WSAEWOULDBLOCK ||
-            WSAGetLastError () == WSAECONNRESET ||
-            WSAGetLastError () == WSAEMFILE ||
-            WSAGetLastError () == WSAENOBUFS);
+		const int lastError = WSAGetLastError();
+        wsa_assert (lastError == WSAEWOULDBLOCK ||
+            lastError == WSAECONNRESET ||
+            lastError == WSAEMFILE ||
+            lastError == WSAENOBUFS);
         return retired_fd;
     }
 #if !defined _WIN32_WCE


### PR DESCRIPTION
remove unnecessary multiple WSAGetLastError() calls