### PR TITLE
CI build does not fail when tests fail. Fix #1527

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -9,8 +9,7 @@ if [ $BUILD_TYPE == "default" ]; then
         if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi )
 
     #   Build and check this project
-    ./autogen.sh && ./configure --with-libsodium=yes && make && make check
-    sudo make install
+    (./autogen.sh && ./configure --with-libsodium=yes && make && make check && sudo make install) || exit 1
 else
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi


### PR DESCRIPTION
Solution: run all builds commands in the same subshell and exit 1 if it returns an error 