### PR TITLE
Container-based CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
 - BUILD_TYPE=default
 - BUILD_TYPE=qt-android
 
+sudo: false
+
 before_script:
 # ZMQ stress tests need more open socket (files) than the usual default
 # On OSX, it seems the way to set the max files limit is constantly changing, so

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 
 if [ $BUILD_TYPE == "default" ]; then
+    mkdir tmp
+    BUILD_PREFIX=$PWD/tmp
+
+    CONFIG_OPTS=()
+    CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+    CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+    CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+    CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+
     #   Build required projects first
 
     #   libsodium
     git clone git://github.com/jedisct1/libsodium.git
-    ( cd libsodium; ./autogen.sh; ./configure; make check; sudo make install;
-        if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi )
+    ( cd libsodium; ./autogen.sh; ./configure --prefix=$BUILD_PREFIX; make check; make install)
 
     #   Build and check this project
-    (./autogen.sh && ./configure --with-libsodium=yes && make && make check && sudo make install) || exit 1
+    (./autogen.sh && ./configure "${CONFIG_OPTS[@]}" --with-libsodium=yes && make && make check && make install) || exit 1
 else
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 if [ $BUILD_TYPE == "default" ]; then
     mkdir tmp
     BUILD_PREFIX=$PWD/tmp


### PR DESCRIPTION
Hello,

Travis is moving away from VM-based builds to container-based builds. Advantages for users are more resources available and less waiting time before a build starts. One of the conditions for eligibility is to avoid using sudo, so these commits remove any use of it and use a local build prefix rather than the default /usr/local/ which requires superuser powers to write to, just like the existing qt-android CI scripts already do.

It can always be reverted by setting "sudo: required" in the travis.yml file, and then a full VM will be used instead.

In case you like this approach, I'll do the work to port it to CZMQ and zproject.

EDIT: also -x is set in ci_build.sh, since it is very useful for debugging purposes to see what command is being run in the Travis log. I can take it out if you'd rather not have it.

Documentation: http://docs.travis-ci.com/user/migrating-from-legacy/