### PR TITLE
Problem: tests fail after PR #1531

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -239,6 +239,7 @@ int zmq::msg_t::close ()
         if (u.base.metadata->drop_ref ()) {
             LIBZMQ_DELETE(u.base.metadata);
         }
+        u.base.metadata = NULL;
     }
 
     //  Make the message invalid.
@@ -393,8 +394,10 @@ void zmq::msg_t::set_metadata (zmq::metadata_t *metadata_)
 void zmq::msg_t::reset_metadata ()
 {
     if (u.base.metadata) {
-        if (u.base.metadata->drop_ref ())
+        if (u.base.metadata->drop_ref ()) {
             LIBZMQ_DELETE(u.base.metadata);
+        }
+        u.base.metadata = NULL;
     }
 }
 
@@ -493,12 +496,12 @@ bool zmq::msg_t::rm_refs (int refs_)
     return true;
 }
 
-uint32_t zmq::msg_t::get_routing_id() 
+uint32_t zmq::msg_t::get_routing_id()
 {
     return u.base.routing_id;
 }
 
-int zmq::msg_t::set_routing_id(uint32_t routing_id_) 
+int zmq::msg_t::set_routing_id(uint32_t routing_id_)
 {
     u.base.routing_id = routing_id_;
     return 0;


### PR DESCRIPTION
This was a very subtle bug.

Before the LIBZMQ_DELETE macro, the logic was like:
```c
if(metadata) {
    if(metadata->drop_ref())
        delete metadata;
    metadata = 0;
}
```

which was replaced by:
```c
if(metadata) {
    if(metadata->drop_ref())
        LIBZMQ_DELETE(metadata);
}
```

After the improved version of LIBZMQ_DELETE macro, which should avoid such situations, some tests began to fail because we accidentially removed the `metadata = 0` statement, which was before executed regardless of `metadata->drop_ref()`.

This PR brings back the zero-ing of `metadata`.