### PR TITLE
problem: trying to support polling on thread safe sockets with zmq_poll failed

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -410,8 +410,16 @@ typedef struct zmq_pollitem_t
 #define ZMQ_POLLITEMS_DFLT 16
 
 ZMQ_EXPORT int  zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
+
+/******************************************************************************/
+/*  Pollfd polling on thread safe socket                                      */
+/******************************************************************************/
+
 ZMQ_EXPORT void *zmq_pollfd_new ();
 ZMQ_EXPORT int  zmq_pollfd_close (void *p);
+ZMQ_EXPORT void zmq_pollfd_recv (void *p);
+ZMQ_EXPORT int  zmq_pollfd_wait (void *p, int timeout_);
+ZMQ_EXPORT int  zmq_pollfd_poll (void *p, zmq_pollitem_t *items, int nitems, long timeout);
 
 #if defined _WIN32
 ZMQ_EXPORT SOCKET zmq_pollfd_fd (void *p);

--- a/tests/test_thread_safe_polling.cpp
+++ b/tests/test_thread_safe_polling.cpp
@@ -50,8 +50,8 @@ int main (void)
     assert (rc == 0);
 
     zmq_pollitem_t items[] = {
-        {server,  zmq_pollfd_fd(pollfd), ZMQ_POLLIN, 0},
-        {server2, zmq_pollfd_fd(pollfd), ZMQ_POLLIN, 0}};
+        {server, 0, ZMQ_POLLIN, 0},
+        {server2, 0, ZMQ_POLLIN, 0}};
 
     rc = zmq_bind (server, "tcp://127.0.0.1:5560");
     assert (rc == 0);
@@ -63,7 +63,7 @@ int main (void)
 
     assert (rc == 0);    
 
-    rc = zmq_poll (items, 2, -1);
+    rc = zmq_pollfd_poll (pollfd, items, 2, -1);
     assert (rc == 1);
 
     assert (items[0].revents == ZMQ_POLLIN);
@@ -74,7 +74,7 @@ int main (void)
     rc = zmq_msg_recv(&msg, server, ZMQ_DONTWAIT);
     assert (rc == 1);    
 
-    rc = zmq_poll (items, 2, -1);
+    rc = zmq_pollfd_poll (pollfd, items, 2, -1);
     assert (rc == 1);
 
     assert (items[0].revents == 0); 
@@ -83,7 +83,7 @@ int main (void)
     rc = zmq_msg_recv(&msg, server2, ZMQ_DONTWAIT);
     assert (rc == 1);
 
-    rc = zmq_poll (items, 2, 0);
+    rc = zmq_pollfd_poll (pollfd, items, 2, 0);
     assert (rc == 0);
 
     assert (items[0].revents == 0); 


### PR DESCRIPTION
solution: revert zmq_poll to the version before the attempt. adding new method zmq_pollfd_poll to poll on thread safe sockets (and regular sockets), migration from the two version should be pretty simple.