### PR TITLE
CI run on OSX needs binutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
 
 sudo: false
 
+before_install:
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils ; fi
+
 before_script:
 # ZMQ stress tests need more open socket (files) than the usual default
 # On OSX, it seems the way to set the max files limit is constantly changing, so


### PR DESCRIPTION
OSX does not ship with binutils, need to install it before the script
run via brew in order to be able to use greadelf, needed by the
qt-android CI script.