### PR TITLE
Addresses zeromq/libzmq#1116.

### DIFF
--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -109,6 +109,7 @@ namespace zmq
         //  applied to the trie, but not yet received by the user.
         typedef std::basic_string <unsigned char> blob_t;
         std::deque <blob_t> pending_data;
+        std::deque <metadata_t*> pending_metadata;
         std::deque <unsigned char> pending_flags;
 
         xpub_t (const xpub_t&);


### PR DESCRIPTION
This patch  adds a new member of type deque to the xpub class that contains pointers to metadata_t. This deque is then used (alongside pending_data and pending_flags) to preserve metadata when copying messages.