### PR TITLE
Set signaler_port to 0 which allows the OS to find a free port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,9 @@ endif()
 #-----------------------------------------------------------------------------
 # default to Release build
 
-if(NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  # CMAKE_BUILD_TYPE is not used for multi-configuration generators like Visual Studio/XCode
+  # which instead use CMAKE_CONFIGURATION_TYPES
   set(CMAKE_BUILD_TYPE Release CACHE STRING
       "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
       FORCE)
@@ -436,7 +438,8 @@ set(cxx-sources
         xsub.cpp
         zmq.cpp
         zmq_utils.cpp
-        decoder_allocators.cpp)
+        decoder_allocators.cpp
+        config.hpp)
 
 set(rc-sources version.rc)
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -89,7 +89,11 @@ namespace zmq
 
         //  On some OSes the signaler has to be emulated using a TCP
         //  connection. In such cases following port is used.
-        signaler_port = 5905
+        //  If 0, it lets the OS choose a free port without requiring use of a 
+        //  global mutex. The original implementation of a Windows signaler 
+        //  socket used port 5905 instead of letting the OS choose a free port.
+        //  https://github.com/zeromq/libzmq/issues/1542
+        signaler_port = 0
     };
 
 }


### PR DESCRIPTION
Rather than crashing if port 5905 is in use (https://github.com/zeromq/libzmq/issues/1542)
Added config.hpp to the source list so it shows up in generated projects
Remove CMAKE_BUILD_TYPE setting for generators that don't use it