### PR TITLE
Problem: Identity frame from router has no metadata

### DIFF
--- a/src/router.cpp
+++ b/src/router.cpp
@@ -326,6 +326,8 @@ int zmq::router_t::xrecv (msg_t *msg_)
         errno_assert (rc == 0);
         memcpy (msg_->data (), identity.data (), identity.size ());
         msg_->set_flags (msg_t::more);
+        if (prefetched_msg.metadata())
+            msg_->set_metadata(prefetched_msg.metadata());
         identity_sent = true;
     }
 


### PR DESCRIPTION
The routing id (identity) frame return when reading from
a router doesn't have the same metadata as the "real"
message that follows.
For example, The ZAP "User-Id" property is missing.

This patch attach the "data message"'s metadata
to the "identity message" when it is read from the router.

See issue #1537 