### PR TITLE
Update zmq_inproc manpage for bind/connect order

### DIFF
--- a/doc/zmq_inproc.txt
+++ b/doc/zmq_inproc.txt
@@ -41,9 +41,11 @@ Connecting a socket
 ~~~~~~~~~~~~~~~~~~~
 When connecting a 'socket' to a peer address using _zmq_connect()_ with the
 'inproc' transport, the 'endpoint' shall be interpreted as an arbitrary string
-identifying the 'name' to connect to.  The 'name' must have been previously
-created by assigning it to at least one 'socket' within the same 0MQ 'context'
-as the 'socket' being connected.
+identifying the 'name' to connect to.  Before version 4.0 he 'name' must have
+been previously created by assigning it to at least one 'socket' within the
+same 0MQ 'context' as the 'socket' being connected.  Since version 4.0 the
+order of _zmq_bind()_ and _zmq_connect()_ does not matter just like for the tcp
+transport type.
 
 
 EXAMPLES


### PR DESCRIPTION
The order of zmq_bind() and zmq_connect() is no longer important
for the inproc transport since libzmq 4.0.  This updates this
in the zmq_inproc manpage.