### PR TITLE
Problem: Tests in Travis are failing randomly

### DIFF
--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -245,8 +245,10 @@ int zmq::xpub_t::xrecv (msg_t *msg_)
     }
 
     // User is reading a message, set last_pipe and remove it from the deque
-    last_pipe = pending_pipes.front ();
-    pending_pipes.pop_front ();
+    if (manual && !pending_pipes.empty ()) {
+        last_pipe = pending_pipes.front ();
+        pending_pipes.pop_front ();
+    }
 
     int rc = msg_->close ();
     errno_assert (rc == 0);
@@ -285,10 +287,13 @@ void zmq::xpub_t::send_unsubscription (unsigned char *data_, size_t size_,
         unsub [0] = 0;
         if (size_ > 0)
             memcpy (&unsub [1], data_, size_);
-        self->last_pipe = NULL;
-        self->pending_pipes.push_back (NULL);
         self->pending_data.push_back (unsub);
         self->pending_metadata.push_back (NULL);
         self->pending_flags.push_back (0);
+
+        if (self->manual) {
+            self->last_pipe = NULL;
+            self->pending_pipes.push_back (NULL);
+        }
     }
 }

--- a/tests/test_xpub_manual.cpp
+++ b/tests/test_xpub_manual.cpp
@@ -199,7 +199,7 @@ int test_xpub_proxy_unsubscribe_on_disconnect()
     assert (zmq_send (xsub_proxy, sub_buff, 2, 0) == 2);
 
     // should receive another unsubscribe msg
-    assert (zmq_recv (xpub_proxy, sub_buff, 2, ZMQ_DONTWAIT) == 2
+    assert (zmq_recv (xpub_proxy, sub_buff, 2, 0) == 2
         && "Should receive the second unsubscribe message.");
     assert (sub_buff [0] == 0);
     assert (sub_buff [1] == *topic);


### PR DESCRIPTION
Since [PR 1569](https://github.com/zeromq/libzmq/pull/1569) some tests were failing at random. The reason were illegal deque calls that were causing undefined behavior, for instance calling `front()` or `pop_front()` on an empty deque. Such calls are now safeguarded.