### PR TITLE
Solution: fix typos

### DIFF
--- a/src/curve_client.hpp
+++ b/src/curve_client.hpp
@@ -107,7 +107,7 @@ namespace zmq
         //  Cookie received from server
         uint8_t cn_cookie [16 + 80];
 
-        //  Intermediary buffer used to seepd up boxing and unboxing.
+        //  Intermediary buffer used to speed up boxing and unboxing.
         uint8_t cn_precom [crypto_box_BEFORENMBYTES];
 
         //  Nonce

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -53,7 +53,7 @@ namespace zmq
     //  This class implements the state machine that parses the incoming buffer.
     //  Derived class should implement individual state machine actions.
     //
-    //  Buffer managment is done by an allocator policy.
+    //  Buffer management is done by an allocator policy.
     template <typename T, typename A = c_single_allocator>
     class decoder_base_t : public i_decoder
     {
@@ -99,11 +99,11 @@ namespace zmq
         }
 
         //  Processes the data in the buffer previously allocated using
-        //  get_buffer function. size_ argument specifies nemuber of bytes
+        //  get_buffer function. size_ argument specifies number of bytes
         //  actually filled into the buffer. Function returns 1 when the
         //  whole message was decoded or 0 when more data is required.
         //  On error, -1 is returned and errno set accordingly.
-        //  Number of bytes processed is returned in byts_used_.
+        //  Number of bytes processed is returned in bytes_used_.
         int decode (const unsigned char *data_, std::size_t size_,
                     std::size_t &bytes_used_)
         {

--- a/src/decoder_allocators.hpp
+++ b/src/decoder_allocators.hpp
@@ -80,7 +80,7 @@ namespace zmq
         c_single_allocator& operator = (c_single_allocator const&);
     };
 
-    // This allocater allocates a reference counted buffer which is used by v2_decoder_t
+    // This allocator allocates a reference counted buffer which is used by v2_decoder_t
     // to use zero-copy msg::init_data to create messages with memory from this buffer as
     // data storage.
     //
@@ -102,7 +102,7 @@ namespace zmq
         // Allocate a new buffer
         //
         // This releases the current buffer to be bound to the lifetime of the messages
-        // created on this bufer.
+        // created on this buffer.
         unsigned char* allocate ();
 
         // force deallocation of buffer.

--- a/src/dist.cpp
+++ b/src/dist.cpp
@@ -148,7 +148,7 @@ int zmq::dist_t::send_to_matching (msg_t *msg_)
     //  Push the message to matching pipes.
     distribute (msg_);
 
-    //  If mutlipart message is fully sent, activate all the eligible pipes.
+    //  If multipart message is fully sent, activate all the eligible pipes.
     if (!msg_more)
         active = eligible;
 

--- a/src/fq.hpp
+++ b/src/fq.hpp
@@ -80,7 +80,7 @@ namespace zmq
         //  there are following parts still waiting in the current pipe.
         bool more;
 
-        //  Holds credential after the last_acive_pipe has terminated.
+        //  Holds credential after the last_active_pipe has terminated.
         blob_t saved_credential;
 
         fq_t (const fq_t&);

--- a/src/i_decoder.hpp
+++ b/src/i_decoder.hpp
@@ -49,7 +49,7 @@ namespace zmq
         virtual void resize_buffer(size_t) = 0;
         //  Decodes data pointed to by data_.
         //  When a message is decoded, 1 is returned.
-        //  When the decoder needs more data, 0 is returnd.
+        //  When the decoder needs more data, 0 is returned.
         //  On error, -1 is returned and errno is set accordingly.
         virtual int decode (const unsigned char *data_, size_t size_,
                             size_t &processed) = 0;

--- a/src/io_thread.hpp
+++ b/src/io_thread.hpp
@@ -52,7 +52,7 @@ namespace zmq
 
         io_thread_t (zmq::ctx_t *ctx_, uint32_t tid_);
 
-        //  Clean-up. If the thread was started, it's neccessary to call 'stop'
+        //  Clean-up. If the thread was started, it's necessary to call 'stop'
         //  before invoking destructor. Otherwise the destructor would hang up.
         ~io_thread_t ();
 
@@ -70,7 +70,7 @@ namespace zmq
         void out_event ();
         void timer_event (int id_);
 
-        //  Used by io_objects to retrieve the assciated poller object.
+        //  Used by io_objects to retrieve the associated poller object.
         poller_t *get_poller ();
 
         //  Command handlers.

--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -103,7 +103,7 @@ void zmq::ipc_connecter_t::process_term (int linger_)
 
 void zmq::ipc_connecter_t::in_event ()
 {
-    //  We are not polling for incomming data, so we are actually called
+    //  We are not polling for incoming data, so we are actually called
     //  because of error here. However, we can get error on out event as well
     //  on some platforms, so we'll simply handle both events in the same way.
     out_event ();
@@ -216,7 +216,7 @@ int zmq::ipc_connecter_t::open ()
         s, addr->resolved.ipc_addr->addr (),
         addr->resolved.ipc_addr->addrlen ());
 
-    //  Connect was successfull immediately.
+    //  Connect was successful immediately.
     if (rc == 0)
         return 0;
         

--- a/src/ipc_connecter.hpp
+++ b/src/ipc_connecter.hpp
@@ -83,7 +83,7 @@ namespace zmq
         int get_new_reconnect_ivl ();
 
         //  Open IPC connecting socket. Returns -1 in case of error,
-        //  0 if connect was successfull immediately. Returns -1 with
+        //  0 if connect was successful immediately. Returns -1 with
         //  EAGAIN errno if async connect was launched.
         int open ();
 
@@ -91,7 +91,7 @@ namespace zmq
         int close ();
 
         //  Get the file descriptor of newly created connection. Returns
-        //  retired_fd if the connection was unsuccessfull.
+        //  retired_fd if the connection was unsuccessful.
         fd_t connect ();
 
         //  Address to connect to. Owned by session_base_t.

--- a/src/ipc_listener.hpp
+++ b/src/ipc_listener.hpp
@@ -84,7 +84,7 @@ namespace zmq
         //  if the connection was dropped while waiting in the listen backlog.
         fd_t accept ();
 
-        //  True, if the undelying file for UNIX domain socket exists.
+        //  True, if the underlying file for UNIX domain socket exists.
         bool has_file;
 
         //  Name of the file associated with the UNIX domain address.
@@ -96,7 +96,7 @@ namespace zmq
         //  Handle corresponding to the listening socket.
         handle_t handle;
 
-        //  Socket the listerner belongs to.
+        //  Socket the listener belongs to.
         zmq::socket_base_t *socket;
 
        // String representation of endpoint to bind to

--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -39,7 +39,7 @@ namespace zmq
 {
 
     //  Abstract class representing security mechanism.
-    //  Different mechanism extedns this class.
+    //  Different mechanism extends this class.
 
     class msg_t;
 

--- a/src/mtrie.cpp
+++ b/src/mtrie.cpp
@@ -91,7 +91,7 @@ bool zmq::mtrie_t::add_helper (unsigned char *prefix_, size_t size_,
     if (c < min || c >= min + count) {
 
         //  The character is out of range of currently handled
-        //  charcters. We have to extend the table.
+        //  characters. We have to extend the table.
         if (!count) {
             min = c;
             count = 1;

--- a/src/norm_engine.hpp
+++ b/src/norm_engine.hpp
@@ -167,7 +167,7 @@ namespace zmq
             bool                    tx_more_bit;
             bool                    zmq_output_ready; // zmq has msg(s) to send 
             bool                    norm_tx_ready;    // norm has tx queue vacancy
-            // tbd - maybe don't need buffer if can access zmq message buffer directly?
+            // TBD - maybe don't need buffer if can access zmq message buffer directly?
             char                    tx_buffer[BUFFER_SIZE];
             unsigned int            tx_index;
             unsigned int            tx_len;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -110,7 +110,7 @@ namespace zmq
         void send_reaped ();
         void send_done ();
 
-        //  These handlers can be overrided by the derived objects. They are
+        //  These handlers can be overridden by the derived objects. They are
         //  called when command arrives from another thread.
         virtual void process_stop ();
         virtual void process_plug ();

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -142,7 +142,7 @@ namespace zmq
         bool raw_socket;
         bool raw_notify;        //  Provide connect notifications
 
-        //  Addres of SOCKS proxy
+        //  Address of SOCKS proxy
         std::string socks_proxy_address;
 
         //  TCP keep-alive settings.

--- a/src/own.cpp
+++ b/src/own.cpp
@@ -138,7 +138,7 @@ void zmq::own_t::terminate ()
     if (terminating)
         return;
 
-    //  As for the root of the ownership tree, there's noone to terminate it,
+    //  As for the root of the ownership tree, there's no one to terminate it,
     //  so it has to terminate itself.
     if (!owner) {
         process_term (options.linger);

--- a/src/own.hpp
+++ b/src/own.hpp
@@ -96,12 +96,12 @@ namespace zmq
         //  specific type of the owned object correctly.
         virtual ~own_t ();
 
-        //  Term handler is protocted rather than private so that it can
+        //  Term handler is protected rather than private so that it can
         //  be intercepted by the derived class. This is useful to add custom
         //  steps to the beginning of the termination process.
         void process_term (int linger_);
 
-        //  A place to hook in when phyicallal destruction of the object
+        //  A place to hook in when physical destruction of the object
         //  is to be delayed.
         virtual void process_destroy ();
 
@@ -119,7 +119,7 @@ namespace zmq
         void process_term_ack ();
         void process_seqnum ();
 
-        //  Check whether all the peding term acks were delivered.
+        //  Check whether all the pending term acks were delivered.
         //  If so, deallocate this object.
         void check_term_acks ();
 

--- a/src/pgm_receiver.cpp
+++ b/src/pgm_receiver.cpp
@@ -226,7 +226,7 @@ void zmq::pgm_receiver_t::in_event ()
             zmq_assert (offset <= insize);
             zmq_assert (it->second.decoder == NULL);
 
-            //  We have to move data to the begining of the first message.
+            //  We have to move data to the beginning of the first message.
             inpos += offset;
             insize -= offset;
 

--- a/src/pgm_sender.cpp
+++ b/src/pgm_sender.cpp
@@ -44,7 +44,7 @@
 #include "wire.hpp"
 #include "stdint.hpp"
 
-zmq::pgm_sender_t::pgm_sender_t (io_thread_t *parent_, 
+zmq::pgm_sender_t::pgm_sender_t (io_thread_t *parent_,
       const options_t &options_) :
     io_object_t (parent_),
     has_tx_timer (false),
@@ -77,7 +77,7 @@ int zmq::pgm_sender_t::init (bool udp_encapsulation_, const char *network_)
 
 void zmq::pgm_sender_t::plug (io_thread_t *io_thread_, session_base_t *session_)
 {
-    //  Alocate 2 fds for PGM socket.
+    //  Allocate 2 fds for PGM socket.
     fd_t downlink_socket_fd = retired_fd;
     fd_t uplink_socket_fd = retired_fd;
     fd_t rdata_notify_fd = retired_fd;
@@ -91,11 +91,11 @@ void zmq::pgm_sender_t::plug (io_thread_t *io_thread_, session_base_t *session_)
 
     handle = add_fd (downlink_socket_fd);
     uplink_handle = add_fd (uplink_socket_fd);
-    rdata_notify_handle = add_fd (rdata_notify_fd);   
+    rdata_notify_handle = add_fd (rdata_notify_fd);
     pending_notify_handle = add_fd (pending_notify_fd);
 
     //  Set POLLIN. We wont never want to stop polling for uplink = we never
-    //  want to stop porocess NAKs.
+    //  want to stop processing NAKs.
     set_pollin (uplink_handle);
     set_pollin (rdata_notify_handle);
     set_pollin (pending_notify_handle);
@@ -169,11 +169,11 @@ void zmq::pgm_sender_t::in_event ()
 
 void zmq::pgm_sender_t::out_event ()
 {
-    //  POLLOUT event from send socket. If write buffer is empty, 
+    //  POLLOUT event from send socket. If write buffer is empty,
     //  try to read new data from the encoder.
     if (write_size == 0) {
 
-        //  First two bytes (sizeof uint16_t) are used to store message 
+        //  First two bytes (sizeof uint16_t) are used to store message
         //  offset in following steps. Note that by passing our buffer to
         //  the get data function we prevent it from returning its own buffer.
         unsigned char *bf = out_buffer + sizeof (uint16_t);

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -263,7 +263,7 @@ void zmq::pipe_t::process_activate_read ()
 
 void zmq::pipe_t::process_activate_write (uint64_t msgs_read_)
 {
-    //  Remember the peers's message sequence number.
+    //  Remember the peer's message sequence number.
     peers_msgs_read = msgs_read_;
 
     if (!out_active && state == active) {
@@ -385,7 +385,7 @@ void zmq::pipe_t::terminate (bool delay_)
     //  Overload the value specified at pipe creation.
     delay = delay_;
 
-    //  If terminate was already called, we can ignore the duplicit invocation.
+    //  If terminate was already called, we can ignore the duplicate invocation.
     if (state == term_req_sent1 || state == term_req_sent2) {
         return;
 	}

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -95,7 +95,7 @@ int zmq::req_t::xsend (msg_t *msg_)
 
         message_begins = false;
 
-        // Eat all currently avaliable messages before the request is fully
+        // Eat all currently available messages before the request is fully
         // sent. This is done to avoid:
         //   REQ sends request to A, A replies, B replies too.
         //   A's reply was first and matches, that is used.

--- a/src/req.hpp
+++ b/src/req.hpp
@@ -65,7 +65,7 @@ namespace zmq
     private:
 
         //  If true, request was already sent and reply wasn't received yet or
-        //  was raceived partially.
+        //  was received partially.
         bool receiving_reply;
 
         //  If true, we are starting to send/recv a message. The first part

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -388,7 +388,7 @@ bool zmq::router_t::xhas_in ()
 bool zmq::router_t::xhas_out ()
 {
     //  In theory, ROUTER socket is always ready for writing. Whether actual
-    //  attempt to write succeeds depends on whitch pipe the message is going
+    //  attempt to write succeeds depends on which pipe the message is going
     //  to be routed to.
     return true;
 }

--- a/src/select.hpp
+++ b/src/select.hpp
@@ -102,7 +102,7 @@ namespace zmq
         //  Checks if an fd_entry_t is retired.
         static bool is_retired_fd (const fd_entry_t &entry);
 
-        //  Set of file descriptors that are used to retreive
+        //  Set of file descriptors that are used to retrieve
         //  information for fd_set.
         typedef std::vector <fd_entry_t> fd_set_t;
         fd_set_t fds;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -162,7 +162,7 @@ bool zmq::server_t::xhas_in ()
 bool zmq::server_t::xhas_out ()
 {
     //  In theory, SERVER socket is always ready for writing. Whether actual
-    //  attempt to write succeeds depends on whitch pipe the message is going
+    //  attempt to write succeeds depends on which pipe the message is going
     //  to be routed to.
     return true;
 }

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -213,7 +213,7 @@ int zmq::signaler_t::wait (int timeout_)
 {
 #ifdef HAVE_FORK
     if (unlikely (pid != getpid ())) {
-        // we have forked and the file descriptor is closed. Emulate an interupt
+        // we have forked and the file descriptor is closed. Emulate an interrupt
         // response.
         //printf("Child process %d signaler_t::wait returning simulating interrupt #1\n", getpid());
         errno = EINTR;
@@ -238,7 +238,7 @@ int zmq::signaler_t::wait (int timeout_)
 #ifdef HAVE_FORK
     else
     if (unlikely (pid != getpid ())) {
-        // we have forked and the file descriptor is closed. Emulate an interupt
+        // we have forked and the file descriptor is closed. Emulate an interrupt
         // response.
         //printf("Child process %d signaler_t::wait returning simulating interrupt #2\n", getpid());
         errno = EINTR;

--- a/src/signaler.hpp
+++ b/src/signaler.hpp
@@ -64,7 +64,7 @@ namespace zmq
 
     private:
 
-        //  Creates a pair of filedescriptors that will be used
+        //  Creates a pair of file descriptors that will be used
         //  to pass the signals.
         static int make_fdpair (fd_t *r_, fd_t *w_);
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -237,7 +237,7 @@ int zmq::socket_base_t::parse_uri (const char *uri_,
 
 int zmq::socket_base_t::check_protocol (const std::string &protocol_)
 {
-    //  First check out whether the protcol is something we are aware of.
+    //  First check out whether the protocol is something we are aware of.
     if (protocol_ != "inproc"
     &&  protocol_ != "ipc"
     &&  protocol_ != "tcp"
@@ -249,7 +249,7 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_)
         return -1;
     }
     //  If 0MQ is not compiled with OpenPGM, pgm and epgm transports
-    //  are not avaialble.
+    //  are not available.
 #if !defined ZMQ_HAVE_OPENPGM
     if (protocol_ == "pgm" || protocol_ == "epgm") {
         errno = EPROTONOSUPPORT;
@@ -512,7 +512,7 @@ int zmq::socket_base_t::bind (const char *addr_)
     }
 
     if (protocol == "pgm" || protocol == "epgm" || protocol == "norm") {
-        //  For convenience's sake, bind can be used interchageable with
+        //  For convenience's sake, bind can be used interchangeable with
         //  connect for PGM, EPGM and NORM transports.
         EXIT_MUTEX();
         rc = connect (addr_);
@@ -521,7 +521,7 @@ int zmq::socket_base_t::bind (const char *addr_)
         return rc;
     }
 
-    //  Remaining trasnports require to be run in an I/O thread, so at this
+    //  Remaining transports require to be run in an I/O thread, so at this
     //  point we'll choose one.
     io_thread_t *io_thread = choose_io_thread (options.affinity);
     if (!io_thread) {

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -99,7 +99,7 @@ namespace zmq
         bool has_in ();
         bool has_out ();
 
-        //  Using this function reaper thread ask the socket to regiter with
+        //  Using this function reaper thread ask the socket to register with
         //  its poller.
         void start_reaping (poller_t *poller_);
 
@@ -171,7 +171,7 @@ namespace zmq
         //  Delay actual destruction of the socket.
         void process_destroy ();
 
-        // Socket event data dispath
+        // Socket event data dispatch
         void monitor_event (int event_, int value_, const std::string& addr_);
 
         // Monitor socket cleanup

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -361,7 +361,7 @@ int zmq::socks_connecter_t::connect_to_proxy ()
     //  Connect to the remote peer.
     rc = ::connect (s, tcp_addr->addr (), tcp_addr->addrlen ());
 
-    //  Connect was successfull immediately.
+    //  Connect was successful immediately.
     if (rc == 0)
         return 0;
 

--- a/src/socks_connecter.hpp
+++ b/src/socks_connecter.hpp
@@ -103,7 +103,7 @@ namespace zmq
         int get_new_reconnect_ivl ();
 
         //  Open TCP connecting socket. Returns -1 in case of error,
-        //  0 if connect was successfull immediately. Returns -1 with
+        //  0 if connect was successful immediately. Returns -1 with
         //  EAGAIN errno if async connect was launched.
         int open ();
 
@@ -111,7 +111,7 @@ namespace zmq
         void close ();
 
         //  Get the file descriptor of newly created connection. Returns
-        //  retired_fd if the connection was unsuccessfull.
+        //  retired_fd if the connection was unsuccessful.
         zmq::fd_t check_proxy_connection ();
 
         socks_greeting_encoder_t greeting_encoder;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -226,7 +226,7 @@ int zmq::stream_t::xrecv (msg_t *msg_)
     zmq_assert ((prefetched_msg.flags () & msg_t::more) == 0);
 
     //  We have received a frame with TCP data.
-    //  Rather than sendig this frame, we keep it in prefetched
+    //  Rather than sending this frame, we keep it in prefetched
     //  buffer and send a frame with peer's ID.
     blob_t identity = pipe->get_identity ();
     rc = msg_->close();

--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -477,7 +477,7 @@ int zmq::tcp_address_t::to_string (std::string &addr_)
         return -1;
     }
 
-    //  Not using service resolv because of
+    //  Not using service resolving because of
     //  https://github.com/zeromq/libzmq/commit/1824574f9b5a8ce786853320e3ea09fe1f822bc4
     char hbuf [NI_MAXHOST];
     int rc = getnameinfo (addr (), addrlen (), hbuf, sizeof hbuf, NULL, 0, NI_NUMERICHOST);

--- a/src/tcp_address.hpp
+++ b/src/tcp_address.hpp
@@ -51,7 +51,7 @@ namespace zmq
         virtual ~tcp_address_t ();
 
         //  This function translates textual TCP address into an address
-        //  strcuture. If 'local' is true, names are resolved as local interface
+        //  structure. If 'local' is true, names are resolved as local interface
         //  names. If it is false, names are resolved as remote hostnames.
         //  If 'ipv6' is true, the name may resolve to IPv6 address.
         int resolve (const char *name_, bool local_, bool ipv6_, bool is_src_ = false);

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -311,7 +311,7 @@ int zmq::tcp_connecter_t::open ()
     //  Connect to the remote peer.
     rc = ::connect (s, tcp_addr->addr (), tcp_addr->addrlen ());
 
-    //  Connect was successfull immediately.
+    //  Connect was successful immediately.
     if (rc == 0)
         return 0;
 

--- a/src/tcp_connecter.hpp
+++ b/src/tcp_connecter.hpp
@@ -83,7 +83,7 @@ namespace zmq
         int get_new_reconnect_ivl ();
 
         //  Open TCP connecting socket. Returns -1 in case of error,
-        //  0 if connect was successfull immediately. Returns -1 with
+        //  0 if connect was successful immediately. Returns -1 with
         //  EAGAIN errno if async connect was launched.
         int open ();
 
@@ -91,7 +91,7 @@ namespace zmq
         void close ();
 
         //  Get the file descriptor of newly created connection. Returns
-        //  retired_fd if the connection was unsuccessfull.
+        //  retired_fd if the connection was unsuccessful.
         fd_t connect ();
 
         //  Address to connect to. Owned by session_base_t.

--- a/src/tcp_listener.hpp
+++ b/src/tcp_listener.hpp
@@ -84,7 +84,7 @@ namespace zmq
         //  Handle corresponding to the listening socket.
         handle_t handle;
 
-        //  Socket the listerner belongs to.
+        //  Socket the listener belongs to.
         zmq::socket_base_t *socket;
 
        // String representation of endpoint to bind to

--- a/src/tipc_connecter.cpp
+++ b/src/tipc_connecter.cpp
@@ -102,7 +102,7 @@ void zmq::tipc_connecter_t::process_term (int linger_)
 
 void zmq::tipc_connecter_t::in_event ()
 {
-    //  We are not polling for incomming data, so we are actually called
+    //  We are not polling for incoming data, so we are actually called
     //  because of error here. However, we can get error on out event as well
     //  on some platforms, so we'll simply handle both events in the same way.
     out_event ();
@@ -213,7 +213,7 @@ int zmq::tipc_connecter_t::open ()
       s, addr->resolved.tipc_addr->addr (),
       addr->resolved.tipc_addr->addrlen ());
 
-    //  Connect was successfull immediately.
+    //  Connect was successful immediately.
     if (rc == 0)
         return 0;
 

--- a/src/tipc_connecter.hpp
+++ b/src/tipc_connecter.hpp
@@ -81,7 +81,7 @@ namespace zmq
         void close ();
 
         //  Get the file descriptor of newly created connection. Returns
-        //  retired_fd if the connection was unsuccessfull.
+        //  retired_fd if the connection was unsuccessful.
         fd_t connect ();
 
         //  Address to connect to. Owned by session_base_t.
@@ -121,7 +121,7 @@ namespace zmq
         int get_new_reconnect_ivl ();
 
         //  Open IPC connecting socket. Returns -1 in case of error,
-        //  0 if connect was successfull immediately. Returns -1 with
+        //  0 if connect was successful immediately. Returns -1 with
         //  EAGAIN errno if async connect was launched.
         int open ();
 

--- a/src/tipc_listener.cpp
+++ b/src/tipc_listener.cpp
@@ -140,7 +140,7 @@ int zmq::tipc_listener_t::set_address (const char *addr_)
     if (rc != 0)
         goto error;
 
-    //  Listen for incomming connections.
+    //  Listen for incoming connections.
     rc = listen (s, options.backlog);
     if (rc != 0)
         goto error;

--- a/src/tipc_listener.hpp
+++ b/src/tipc_listener.hpp
@@ -89,7 +89,7 @@ namespace zmq
         //  Handle corresponding to the listening socket.
         handle_t handle;
 
-        //  Socket the listerner belongs to.
+        //  Socket the listener belongs to.
         zmq::socket_base_t *socket;
 
        // String representation of endpoint to bind to

--- a/src/trie.cpp
+++ b/src/trie.cpp
@@ -75,7 +75,7 @@ bool zmq::trie_t::add (unsigned char *prefix_, size_t size_)
     if (c < min || c >= min + count) {
 
         //  The character is out of range of currently handled
-        //  charcters. We have to extend the table.
+        //  characters. We have to extend the table.
         if (!count) {
             min = c;
             count = 1;

--- a/src/v2_decoder.cpp
+++ b/src/v2_decoder.cpp
@@ -117,7 +117,7 @@ int zmq::v2_decoder_t::size_ready(uint64_t msg_size, unsigned char const* read_p
     if (unlikely ((unsigned char*)read_pos + msg_size > (data() + size())))
     {
         // a new message has started, but the size would exceed the pre-allocated arena
-        // this happens everytime when a message does not fit completely into the buffer
+        // this happens every time when a message does not fit completely into the buffer
         rc = in_progress.init_size (static_cast <size_t> (msg_size));
     }
     else

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -281,8 +281,8 @@ void zmq::xpub_t::send_unsubscription (unsigned char *data_, size_t size_,
     xpub_t *self = (xpub_t*) arg_;
 
     if (self->options.type != ZMQ_PUB) {
-        //  Place the unsubscription to the queue of pending (un)sunscriptions
-        //  to be retrived by the user later on.
+        //  Place the unsubscription to the queue of pending (un)subscriptions
+        //  to be retrieved by the user later on.
         blob_t unsub (size_ + 1, 0);
         unsub [0] = 0;
         if (size_ > 0)

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -68,7 +68,7 @@ namespace zmq
 
     private:
 
-        //  Function to be applied to the trie to send all the subsciptions
+        //  Function to be applied to the trie to send all the subscriptions
         //  upstream.
         static void send_unsubscription (unsigned char *data_, size_t size_,
             void *arg_);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -841,7 +841,7 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
                 nevents++;
         }
 
-        //  If timout is zero, exit immediately whether there are events or not.
+        //  If timeout is zero, exit immediately whether there are events or not.
         if (timeout_ == 0)
             break;
 
@@ -1024,7 +1024,7 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
                 nevents++;
         }
 
-        //  If timout is zero, exit immediately whether there are events or not.
+        //  If timeout is zero, exit immediately whether there are events or not.
         if (timeout_ == 0)
             break;
 
@@ -1298,7 +1298,7 @@ int zmq_pollfd_poll (void* p_, zmq_pollitem_t *items_, int nitems_, long timeout
                 nevents++;
         }
 
-        //  If timout is zero, exit immediately whether there are events or not.
+        //  If timeout is zero, exit immediately whether there are events or not.
         if (timeout_ == 0)
             break;
 
@@ -1513,7 +1513,7 @@ int zmq_pollfd_poll (void* p_, zmq_pollitem_t *items_, int nitems_, long timeout
                 nevents++;
         }
 
-        //  If timout is zero, exit immediately whether there are events or not.
+        //  If timeout is zero, exit immediately whether there are events or not.
         if (timeout_ == 0)
             break;
 


### PR DESCRIPTION
Fixed a few typos in `src/` directory.
Hope this makes reading the source a little bit more pleasant.
Interestingly, the most common typo was _"(un)successfull"_.