### PR TITLE
Fix pointer indirection precedence issue in docs

### DIFF
--- a/doc/zmq_socket_monitor.txt
+++ b/doc/zmq_socket_monitor.txt
@@ -150,7 +150,7 @@ get_monitor_event (void *monitor, int *value, char **address)
         size_t size = zmq_msg_size (&msg);
         *address = (char *) malloc (size + 1);
         memcpy (*address, data, size);
-        *address [size] = 0;
+        (*address)[size] = 0;
     }
     return event;
 }


### PR DESCRIPTION
Without this change, a segmentation fault is likely to occur when using the proposed snippet of code, as `*address[size]` is equivalent to `*(address[size])`, not `(*address)[size]` as clearly intended.