### PR TITLE
fix error with gcc 5.2

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -554,7 +554,8 @@ int zmq_recviov (void *s_, iovec *a_, size_t *count_, int flags_)
         memcpy(a_[i].iov_base,static_cast<char *> (zmq_msg_data (&msg)),
                a_[i].iov_len);
         // Assume zmq_socket ZMQ_RVCMORE is properly set.
-        recvmore = ((zmq::msg_t*) &msg)->flags () & zmq::msg_t::more;
+        zmq::msg_t* p_msg = reinterpret_cast<zmq::msg_t*>(&msg);
+        recvmore = p_msg->flags() & zmq::msg_t::more;
         rc = zmq_msg_close(&msg);
         errno_assert (rc == 0);
         ++*count_;


### PR DESCRIPTION
compiling with gcc version 6.0.0 20150912 (experimental) (GCC) 
I'm getting the following error:

src/zmq.cpp: In function 'int zmq_recviov(void*, iovec*, size_t*, int)':
src/zmq.cpp:555:49: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
         recvmore = ((zmq::msg_t*) (void *) &msg)->flags () & zmq::msg_t::more;

this patch fix the problem 