### PR TITLE
create signaler::recv_failable()

### DIFF
--- a/src/mailbox.cpp
+++ b/src/mailbox.cpp
@@ -77,14 +77,18 @@ int zmq::mailbox_t::recv (command_t *cmd_, int timeout_)
     }
 
     //  Wait for signal from the command sender.
-    const int rc = signaler.wait (timeout_);
+    int rc = signaler.wait (timeout_);
     if (rc == -1) {
         errno_assert (errno == EAGAIN || errno == EINTR);
         return -1;
     }
 
     //  Receive the signal.
-    signaler.recv ();
+    rc = signaler.recv_failable ();
+    if (rc == -1) {
+        errno_assert (errno == EAGAIN);
+        return -1;
+    }
 
     //  Switch into active state.
     active = true;

--- a/src/signaler.hpp
+++ b/src/signaler.hpp
@@ -55,6 +55,7 @@ namespace zmq
         void send ();
         int wait (int timeout_);
         void recv ();
+        int recv_failable ();
 
 #ifdef HAVE_FORK
         // close the file descriptors in a forked child process so that they


### PR DESCRIPTION
In real world usage, there have been reported signaler failures where the
eventfd read() or socket recv() system call in signaler::recv() fails,
despite having made a prior successful signaler::wait() call.

this patch creates a signaler::recv_failable() method that allows
unreadable eventfd / socket to return an error without asserting.