### PR TITLE
Fixes issue #1556

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -417,9 +417,9 @@ fi
 have_sodium_library="no"
 
 AC_ARG_WITH([libsodium], [AS_HELP_STRING([--with-libsodium],
-    [require libzmq build with libsodium. Requires pkg-config [default=no]])],
+    [require libzmq build with libsodium crypto library. Requires pkg-config [default=yes]])],
     [require_libsodium_ext=$withval],
-    [require_libsodium_ext=no])
+    [require_libsodium_ext=yes])
 
 # conditionally require libsodium package
 if test "x$require_libsodium_ext" != "xno"; then

--- a/configure.ac
+++ b/configure.ac
@@ -184,9 +184,6 @@ case "${host_os}" in
         if test "x$solaris_has_atomic" = "xno"; then
             AC_DEFINE(ZMQ_FORCE_MUTEXES, 1, [Force to use mutexes])
         fi
-        # ssp library is required for libsodium on Solaris-like systems
-        LDFLAGS="-lssp $LDFLAGS"
-        CPPFLAGS="$CPPFLAGS -Wno-long-long"
         ;;
     *freebsd*)
         # Define on FreeBSD to enable all library features
@@ -422,7 +419,7 @@ have_sodium_library="no"
 AC_ARG_WITH([libsodium], [AS_HELP_STRING([--with-libsodium],
     [require libzmq build with libsodium. Requires pkg-config [default=no]])],
     [require_libsodium_ext=$withval],
-    [require_libsodium_ext=yes])
+    [require_libsodium_ext=no])
 
 # conditionally require libsodium package
 if test "x$require_libsodium_ext" != "xno"; then
@@ -431,7 +428,16 @@ fi
 
 if test "x$have_sodium_library" != "xno"; then
     AC_DEFINE(HAVE_LIBSODIUM, 1, [The libsodium library is to be used.])
+
+    # ssp library is required for libsodium on Solaris-like systems
+    case "${host_os}" in
+        *solaris*)
+            LDFLAGS="-lssp $LDFLAGS"
+            CPPFLAGS="$CPPFLAGS -Wno-long-long"
+        ;;
+    esac
 fi
+
 
 AM_CONDITIONAL(HAVE_SODIUM, test "x$have_sodium_library" != "xno")
 


### PR DESCRIPTION
Changes:
* libsodium is considered required by default, according to the help message.
* the test for the need of the ssp library for Solaris was moved in the region where we test for libsodium. It seemed to me more clear to test it here than before checking for libsodium.

I don't have a Solaris system, so I couldn't test : I am not sure if it still works on Solaris...