### PR TITLE
CTest: add all sources in tests folder to CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WITH_SODIUM)
   endif()
 endif()
 
-if(WITH_TWEETNACL AND NOT SODIUM_FOUND)
+if(WITH_TWEETNACL)
   message(STATUS "Building with TweetNaCL")
   set(USE_TWEETNACL ON)
   add_definitions(-DHAVE_TWEETNACL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,21 @@ set(tests
         test_sockopt_hwm
         test_heartbeats
         test_poller
+        test_atomics
+        test_bind_src_address
+        test_capabilities
+        test_ipc_wildcard
+        test_metadata
+        test_pair_tipc
+        test_reqrep_device_tipc
+        test_reqrep_tipc
+        test_router_handover
+        test_router_mandatory_tipc
+        test_srcfd
+        test_stream_timeout
+        test_sub_forward_tipc
+        test_xpub_manual
+        test_xpub_welcome_msg
 )
 if(NOT WIN32)
   list(APPEND tests
@@ -65,6 +80,11 @@ if(NOT WIN32)
           test_proxy_terminate
           test_getsockopt_memset
           test_filter_ipc
+          test_connect_delay_tipc
+          test_shutdown_stress_tipc
+          test_stream_exceeds_buffer
+          test_router_mandatory_hwm
+          test_term_endpoint_tipc
   )
   if(HAVE_FORK)
     list(APPEND tests test_fork)
@@ -92,3 +112,13 @@ if(NOT WIN32)
   endif()
 endif()
 
+#Check whether all tests in the current folder are present
+file(READ "${CMAKE_CURRENT_LIST_FILE}" CURRENT_LIST_FILE_CONTENT)
+file(GLOB ALL_TEST_SOURCES "test_*.cpp")
+foreach(TEST_SOURCE ${ALL_TEST_SOURCES})
+  get_filename_component(TESTNAME "${TEST_SOURCE}" NAME_WE)
+  string(REGEX MATCH "${TESTNAME}" MATCH_TESTNAME "${CURRENT_LIST_FILE_CONTENT}")
+  if (NOT MATCH_TESTNAME)
+    message(AUTHOR_WARNING "Test '${TESTNAME}' is not known to CTest.")
+  endif()
+endforeach()


### PR DESCRIPTION
Changes introduced by this PR:
- CMake: Build with both libsodium and tweetNaCL
- In the tests folder, there were some `test_XXX.cpp` files which were not included in CTest. I have checked which tests could be compiled on Linux and which one could be compiled on Windows. I have added them to the correct category (I think).
  * In addition to this, CMake will test whether there is a test_XXX.cpp present in the tests folder that is not known to CTest. If so, a developper warning will be shown. Hopefully, this feature will avoid having a test not run on the CI.
  * **Main problem is that some of these tests fail.**

The following tests fail on both Linux and Windows:
58 - test_pair_tipc (OTHER_FAULT)
59 - test_reqrep_device_tipc (OTHER_FAULT)
60 - test_reqrep_tipc (OTHER_FAULT)
62 - test_router_mandatory_tipc (OTHER_FAULT)
65 - test_sub_forward_tipc (OTHER_FAULT)

The following tests fail only on Windows:
56 - test_ipc_wildcard (Timeout)
63 - test_srcfd (OTHER_FAULT)
66 - test_xpub_manual (OTHER_FAULT)

The following tests fail only on Linux:
77 - test_connect_delay_tipc (OTHER_FAULT)
78 - test_shutdown_stress_tipc (OTHER_FAULT)
81 - test_term_endpoint_tipc (OTHER_FAULT)

appveyor output:
https://ci.appveyor.com/project/madebr/libzmq/build/build-32