### PR TITLE
Cmake winci fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,7 +611,8 @@ else()
                           PUBLIC_HEADER "${public_headers}"
                           VERSION ${ZMQ_VERSION}
                           SOVERSION "${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.0"
-                          OUTPUT_NAME "libzmq")
+                          OUTPUT_NAME "libzmq"
+                          PREFIX "")
     if(ZMQ_BUILD_FRAMEWORK)
       set_target_properties(libzmq PROPERTIES
                             FRAMEWORK TRUE
@@ -629,7 +630,8 @@ else()
     set_target_properties(libzmq-static PROPERTIES
       PUBLIC_HEADER "${public_headers}"
       COMPILE_DEFINITIONS "ZMQ_STATIC"
-      OUTPUT_NAME "libzmq-static")
+      OUTPUT_NAME "libzmq-static"
+      PREFIX "")
 endif()
 
 target_link_libraries(libzmq ${CMAKE_THREAD_LIBS_INIT})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,22 +14,26 @@ environment:
     - platform: Win32
       configuration: Release
       WITH_SODIUM: ON
-      WITH_TWEETNACL: OFF
+      WITH_TWEETNACL: ON
     - platform: Win32
+      configuration: Debug
+      WITH_SODIUM: ON
+      WITH_TWEETNACL: ON
+    - platform: x64
       configuration: Release
       WITH_SODIUM: ON
-      WITH_TWEETNACL: OFF
+      WITH_TWEETNACL: ON
     - platform: x64
       configuration: Debug
       WITH_SODIUM: ON
-      WITH_TWEETNACL: OFF
-    - platform: x64
-      configuration: Debug
-      WITH_SODIUM: ON
-      WITH_TWEETNACL: OFF
+      WITH_TWEETNACL: ON
     - platform: Win32
       configuration: Release
       WITH_SODIUM: OFF
+      WITH_TWEETNACL: OFF
+    - platform: Win32
+      configuration: Release
+      WITH_SODIUM: ON
       WITH_TWEETNACL: OFF
     - platform: Win32
       configuration: Release

--- a/tweetnacl/contrib/randombytes/winrandom.c
+++ b/tweetnacl/contrib/randombytes/winrandom.c
@@ -22,7 +22,7 @@ void randombytes(unsigned char *x,unsigned long long xlen)
     if (xlen < 1048576) i = (unsigned) xlen; else i = 1048576;
 
     ret = CryptGenRandom(hProvider, i, x);
-    if (ret != FALSE) {
+    if (ret == FALSE) {
       Sleep(1);
       continue;
     }


### PR DESCRIPTION
Changes introduced with this PR:
- cmake did generate `liblibzmq.so` libraries on linux. So clear the prefix.
- the windows CI did not test all combinations, and some were included double.
- the implementation of winrandom was incorrect. Fixed that.

Result of Windows CI: https://ci.appveyor.com/project/madebr/libzmq/build/build-35