### PR TITLE
Problem: libzmq appveyor build status is not visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ZeroMQ
 
 [![Build Status](https://travis-ci.org/zeromq/libzmq.png?branch=master)](https://travis-ci.org/zeromq/libzmq)
+[![Build status](https://ci.appveyor.com/api/projects/status/e2ks424yrs1un3wt?svg=true)](https://ci.appveyor.com/project/zeromq/libzmq)
 
 ## Welcome
 


### PR DESCRIPTION
Solution: Add a travis like badge to the README

fixes #1622