### PR TITLE
Acutally allow specifying interfaces as source address

### DIFF
--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -445,7 +445,7 @@ int zmq::tcp_address_t::resolve (const char *name_, bool local_, bool ipv6_, boo
 
     //  Resolve the IP address.
     int rc;
-    if (local_)
+    if (local_ || is_src_)
         rc = resolve_interface (addr_str.c_str (), ipv6_, is_src_);
     else
         rc = resolve_hostname (addr_str.c_str (), ipv6_, is_src_);


### PR DESCRIPTION
Currently URL  "tcp://eth1:0;remote.host.com:7777" does not work correctly since code does not try to resolve "eth1" as an interface item. This trivial patch forces interface lookup when src portion of URL is processed.

Generally speaking, current way to select source address is not correct since source address should be chosen AFTER dst part of the URL is resolved. For now it grabs first IPv4/6 address from the interface and once address family of source address does not match destination source address this patch is totally useless. This change would not be trivial though.