### PR TITLE
Tcp buffer options to set RECV/SEND buffer

### DIFF
--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -736,6 +736,33 @@ Option value unit:: N/A
 Default value:: not set
 Applicable socket types:: all, when using TCP transport
 
+ZMQ_TCP_RECV_BUFFER: Size of the TCP receive buffer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_RECV_BUFFER' specifies the maximum number of bytes which can
+be received by an individual syscall to receive data from the TCP
+socket. The buffer size is specified as an integer number from 0 (very small)
+to 10 (very large). The default value is 3.
+
+
+[horizontal]
+Option value type:: int
+Option value unit:: N/A
+Default value:: 3
+Applicable socket types:: all, when using TCP transport
+
+ZMQ_TCP_SEND_BUFFER: Size of the TCP receive buffer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_SEND_BUFFER' specifies the maximum number of bytes which can
+be sent by an individual syscall to transmit data to the TCP
+socket. The buffer size is specified as an integer number from 0 (very small)
+to 10 (very large). The default value is 3.
+
+
+[horizontal]
+Option value type:: int
+Option value unit:: N/A
+Default value:: 3
+Applicable socket types:: all, when using TCP transport
 
 RETURN VALUE
 ------------

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1071,6 +1071,33 @@ Option value unit:: boolean
 Default value:: 1 (true)
 Applicable socket types:: all, when using TCP transports.
 
+ZMQ_TCP_RECV_BUFFER: Size of the TCP receive buffer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_RECV_BUFFER' specifies the maximum number of bytes which can
+be received by an individual syscall to receive data from the TCP
+socket. The buffer size is specified as an integer number from 0 (very small)
+to 10 (very large). The default value is 3.
+
+
+[horizontal]
+Option value type:: int
+Option value unit:: N/A
+Default value:: 3
+Applicable socket types:: all, when using TCP transport
+
+ZMQ_TCP_SEND_BUFFER: Size of the TCP receive buffer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_SEND_BUFFER' specifies the maximum number of bytes which can
+be sent by an individual syscall to transmit data to the TCP
+socket. The buffer size is specified as an integer number from 0 (very small)
+to 10 (very large). The default value is 3.
+
+
+[horizontal]
+Option value type:: int
+Option value unit:: N/A
+Default value:: 3
+Applicable socket types:: all, when using TCP transport
 
 RETURN VALUE
 ------------

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -323,6 +323,8 @@ ZMQ_EXPORT uint32_t zmq_msg_routing_id (zmq_msg_t *msg);
 #define ZMQ_CONNECT_TIMEOUT 79
 #define ZMQ_TCP_RETRANSMIT_TIMEOUT 80
 #define ZMQ_THREAD_SAFE 81
+#define ZMQ_TCP_RECV_BUFFER 82
+#define ZMQ_TCP_SEND_BUFFER 83
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -28,6 +28,7 @@
 */
 
 #include <string.h>
+#include <cmath>
 
 #include "options.hpp"
 #include "err.hpp"
@@ -65,6 +66,8 @@ zmq::options_t::options_t () :
     tcp_keepalive_cnt (-1),
     tcp_keepalive_idle (-1),
     tcp_keepalive_intvl (-1),
+    tcp_recv_buffer_size (3),
+    tcp_send_buffer_size (3),
     mechanism (ZMQ_NULL),
     as_server (0),
     gss_plaintext (false),
@@ -277,6 +280,18 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             if (is_int && (value == -1 || value >= 0)) {
                 tcp_keepalive_intvl = value;
                 return 0;
+            }
+            break;
+
+        case ZMQ_TCP_RECV_BUFFER:
+            if (is_int && (value >= 0 && value <= 10) ) {
+                tcp_send_buffer_size = static_cast<int>(std::pow(2, value)) * 1024;
+            }
+            break;
+
+        case ZMQ_TCP_SEND_BUFFER:
+            if (is_int && (value >= 0 && value <= 10) ) {
+                tcp_send_buffer_size = static_cast<int>(std::pow(2, value)) * 1024;
             }
             break;
 
@@ -786,6 +801,20 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
         case ZMQ_TCP_KEEPALIVE_INTVL:
             if (is_int) {
                 *value = tcp_keepalive_intvl;
+                return 0;
+            }
+            break;
+
+        case ZMQ_TCP_SEND_BUFFER:
+            if (is_int) {
+                *value = tcp_send_buffer_size;
+                return 0;
+            }
+            break;
+
+        case ZMQ_TCP_RECV_BUFFER:
+            if (is_int) {
+                *value = tcp_recv_buffer_size;
                 return 0;
             }
             break;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -285,7 +285,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
 
         case ZMQ_TCP_RECV_BUFFER:
             if (is_int && (value >= 0 && value <= 10) ) {
-                tcp_send_buffer_size = static_cast<int>(std::pow(2, value)) * 1024;
+                tcp_recv_buffer_size = static_cast<int>(std::pow(2, value)) * 1024;
             }
             break;
 

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -156,6 +156,10 @@ namespace zmq
         typedef std::vector <tcp_address_mask_t> tcp_accept_filters_t;
         tcp_accept_filters_t tcp_accept_filters;
 
+        // TCO buffer sizes
+        int tcp_recv_buffer_size;
+        int tcp_send_buffer_size;
+
         // IPC accept() filters
 #       if defined ZMQ_HAVE_SO_PEERCRED || defined ZMQ_HAVE_LOCAL_PEERCRED
         bool zap_ipc_creds;


### PR DESCRIPTION
I've added two new socket options to set the receive/send buffer for TCP sockets. This could be useful to specify a different buffer size from applications to reduce overhead from syscalls, e.g. when sending many large messages.