### PR TITLE
Solution: change behaviour of tcp_send/recv_buffer_size option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ test_server_drop_more
 test_thread_safe
 test_thread_safe_polling
 test_getsockopt_memset
+test_setsockopt
 test_stream_exceeds_buffer
 test_poller
 tests/test*.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -351,6 +351,7 @@ test_apps = \
 	tests/test_proxy_single_socket \
 	tests/test_proxy_terminate \
 	tests/test_getsockopt_memset \
+	tests/test_setsockopt \
 	tests/test_many_sockets \
 	tests/test_ipc_wildcard \
 	tests/test_diffserv \
@@ -565,6 +566,9 @@ tests_test_thread_safe_LDADD = src/libzmq.la
 
 tests_test_socketopt_hwm_SOURCES = tests/test_sockopt_hwm.cpp
 tests_test_socketopt_hwm_LDADD = src/libzmq.la
+
+tests_test_setsockopt_SOURCES = tests/test_setsockopt.cpp
+tests_test_setsockopt_LDADD = src/libzmq.la
 
 tests_test_heartbeats_SOURCES = tests/test_heartbeats.cpp
 tests_test_heartbeats_LDADD = src/libzmq.la

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -738,10 +738,9 @@ Applicable socket types:: all, when using TCP transport
 
 ZMQ_TCP_RECV_BUFFER: Size of the TCP receive buffer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_RECV_BUFFER' specifies the maximum number of bytes which can
-be received by an individual syscall to receive data from the TCP
-socket. The buffer size is specified as an integer number from 0 (very small)
-to 10 (very large). The default value is 3.
+The 'ZMQ_TCP_RECV_BUFFER' specifies the maximum number of bytes which can
+be received by an individual syscall to receive data from the TCP socket.
+The default value is 8192.
 
 
 [horizontal]
@@ -752,10 +751,9 @@ Applicable socket types:: all, when using TCP transport
 
 ZMQ_TCP_SEND_BUFFER: Size of the TCP receive buffer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_SEND_BUFFER' specifies the maximum number of bytes which can
-be sent by an individual syscall to transmit data to the TCP
-socket. The buffer size is specified as an integer number from 0 (very small)
-to 10 (very large). The default value is 3.
+The 'ZMQ_TCP_SEND_BUFFER' specifies the maximum number of bytes which can
+be sent by an individual syscall to transmit data to the TCP socket.
+The default value is 8192.
 
 
 [horizontal]

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -745,8 +745,8 @@ The default value is 8192.
 
 [horizontal]
 Option value type:: int
-Option value unit:: N/A
-Default value:: 3
+Option value unit:: >0
+Default value:: 8192
 Applicable socket types:: all, when using TCP transport
 
 ZMQ_TCP_SEND_BUFFER: Size of the TCP receive buffer
@@ -758,8 +758,8 @@ The default value is 8192.
 
 [horizontal]
 Option value type:: int
-Option value unit:: N/A
-Default value:: 3
+Option value unit:: >0
+Default value:: 8192
 Applicable socket types:: all, when using TCP transport
 
 RETURN VALUE

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1073,10 +1073,9 @@ Applicable socket types:: all, when using TCP transports.
 
 ZMQ_TCP_RECV_BUFFER: Size of the TCP receive buffer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_RECV_BUFFER' specifies the maximum number of bytes which can
-be received by an individual syscall to receive data from the TCP
-socket. The buffer size is specified as an integer number from 0 (very small)
-to 10 (very large). The default value is 3.
+The 'ZMQ_TCP_RECV_BUFFER' specifies the maximum number of bytes which can
+be received by an individual syscall to receive data from the TCP socket.
+The default value is 8192.
 
 
 [horizontal]
@@ -1087,10 +1086,9 @@ Applicable socket types:: all, when using TCP transport
 
 ZMQ_TCP_SEND_BUFFER: Size of the TCP receive buffer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_SEND_BUFFER' specifies the maximum number of bytes which can
-be sent by an individual syscall to transmit data to the TCP
-socket. The buffer size is specified as an integer number from 0 (very small)
-to 10 (very large). The default value is 3.
+The 'ZMQ_TCP_SEND_BUFFER' specifies the maximum number of bytes which can
+be sent by an individual syscall to transmit data to the TCP socket.
+The default value is 8192.
 
 
 [horizontal]

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1080,8 +1080,8 @@ The default value is 8192.
 
 [horizontal]
 Option value type:: int
-Option value unit:: N/A
-Default value:: 3
+Option value unit:: >0
+Default value:: 8192
 Applicable socket types:: all, when using TCP transport
 
 ZMQ_TCP_SEND_BUFFER: Size of the TCP receive buffer
@@ -1093,8 +1093,8 @@ The default value is 8192.
 
 [horizontal]
 Option value type:: int
-Option value unit:: N/A
-Default value:: 3
+Option value unit:: >0
+Default value:: 8192
 Applicable socket types:: all, when using TCP transport
 
 RETURN VALUE

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -28,7 +28,6 @@
 */
 
 #include <string.h>
-#include <cmath>
 
 #include "options.hpp"
 #include "err.hpp"
@@ -66,8 +65,8 @@ zmq::options_t::options_t () :
     tcp_keepalive_cnt (-1),
     tcp_keepalive_idle (-1),
     tcp_keepalive_intvl (-1),
-    tcp_recv_buffer_size (3),
-    tcp_send_buffer_size (3),
+    tcp_recv_buffer_size (8192),
+    tcp_send_buffer_size (8192),
     mechanism (ZMQ_NULL),
     as_server (0),
     gss_plaintext (false),
@@ -284,14 +283,16 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             break;
 
         case ZMQ_TCP_RECV_BUFFER:
-            if (is_int && (value >= 0 && value <= 10) ) {
-                tcp_recv_buffer_size = static_cast<unsigned int>(std::pow(2.0, value)) * 1024;
+            if (is_int && (value > 0) ) {
+                tcp_recv_buffer_size = static_cast<unsigned int>(value);
+                return 0;
             }
             break;
 
         case ZMQ_TCP_SEND_BUFFER:
-            if (is_int && (value >= 0 && value <= 10) ) {
-                tcp_send_buffer_size = static_cast<unsigned int>(std::pow(2.0, value)) * 1024;
+            if (is_int && (value > 0) ) {
+                tcp_send_buffer_size = static_cast<unsigned int>(value);
+                return 0;
             }
             break;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(tests
         test_pub_invert_matching
         test_thread_safe
         test_client_server
+        test_setsockopt
         test_sockopt_hwm
         test_heartbeats
         test_poller

--- a/tests/test_setsockopt.cpp
+++ b/tests/test_setsockopt.cpp
@@ -1,0 +1,78 @@
+#include "testutil.hpp"
+
+void test_setsockopt_tcp_recv_buffer()
+{
+    int rc;
+    void *ctx = zmq_ctx_new();
+    void *socket = zmq_socket(ctx, ZMQ_PUSH);
+
+    int val = 0;
+    size_t placeholder = sizeof(val);
+
+    rc = zmq_getsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, &placeholder);
+    assert(rc == 0);
+    assert(val == 8192);
+
+    rc = zmq_setsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, sizeof(val));
+    assert(rc == 0);
+    assert(val == 8192);
+
+    rc = zmq_getsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, &placeholder);
+    assert(rc == 0);
+    assert(val == 8192);
+
+    val = 16384;
+
+    rc = zmq_setsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, sizeof(val));
+    assert(rc == 0);
+    assert(val == 16384);
+
+    rc = zmq_getsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, &placeholder);
+    assert(rc == 0);
+    assert(val == 16384);
+
+    zmq_close(socket);
+    zmq_ctx_term(ctx);
+}
+
+void test_setsockopt_tcp_send_buffer()
+{
+    int rc;
+    void *ctx = zmq_ctx_new();
+    void *socket = zmq_socket(ctx, ZMQ_PUSH);
+
+    int val = 0;
+    size_t placeholder = sizeof(val);
+
+    rc = zmq_getsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, &placeholder);
+    assert(rc == 0);
+    assert(val == 8192);
+
+    rc = zmq_setsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, sizeof(val));
+    assert(rc == 0);
+    assert(val == 8192);
+
+    rc = zmq_getsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, &placeholder);
+    assert(rc == 0);
+    assert(val == 8192);
+
+    val = 16384;
+
+    rc = zmq_setsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, sizeof(val));
+    assert(rc == 0);
+    assert(val == 16384);
+
+    rc = zmq_getsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, &placeholder);
+    assert(rc == 0);
+    assert(val == 16384);
+
+    zmq_close(socket);
+    zmq_ctx_term(ctx);
+}
+
+
+int main()
+{
+    test_setsockopt_tcp_recv_buffer();
+    test_setsockopt_tcp_send_buffer();
+}


### PR DESCRIPTION
This patch is related to #1638.

It changes the meaning of the new tcp buffer options from a scale factor to the actual byte size, with the previous defined default of 8192 bytes. Since the new options are just introduced in master branch, changing the behaviour does not harm.

Also, a new test case for the setsockopt calls is introduced.
