### PR TITLE
Problem: when STREAM socket HWM is reached an assert will happen as metadata is trying to set twice

### DIFF
--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -869,7 +869,7 @@ int zmq::stream_engine_t::push_msg_to_session (msg_t *msg_)
 }
 
 int zmq::stream_engine_t::push_raw_msg_to_session (msg_t *msg_) {
-    if (metadata)
+    if (metadata && metadata != msg_->metadata())
         msg_->set_metadata(metadata);
     return push_msg_to_session(msg_);
 }


### PR DESCRIPTION
solution: check if the metadata already set.