### PR TITLE
Fix pipe activation race

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -460,14 +460,9 @@ int zmq::pipe_t::compute_lwm (int hwm_)
     //     result in low performance.
     //
     //  Given the 3. it would be good to keep HWM and LWM as far apart as
-    //  possible to reduce the thread switching overhead to almost zero,
-    //  say HWM-LWM should be max_wm_delta.
-    //
-    //  That done, we still we have to account for the cases where
-    //  HWM < max_wm_delta thus driving LWM to negative numbers.
-    //  Let's make LWM 1/2 of HWM in such cases.
-    int result = (hwm_ > max_wm_delta * 2) ?
-        hwm_ - max_wm_delta : (hwm_ + 1) / 2;
+    //  possible to reduce the thread switching overhead to almost zero.
+    //  Let's make LWM 1/2 of HWM.
+    int result = (hwm_ + 1) / 2;
 
     return result;
 }


### PR DESCRIPTION
Using ZeroMQ in a system with throughput of several million messages per second I was observing occasional drops of small number of messages, even when HWM is set to a value sufficient to accommodate all possible bursts in the flow.

The problem seems be caused by a race between process_activate_write() and check_hwm() on peers_msgs_read variable in zmq::pipe_t.

This PR adds isolated test and fixes the problem by increasing difference between LWM and HWM from fixed 1024 messages to 1/2 of HWM.