### PR TITLE
Solution: print test-suite.log if "make check" fails

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -21,7 +21,13 @@ if [ $BUILD_TYPE == "default" ]; then
     ( cd libsodium; ./autogen.sh; ./configure --prefix=$BUILD_PREFIX; make check; make install)
 
     #   Build and check this project
-    (./autogen.sh && ./configure "${CONFIG_OPTS[@]}" --with-libsodium=yes && make && make check && make install) || exit 1
+    (
+        ./autogen.sh &&
+        ./configure "${CONFIG_OPTS[@]}" --with-libsodium=yes &&
+        make &&
+        ( if make check; then true; else cat test-suite.log; exit 1; fi ) &&
+        make install
+    ) || exit 1
 else
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi


### PR DESCRIPTION
Problem: test-suite.log is not accessible on failing CI build

Currently, a test fails on Travis-CI but that can not be reproduced locally.
Without the contents of the test-suite.log, this is difficult to analyze.

Solution: print test-suite.log if "make check" fails

This is based on the following answer on SO:
http://stackoverflow.com/a/32597140