### PR TITLE
Add missing header for the if_nametoindex on Windows.

### DIFF
--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -50,10 +50,11 @@
 #define _WIN32_WINNT 0x0501
 #endif
 #endif
- 
+
 #include <winsock2.h>
 #include <windows.h>
 #include <mswsock.h>
+#include <iphlpapi.h>
 
 #if !defined __MINGW32__
 #include <Mstcpip.h>


### PR DESCRIPTION
This change should be backported to `#include <iphlpapi.h>` along with raising min version to Windows Vista.