### PR TITLE
Problem: build scripts don't need full git history

### DIFF
--- a/builds/android/Dockerfile
+++ b/builds/android/Dockerfile
@@ -18,5 +18,5 @@ ENV TOOLCHAIN_HOST arm-linux-androideabi
 ENV TOOLCHAIN_PATH ${ANDROID_NDK_ROOT}/toolchains/${TOOLCHAIN_NAME}/prebuilt/linux-x86_64/bin
 ENV TOOLCHAIN_ARCH arm
 # build libzmq for android
-RUN cd ~ && git clone https://github.com/zeromq/libzmq.git
+RUN cd ~ && git clone --depth 1 https://github.com/zeromq/libzmq.git
 RUN cd ~/libzmq/builds/android && ./build.sh

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -30,7 +30,7 @@ fi
 
 (android_build_verify_so "libsodium.so" &> /dev/null) || {
     rm -rf "${cache}/libsodium"
-    (cd "${cache}" && git clone git://github.com/jedisct1/libsodium.git) || exit 1
+    (cd "${cache}" && git clone --depth 1 git://github.com/jedisct1/libsodium.git) || exit 1
     (cd "${cache}/libsodium" && ./autogen.sh \
         && ./configure "${ANDROID_BUILD_OPTS[@]}" --disable-soname-versions \
         && make \

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -17,7 +17,7 @@ if [ $BUILD_TYPE == "default" ]; then
     #   Build required projects first
 
     #   libsodium
-    git clone git://github.com/jedisct1/libsodium.git
+    git clone --depth 1 git://github.com/jedisct1/libsodium.git
     ( cd libsodium; ./autogen.sh; ./configure --prefix=$BUILD_PREFIX; make check; make install)
 
     #   Build and check this project


### PR DESCRIPTION
Solution: add `--depth 1` parameter to `git clone` commands