### PR TITLE
Problem: MSVC projects don't include timers.cpp/hpp

### DIFF
--- a/builds/msvc/vs2008/libzmq/libzmq.vcproj
+++ b/builds/msvc/vs2008/libzmq/libzmq.vcproj
@@ -160,6 +160,7 @@
       <File RelativePath="..\..\..\..\src\tcp_connecter.cpp" />
       <File RelativePath="..\..\..\..\src\tcp_listener.cpp" />
       <File RelativePath="..\..\..\..\src\thread.cpp" />
+      <File RelativePath="..\..\..\..\src\timers.cpp" />
       <File RelativePath="..\..\..\..\src\trie.cpp" />
       <File RelativePath="..\..\..\..\src\v1_decoder.cpp" />
       <File RelativePath="..\..\..\..\src\v1_encoder.cpp" />
@@ -243,6 +244,7 @@
       <File RelativePath="..\..\..\..\src\tcp_connecter.hpp" />
       <File RelativePath="..\..\..\..\src\tcp_listener.hpp" />
       <File RelativePath="..\..\..\..\src\thread.hpp" />
+      <File RelativePath="..\..\..\..\src\timers.hpp" />
       <File RelativePath="..\..\..\..\src\trie.hpp" />
       <File RelativePath="..\..\..\..\src\v1_decoder.hpp" />
       <File RelativePath="..\..\..\..\src\v1_encoder.hpp" />

--- a/builds/msvc/vs2010/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2010/libzmq/libzmq.vcxproj
@@ -147,6 +147,7 @@
     <ClInclude Include="..\..\..\..\src\tcp_connecter.hpp" />
     <ClInclude Include="..\..\..\..\src\tcp_listener.hpp" />
     <ClInclude Include="..\..\..\..\src\thread.hpp" />
+    <ClInclude Include="..\..\..\..\src\timer.hpp" />
     <ClInclude Include="..\..\..\..\src\trie.hpp" />
     <ClInclude Include="..\..\..\..\src\v1_decoder.hpp" />
     <ClInclude Include="..\..\..\..\src\v1_encoder.hpp" />
@@ -233,6 +234,7 @@
     <ClCompile Include="..\..\..\..\src\tcp_connecter.cpp" />
     <ClCompile Include="..\..\..\..\src\tcp_listener.cpp" />
     <ClCompile Include="..\..\..\..\src\thread.cpp" />
+    <ClInclude Include="..\..\..\..\src\timer.cpp" />
     <ClCompile Include="..\..\..\..\src\trie.cpp" />
     <ClCompile Include="..\..\..\..\src\v1_decoder.cpp" />
     <ClCompile Include="..\..\..\..\src\v1_encoder.cpp" />

--- a/builds/msvc/vs2012/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2012/libzmq/libzmq.vcxproj
@@ -147,6 +147,7 @@
     <ClInclude Include="..\..\..\..\src\tcp_connecter.hpp" />
     <ClInclude Include="..\..\..\..\src\tcp_listener.hpp" />
     <ClInclude Include="..\..\..\..\src\thread.hpp" />
+    <ClInclude Include="..\..\..\..\src\timer.hpp" />
     <ClInclude Include="..\..\..\..\src\trie.hpp" />
     <ClInclude Include="..\..\..\..\src\v1_decoder.hpp" />
     <ClInclude Include="..\..\..\..\src\v1_encoder.hpp" />
@@ -233,6 +234,7 @@
     <ClCompile Include="..\..\..\..\src\tcp_connecter.cpp" />
     <ClCompile Include="..\..\..\..\src\tcp_listener.cpp" />
     <ClCompile Include="..\..\..\..\src\thread.cpp" />
+    <ClInclude Include="..\..\..\..\src\timer.cpp" />
     <ClCompile Include="..\..\..\..\src\trie.cpp" />
     <ClCompile Include="..\..\..\..\src\v1_decoder.cpp" />
     <ClCompile Include="..\..\..\..\src\v1_encoder.cpp" />

--- a/builds/msvc/vs2013/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2013/libzmq/libzmq.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="..\..\..\..\src\tcp_address.hpp" />
     <ClInclude Include="..\..\..\..\src\tcp_connecter.hpp" />
     <ClInclude Include="..\..\..\..\src\tcp_listener.hpp" />
+    <ClInclude Include="..\..\..\..\src\timer.hpp" />
     <ClInclude Include="..\..\..\..\src\thread.hpp" />
     <ClInclude Include="..\..\..\..\src\trie.hpp" />
     <ClInclude Include="..\..\..\..\src\v1_decoder.hpp" />
@@ -233,6 +234,7 @@
     <ClCompile Include="..\..\..\..\src\tcp_connecter.cpp" />
     <ClCompile Include="..\..\..\..\src\tcp_listener.cpp" />
     <ClCompile Include="..\..\..\..\src\thread.cpp" />
+    <ClInclude Include="..\..\..\..\src\timer.cpp" />
     <ClCompile Include="..\..\..\..\src\trie.cpp" />
     <ClCompile Include="..\..\..\..\src\v1_decoder.cpp" />
     <ClCompile Include="..\..\..\..\src\v1_encoder.cpp" />

--- a/builds/msvc/vs2015/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2015/libzmq/libzmq.vcxproj
@@ -147,6 +147,7 @@
     <ClInclude Include="..\..\..\..\src\tcp_connecter.hpp" />
     <ClInclude Include="..\..\..\..\src\tcp_listener.hpp" />
     <ClInclude Include="..\..\..\..\src\thread.hpp" />
+    <ClInclude Include="..\..\..\..\src\timer.hpp" />
     <ClInclude Include="..\..\..\..\src\trie.hpp" />
     <ClInclude Include="..\..\..\..\src\v1_decoder.hpp" />
     <ClInclude Include="..\..\..\..\src\v1_encoder.hpp" />
@@ -233,6 +234,7 @@
     <ClCompile Include="..\..\..\..\src\tcp_connecter.cpp" />
     <ClCompile Include="..\..\..\..\src\tcp_listener.cpp" />
     <ClCompile Include="..\..\..\..\src\thread.cpp" />
+    <ClInclude Include="..\..\..\..\src\timer.cpp" />
     <ClCompile Include="..\..\..\..\src\trie.cpp" />
     <ClCompile Include="..\..\..\..\src\v1_decoder.cpp" />
     <ClCompile Include="..\..\..\..\src\v1_encoder.cpp" />

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1180,7 +1180,7 @@ int zmq_poller_wait (void *poller_, zmq_poller_event_t *event, long timeout_)
 
 //  Timers
 
-void *zmq_timers_new ()
+void *zmq_timers_new (void)
 {
     zmq::timers_t *timers = new (std::nothrow) zmq::timers_t;
     alloc_assert (timers);


### PR DESCRIPTION
Causes link errors during build.

Solution: add these.