### PR TITLE
Fixed issue #1690 (ZMQ_REQ_RELAXED)

### DIFF
--- a/src/req.cpp
+++ b/src/req.cpp
@@ -60,8 +60,6 @@ int zmq::req_t::xsend (msg_t *msg_)
             return -1;
         }
 
-        if (reply_pipe)
-            reply_pipe->terminate (false);
         receiving_reply = false;
         message_begins = true;
     }


### PR DESCRIPTION
When using ZMQ_REQ_RELAXED and a 'send' is executed after another 'send' the
previous code would terminate the 'reply_pipe' if any.
This is incorrect as terminating the reply pipe also terminates the send pipe
as they are the same (a pipe associated with a socket is bidirectional).
Doing a terminate on the pipe sets an internal flag called out_active to false
and the pipe can no longer send messages.
Removing the 'terminate' solves the problem. Removing this call is not an issue
as the incorrect ordering of messages that could be incurred is taken care of
by the ZMQ_REQ_CORRELATE option if needed.