### PR TITLE
restore check for MSC 1600 before including stdint.h

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -84,6 +84,16 @@ extern "C" {
 #define ZMQ_DEFINED_STDINT 1
 #if defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_OPENVMS
 #   include <inttypes.h>
+#elif defined _MSC_VER && _MSC_VER < 1600
+#   ifndef int32_t
+        typedef __int32 int32_t;
+#   endif
+#   ifndef uint16_t
+        typedef unsigned __int16 uint16_t;
+#   endif
+#   ifndef uint8_t
+        typedef unsigned __int8 uint8_t;
+#   endif
 #else
 #   include <stdint.h>
 #endif


### PR DESCRIPTION
MSC < 1600, which is used by Python 2.7, doesn't have stdint.h.

This same check is in stdint.hpp