### PR TITLE
Problem: client over inproc receives the msg with routing id set

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -512,6 +512,12 @@ int zmq::msg_t::set_routing_id (uint32_t routing_id_)
     return -1;
 }
 
+int zmq::msg_t::reset_routing_id ()
+{
+    u.base.routing_id = 0;
+    return 0;
+}
+
 zmq::atomic_counter_t *zmq::msg_t::refcnt()
 {
     switch(u.base.type)

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -99,6 +99,7 @@ namespace zmq
         bool is_zcmsg() const;
         uint32_t get_routing_id ();
         int set_routing_id (uint32_t routing_id_);
+        int reset_routing_id ();
 
         //  After calling this function you can copy the message in POD-style
         //  refs_ times. No need to call copy.

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -113,6 +113,11 @@ int zmq::server_t::xsend (msg_t *msg_)
         errno = EHOSTUNREACH;
         return -1;
     }
+
+    //  Message might be delivired over inproc, so we reset routing id
+    int rc = msg_->reset_routing_id ();
+    errno_assert (rc == 0);
+
     bool ok = it->second.pipe->write (msg_);
     if (unlikely (!ok)) {
         // Message failed to send - we must close it ourselves.
@@ -123,7 +128,7 @@ int zmq::server_t::xsend (msg_t *msg_)
         it->second.pipe->flush ();
 
     //  Detach the message from the data buffer.
-    int rc = msg_->init ();
+    rc = msg_->init ();
     errno_assert (rc == 0);
 
     return 0;

--- a/tests/test_client_server.cpp
+++ b/tests/test_client_server.cpp
@@ -38,10 +38,10 @@ int main (void)
     void *server = zmq_socket (ctx, ZMQ_SERVER);
     void *client = zmq_socket (ctx, ZMQ_CLIENT);
 
-    int rc = zmq_bind (server, "tcp://127.0.0.1:5560");
+    int rc = zmq_bind (server, "inproc://test-client-server");
     assert (rc == 0);
 
-    rc = zmq_connect (client, "tcp://127.0.0.1:5560");
+    rc = zmq_connect (client, "inproc://test-client-server");
     assert (rc == 0);
 
     zmq_msg_t msg;
@@ -87,6 +87,9 @@ int main (void)
     rc = zmq_msg_recv (&msg, client, 0);
     assert (rc == 1);
 
+    routing_id = zmq_msg_routing_id (&msg);
+    assert (routing_id == 0);
+
     rc = zmq_msg_close (&msg);
     assert (rc == 0);
 
@@ -101,5 +104,3 @@ int main (void)
 
     return 0 ;
 }
-
-


### PR DESCRIPTION
routing id has no meaning on client socket and should be zero.

solution: server should reset routing id before writing the message to a pipe