### PR TITLE
Problem: build fails due to undefined INT_MAX

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -63,6 +63,7 @@ struct iovec {
 #include <string.h>
 #include <stdlib.h>
 #include <new>
+#include <climits>
 
 #include "proxy.hpp"
 #include "socket_base.hpp"

--- a/tests/test_large_msg.cpp
+++ b/tests/test_large_msg.cpp
@@ -28,6 +28,7 @@
 */
 
 #include <limits.h>
+#include <stdint.h>
 #include "testutil.hpp"
 
 int main (void)

--- a/tests/test_large_msg.cpp
+++ b/tests/test_large_msg.cpp
@@ -28,7 +28,6 @@
 */
 
 #include <limits.h>
-#include <stdint.h>
 #include "testutil.hpp"
 
 int main (void)
@@ -49,7 +48,6 @@ int main (void)
     
     zmq_msg_t msg, rcv;
     size_t big = 64 + (size_t) INT_MAX;
-    printf("Large msg: %u %llu %lu\n", INT_MAX, SIZE_MAX, big);
     
     rc = zmq_msg_init_size (&msg, big);
     assert (rc == 0);


### PR DESCRIPTION
Solution: include climits

Fixes #1720