### PR TITLE
problem: radio-dish is still hacky

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -239,6 +239,8 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int property, int optval);
 ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 ZMQ_EXPORT int zmq_msg_set_routing_id (zmq_msg_t *msg, uint32_t routing_id);
 ZMQ_EXPORT uint32_t zmq_msg_routing_id (zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_set_group (zmq_msg_t *msg, const char *group);
+ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 
 
 /******************************************************************************/
@@ -359,7 +361,7 @@ ZMQ_EXPORT uint32_t zmq_msg_routing_id (zmq_msg_t *msg);
 #define ZMQ_GSSAPI 3
 
 /*  RADIO-DISH protocol                                                       */
-#define ZMQ_GROUP_MAX_LENGTH        255
+#define ZMQ_GROUP_MAX_LENGTH        15
 
 /*  Deprecated options and aliases                                            */
 #define ZMQ_TCP_ACCEPT_FILTER       38

--- a/src/decoder_allocators.cpp
+++ b/src/decoder_allocators.cpp
@@ -37,7 +37,7 @@ zmq::shared_message_memory_allocator::shared_message_memory_allocator (std::size
     buf(NULL),
     bufsize(0),
     max_size(bufsize_),
-    msg_refcnt(NULL),
+    msg_content(NULL),
     maxCounters (static_cast <size_t> (std::ceil (static_cast <double> (max_size) / static_cast <double> (msg_t::max_vsm_size))))
 {
 }
@@ -46,7 +46,7 @@ zmq::shared_message_memory_allocator::shared_message_memory_allocator (std::size
     buf(NULL),
     bufsize(0),
     max_size(bufsize_),
-    msg_refcnt(NULL),
+    msg_content(NULL),
     maxCounters(maxMessages)
 {
 }
@@ -77,7 +77,7 @@ unsigned char* zmq::shared_message_memory_allocator::allocate ()
         // allocate memory for reference counters together with reception buffer
         std::size_t const allocationsize =
               max_size + sizeof (zmq::atomic_counter_t) +
-              maxCounters * sizeof (zmq::atomic_counter_t);
+              maxCounters * sizeof (zmq::msg_t::content_t);
 
         buf = static_cast <unsigned char *> (std::malloc (allocationsize));
         alloc_assert (buf);
@@ -90,7 +90,7 @@ unsigned char* zmq::shared_message_memory_allocator::allocate ()
     }
 
     bufsize = max_size;
-    msg_refcnt = reinterpret_cast <zmq::atomic_counter_t*> (buf + sizeof (atomic_counter_t) + max_size);
+    msg_content = reinterpret_cast <zmq::msg_t::content_t*> (buf + sizeof (atomic_counter_t) + max_size);
     return buf + sizeof (zmq::atomic_counter_t);
 }
 
@@ -108,7 +108,7 @@ unsigned char* zmq::shared_message_memory_allocator::release ()
     unsigned char* b = buf;
     buf = NULL;
     bufsize = 0;
-    msg_refcnt = NULL;
+    msg_content = NULL;
 
     return b;
 }

--- a/src/decoder_allocators.hpp
+++ b/src/decoder_allocators.hpp
@@ -34,6 +34,7 @@
 #include <cstdlib>
 
 #include "atomic_counter.hpp"
+#include "msg.hpp"
 #include "err.hpp"
 
 namespace zmq
@@ -132,21 +133,21 @@ namespace zmq
             bufsize = new_size;
         }
 
-        zmq::atomic_counter_t* provide_refcnt ()
+        zmq::msg_t::content_t* provide_content ()
         {
-            return msg_refcnt;
+            return msg_content;
         }
 
-        void advance_refcnt ()
+        void advance_content ()
         {
-            msg_refcnt++;
+            msg_content++;
         }
 
     private:
         unsigned char* buf;
         std::size_t bufsize;
         std::size_t max_size;
-        zmq::atomic_counter_t* msg_refcnt;
+        zmq::msg_t::content_t* msg_content;
         std::size_t maxCounters;
     };
 }

--- a/src/dish.cpp
+++ b/src/dish.cpp
@@ -90,13 +90,15 @@ void zmq::dish_t::xhiccuped (pipe_t *pipe_)
 
 int zmq::dish_t::xjoin (const char* group_)
 {
-    if (strlen (group_) > ZMQ_GROUP_MAX_LENGTH) {
+    std::string group = std::string (group_);
+
+    if (group.length () > ZMQ_GROUP_MAX_LENGTH) {
         errno = EINVAL;
         return -1;
     }
 
     subscriptions_t::iterator it =
-        std::find (subscriptions.begin (), subscriptions.end (), std::string(group_));
+        std::find (subscriptions.begin (), subscriptions.end (), group);
 
     //  User cannot join same group twice
     if (it != subscriptions.end ()) {
@@ -104,16 +106,14 @@ int zmq::dish_t::xjoin (const char* group_)
         return -1;
     }
 
-    subscriptions.push_back (std::string (group_));
+    subscriptions.push_back (group);
 
-    size_t len = strlen (group_);
     msg_t msg;
-    int rc = msg.init_size (len + 1);
+    int rc = msg.init_join ();
     errno_assert (rc == 0);
 
-    char *data = (char*) msg.data ();
-    data[0] = 'J';
-    memcpy (data + 1, group_, len);
+    rc = msg.set_group (group_);
+    errno_assert (rc == 0);
 
     int err = 0;
     rc = dist.send_to_all (&msg);
@@ -128,12 +128,14 @@ int zmq::dish_t::xjoin (const char* group_)
 
 int zmq::dish_t::xleave (const char* group_)
 {
-    if (strlen (group_) > ZMQ_GROUP_MAX_LENGTH) {
+    std::string group = std::string (group_);
+
+    if (group.length () > ZMQ_GROUP_MAX_LENGTH) {
         errno = EINVAL;
         return -1;
     }
 
-    subscriptions_t::iterator it =  std::find (subscriptions.begin (), subscriptions.end (), std::string (group_));
+    subscriptions_t::iterator it =  std::find (subscriptions.begin (), subscriptions.end (), group);
 
     if (it == subscriptions.end ()) {
         errno = EINVAL;
@@ -142,14 +144,12 @@ int zmq::dish_t::xleave (const char* group_)
 
     subscriptions.erase (it);
 
-    size_t len = strlen (group_);
     msg_t msg;
-    int rc = msg.init_size (len + 1);
+    int rc = msg.init_leave ();
     errno_assert (rc == 0);
 
-    char *data = (char*) msg.data ();
-    data[0] = 'L';
-    memcpy (data + 1, group_, len);
+    rc = msg.set_group (group_);
+    errno_assert (rc == 0);
 
     int err = 0;
     rc = dist.send_to_all (&msg);
@@ -226,21 +226,15 @@ void zmq::dish_t::send_subscriptions (pipe_t *pipe_)
 {
     for (subscriptions_t::iterator it = subscriptions.begin (); it != subscriptions.end (); ++it) {
         msg_t msg;
-        int rc = msg.init_size (it->length () + 1);
+        int rc = msg.init_join ();
         errno_assert (rc == 0);
-        char *data = (char*) msg.data ();
-        data [0] = 'J';
-        it->copy (data + 1, it->length ());
+
+        rc = msg.set_group (it->c_str());
+        errno_assert (rc == 0);
 
         //  Send it to the pipe.
-        bool sent = pipe_->write (&msg);
-
-        //  If we reached the SNDHWM, and thus cannot send the subscription, drop
-        //  the subscription message instead. This matches the behaviour of
-        //  zmq_setsockopt(ZMQ_SUBSCRIBE, ...), which also drops subscriptions
-        //  when the SNDHWM is reached.
-        if (!sent)
-            msg.close ();
+        pipe_->write (&msg);
+        msg.close ();
     }
 
     pipe_->flush ();
@@ -300,6 +294,48 @@ int zmq::dish_session_t::push_msg (msg_t *msg_)
             state = group;
 
         return rc;
+    }
+}
+
+int zmq::dish_session_t::pull_msg (msg_t *msg_)
+{
+    int rc = session_base_t::pull_msg (msg_);
+
+    if (rc != 0)
+        return rc;
+
+    if (!msg_->is_join () && !msg_->is_leave ())
+        return rc;
+    else {
+        int group_length = strlen (msg_->group ());
+
+        msg_t command;
+        int offset;
+
+        if (msg_->is_join ()) {
+            command.init_size (group_length + 5);
+            offset = 5;
+            memcpy (command.data (), "\4JOIN", 5);
+        }
+        else {
+            command.init_size (group_length + 6);
+            offset = 6;
+            memcpy (command.data (), "\5LEAVE", 6);
+        }
+
+        command.set_flags (msg_t::command);
+        char* command_data = (char*)command.data ();
+
+        //  Copy the group
+        memcpy (command_data + offset, msg_->group (), group_length);
+
+        //  Close the join message
+        int rc = msg_->close ();
+        errno_assert (rc == 0);
+
+        *msg_ = command;
+
+        return 0;
     }
 }
 

--- a/src/dish.hpp
+++ b/src/dish.hpp
@@ -81,7 +81,7 @@ namespace zmq
         dist_t dist;
 
         //  The repository of subscriptions.
-        typedef std::vector<std::string> subscriptions_t;
+        typedef std::set<std::string> subscriptions_t;
         subscriptions_t subscriptions;
 
         //  If true, 'message' contains a matching message to return on the

--- a/src/dish.hpp
+++ b/src/dish.hpp
@@ -71,7 +71,7 @@ namespace zmq
         int xleave (const char *group_);
     private:
 
-        //  Send subscriptions to a pipe        
+        //  Send subscriptions to a pipe
         void send_subscriptions (pipe_t *pipe_);
 
         //  Fair queueing object for inbound pipes.
@@ -91,6 +91,32 @@ namespace zmq
 
         dish_t (const dish_t&);
         const dish_t &operator = (const dish_t&);
+    };
+
+    class dish_session_t : public session_base_t
+    {
+    public:
+
+        dish_session_t (zmq::io_thread_t *io_thread_, bool connect_,
+            zmq::socket_base_t *socket_, const options_t &options_,
+            address_t *addr_);
+        ~dish_session_t ();
+
+        //  Overrides of the functions from session_base_t.
+        int push_msg (msg_t *msg_);
+        void reset ();
+
+    private:
+
+        enum {
+            group,
+            body
+        } state;
+
+        msg_t group_msg;
+
+        dish_session_t (const dish_session_t&);
+        const dish_session_t &operator = (const dish_session_t&);
     };
 
 }

--- a/src/dish.hpp
+++ b/src/dish.hpp
@@ -104,6 +104,7 @@ namespace zmq
 
         //  Overrides of the functions from session_base_t.
         int push_msg (msg_t *msg_);
+        int pull_msg (msg_t *msg_);
         void reset ();
 
     private:

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -533,13 +533,19 @@ const char * zmq::msg_t::group ()
 
 int zmq::msg_t::set_group (const char * group_)
 {
-    if (strlen (group_) > ZMQ_GROUP_MAX_LENGTH)
+    return set_group (group_, strlen (group_));
+}
+
+int zmq::msg_t::set_group (const char * group_, size_t length_)
+{
+    if (length_> ZMQ_GROUP_MAX_LENGTH)
     {
         errno = EINVAL;
         return -1;
     }
 
-    strcpy (u.base.group, group_);
+    strncpy (u.base.group, group_, length_);
+    u.base.group[length_] = '\0';
 
     return 0;
 }

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -200,6 +200,28 @@ int zmq::msg_t::init_delimiter ()
     return 0;
 }
 
+int zmq::msg_t::init_join ()
+{
+    u.base.metadata = NULL;
+    u.base.type = type_join;
+    u.base.flags = 0;
+    u.base.group[0] = '\0';
+    u.base.routing_id = 0;
+    u.base.fd = retired_fd;
+    return 0;
+}
+
+int zmq::msg_t::init_leave ()
+{
+    u.base.metadata = NULL;
+    u.base.type = type_leave;
+    u.base.flags = 0;
+    u.base.group[0] = '\0';
+    u.base.routing_id = 0;
+    u.base.fd = retired_fd;
+    return 0;
+}
+
 int zmq::msg_t::close ()
 {
     //  Check the validity of the message.
@@ -438,6 +460,16 @@ bool zmq::msg_t::is_cmsg () const
 bool zmq::msg_t::is_zcmsg() const
 {
     return u.base.type == type_zclmsg;
+}
+
+bool zmq::msg_t::is_join() const
+{
+    return u.base.type == type_join;
+}
+
+bool zmq::msg_t::is_leave() const
+{
+    return u.base.type == type_leave;
 }
 
 void zmq::msg_t::add_refs (int refs_)

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -84,6 +84,7 @@ int zmq::msg_t::init ()
     u.vsm.type = type_vsm;
     u.vsm.flags = 0;
     u.vsm.size = 0;
+    u.vsm.group[0] = '\0';
     u.vsm.routing_id = 0;
     u.vsm.fd = retired_fd;
     return 0;
@@ -96,6 +97,7 @@ int zmq::msg_t::init_size (size_t size_)
         u.vsm.type = type_vsm;
         u.vsm.flags = 0;
         u.vsm.size = (unsigned char) size_;
+        u.vsm.group[0] = '\0';
         u.vsm.routing_id = 0;
         u.vsm.fd = retired_fd;
     }
@@ -103,6 +105,7 @@ int zmq::msg_t::init_size (size_t size_)
         u.lmsg.metadata = NULL;
         u.lmsg.type = type_lmsg;
         u.lmsg.flags = 0;
+        u.lmsg.group[0] = '\0';
         u.lmsg.routing_id = 0;
         u.lmsg.fd = retired_fd;
         u.lmsg.content = NULL;
@@ -131,6 +134,7 @@ int zmq::msg_t::init_external_storage(content_t* content_, void* data_, size_t s
     u.zclmsg.metadata = NULL;
     u.zclmsg.type = type_zclmsg;
     u.zclmsg.flags = 0;
+    u.zclmsg.group[0] = '\0';
     u.zclmsg.routing_id = 0;
     u.zclmsg.fd = retired_fd;
 
@@ -158,6 +162,7 @@ int zmq::msg_t::init_data (void *data_, size_t size_,
         u.cmsg.flags = 0;
         u.cmsg.data = data_;
         u.cmsg.size = size_;
+        u.cmsg.group[0] = '\0';
         u.cmsg.routing_id = 0;
         u.cmsg.fd = retired_fd;
     }
@@ -165,6 +170,7 @@ int zmq::msg_t::init_data (void *data_, size_t size_,
         u.lmsg.metadata = NULL;
         u.lmsg.type = type_lmsg;
         u.lmsg.flags = 0;
+        u.lmsg.group[0] = '\0';
         u.lmsg.routing_id = 0;
         u.lmsg.fd = retired_fd;
         u.lmsg.content = (content_t*) malloc (sizeof (content_t));
@@ -188,6 +194,7 @@ int zmq::msg_t::init_delimiter ()
     u.delimiter.metadata = NULL;
     u.delimiter.type = type_delimiter;
     u.delimiter.flags = 0;
+    u.delimiter.group[0] = '\0';
     u.delimiter.routing_id = 0;
     u.delimiter.fd = retired_fd;
     return 0;
@@ -516,6 +523,24 @@ int zmq::msg_t::set_routing_id (uint32_t routing_id_)
 int zmq::msg_t::reset_routing_id ()
 {
     u.base.routing_id = 0;
+    return 0;
+}
+
+const char * zmq::msg_t::group ()
+{
+    return u.base.group;
+}
+
+int zmq::msg_t::set_group (const char * group_)
+{
+    if (strlen (group_) > ZMQ_GROUP_MAX_LENGTH)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    strcpy (u.base.group, group_);
+
     return 0;
 }
 

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -95,6 +95,8 @@ namespace zmq
         int init_external_storage(content_t* content_, void *data_, size_t size_,
                                   msg_free_fn *ffn_, void *hint_);
         int init_delimiter ();
+        int init_join ();
+        int init_leave ();
         int close ();
         int move (msg_t &src_);
         int copy (msg_t &src_);
@@ -111,6 +113,8 @@ namespace zmq
         bool is_identity () const;
         bool is_credential () const;
         bool is_delimiter () const;
+        bool is_join () const;
+        bool is_leave () const;
         bool is_vsm () const;
         bool is_cmsg () const;
         bool is_zcmsg() const;
@@ -137,7 +141,6 @@ namespace zmq
                                             16 +
                                             sizeof (uint32_t) +
                                             sizeof (fd_t))};
-
     private:
         zmq::atomic_counter_t* refcnt();
 
@@ -157,7 +160,13 @@ namespace zmq
             // zero-copy LMSG message for v2_decoder
             type_zclmsg = 105,
 
-            type_max = 105
+            //  Join message for radio_dish
+            type_join = 106,
+
+            //  Leave message for radio_dish
+            type_leave = 107,
+
+            type_max = 107
         };
 
         //  Note that fields shared between different message types are not

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -117,6 +117,8 @@ namespace zmq
         uint32_t get_routing_id ();
         int set_routing_id (uint32_t routing_id_);
         int reset_routing_id ();
+        const char * group ();
+        int set_group (const char* group_);
 
         //  After calling this function you can copy the message in POD-style
         //  refs_ times. No need to call copy.
@@ -131,8 +133,9 @@ namespace zmq
         enum { msg_t_size = 64 };
         enum { max_vsm_size = msg_t_size - (sizeof (metadata_t *) +
                                             3 +
+                                            16 +
                                             sizeof (uint32_t) +
-                                            sizeof (fd_t)) };
+                                            sizeof (fd_t))};
 
     private:
         zmq::atomic_counter_t* refcnt();
@@ -165,10 +168,12 @@ namespace zmq
                 metadata_t *metadata;
                 unsigned char unused [msg_t_size - (sizeof (metadata_t *) +
                                                     2 +
+                                                    16 +
                                                     sizeof (uint32_t) +
                                                     sizeof (fd_t))];
                 unsigned char type;
                 unsigned char flags;
+                char group [16];
                 uint32_t routing_id;
                 fd_t fd;
             } base;
@@ -178,6 +183,7 @@ namespace zmq
                 unsigned char size;
                 unsigned char type;
                 unsigned char flags;
+                char group [16];
                 uint32_t routing_id;
                 fd_t fd;
             } vsm;
@@ -187,10 +193,12 @@ namespace zmq
                 unsigned char unused [msg_t_size - (sizeof (metadata_t *) +
                                                     sizeof (content_t*) +
                                                     2 +
+                                                    16 +
                                                     sizeof (uint32_t) +
                                                     sizeof (fd_t))];
                 unsigned char type;
                 unsigned char flags;
+                char group [16];
                 uint32_t routing_id;
                 fd_t fd;
             } lmsg;
@@ -200,10 +208,12 @@ namespace zmq
                 unsigned char unused [msg_t_size - (sizeof (metadata_t *) +
                                                     sizeof (content_t*) +
                                                     2 +
+                                                    16 +
                                                     sizeof (uint32_t) +
                                                     sizeof (fd_t))];
                 unsigned char type;
                 unsigned char flags;
+                char group [16];
                 uint32_t routing_id;
                 fd_t fd;
             } zclmsg;
@@ -215,10 +225,12 @@ namespace zmq
                                                     sizeof (void*) +
                                                     sizeof (size_t) +
                                                     2 +
+                                                    16 +
                                                     sizeof (uint32_t) +
                                                     sizeof (fd_t))];
                 unsigned char type;
                 unsigned char flags;
+                char group [16];
                 uint32_t routing_id;
                 fd_t fd;
             } cmsg;
@@ -226,10 +238,12 @@ namespace zmq
                 metadata_t *metadata;
                 unsigned char unused [msg_t_size - (sizeof (metadata_t *) +
                                                     2 +
+                                                    16 +
                                                     sizeof (uint32_t) +
                                                     sizeof (fd_t))];
                 unsigned char type;
                 unsigned char flags;
+                char group [16];
                 uint32_t routing_id;
                 fd_t fd;
             } delimiter;

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -119,6 +119,7 @@ namespace zmq
         int reset_routing_id ();
         const char * group ();
         int set_group (const char* group_);
+        int set_group (const char*, size_t length);
 
         //  After calling this function you can copy the message in POD-style
         //  refs_ times. No need to call copy.

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -65,15 +65,13 @@ void zmq::radio_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
 void zmq::radio_t::xread_activated (pipe_t *pipe_)
 {
     //  There are some subscriptions waiting. Let's process them.
-    msg_t sub;
-    while (pipe_->read (&sub)) {
+    msg_t msg;
+    while (pipe_->read (&msg)) {
         //  Apply the subscription to the trie
-        const char * data = (char *) sub.data ();
-        const size_t size = sub.size ();
-        if (size > 0 && (*data == 'J' || *data == 'L')) {
-            std::string group = std::string (data + 1, sub. size() - 1);
+        if (msg.is_join () || msg.is_leave ()) {
+            std::string group = std::string (msg.group ());
 
-            if (*data == 'J')
+            if (msg.is_join ())
                 subscriptions.insert (subscriptions_t::value_type (group, pipe_));
             else {
                 std::pair<subscriptions_t::iterator, subscriptions_t::iterator> range =
@@ -87,7 +85,7 @@ void zmq::radio_t::xread_activated (pipe_t *pipe_)
                 }
             }
         }
-        sub.close ();
+        msg.close ();
     }
 }
 
@@ -155,6 +153,52 @@ zmq::radio_session_t::radio_session_t (io_thread_t *io_thread_, bool connect_,
 
 zmq::radio_session_t::~radio_session_t ()
 {
+}
+
+int zmq::radio_session_t::push_msg (msg_t *msg_)
+{
+    if (msg_->flags() & msg_t::command) {
+        char *command_data =
+            static_cast <char *> (msg_->data ());
+        const size_t data_size = msg_->size ();
+
+        int group_length;
+        char * group;
+
+        msg_t join_leave_msg;
+        int rc;
+
+        //  Set the msg type to either JOIN or LEAVE
+        if (data_size >= 5 && memcmp (command_data, "\4JOIN", 5) == 0) {
+            group_length = data_size - 5;
+            group = command_data + 5;
+            rc = join_leave_msg.init_join ();
+        }
+        else if (data_size >= 6 && memcmp (command_data, "\5LEAVE", 6) == 0) {
+            group_length = data_size - 6;
+            group = command_data + 6;
+            rc = join_leave_msg.init_leave ();
+        }
+        //  If it is not a JOIN or LEAVE just push the message
+        else
+            return session_base_t::push_msg (msg_);
+
+        errno_assert (rc == 0);
+
+        //  Set the group
+        rc = join_leave_msg.set_group (group, group_length);
+        errno_assert (rc == 0);
+
+        //  Close the current command
+        rc = msg_->close ();
+        errno_assert (rc == 0);
+
+        //  Push the join or leave command
+        *msg_ = join_leave_msg;
+        return session_base_t::push_msg (msg_);
+    }
+    else
+        return session_base_t::push_msg (msg_);
 }
 
 int zmq::radio_session_t::pull_msg (msg_t *msg_)

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -115,33 +115,10 @@ int zmq::radio_t::xsend (msg_t *msg_)
         return -1;
     }
 
-    size_t size = msg_->size ();
-    char *group = (char*) msg_->data();
-
-    //  Maximum allowed group length is 255
-    if (size > ZMQ_GROUP_MAX_LENGTH)
-        size = ZMQ_GROUP_MAX_LENGTH;
-
-    //  Check if NULL terminated
-    bool terminated = false;
-
-    for (size_t index = 0; index < size; index++) {
-        if (group[index] == '\0') {
-            terminated = true;
-            break;
-        }
-    }
-
-    if (!terminated) {
-        //  User didn't include a group in the message
-        errno = EINVAL;
-        return -1;
-    }
-
     dist.unmatch ();
 
     std::pair<subscriptions_t::iterator, subscriptions_t::iterator> range =
-        subscriptions.equal_range (std::string(group));
+        subscriptions.equal_range (std::string(msg_->group ()));
 
     for (subscriptions_t::iterator it = range.first; it != range.second; ++it) {
         dist.match (it-> second);

--- a/src/radio.hpp
+++ b/src/radio.hpp
@@ -87,6 +87,7 @@ namespace zmq
         ~radio_session_t ();
 
         //  Overrides of the functions from session_base_t.
+        int push_msg (msg_t *msg_);
         int pull_msg (msg_t *msg_);
         void reset ();
     private:

--- a/src/radio.hpp
+++ b/src/radio.hpp
@@ -77,6 +77,30 @@ namespace zmq
         const radio_t &operator = (const radio_t&);
     };
 
+    class radio_session_t : public session_base_t
+    {
+    public:
+
+        radio_session_t (zmq::io_thread_t *io_thread_, bool connect_,
+            zmq::socket_base_t *socket_, const options_t &options_,
+            address_t *addr_);
+        ~radio_session_t ();
+
+        //  Overrides of the functions from session_base_t.
+        int pull_msg (msg_t *msg_);
+        void reset ();
+    private:
+
+        enum {
+            group,
+            body
+        } state;
+
+        msg_t pending_msg;
+
+        radio_session_t (const radio_session_t&);
+        const radio_session_t &operator = (const radio_session_t&);
+    };
 }
 
 #endif

--- a/src/raw_decoder.cpp
+++ b/src/raw_decoder.cpp
@@ -62,13 +62,13 @@ int zmq::raw_decoder_t::decode (const uint8_t *data_, size_t size_,
 {
     int rc = in_progress.init ((unsigned char*)data_, size_,
                                shared_message_memory_allocator::call_dec_ref,
-                               allocator.buffer(),
-                               allocator.provide_refcnt() );
+                               allocator.buffer (),
+                               allocator.provide_content ());
 
     // if the buffer serves as memory for a zero-copy message, release it
     // and allocate a new buffer in get_buffer for the next decode
-    if (in_progress.is_zcmsg()) {
-        allocator.advance_refcnt();
+    if (in_progress.is_zcmsg ()) {
+        allocator.advance_content();
         allocator.release();
     }
 

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -45,6 +45,8 @@
 
 #include "ctx.hpp"
 #include "req.hpp"
+#include "radio.hpp"
+#include "dish.hpp"
 
 zmq::session_base_t *zmq::session_base_t::create (class io_thread_t *io_thread_,
     bool active_, class socket_base_t *socket_, const options_t &options_,
@@ -56,6 +58,14 @@ zmq::session_base_t *zmq::session_base_t::create (class io_thread_t *io_thread_,
         s = new (std::nothrow) req_session_t (io_thread_, active_,
             socket_, options_, addr_);
         break;
+    case ZMQ_RADIO:
+        s = new (std::nothrow) radio_session_t (io_thread_, active_,
+            socket_, options_, addr_);
+        break;
+    case ZMQ_DISH:
+        s = new (std::nothrow) dish_session_t (io_thread_, active_,
+            socket_, options_, addr_);
+            break;
     case ZMQ_DEALER:
     case ZMQ_REP:
     case ZMQ_ROUTER:
@@ -69,8 +79,6 @@ zmq::session_base_t *zmq::session_base_t::create (class io_thread_t *io_thread_,
     case ZMQ_STREAM:
     case ZMQ_SERVER:
     case ZMQ_CLIENT:
-    case ZMQ_RADIO:
-    case ZMQ_DISH:
         s = new (std::nothrow) session_base_t (io_thread_, active_,
             socket_, options_, addr_);
         break;

--- a/src/v2_decoder.cpp
+++ b/src/v2_decoder.cpp
@@ -127,12 +127,12 @@ int zmq::v2_decoder_t::size_ready(uint64_t msg_size, unsigned char const* read_p
         // if the message will be a large message, pass a valid refcnt memory location as well
         rc = in_progress.init ((unsigned char *) read_pos, static_cast <size_t> (msg_size),
                                 shared_message_memory_allocator::call_dec_ref, buffer(),
-                                provide_refcnt ());
+                                provide_content ());
 
         // For small messages, data has been copied and refcount does not have to be increased
         if (in_progress.is_zcmsg())
         {
-            advance_refcnt();
+            advance_content();
             inc_ref();
         }
     }

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -695,6 +695,16 @@ uint32_t zmq_msg_routing_id (zmq_msg_t *msg_)
     return ((zmq::msg_t *) msg_)->get_routing_id ();
 }
 
+int zmq_msg_set_group (zmq_msg_t *msg_, const char *group_)
+{
+    return ((zmq::msg_t *) msg_)->set_group (group_);
+}
+
+const char *zmq_msg_group (zmq_msg_t *msg_)
+{
+    return ((zmq::msg_t *) msg_)->group ();
+}
+
 //  Get message metadata string
 
 const char *zmq_msg_gets (zmq_msg_t *msg_, const char *property_)

--- a/tests/test_radio_dish.cpp
+++ b/tests/test_radio_dish.cpp
@@ -60,7 +60,7 @@ int msg_recv_cmp (zmq_msg_t *msg_, void *s_, const char* group_, const char* bod
     if (recv_rc == -1)
         return -1;
 
-        if (strcmp (zmq_msg_group (msg_), group_) != 0)
+    if (strcmp (zmq_msg_group (msg_), group_) != 0)
     {
         zmq_msg_close (msg_);
         return -1;

--- a/tests/test_radio_dish.cpp
+++ b/tests/test_radio_dish.cpp
@@ -89,7 +89,7 @@ int main (void)
     void *radio = zmq_socket (ctx, ZMQ_RADIO);
     void *dish = zmq_socket (ctx, ZMQ_DISH);
 
-    int rc = zmq_bind (radio, "inproc://test-radio-dish");
+    int rc = zmq_bind (radio, "tcp://127.0.0.1:5556");
     assert (rc == 0);
 
     //  Leaving a group which we didn't join
@@ -113,7 +113,7 @@ int main (void)
     assert (rc == -1);
 
     // Connecting
-    rc = zmq_connect (dish, "inproc://test-radio-dish");
+    rc = zmq_connect (dish, "tcp://127.0.0.1:5556");
     assert (rc == 0);
 
     zmq_sleep (1);


### PR DESCRIPTION
You still have to encode the group into the message you publish and the protocol between radio-dish send regular messages over the wire.

Solution:
* zmq_msg introduce new field called group
* set the group to indicate the group of the message
* On the wire join and leave command are sent from dish to radio
* first frame of a message from radio to dish is the group, second frame is the body.