### PR TITLE
Problem: Spelling of identifier "interface" matched a macro definition in VS2015

### DIFF
--- a/src/udp_address.cpp
+++ b/src/udp_address.cpp
@@ -100,8 +100,8 @@ int zmq::udp_address_t::resolve (const char *name_)
     else
         is_mutlicast = false;
 
-    interface.s_addr = htons (INADDR_ANY);
-    if (interface.s_addr == INADDR_NONE) {
+    Interface.s_addr = htons (INADDR_ANY);
+    if (Interface.s_addr == INADDR_NONE) {
         errno = EINVAL;
         return -1;
     }
@@ -153,7 +153,7 @@ const in_addr zmq::udp_address_t::multicast_ip () const
 
 const in_addr zmq::udp_address_t::interface_ip () const
 {
-    return interface;
+    return Interface;
 }
 
 #if defined ZMQ_HAVE_WINDOWS

--- a/src/udp_address.hpp
+++ b/src/udp_address.hpp
@@ -73,7 +73,7 @@ namespace zmq
     private:
 
         in_addr  multicast;
-        in_addr  interface;
+        in_addr  Interface;
         sockaddr_in bind_address;
         sockaddr_in dest_address;
         bool is_mutlicast;


### PR DESCRIPTION
Solution: spelling correction to "Interface".

Affected files:
udp_address.hpp
udp_address.cpp