### PR TITLE
ctest: Add missing test_udp and test_large_msg

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,7 +70,9 @@ set(tests
         test_xpub_manual
         test_xpub_welcome_msg
         test_timers
+        test_large_msg
         test_radio_dish
+        test_udp
 )
 if(NOT WIN32)
   list(APPEND tests


### PR DESCRIPTION
This commit fixes the author warnings reported below. These tests
have originally been introduced in zeromq/libzmq@5ebfd17 and
zeromq/libzmq@5fe75f0.

8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---
CMake Warning (dev) at tests/CMakeLists.txt:133 (message):
  Test 'test_udp' is not known to CTest.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at tests/CMakeLists.txt:133 (message):
  Test 'test_large_msg' is not known to CTest.
This warning is for project developers.  Use -Wno-dev to suppress it.
8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---