### PR TITLE
Fix unused-parameter/unused-but-set-variable/missing-field-initializers warnings

### DIFF
--- a/src/dish.cpp
+++ b/src/dish.cpp
@@ -163,6 +163,7 @@ int zmq::dish_t::xleave (const char* group_)
 
 int zmq::dish_t::xsend (msg_t *msg_)
 {
+    LIBZMQ_UNUSED (msg_);
     errno = ENOTSUP;
     return -1;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -31,6 +31,7 @@
 
 #include "options.hpp"
 #include "err.hpp"
+#include "macros.hpp"
 #include "../include/zmq_utils.h"
 
 zmq::options_t::options_t () :
@@ -1047,5 +1048,6 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
 
 bool zmq::options_t::is_valid (int option_) const
 {
+    LIBZMQ_UNUSED (option_);
     return true;
 }

--- a/src/plain_client.cpp
+++ b/src/plain_client.cpp
@@ -27,6 +27,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "macros.hpp"
 #include "platform.hpp"
 #ifdef ZMQ_HAVE_WINDOWS
 #include "windows.hpp"
@@ -145,6 +146,8 @@ int zmq::plain_client_t::produce_hello (msg_t *msg_) const
 int zmq::plain_client_t::process_welcome (
         const unsigned char *cmd_data, size_t data_size)
 {
+    LIBZMQ_UNUSED (cmd_data);
+
     if (state != waiting_for_welcome) {
         errno = EPROTO;
         return -1;

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -145,6 +145,7 @@ bool zmq::radio_t::xhas_out ()
 int zmq::radio_t::xrecv (msg_t *msg_)
 {
     //  Messages cannot be received from PUB socket.
+    LIBZMQ_UNUSED (msg_);
     errno = ENOTSUP;
     return -1;
 }

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1444,12 +1444,14 @@ bool zmq::socket_base_t::xhas_in ()
 
 int zmq::socket_base_t::xjoin (const char *group_)
 {
+    LIBZMQ_UNUSED (group_);
     errno = ENOTSUP;
     return -1;
 }
 
 int zmq::socket_base_t::xleave (const char *group_)
 {
+    LIBZMQ_UNUSED (group_);
     errno = ENOTSUP;
     return -1;
 }

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -89,7 +89,11 @@ int zmq::socket_poller_t::add (socket_base_t *socket_, void* user_data_, short e
            return -1;
     }
 
-    item_t item = {socket_, 0, user_data_, events_};
+    item_t item = {socket_, 0, user_data_, events_
+#if defined ZMQ_POLL_BASED_ON_POLL
+                   ,-1
+#endif
+    };
     items.push_back (item);
     need_rebuild = true;
 
@@ -105,7 +109,11 @@ int zmq::socket_poller_t::add_fd (fd_t fd_, void *user_data_, short events_)
         }
     }
 
-    item_t item = {NULL, fd_, user_data_, events_};
+    item_t item = {NULL, fd_, user_data_, events_
+#if defined ZMQ_POLL_BASED_ON_POLL
+                   ,-1
+#endif
+                   };
     items.push_back (item);
     need_rebuild = true;
 

--- a/tests/test_msg_ffn.cpp
+++ b/tests/test_msg_ffn.cpp
@@ -27,9 +27,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "macros.hpp"
 #include "testutil.hpp"
 
 void ffn(void *data, void *hint) {
+    LIBZMQ_UNUSED (data);
     // Signal that ffn has been called by writing "freed" to hint
     memcpy(hint, (void *) "freed", 5);
 }

--- a/tests/test_stream_exceeds_buffer.cpp
+++ b/tests/test_stream_exceeds_buffer.cpp
@@ -77,5 +77,7 @@ int main()
     assert(rcvbuf[2]==0xbe);
     assert(rcvbuf[1]==0xad);
     assert(rcvbuf[0]==0xde);
+
+    (void)(rc); // avoid -Wunused-but-set-variable warning in release build
 }
 

--- a/tests/test_timers.cpp
+++ b/tests/test_timers.cpp
@@ -27,6 +27,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "macros.hpp"
 #include "testutil.hpp"
 #include "../include/zmq_utils.h"
 
@@ -49,6 +50,7 @@ void sleep_ (long timeout_)
 
 void handler (int timer_id, void* arg)
 {
+    LIBZMQ_UNUSED (timer_id);
     *((bool *)arg) = true;
 }
 


### PR DESCRIPTION
* Style: Fix `unused-parameter` compilation warnings
* Style: Fix `-Wunused-but-set-variable` in test_stream_exceeds_buffer.cpp
* Style: Fix `-Wmissing-field-initializers` in socket_poller.cpp