### PR TITLE
allow underscores in domain names

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -845,8 +845,10 @@ int zmq::socket_base_t::connect (const char *addr_)
             while (isalnum  (*check)
                 || isxdigit (*check)
                 || *check == '.' || *check == '-' || *check == ':' || *check == '%'
-                || *check == ';' || *check == ']')
+                || *check == ';' || *check == ']' || *check == '_'
+            ) {
                 check++;
+            }
         }
         //  Assume the worst, now look for success
         rc = -1;


### PR DESCRIPTION
Since they are allowed

(They are not, however, allowed in hostnames)

closes zeromq/pyzmq#801