### PR TITLE
Problem: deprecated `zmq_utils.h` is still included

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,8 +497,7 @@ if(MINGW)
 endif()
 
 include_directories(include ${CMAKE_CURRENT_BINARY_DIR})
-set(public_headers include/zmq.h
-                   include/zmq_utils.h)
+set(public_headers include/zmq.h)
 
 set(readme-docs AUTHORS
                 COPYING

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -28,8 +28,8 @@
 
     *************************************************************************
     NOTE to contributors. This file comprises the principal public contract
-    for ZeroMQ API users (along with zmq_utils.h). Any change to this file
-    supplied in a stable release SHOULD not break existing applications.
+    for ZeroMQ API users. Any change to this file supplied in a stable
+    release SHOULD not break existing applications.
     In practice this means that the value of constants must not change, and
     that old values may not be reused for new constants.
     *************************************************************************

--- a/packaging/redhat/zeromq.spec.in
+++ b/packaging/redhat/zeromq.spec.in
@@ -120,7 +120,6 @@ This package contains ZeroMQ related development libraries and header files.
 %files devel
 %defattr(-,root,root,-)
 %{_includedir}/zmq.h
-%{_includedir}/zmq_utils.h
 
 %{_libdir}/libzmq.la
 %{_libdir}/libzmq.a

--- a/perf/inproc_lat.cpp
+++ b/perf/inproc_lat.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "../include/zmq.h"
-#include "../include/zmq_utils.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/perf/inproc_thr.cpp
+++ b/perf/inproc_thr.cpp
@@ -30,7 +30,6 @@
 */
 
 #include "../include/zmq.h"
-#include "../include/zmq_utils.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/perf/local_lat.cpp
+++ b/perf/local_lat.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "../include/zmq.h"
-#include "../include/zmq_utils.h"
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/perf/local_thr.cpp
+++ b/perf/local_thr.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "../include/zmq.h"
-#include "../include/zmq_utils.h"
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/perf/remote_lat.cpp
+++ b/perf/remote_lat.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "../include/zmq.h"
-#include "../include/zmq_utils.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/perf/remote_thr.cpp
+++ b/perf/remote_thr.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "../include/zmq.h"
-#include "../include/zmq_utils.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -36,7 +36,6 @@
 #include "atomic_counter.hpp"
 #include "atomic_ptr.hpp"
 #include <assert.h>
-#include "../include/zmq_utils.h"
 
 #if !defined ZMQ_HAVE_WINDOWS
 #include <unistd.h>

--- a/tests/test_poller.cpp
+++ b/tests/test_poller.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "testutil.hpp"
-#include "../include/zmq_utils.h"
 
 int main (void)
 {

--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "testutil.hpp"
-#include "../include/zmq_utils.h"
 
 // Asynchronous client-to-server (DEALER to ROUTER) - pure libzmq
 //

--- a/tests/test_proxy_single_socket.cpp
+++ b/tests/test_proxy_single_socket.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "testutil.hpp"
-#include "../include/zmq_utils.h"
 
 
 

--- a/tests/test_proxy_terminate.cpp
+++ b/tests/test_proxy_terminate.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "testutil.hpp"
-#include "../include/zmq_utils.h"
 
 // This is a test for issue #1382. The server thread creates a SUB-PUSH
 // steerable proxy. The main process then sends messages to the SUB

--- a/tests/test_sub_forward_tipc.cpp
+++ b/tests/test_sub_forward_tipc.cpp
@@ -30,7 +30,6 @@
 */
 
 #include "../include/zmq.h"
-#include "../include/zmq_utils.h"
 #include <stdio.h>
 
 #undef NDEBUG

--- a/tests/test_term_endpoint_tipc.cpp
+++ b/tests/test_term_endpoint_tipc.cpp
@@ -30,7 +30,6 @@
 */
 
 #include "../include/zmq.h"
-#include "../include/zmq_utils.h"
 #include <string.h>
 #include <unistd.h>
 

--- a/tests/test_timers.cpp
+++ b/tests/test_timers.cpp
@@ -29,7 +29,6 @@
 
 #include "macros.hpp"
 #include "testutil.hpp"
-#include "../include/zmq_utils.h"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include "windows.hpp"


### PR DESCRIPTION
Solution: remove all remaining references to `zmq_utils.h`