### PR TITLE
Problem: deprecated use and reference of `zmq_term`

### DIFF
--- a/builds/zos/test_fork.cpp
+++ b/builds/zos/test_fork.cpp
@@ -52,7 +52,7 @@ int main (void)
         //  Child process
         //  Immediately close parent sockets and context
         zmq_close (pull);
-        zmq_term (ctx);
+        zmq_ctx_term (ctx);
 
         //  Create new context, socket, connect and send some messages
         void *child_ctx = zmq_ctx_new ();

--- a/doc/zmq_close.txt
+++ b/doc/zmq_close.txt
@@ -22,8 +22,8 @@ not yet physically transferred to the network depends on the value of the
 _ZMQ_LINGER_ socket option for the specified 'socket'.
 
 NOTE: The default setting of _ZMQ_LINGER_ does not discard unsent messages;
-this behaviour may cause the application to block when calling _zmq_term()_.
-For details refer to linkzmq:zmq_setsockopt[3] and linkzmq:zmq_term[3].
+this behaviour may cause the application to block when calling _zmq_ctx_term()_.
+For details refer to linkzmq:zmq_setsockopt[3] and linkzmq:zmq_ctx_term[3].
 
 
 RETURN VALUE
@@ -41,7 +41,7 @@ The provided 'socket' was invalid.
 SEE ALSO
 --------
 linkzmq:zmq_socket[3]
-linkzmq:zmq_term[3]
+linkzmq:zmq_ctx_term[3]
 linkzmq:zmq_setsockopt[3]
 linkzmq:zmq[7]
 

--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -30,7 +30,7 @@ applications receive termination messages, and then terminate the context
 with 'ZMQ_LINGER' set to zero on all sockets. This setting is an easier way
 to get the same result. When 'ZMQ_BLOCKY' is set to false, all new sockets
 are given a linger timeout of zero. You must still close all sockets before
-calling zmq_term.
+calling zmq_ctx_term.
 
 [horizontal]
 Default value:: true (old behavior)

--- a/doc/zmq_disconnect.txt
+++ b/doc/zmq_disconnect.txt
@@ -25,8 +25,8 @@ _ZMQ_LINGER_ socket option for the specified 'socket'.
 The 'endpoint' argument is as described in linkzmq:zmq_connect[3]
 
 NOTE: The default setting of _ZMQ_LINGER_ does not discard unsent messages;
-this behaviour may cause the application to block when calling _zmq_term()_.
-For details refer to linkzmq:zmq_setsockopt[3] and linkzmq:zmq_term[3].
+this behaviour may cause the application to block when calling _zmq_ctx_term()_.
+For details refer to linkzmq:zmq_setsockopt[3] and linkzmq:zmq_ctx_term[3].
 
 
 RETURN VALUE

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -349,12 +349,12 @@ The 'ZMQ_LINGER' option shall retrieve the linger period for the specified
 'socket'.  The linger period determines how long pending messages which have
 yet to be sent to a peer shall linger in memory after a socket is closed with
 linkzmq:zmq_close[3], and further affects the termination of the socket's
-context with linkzmq:zmq_term[3]. The following outlines the different
+context with linkzmq:zmq_ctx_term[3]. The following outlines the different
 behaviours:
 
 * The default value of '-1' specifies an infinite linger period. Pending
   messages shall not be discarded after a call to _zmq_close()_; attempting to
-  terminate the socket's context with _zmq_term()_ shall block until all
+  terminate the socket's context with _zmq_ctx_term()_ shall block until all
   pending messages have been sent to a peer.
 
 * The value of '0' specifies no linger period. Pending messages shall be
@@ -362,7 +362,7 @@ behaviours:
 
 * Positive values specify an upper bound for the linger period in milliseconds.
   Pending messages shall not be discarded after a call to _zmq_close()_;
-  attempting to terminate the socket's context with _zmq_term()_ shall block
+  attempting to terminate the socket's context with _zmq_ctx_term()_ shall block
   until either all pending messages have been sent to a peer, or the linger
   period expires, after which any pending messages shall be discarded.
 

--- a/doc/zmq_init.txt
+++ b/doc/zmq_init.txt
@@ -43,7 +43,7 @@ An invalid number of 'io_threads' was requested.
 SEE ALSO
 --------
 linkzmq:zmq[7]
-linkzmq:zmq_term[3]
+linkzmq:zmq_ctx_term[3]
 
 
 AUTHORS

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -385,12 +385,12 @@ The 'ZMQ_LINGER' option shall set the linger period for the specified 'socket'.
 The linger period determines how long pending messages which have yet to be
 sent to a peer shall linger in memory after a socket is disconnected with
 linkzmq:zmq_disconnect[3] or closed with linkzmq:zmq_close[3], and further
-affects the termination of the socket's context with linkzmq:zmq_term[3]. The
-following outlines the different behaviours:
+affects the termination of the socket's context with linkzmq:zmq_ctx_term[3].
+The following outlines the different behaviours:
 
 * A value of '-1' specifies an infinite linger period. Pending
   messages shall not be discarded after a call to _zmq_disconnect()_ or
-  _zmq_close()_; attempting to terminate the socket's context with _zmq_term()_
+  _zmq_close()_; attempting to terminate the socket's context with _zmq_ctx_term()_
   shall block until all pending messages have been sent to a peer.
 
 * The value of '0' specifies no linger period. Pending messages shall be
@@ -398,7 +398,7 @@ following outlines the different behaviours:
 
 * Positive values specify an upper bound for the linger period in milliseconds.
   Pending messages shall not be discarded after a call to _zmq_disconnect()_ or
-  _zmq_close()_; attempting to terminate the socket's context with _zmq_term()_
+  _zmq_close()_; attempting to terminate the socket's context with _zmq_ctx_term()_
   shall block until either all pending messages have been sent to a peer, or the
   linger period expires, after which any pending messages shall be discarded.
 

--- a/perf/inproc_lat.cpp
+++ b/perf/inproc_lat.cpp
@@ -229,9 +229,9 @@ int main (int argc, char *argv [])
         return -1;
     }
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     if (rc != 0) {
-        printf ("error in zmq_term: %s\n", zmq_strerror (errno));
+        printf ("error in zmq_ctx_term: %s\n", zmq_strerror (errno));
         return -1;
     }
 

--- a/perf/inproc_thr.cpp
+++ b/perf/inproc_thr.cpp
@@ -232,9 +232,9 @@ int main (int argc, char *argv [])
         return -1;
     }
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     if (rc != 0) {
-        printf ("error in zmq_term: %s\n", zmq_strerror (errno));
+        printf ("error in zmq_ctx_term: %s\n", zmq_strerror (errno));
         return -1;
     }
 

--- a/perf/local_lat.cpp
+++ b/perf/local_lat.cpp
@@ -106,9 +106,9 @@ int main (int argc, char *argv [])
         return -1;
     }
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     if (rc != 0) {
-        printf ("error in zmq_term: %s\n", zmq_strerror (errno));
+        printf ("error in zmq_ctx_term: %s\n", zmq_strerror (errno));
         return -1;
     }
 

--- a/perf/local_thr.cpp
+++ b/perf/local_thr.cpp
@@ -130,9 +130,9 @@ int main (int argc, char *argv [])
         return -1;
     }
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     if (rc != 0) {
-        printf ("error in zmq_term: %s\n", zmq_strerror (errno));
+        printf ("error in zmq_ctx_term: %s\n", zmq_strerror (errno));
         return -1;
     }
 

--- a/perf/remote_lat.cpp
+++ b/perf/remote_lat.cpp
@@ -119,9 +119,9 @@ int main (int argc, char *argv [])
         return -1;
     }
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     if (rc != 0) {
-        printf ("error in zmq_term: %s\n", zmq_strerror (errno));
+        printf ("error in zmq_ctx_term: %s\n", zmq_strerror (errno));
         return -1;
     }
 

--- a/perf/remote_thr.cpp
+++ b/perf/remote_thr.cpp
@@ -97,9 +97,9 @@ int main (int argc, char *argv [])
         return -1;
     }
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     if (rc != 0) {
-        printf ("error in zmq_term: %s\n", zmq_strerror (errno));
+        printf ("error in zmq_ctx_term: %s\n", zmq_strerror (errno));
         return -1;
     }
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -135,19 +135,19 @@ zmq::ctx_t::~ctx_t ()
 
 int zmq::ctx_t::terminate ()
 {
-	slot_sync.lock();
+    slot_sync.lock();
 
-	bool saveTerminating = terminating;
-	terminating = false;
+    bool saveTerminating = terminating;
+    terminating = false;
 
-	// Connect up any pending inproc connections, otherwise we will hang
+    // Connect up any pending inproc connections, otherwise we will hang
     pending_connections_t copy = pending_connections;
     for (pending_connections_t::iterator p = copy.begin (); p != copy.end (); ++p) {
         zmq::socket_base_t *s = create_socket (ZMQ_PAIR);
         s->bind (p->first.c_str ());
         s->close ();
     }
-	terminating = saveTerminating;
+    terminating = saveTerminating;
 
     if (!starting) {
 

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -75,7 +75,7 @@ namespace zmq
         //  Returns false if object is not a context.
         bool check_tag ();
 
-        //  This function is called when user invokes zmq_term. If there are
+        //  This function is called when user invokes zmq_ctx_term. If there are
         //  no more sockets open it'll cause all the infrastructure to be shut
         //  down. If there are open sockets still, the deallocation happens
         //  after the last one is closed.
@@ -146,8 +146,8 @@ namespace zmq
         uint32_t tag;
 
         //  Sockets belonging to this context. We need the list so that
-        //  we can notify the sockets when zmq_term() is called. The sockets
-        //  will return ETERM then.
+        //  we can notify the sockets when zmq_ctx_term() is called.
+        //  The sockets will return ETERM then.
         typedef array_t <socket_base_t> sockets_t;
         sockets_t sockets;
 
@@ -159,7 +159,7 @@ namespace zmq
         //  yet. Launching of I/O threads is delayed.
         bool starting;
 
-        //  If true, zmq_term was already called.
+        //  If true, zmq_ctx_term was already called.
         bool terminating;
 
         //  Synchronisation of accesses to global slot-related data:
@@ -179,7 +179,7 @@ namespace zmq
         uint32_t slot_count;
         i_mailbox **slots;
 
-        //  Mailbox for zmq_term thread.
+        //  Mailbox for zmq_ctx_term thread.
         mailbox_t term_mailbox;
 
         //  List of inproc endpoints within this context.

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -223,8 +223,8 @@ zmq::i_mailbox *zmq::socket_base_t::get_mailbox ()
 
 void zmq::socket_base_t::stop ()
 {
-    //  Called by ctx when it is terminated (zmq_term).
-    //  'stop' command is sent from the threads that called zmq_term to
+    //  Called by ctx when it is terminated (zmq_ctx_term).
+    //  'stop' command is sent from the threads that called zmq_ctx_term to
     //  the thread owning the socket. This way, blocking call in the
     //  owner thread can be interrupted.
     send_stop ();
@@ -1376,7 +1376,7 @@ int zmq::socket_base_t::process_commands (int timeout_, bool throttle_)
 
 void zmq::socket_base_t::process_stop ()
 {
-    //  Here, someone have called zmq_term while the socket was still alive.
+    //  Here, someone have called zmq_ctx_term while the socket was still alive.
     //  We'll remember the fact so that any blocking call is interrupted and any
     //  further attempt to use the socket will return ETERM. The user is still
     //  responsible for calling zmq_close on the socket though!

--- a/tests/test_conflate.cpp
+++ b/tests/test_conflate.cpp
@@ -75,7 +75,7 @@ int main (int, char *[])
     rc = zmq_close (s_out);
     assert (rc == 0);
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
     return 0;

--- a/tests/test_connect_delay_tipc.cpp
+++ b/tests/test_connect_delay_tipc.cpp
@@ -104,7 +104,7 @@ int main (void)
     rc = zmq_close (to);
     assert (rc == 0);
 
-    rc = zmq_term (context);
+    rc = zmq_ctx_term (context);
     assert (rc == 0);
 
     // TEST 2
@@ -169,7 +169,7 @@ int main (void)
     rc = zmq_close (to);
     assert (rc == 0);
 
-    rc = zmq_term (context);
+    rc = zmq_ctx_term (context);
     assert (rc == 0);
 
     // TEST 3
@@ -242,7 +242,7 @@ int main (void)
     rc = zmq_close (frontend);
     assert (rc == 0);
 
-    rc = zmq_term (context);
+    rc = zmq_ctx_term (context);
     assert (rc == 0);
 }
 

--- a/tests/test_fork.cpp
+++ b/tests/test_fork.cpp
@@ -50,7 +50,7 @@ int main (void)
         //  Child process
         //  Immediately close parent sockets and context
         zmq_close (pull);
-        zmq_term (ctx);
+        zmq_ctx_term (ctx);
 
         //  Create new context, socket, connect and send some messages
         void *child_ctx = zmq_ctx_new ();

--- a/tests/test_pair_tipc.cpp
+++ b/tests/test_pair_tipc.cpp
@@ -57,7 +57,7 @@ int main (void)
     rc = zmq_close (sb);
     assert (rc == 0);
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
     return 0 ;

--- a/tests/test_reqrep_device_tipc.cpp
+++ b/tests/test_reqrep_device_tipc.cpp
@@ -146,7 +146,7 @@ int main (void)
     assert (rc == 0);
     rc = zmq_close (dealer);
     assert (rc == 0);
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
     return 0 ;

--- a/tests/test_reqrep_tipc.cpp
+++ b/tests/test_reqrep_tipc.cpp
@@ -57,7 +57,7 @@ int main (void)
     rc = zmq_close (sb);
     assert (rc == 0);
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
     return 0 ;

--- a/tests/test_router_mandatory_tipc.cpp
+++ b/tests/test_router_mandatory_tipc.cpp
@@ -65,7 +65,7 @@ int main (void)
     rc = zmq_close (sa);
     assert (rc == 0);
 
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
     return 0 ;

--- a/tests/test_shutdown_stress_tipc.cpp
+++ b/tests/test_shutdown_stress_tipc.cpp
@@ -95,7 +95,7 @@ int main (void)
         rc = zmq_close (s1);
         assert (rc == 0);
 
-        rc = zmq_term (ctx);
+        rc = zmq_ctx_term (ctx);
         assert (rc == 0);
     }
 

--- a/tests/test_sub_forward_tipc.cpp
+++ b/tests/test_sub_forward_tipc.cpp
@@ -103,7 +103,7 @@ int main (void)
     assert (rc == 0);
     rc = zmq_close (sub);
     assert (rc == 0);
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
     return 0 ;

--- a/tests/test_term_endpoint_tipc.cpp
+++ b/tests/test_term_endpoint_tipc.cpp
@@ -81,7 +81,7 @@ int main (void)
     assert (rc == 0);
     rc = zmq_close (push);
     assert (rc == 0);
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
 
@@ -122,7 +122,7 @@ int main (void)
     assert (rc == 0);
     rc = zmq_close (push);
     assert (rc == 0);
-    rc = zmq_term (ctx);
+    rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
     return 0;


### PR DESCRIPTION
Solution: replace occurrences with `zmq_ctx_term`