### PR TITLE
Problem: MSVC build does not detect libsodium

### DIFF
--- a/builds/msvc/vs2015/inproc_lat/inproc_lat.props
+++ b/builds/msvc/vs2015/inproc_lat/inproc_lat.props
@@ -22,27 +22,27 @@
 
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)libzmq.import.props" />
-    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_SODIUM)'=='1'" />
+    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_LIBSODIUM)'=='1'" />
   </ImportGroup>
   
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
     <Linkage-libzmq>dynamic</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'" >dynamic</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'" >dynamic</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
     <Linkage-libzmq>ltcg</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">ltcg</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">ltcg</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
     <Linkage-libzmq>static</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">static</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">static</Linkage-libsodium>
   </PropertyGroup>  
 
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
     <Message Text="Linkage-libzmq    : $(Linkage-libzmq)" Importance="high"/>
-    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high"  Condition="'$(HAVE_SODIUM)'=='1'"/>
+    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high"  Condition="'$(HAVE_LIBSODIUM)'=='1'"/>
   </Target>
 
 </Project>

--- a/builds/msvc/vs2015/inproc_thr/inproc_thr.props
+++ b/builds/msvc/vs2015/inproc_thr/inproc_thr.props
@@ -22,27 +22,27 @@
 
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)libzmq.import.props" />
-    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_SODIUM)'=='1'" />
+    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_LIBSODIUM)'=='1'" />
   </ImportGroup>
 
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
     <Linkage-libzmq>dynamic</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">dynamic</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">dynamic</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
     <Linkage-libzmq>ltcg</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">ltcg</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">ltcg</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
     <Linkage-libzmq>static</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">static</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">static</Linkage-libsodium>
   </PropertyGroup>  
 
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
     <Message Text="Linkage-libzmq    : $(Linkage-libzmq)" Importance="high"/>
-    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_SODIUM)'=='1'"/>
+    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_LIBSODIUM)'=='1'"/>
   </Target>
 
 </Project>

--- a/builds/msvc/vs2015/libzmq/libzmq.props
+++ b/builds/msvc/vs2015/libzmq/libzmq.props
@@ -36,17 +36,17 @@
   <!-- Dependencies -->
 
   <ImportGroup Label="PropertySheets">
-    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_SODIUM)'=='1'" />
+    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_LIBSODIUM)'=='1'" />
   </ImportGroup>
   
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">dynamic</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">dynamic</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">ltcg</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">ltcg</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">static</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">static</Linkage-libsodium>
   </PropertyGroup>
 
   <!-- Messages -->
@@ -57,7 +57,7 @@
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
-    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_SODIUM)'=='1'"/>
+    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_LIBSODIUM)'=='1'"/>
   </Target>
 
 </Project>

--- a/builds/msvc/vs2015/local_lat/local_lat.props
+++ b/builds/msvc/vs2015/local_lat/local_lat.props
@@ -22,27 +22,27 @@
 
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)libzmq.import.props" />
-    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_SODIUM)'=='1'" />
+    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_LIBSODIUM)'=='1'" />
   </ImportGroup>
 
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
     <Linkage-libzmq>dynamic</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">dynamic</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">dynamic</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
     <Linkage-libzmq>ltcg</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">ltcg</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">ltcg</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
     <Linkage-libzmq>static</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">static</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">static</Linkage-libsodium>
   </PropertyGroup>  
 
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
     <Message Text="Linkage-libzmq    : $(Linkage-libzmq)" Importance="high"/>
-    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_SODIUM)'=='1'"/>
+    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_LIBSODIUM)'=='1'"/>
   </Target>
 
 </Project>

--- a/builds/msvc/vs2015/local_thr/local_thr.props
+++ b/builds/msvc/vs2015/local_thr/local_thr.props
@@ -22,27 +22,27 @@
 
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)libzmq.import.props" />
-    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_SODIUM)'=='1'" />
+    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_LIBSODIUM)'=='1'" />
   </ImportGroup>
 
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
     <Linkage-libzmq>dynamic</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">dynamic</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">dynamic</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
     <Linkage-libzmq>ltcg</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">ltcg</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">ltcg</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
     <Linkage-libzmq>static</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">static</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">static</Linkage-libsodium>
   </PropertyGroup>  
 
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
     <Message Text="Linkage-libzmq    : $(Linkage-libzmq)" Importance="high"/>
-    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_SODIUM)'=='1'"/>
+    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_LIBSODIUM)'=='1'"/>
   </Target>
 
 </Project>

--- a/builds/msvc/vs2015/remote_lat/remote_lat.props
+++ b/builds/msvc/vs2015/remote_lat/remote_lat.props
@@ -22,27 +22,27 @@
 
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)libzmq.import.props" />
-    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_SODIUM)'=='1'" />
+    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_LIBSODIUM)'=='1'" />
   </ImportGroup>
 
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
     <Linkage-libzmq>dynamic</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">dynamic</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">dynamic</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
     <Linkage-libzmq>ltcg</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">ltcg</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">ltcg</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
     <Linkage-libzmq>static</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">static</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">static</Linkage-libsodium>
   </PropertyGroup>  
 
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
     <Message Text="Linkage-libzmq    : $(Linkage-libzmq)" Importance="high"/>
-    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_SODIUM)'=='1'"/>
+    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_LIBSODIUM)'=='1'"/>
   </Target>
 
 </Project>

--- a/builds/msvc/vs2015/remote_thr/remote_thr.props
+++ b/builds/msvc/vs2015/remote_thr/remote_thr.props
@@ -22,27 +22,27 @@
 
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)libzmq.import.props" />
-    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_SODIUM)'=='1'" />
+    <Import Project="$(SolutionDir)libsodium.import.props" Condition="'$(HAVE_LIBSODIUM)'=='1'" />
   </ImportGroup>
 
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'dynamic'">
     <Linkage-libzmq>dynamic</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">dynamic</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">dynamic</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'ltcg'">
     <Linkage-libzmq>ltcg</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">ltcg</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">ltcg</Linkage-libsodium>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DefaultLinkage)' == 'static'">
     <Linkage-libzmq>static</Linkage-libzmq>
-    <Linkage-libsodium Condition="'$(HAVE_SODIUM)'=='1'">static</Linkage-libsodium>
+    <Linkage-libsodium Condition="'$(HAVE_LIBSODIUM)'=='1'">static</Linkage-libsodium>
   </PropertyGroup>  
 
   <!-- Messages -->
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">
     <Message Text="Linkage-libzmq    : $(Linkage-libzmq)" Importance="high"/>
-    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_SODIUM)'=='1'"/>
+    <Message Text="Linkage-libsodium : $(Linkage-libsodium)" Importance="high" Condition="'$(HAVE_LIBSODIUM)'=='1'"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
Caused by error in last commit which used HAVE_LIBSODIUM instead
of HAVE_SODIUM.

Solution: use HAVE_LIBSODIUM as we do in other configure scripts.

The project is called 'libsodium' and not 'sodium'.