### PR TITLE
Problem: Valgrind reports read of freed memory

### DIFF
--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -99,9 +99,11 @@ void zmq::radio_t::xwrite_activated (pipe_t *pipe_)
 
 void zmq::radio_t::xpipe_terminated (pipe_t *pipe_)
 {
-    for (subscriptions_t::iterator it = subscriptions.begin (); it != subscriptions.end (); ++it) {
+    for (subscriptions_t::iterator it = subscriptions.begin (); it != subscriptions.end (); ) {
         if (it->second == pipe_) {
-            subscriptions.erase (it);
+            subscriptions.erase (it++);
+        } else {
+            ++it;
         }
     }
 


### PR DESCRIPTION
Solution: when iterating over a map and conditionally deleting
elements, an erased iterator gets invalidated. Call erase using postfix
increment on iterator to avoid using an invalid element in the next
iteration.