### PR TITLE
Problem: CI builds libsodium from dev branch

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -17,7 +17,7 @@ if [ $BUILD_TYPE == "default" ]; then
     #   Build required projects first
 
     #   libsodium
-    git clone --depth 1 git://github.com/jedisct1/libsodium.git
+    git clone --depth 1 -b stable git://github.com/jedisct1/libsodium.git
     ( cd libsodium; ./autogen.sh; ./configure --prefix=$BUILD_PREFIX; make check; make install)
 
     #   Build and check this project


### PR DESCRIPTION
Solution: checkout stable branch instead.
Several warnings are printed when building from the master branch,
and developers recommend using the stable branch instead.