### PR TITLE
updates for bumped _WIN32_WINNT version with mingw builds

### DIFF
--- a/src/dish.cpp
+++ b/src/dish.cpp
@@ -29,6 +29,12 @@
 
 #include <string.h>
 
+#include "platform.hpp"
+
+#ifdef ZMQ_HAVE_WINDOWS
+#include "windows.hpp"
+#endif
+
 #include "../include/zmq.h"
 #include "macros.hpp"
 #include "dish.hpp"

--- a/src/err.cpp
+++ b/src/err.cpp
@@ -28,7 +28,6 @@
 */
 
 #include "err.hpp"
-#include "platform.hpp"
 
 const char *zmq::errno_to_string (int errno_)
 {

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -41,16 +41,17 @@
 #include <stdio.h>
 
 #include "platform.hpp"
-#include "likely.hpp"
-
-//  0MQ-specific error codes are defined in zmq.h
-#include "../include/zmq.h"
 
 #ifdef ZMQ_HAVE_WINDOWS
 #include "windows.hpp"
 #else
 #include <netdb.h>
 #endif
+
+#include "likely.hpp"
+
+//  0MQ-specific error codes are defined in zmq.h
+#include "../include/zmq.h"
 
 // EPROTO is not used by OpenBSD and maybe other platforms.
 #ifndef EPROTO

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -434,7 +434,7 @@ bool zmq::select_t::is_retired_fd (const fd_entry_t &entry)
 #if defined ZMQ_HAVE_WINDOWS
 u_short zmq::select_t::get_fd_family (fd_t fd_)
 {
-    sockaddr addr{ 0 };
+    sockaddr addr = { 0 };
     int addr_size = sizeof addr;
     int rc = getsockname (fd_, &addr, &addr_size);
 

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -44,10 +44,10 @@
 
 #ifdef __MINGW32__
 //  Require Windows XP or higher with MinGW for getaddrinfo().
-#if(_WIN32_WINNT >= 0x0501)
+#if(_WIN32_WINNT >= 0x0600)
 #else
 #undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0501
+#define _WIN32_WINNT 0x0600
 #endif
 #endif
 

--- a/tests/test_heartbeats.cpp
+++ b/tests/test_heartbeats.cpp
@@ -185,11 +185,11 @@ test_heartbeat_timeout (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons(5556);
-+#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
-+    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
-+#else
-+    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
-+#endif
+#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
+    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
+#else
+    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+#endif
 
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     rc = connect (s, (struct sockaddr*) &ip4addr, sizeof ip4addr);

--- a/tests/test_heartbeats.cpp
+++ b/tests/test_heartbeats.cpp
@@ -185,7 +185,11 @@ test_heartbeat_timeout (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons(5556);
-    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
++#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
++    ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
++#else
++    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
++#endif
 
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     rc = connect (s, (struct sockaddr*) &ip4addr, sizeof ip4addr);

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -245,7 +245,7 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons (9998);
-#if (_WIN32_WINNT < 0x0600)
+#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
     ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
 #else
     inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);

--- a/tests/test_security_null.cpp
+++ b/tests/test_security_null.cpp
@@ -158,7 +158,7 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons(9003);
-#if (_WIN32_WINNT < 0x0600)
+#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
     ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
 #else
     inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);

--- a/tests/test_security_plain.cpp
+++ b/tests/test_security_plain.cpp
@@ -164,7 +164,7 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons (9998);
-#if (_WIN32_WINNT < 0x0600)
+#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
     ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
 #else
     inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);

--- a/tests/test_stream_exceeds_buffer.cpp
+++ b/tests/test_stream_exceeds_buffer.cpp
@@ -2,8 +2,18 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <netinet/in.h>
-#include <unistd.h>
+#include "testutil.hpp"
+#if defined (ZMQ_HAVE_WINDOWS)
+#   include <winsock2.h>
+#   include <ws2tcpip.h>
+#   include <stdexcept>
+#   define close closesocket
+#else
+#   include <sys/socket.h>
+#   include <netinet/in.h>
+#   include <arpa/inet.h>
+#   include <unistd.h>
+#endif
 
 #include <zmq.h>
 

--- a/tests/test_timers.cpp
+++ b/tests/test_timers.cpp
@@ -28,13 +28,14 @@
 */
 
 #include "macros.hpp"
-#include "testutil.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include "windows.hpp"
 #else
 #include <unistd.h>
 #endif
+
+#include "testutil.hpp"
 
 void sleep_ (long timeout_)
 {


### PR DESCRIPTION
minimum mingw _WIN32_WINNT version bumped to 0x0600 as in line with the default version

mingw builds with bumped _WIN32_WINNT to 0x0600 would crash in a few places, solver by adding windows.hpp with include guard.

tests updated to check windows before conditional check for inet_pton as it isn't available with mingw's default _WIN32_WINNT setting (0x0502)

test_timers moved platform headers before zmq.h

added platform headers to test_stream_exceeds_buffer