### PR TITLE
Use memcpy instead of assuming option values are aligned

### DIFF
--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -70,7 +70,8 @@ int zmq::dealer_t::xsetsockopt (int option_, const void *optval_,
     size_t optvallen_)
 {
     bool is_int = (optvallen_ == sizeof (int));
-    int value = is_int? *((int *) optval_): 0;
+    int value = 0;
+    if (is_int) memcpy(&value, optval_, sizeof (int));
 
     switch (option_) {
         case ZMQ_PROBE_ROUTER:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -92,7 +92,8 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
     size_t optvallen_)
 {
     bool is_int = (optvallen_ == sizeof (int));
-    int value = is_int? *((int *) optval_): 0;
+    int value = 0;
+    if (is_int) memcpy(&value, optval_, sizeof (int));
 #if defined (ZMQ_ACT_MILITANT)
     bool malformed = true;          //  Did caller pass a bad option value?
 #endif

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -204,7 +204,8 @@ bool zmq::req_t::xhas_out ()
 int zmq::req_t::xsetsockopt (int option_, const void *optval_, size_t optvallen_)
 {
     bool is_int = (optvallen_ == sizeof (int));
-    int value = is_int? *((int *) optval_): 0;
+    int value = 0;
+    if (is_int) memcpy(&value, optval_, sizeof (int));
 
     switch (option_) {
         case ZMQ_REQ_CORRELATE:

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -97,7 +97,8 @@ int zmq::router_t::xsetsockopt (int option_, const void *optval_,
     size_t optvallen_)
 {
     bool is_int = (optvallen_ == sizeof (int));
-    int value = is_int? *((int *) optval_): 0;
+    int value = 0;
+    if (is_int) memcpy(&value, optval_, sizeof (int));
 
     switch (option_) {
         case ZMQ_CONNECT_RID:

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -178,7 +178,8 @@ int zmq::stream_t::xsetsockopt (int option_, const void *optval_,
     size_t optvallen_)
 {
     bool is_int = (optvallen_ == sizeof (int));
-    int value = is_int? *((int *) optval_): 0;
+    int value = 0;
+    if (is_int) memcpy(&value, optval_, sizeof (int));
 
     switch (option_) {
         case ZMQ_CONNECT_RID:


### PR DESCRIPTION
Otherwise, it's undefined behavior. ubsan catches alignment issues in
the libzmq test suite without this.