### PR TITLE
CMake and tweetnacl CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,16 @@ env:
 - BUILD_TYPE=default
 - BUILD_TYPE=android
 - BUILD_TYPE=tweetnacl
+- BUILD_TYPE=cmake
 
 sudo: false
+
+addons:
+  apt:
+    sources:
+    - kubuntu-backports
+    packages:
+    - cmake
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ os:
 env:
 - BUILD_TYPE=default
 - BUILD_TYPE=android
+- BUILD_TYPE=tweetnacl
 
 sudo: false
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build script for ZeroMQ
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(ZeroMQ)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}")

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -x
+
+mkdir tmp
+BUILD_PREFIX=$PWD/tmp
+
+CONFIG_OPTS=()
+CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+
+CMAKE_OPTS=()
+CMAKE_OPTS+=("-DCMAKE_INSTALL_PREFIX:PATH=${BUILD_PREFIX}")
+CMAKE_OPTS+=("-DCMAKE_PREFIX_PATH:PATH=${BUILD_PREFIX}")
+CMAKE_OPTS+=("-DCMAKE_LIBRARY_PATH:PATH=${BUILD_PREFIX}/lib")
+CMAKE_OPTS+=("-DCMAKE_INCLUDE_PATH:PATH=${BUILD_PREFIX}/include")
+
+git clone --depth 1 -b stable git://github.com/jedisct1/libsodium.git &&
+( cd libsodium; ./autogen.sh && ./configure --prefix=$BUILD_PREFIX && make && make install ) || exit 1
+
+# Build, check, and install from local source
+( cd ../..; mkdir build_cmake && cd build_cmake && PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig cmake "${CMAKE_OPTS[@]}" .. && make all VERBOSE=1 && make install ) || exit 1

--- a/builds/tweetnacl/ci_build.sh
+++ b/builds/tweetnacl/ci_build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -x
+
+mkdir tmp
+BUILD_PREFIX=$PWD/tmp
+
+CONFIG_OPTS=()
+CONFIG_OPTS+=("CFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CPPFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("CXXFLAGS=-I${BUILD_PREFIX}/include")
+CONFIG_OPTS+=("LDFLAGS=-L${BUILD_PREFIX}/lib")
+CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
+CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
+
+#   Build and check this project
+(
+    cd ../..;
+    ./autogen.sh &&
+    ./configure "${CONFIG_OPTS[@]}" --with-tweetnacl=yes &&
+    make &&
+    ( if make check; then true; else cat test-suite.log; exit 1; fi ) &&
+    make install
+) || exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -470,6 +470,7 @@ if test "x$have_sodium_library" != "xno"; then
 elif test "x$with_tweetnacl" != "xno"; then
     AC_DEFINE(HAVE_LIBSODIUM, 1, [Sodium is provided by tweetnacl.])
     AC_DEFINE(HAVE_TWEETNACL, 1, [Using tweetnacl.])
+    libzmq_pedantic="no"
 fi
 
 AM_CONDITIONAL(HAVE_SODIUM, test "x$have_sodium_library" != "xno")


### PR DESCRIPTION
CMake 2.8.12 is required in order to use target_include_directories, so use an apt source repository in Travis to get a newer version, since Precise shipped with an older one.

Tweetnacl needs to be built either with C++0x or without -pedantic, since it uses "long long int", which is not available in ISO C++ 98. I've chosen to disable -pedantic in tweetnacl builds (still enabled in other builds of course, so we don't lose coverage) as that's the least invasive change for the project.