### PR TITLE
Problem: ZMQ_PRE_ALLOCATED_FD is too long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,8 +125,8 @@ test_timers
 test_radio_dish
 test_udp
 test_large_msg
-test_pre_allocated_fd_ipc
-test_pre_allocated_fd_tcp
+test_usefd_ipc
+test_usefd_tcp
 tests/test*.log
 tests/test*.trs
 src/platform.hpp*

--- a/Makefile.am
+++ b/Makefile.am
@@ -626,8 +626,8 @@ test_apps += \
 	tests/test_shutdown_stress \
 	tests/test_pair_ipc \
 	tests/test_reqrep_ipc \
-	tests/test_pre_allocated_fd_ipc \
-	tests/test_pre_allocated_fd_tcp \
+	tests/test_usefd_ipc \
+	tests/test_usefd_tcp \
 	tests/test_timeo \
 	tests/test_filter_ipc
 
@@ -650,15 +650,15 @@ tests_test_timeo_LDADD = src/libzmq.la
 tests_test_filter_ipc_SOURCES = tests/test_filter_ipc.cpp
 tests_test_filter_ipc_LDADD = src/libzmq.la
 
-tests_test_pre_allocated_fd_ipc_SOURCES = \
-	tests/test_pre_allocated_fd_ipc.cpp \
+tests_test_usefd_ipc_SOURCES = \
+	tests/test_usefd_ipc.cpp \
 	tests/testutil.hpp
-tests_test_pre_allocated_fd_ipc_LDADD = src/libzmq.la
+tests_test_usefd_ipc_LDADD = src/libzmq.la
 
-tests_test_pre_allocated_fd_tcp_SOURCES = \
-	tests/test_pre_allocated_fd_tcp.cpp \
+tests_test_usefd_tcp_SOURCES = \
+	tests/test_usefd_tcp.cpp \
 	tests/testutil.hpp
-tests_test_pre_allocated_fd_tcp_LDADD = src/libzmq.la
+tests_test_usefd_tcp_LDADD = src/libzmq.la
 
 if HAVE_FORK
 test_apps += tests/test_fork

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -464,9 +464,9 @@ Default value:: null string
 Applicable socket types:: all, when using TCP or IPC transports
 
 
-ZMQ_PRE_ALLOCATED_FD: Retrieve the pre-allocated socket file descriptor
+ZMQ_USEFD: Retrieve the pre-allocated socket file descriptor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_PRE_ALLOCATED_FD' option shall retrieve the pre-allocated file
+The 'ZMQ_USEFD' option shall retrieve the pre-allocated file
 descriptor that has been assigned to a ZMQ socket, if any. -1 shall be
 returned if a pre-allocated file descriptor was not set for the socket.
 

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -492,7 +492,7 @@ Default value:: not set
 Applicable socket types:: all, when using TCP transport
 
 
-ZMQ_PRE_ALLOCATED_FD: Set the pre-allocated socket file descriptor
+ZMQ_USEFD: Set the pre-allocated socket file descriptor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When set to a positive integer value before zmq_bind is called on the socket,
 the socket shall use the corresponding file descriptor for connections over

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -344,7 +344,7 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_VMCI_BUFFER_MIN_SIZE 86
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
-#define ZMQ_PRE_ALLOCATED_FD 89
+#define ZMQ_USEFD 89
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -158,7 +158,7 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
     //  MUST NOT unlink if the FD is managed by the user, or it will stop
     //  working after the first client connects. The user will take care of
     //  cleaning up the file after the service is stopped.
-    if (options.pre_allocated_fd == -1) {
+    if (options.usefd == -1) {
         ::unlink (addr.c_str());
     }
     filename.clear ();
@@ -171,8 +171,8 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
 
     address.to_string (endpoint);
 
-    if (options.pre_allocated_fd != -1) {
-        s = options.pre_allocated_fd;
+    if (options.usefd != -1) {
+        s = options.usefd;
     } else {
         //  Create a listening socket.
         s = open_socket (AF_UNIX, SOCK_STREAM, 0);
@@ -216,7 +216,7 @@ int zmq::ipc_listener_t::close ()
     //  MUST NOT unlink if the FD is managed by the user, or it will stop
     //  working after the first client connects. The user will take care of
     //  cleaning up the file after the service is stopped.
-    if (has_file && !filename.empty () && options.pre_allocated_fd == -1) {
+    if (has_file && !filename.empty () && options.usefd == -1) {
         rc = ::unlink(filename.c_str ());
         if (rc != 0) {
             socket->event_close_failed (endpoint, zmq_errno());

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -78,7 +78,7 @@ zmq::options_t::options_t () :
     heartbeat_ttl (0),
     heartbeat_interval (0),
     heartbeat_timeout (-1),
-    pre_allocated_fd (-1)
+    usefd (-1)
 {
 #if defined ZMQ_HAVE_VMCI
     vmci_buffer_size = 0;
@@ -623,9 +623,9 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             break;
 #       endif
 
-        case ZMQ_PRE_ALLOCATED_FD:
+        case ZMQ_USEFD:
             if (is_int && value >= -1) {
-                pre_allocated_fd = value;
+                usefd = value;
                 return 0;
             }
             break;
@@ -1040,9 +1040,9 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
             }
             break;
 
-        case ZMQ_PRE_ALLOCATED_FD:
+        case ZMQ_USEFD:
             if (is_int) {
-                *value = pre_allocated_fd;
+                *value = usefd;
                 return 0;
             }
             break;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -235,7 +235,7 @@ namespace zmq
         //  When creating a new ZMQ socket, if this option is set the value
         //  will be used as the File Descriptor instead of allocating a new
         //  one via the socket () system call.
-        int pre_allocated_fd;
+        int usefd;
     };
 }
 

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -168,8 +168,8 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
 
     address.to_string (endpoint);
 
-    if (options.pre_allocated_fd != -1) {
-        s = options.pre_allocated_fd;
+    if (options.usefd != -1) {
+        s = options.usefd;
         socket->event_listening (endpoint, (int) s);
         return 0;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,8 +90,8 @@ if(NOT WIN32)
           test_stream_exceeds_buffer
           test_router_mandatory_hwm
           test_term_endpoint_tipc
-          test_pre_allocated_fd_ipc
-          test_pre_allocated_fd_tcp
+          test_usefd_ipc
+          test_usefd_tcp
   )
   if(HAVE_FORK)
     list(APPEND tests test_fork)

--- a/tests/test_setsockopt.cpp
+++ b/tests/test_setsockopt.cpp
@@ -70,7 +70,7 @@ void test_setsockopt_tcp_send_buffer()
     zmq_ctx_term(ctx);
 }
 
-void test_setsockopt_pre_allocated_fd()
+void test_setsockopt_usefd()
 {
     int rc;
     void *ctx = zmq_ctx_new();
@@ -79,17 +79,17 @@ void test_setsockopt_pre_allocated_fd()
     int val = 0;
     size_t placeholder = sizeof(val);
 
-    rc = zmq_getsockopt(socket, ZMQ_PRE_ALLOCATED_FD, &val, &placeholder);
+    rc = zmq_getsockopt(socket, ZMQ_USEFD, &val, &placeholder);
     assert(rc == 0);
     assert(val == -1);
 
     val = 3;
 
-    rc = zmq_setsockopt(socket, ZMQ_PRE_ALLOCATED_FD, &val, sizeof(val));
+    rc = zmq_setsockopt(socket, ZMQ_USEFD, &val, sizeof(val));
     assert(rc == 0);
     assert(val == 3);
 
-    rc = zmq_getsockopt(socket, ZMQ_PRE_ALLOCATED_FD, &val, &placeholder);
+    rc = zmq_getsockopt(socket, ZMQ_USEFD, &val, &placeholder);
     assert(rc == 0);
     assert(val == 3);
 
@@ -102,5 +102,5 @@ int main()
 {
     test_setsockopt_tcp_recv_buffer();
     test_setsockopt_tcp_send_buffer();
-    test_setsockopt_pre_allocated_fd();
+    test_setsockopt_usefd();
 }

--- a/tests/test_usefd_tcp.cpp
+++ b/tests/test_usefd_tcp.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2007-2016 Contributors as noted in the AUTHORS file
+    Copyright (c) 2016 Contributors as noted in the AUTHORS file
 
     This file is part of libzmq, the ZeroMQ core engine in C++.
 
@@ -29,28 +29,30 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sys/un.h>
+#include <netdb.h>
 #include "testutil.hpp"
 
-void pre_allocate_sock (void *zmq_socket, const char *path)
+void pre_allocate_sock (void *zmq_socket, const char *address,
+        const char *port)
 {
-    struct sockaddr_un addr;
-    addr.sun_family = AF_UNIX;
-    strcpy (addr.sun_path, path);
+    struct addrinfo *addr;
+    int rc = getaddrinfo (address, port, NULL, &addr);
+    assert (rc == 0);
 
-    unlink (path);
-
-    int s_pre = socket (AF_UNIX, SOCK_STREAM, 0);
+    int s_pre = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     assert (s_pre != -1);
 
-    int rc = bind (s_pre, (struct sockaddr *) &addr,
-            sizeof (struct sockaddr_un));
+    int flag = 1;
+    rc = setsockopt (s_pre, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof (int));
+    assert (rc == 0);
+
+    rc = bind (s_pre, addr->ai_addr, addr->ai_addrlen);
     assert (rc == 0);
 
     rc = listen (s_pre, SOMAXCONN);
     assert (rc == 0);
 
-    rc = zmq_setsockopt (zmq_socket, ZMQ_PRE_ALLOCATED_FD, &s_pre,
+    rc = zmq_setsockopt (zmq_socket, ZMQ_USEFD, &s_pre,
             sizeof (s_pre));
     assert(rc == 0);
 }
@@ -63,14 +65,14 @@ void test_req_rep ()
     void *sb = zmq_socket (ctx, ZMQ_REP);
     assert (sb);
 
-    pre_allocate_sock(sb, "/tmp/tester");
+    pre_allocate_sock(sb, "127.0.0.1", "5560");
 
-    int rc = zmq_bind (sb, "ipc:///tmp/tester");
+    int rc = zmq_bind (sb, "tcp://127.0.0.1:5560");
     assert (rc == 0);
 
     void *sc = zmq_socket (ctx, ZMQ_REQ);
     assert (sc);
-    rc = zmq_connect (sc, "ipc:///tmp/tester");
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5560");
     assert (rc == 0);
 
     bounce (sb, sc);
@@ -82,9 +84,6 @@ void test_req_rep ()
     assert (rc == 0);
 
     rc = zmq_ctx_term (ctx);
-    assert (rc == 0);
-
-    rc = unlink ("/tmp/tester");
     assert (rc == 0);
 }
 
@@ -96,14 +95,14 @@ void test_pair ()
     void *sb = zmq_socket (ctx, ZMQ_PAIR);
     assert (sb);
 
-    pre_allocate_sock(sb, "/tmp/tester");
+    pre_allocate_sock(sb, "127.0.0.1", "5560");
 
-    int rc = zmq_bind (sb, "ipc:///tmp/tester");
+    int rc = zmq_bind (sb, "tcp://127.0.0.1:5560");
     assert (rc == 0);
 
     void *sc = zmq_socket (ctx, ZMQ_PAIR);
     assert (sc);
-    rc = zmq_connect (sc, "ipc:///tmp/tester");
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5560");
     assert (rc == 0);
 
     bounce (sb, sc);
@@ -116,9 +115,6 @@ void test_pair ()
 
     rc = zmq_ctx_term (ctx);
     assert (rc == 0);
-
-    rc = unlink ("/tmp/tester");
-    assert (rc == 0);
 }
 
 void test_client_server ()
@@ -129,14 +125,14 @@ void test_client_server ()
     void *sb = zmq_socket (ctx, ZMQ_SERVER);
     assert (sb);
 
-    pre_allocate_sock(sb, "/tmp/tester");
+    pre_allocate_sock(sb, "127.0.0.1", "5560");
 
-    int rc = zmq_bind (sb, "ipc:///tmp/tester");
+    int rc = zmq_bind (sb, "tcp://127.0.0.1:5560");
     assert (rc == 0);
 
     void *sc = zmq_socket (ctx, ZMQ_CLIENT);
     assert (sc);
-    rc = zmq_connect (sc, "ipc:///tmp/tester");
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5560");
     assert (rc == 0);
 
     zmq_msg_t msg;
@@ -195,9 +191,6 @@ void test_client_server ()
     assert (rc == 0);
 
     rc = zmq_ctx_term (ctx);
-    assert (rc == 0);
-
-    rc = unlink ("/tmp/tester");
     assert (rc == 0);
 }
 


### PR DESCRIPTION
Solution: rename socket option (and variables and files) from
pre_allocated_fd to usefd.

@hintjens - better like this? I've renamed everything to keep it consistent, but I can rename just the user-visible option if you want to keep the churn to a minimum.