### PR TITLE
Problem: ZMQ_USEFD does not follow conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,8 +125,8 @@ test_timers
 test_radio_dish
 test_udp
 test_large_msg
-test_usefd_ipc
-test_usefd_tcp
+test_use_fd_ipc
+test_use_fd_tcp
 tests/test*.log
 tests/test*.trs
 src/platform.hpp*

--- a/Makefile.am
+++ b/Makefile.am
@@ -626,8 +626,8 @@ test_apps += \
 	tests/test_shutdown_stress \
 	tests/test_pair_ipc \
 	tests/test_reqrep_ipc \
-	tests/test_usefd_ipc \
-	tests/test_usefd_tcp \
+	tests/test_use_fd_ipc \
+	tests/test_use_fd_tcp \
 	tests/test_timeo \
 	tests/test_filter_ipc
 
@@ -650,15 +650,15 @@ tests_test_timeo_LDADD = src/libzmq.la
 tests_test_filter_ipc_SOURCES = tests/test_filter_ipc.cpp
 tests_test_filter_ipc_LDADD = src/libzmq.la
 
-tests_test_usefd_ipc_SOURCES = \
-	tests/test_usefd_ipc.cpp \
+tests_test_use_fd_ipc_SOURCES = \
+	tests/test_use_fd_ipc.cpp \
 	tests/testutil.hpp
-tests_test_usefd_ipc_LDADD = src/libzmq.la
+tests_test_use_fd_ipc_LDADD = src/libzmq.la
 
-tests_test_usefd_tcp_SOURCES = \
-	tests/test_usefd_tcp.cpp \
+tests_test_use_fd_tcp_SOURCES = \
+	tests/test_use_fd_tcp.cpp \
 	tests/testutil.hpp
-tests_test_usefd_tcp_LDADD = src/libzmq.la
+tests_test_use_fd_tcp_LDADD = src/libzmq.la
 
 if HAVE_FORK
 test_apps += tests/test_fork

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -464,9 +464,9 @@ Default value:: null string
 Applicable socket types:: all, when using TCP or IPC transports
 
 
-ZMQ_USEFD: Retrieve the pre-allocated socket file descriptor
+ZMQ_USE_FD: Retrieve the pre-allocated socket file descriptor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_USEFD' option shall retrieve the pre-allocated file
+The 'ZMQ_USE_FD' option shall retrieve the pre-allocated file
 descriptor that has been assigned to a ZMQ socket, if any. -1 shall be
 returned if a pre-allocated file descriptor was not set for the socket.
 

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -492,7 +492,7 @@ Default value:: not set
 Applicable socket types:: all, when using TCP transport
 
 
-ZMQ_USEFD: Set the pre-allocated socket file descriptor
+ZMQ_USE_FD: Set the pre-allocated socket file descriptor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When set to a positive integer value before zmq_bind is called on the socket,
 the socket shall use the corresponding file descriptor for connections over

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -344,7 +344,7 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_VMCI_BUFFER_MIN_SIZE 86
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
-#define ZMQ_USEFD 89
+#define ZMQ_USE_FD 89
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -158,7 +158,7 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
     //  MUST NOT unlink if the FD is managed by the user, or it will stop
     //  working after the first client connects. The user will take care of
     //  cleaning up the file after the service is stopped.
-    if (options.usefd == -1) {
+    if (options.use_fd == -1) {
         ::unlink (addr.c_str());
     }
     filename.clear ();
@@ -171,8 +171,8 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
 
     address.to_string (endpoint);
 
-    if (options.usefd != -1) {
-        s = options.usefd;
+    if (options.use_fd != -1) {
+        s = options.use_fd;
     } else {
         //  Create a listening socket.
         s = open_socket (AF_UNIX, SOCK_STREAM, 0);
@@ -216,7 +216,7 @@ int zmq::ipc_listener_t::close ()
     //  MUST NOT unlink if the FD is managed by the user, or it will stop
     //  working after the first client connects. The user will take care of
     //  cleaning up the file after the service is stopped.
-    if (has_file && !filename.empty () && options.usefd == -1) {
+    if (has_file && !filename.empty () && options.use_fd == -1) {
         rc = ::unlink(filename.c_str ());
         if (rc != 0) {
             socket->event_close_failed (endpoint, zmq_errno());

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -78,7 +78,7 @@ zmq::options_t::options_t () :
     heartbeat_ttl (0),
     heartbeat_interval (0),
     heartbeat_timeout (-1),
-    usefd (-1)
+    use_fd (-1)
 {
 #if defined ZMQ_HAVE_VMCI
     vmci_buffer_size = 0;
@@ -623,9 +623,9 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             break;
 #       endif
 
-        case ZMQ_USEFD:
+        case ZMQ_USE_FD:
             if (is_int && value >= -1) {
-                usefd = value;
+                use_fd = value;
                 return 0;
             }
             break;
@@ -1040,9 +1040,9 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
             }
             break;
 
-        case ZMQ_USEFD:
+        case ZMQ_USE_FD:
             if (is_int) {
-                *value = usefd;
+                *value = use_fd;
                 return 0;
             }
             break;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -235,7 +235,7 @@ namespace zmq
         //  When creating a new ZMQ socket, if this option is set the value
         //  will be used as the File Descriptor instead of allocating a new
         //  one via the socket () system call.
-        int usefd;
+        int use_fd;
     };
 }
 

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -168,8 +168,8 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
 
     address.to_string (endpoint);
 
-    if (options.usefd != -1) {
-        s = options.usefd;
+    if (options.use_fd != -1) {
+        s = options.use_fd;
         socket->event_listening (endpoint, (int) s);
         return 0;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,8 +90,8 @@ if(NOT WIN32)
           test_stream_exceeds_buffer
           test_router_mandatory_hwm
           test_term_endpoint_tipc
-          test_usefd_ipc
-          test_usefd_tcp
+          test_use_fd_ipc
+          test_use_fd_tcp
   )
   if(HAVE_FORK)
     list(APPEND tests test_fork)

--- a/tests/test_setsockopt.cpp
+++ b/tests/test_setsockopt.cpp
@@ -70,7 +70,7 @@ void test_setsockopt_tcp_send_buffer()
     zmq_ctx_term(ctx);
 }
 
-void test_setsockopt_usefd()
+void test_setsockopt_use_fd()
 {
     int rc;
     void *ctx = zmq_ctx_new();
@@ -79,17 +79,17 @@ void test_setsockopt_usefd()
     int val = 0;
     size_t placeholder = sizeof(val);
 
-    rc = zmq_getsockopt(socket, ZMQ_USEFD, &val, &placeholder);
+    rc = zmq_getsockopt(socket, ZMQ_USE_FD, &val, &placeholder);
     assert(rc == 0);
     assert(val == -1);
 
     val = 3;
 
-    rc = zmq_setsockopt(socket, ZMQ_USEFD, &val, sizeof(val));
+    rc = zmq_setsockopt(socket, ZMQ_USE_FD, &val, sizeof(val));
     assert(rc == 0);
     assert(val == 3);
 
-    rc = zmq_getsockopt(socket, ZMQ_USEFD, &val, &placeholder);
+    rc = zmq_getsockopt(socket, ZMQ_USE_FD, &val, &placeholder);
     assert(rc == 0);
     assert(val == 3);
 
@@ -102,5 +102,5 @@ int main()
 {
     test_setsockopt_tcp_recv_buffer();
     test_setsockopt_tcp_send_buffer();
-    test_setsockopt_usefd();
+    test_setsockopt_use_fd();
 }

--- a/tests/test_use_fd_ipc.cpp
+++ b/tests/test_use_fd_ipc.cpp
@@ -50,7 +50,7 @@ void pre_allocate_sock (void *zmq_socket, const char *path)
     rc = listen (s_pre, SOMAXCONN);
     assert (rc == 0);
 
-    rc = zmq_setsockopt (zmq_socket, ZMQ_USEFD, &s_pre,
+    rc = zmq_setsockopt (zmq_socket, ZMQ_USE_FD, &s_pre,
             sizeof (s_pre));
     assert(rc == 0);
 }

--- a/tests/test_use_fd_tcp.cpp
+++ b/tests/test_use_fd_tcp.cpp
@@ -52,7 +52,7 @@ void pre_allocate_sock (void *zmq_socket, const char *address,
     rc = listen (s_pre, SOMAXCONN);
     assert (rc == 0);
 
-    rc = zmq_setsockopt (zmq_socket, ZMQ_USEFD, &s_pre,
+    rc = zmq_setsockopt (zmq_socket, ZMQ_USE_FD, &s_pre,
             sizeof (s_pre));
     assert(rc == 0);
 }


### PR DESCRIPTION
Solution: rename socket option (and variables and files) from usefd
to use_fd.