### PR TITLE
Cleaning up recent option names

### DIFF
--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -26,19 +26,29 @@ ZMQ_IO_THREADS: Get number of I/O threads
 The 'ZMQ_IO_THREADS' argument returns the size of the 0MQ thread pool
 for this context.
 
+
 ZMQ_MAX_SOCKETS: Get maximum number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_MAX_SOCKETS' argument returns the maximum number of sockets
 allowed for this context.
+
+
+ZMQ_MAX_MSGSZ: Get maximum message size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_MAX_MSGSZ' argument returns the maximum size of a message
+allowed for this context. Default value is INT_MAX.
+
 
 ZMQ_SOCKET_LIMIT: Get largest configurable number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_SOCKET_LIMIT' argument returns the largest number of sockets that
 linkzmq:zmq_ctx_set[3] will accept.
 
+
 ZMQ_IPV6: Set IPv6 option
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_IPV6' argument returns the IPv6 option for the context.
+
 
 ZMQ_BLOCKY: Get blocky setting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -47,6 +47,7 @@ context.
 [horizontal]
 Default value:: 1
 
+
 ZMQ_THREAD_SCHED_POLICY: Set scheduling policy for I/O threads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_THREAD_SCHED_POLICY' argument sets the scheduling policy for
@@ -57,6 +58,7 @@ This option only applies before creating any sockets on the context.
 
 [horizontal]
 Default value:: -1
+
 
 ZMQ_THREAD_PRIORITY: Set scheduling priority for I/O threads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -69,6 +71,19 @@ This option only applies before creating any sockets on the context.
 [horizontal]
 Default value:: -1
 
+
+ZMQ_MAX_MSGSZ: Set maximum message size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_MAX_MSGSZ' argument sets the maximum allowed size
+of a message sent in the context. You can query the maximal
+allowed value with linkzmq:zmq_ctx_get[3] using the
+'ZMQ_MAX_MSGSZ' option.
+
+[horizontal]
+Default value:: INT_MAX
+Maximum value:: INT_MAX
+
+
 ZMQ_MAX_SOCKETS: Set maximum number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_MAX_SOCKETS' argument sets the maximum number of sockets allowed
@@ -77,6 +92,7 @@ linkzmq:zmq_ctx_get[3] using the 'ZMQ_SOCKET_LIMIT' option.
 
 [horizontal]
 Default value:: 1024
+
 
 ZMQ_IPV6: Set IPv6 option
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -715,9 +715,9 @@ Default value:: 0 (leave to OS default)
 Applicable socket types:: all, when using TCP transports.
 
 
-ZMQ_THREADSAFE: Retrieve socket thread safety
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_THREADSAFE' option shall retrieve a boolean value indicating whether
+ZMQ_THREAD_SAFE: Retrieve socket thread safety
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_THREAD_SAFE' option shall retrieve a boolean value indicating whether
 or not the socket is threadsafe. Currently 'ZMQ_CLIENT' and 'ZMQ_SERVER' sockets
 are threadsafe.
 

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -498,6 +498,7 @@ documentation for the 'SO_RCVBUF' socket option.
 [horizontal]
 Option value type:: int
 Option value unit:: bytes
+Default value:: 8192
 Applicable socket types:: all
 
 
@@ -612,6 +613,7 @@ documentation for the 'SO_SNDBUF' socket option.
 [horizontal]
 Option value type:: int
 Option value unit:: bytes
+Default value:: 8192
 Applicable socket types:: all
 
 
@@ -763,31 +765,6 @@ Option value unit:: N/A
 Default value:: not set
 Applicable socket types:: all, when using TCP transport
 
-ZMQ_TCP_RECV_BUFFER: Size of the TCP receive buffer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_TCP_RECV_BUFFER' specifies the maximum number of bytes which can
-be received by an individual syscall to receive data from the TCP socket.
-The default value is 8192.
-
-
-[horizontal]
-Option value type:: int
-Option value unit:: >0
-Default value:: 8192
-Applicable socket types:: all, when using TCP transport
-
-ZMQ_TCP_SEND_BUFFER: Size of the TCP receive buffer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_TCP_SEND_BUFFER' specifies the maximum number of bytes which can
-be sent by an individual syscall to transmit data to the TCP socket.
-The default value is 8192.
-
-
-[horizontal]
-Option value type:: int
-Option value unit:: >0
-Default value:: 8192
-Applicable socket types:: all, when using TCP transport
 
 ZMQ_VMCI_BUFFER_SIZE: Retrieve buffer size of the VMCI socket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -700,14 +700,13 @@ Default value:: -1 (leave to OS default)
 Applicable socket types:: all, when using TCP transports.
 
 
-ZMQ_TCP_RETRANSMIT_TIMEOUT: Retrieve TCP Retransmit Timeout
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ZMQ_TCP_MAXRT: Retrieve Max TCP Retransmit Timeout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 On OSes where it is supported, retrieves how long before an unacknowledged TCP
-retransmit times out.
-The system normally attempts many TCP retransmits following an exponential
-backoff strategy. This means that after a network outage, it may take a long
-time before the session can be re-established. Setting this option allows
-the timeout to happen at a shorter interval.
+retransmit times out. The system normally attempts many TCP retransmits
+following an exponential backoff strategy. This means that after a network
+outage, it may take a long time before the session can be re-established.
+Setting this option allows the timeout to happen at a shorter interval.
 
 [horizontal]
 Option value type:: int

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -915,11 +915,11 @@ Default value:: N/A
 Applicable socket types:: ZMQ_SUB
 
 
-ZMQ_XPUB_VERBOSE: provide all subscription messages on XPUB sockets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Sets the 'XPUB' socket behaviour on new subscriptions and unsubscriptions.
-A value of '0' is the default and passes only new subscription messages to
-upstream. A value of '1' passes all subscription messages upstream.
+ZMQ_XPUB_VERBOSE: pass subscribe messages on XPUB socket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the 'XPUB' socket behaviour on new subscriptions. If enabled,
+the socket passes all subscribe messages to the caller. If disabled,
+these are not visible to the caller. The default is 0 (disabled).
 
 [horizontal]
 Option value type:: int
@@ -928,17 +928,12 @@ Default value:: 0
 Applicable socket types:: ZMQ_XPUB
 
 
-ZMQ_XPUB_VERBOSE_UNSUBSCRIBE: provide all unsubscription messages on XPUB sockets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Sets the 'XPUB' socket behaviour on new subscriptions and unsubscriptions.
-A value of '0' is the default and passes only the last unsubscription message to
-upstream. A value of '1' passes all unsubscription messages upstream.
-
-This behaviour should be enabled in all the intermediary XPUB sockets if
-ZMQ_XPUB_VERBOSE is also being used in order to allow the correct forwarding
-of all the unsubscription messages.
-
-NOTE: This behaviour only takes effect when ZMQ_XPUB_VERBOSE is also enabled.
+ZMQ_XPUB_VERBOSER: pass subscribe and unsubscribe messages on XPUB socket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the 'XPUB' socket behaviour on new subscriptions and ubsubscriptions.
+If enabled, the socket passes all subscribe and unsubscribe messages to the
+caller. If disabled, these are not visible to the caller. The default is 0
+(disabled).
 
 [horizontal]
 Option value type:: int

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -870,14 +870,13 @@ Default value:: -1 (leave to OS default)
 Applicable socket types:: all, when using TCP transports.
 
 
-ZMQ_TCP_RETRANSMIT_TIMEOUT: Set TCP Retransmit Timeout
+ZMQ_TCP_MAXRT: Set TCP Maximum Retransmit Timeout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 On OSes where it is supported, sets how long before an unacknowledged TCP
-retransmit times out.
-The system normally attempts many TCP retransmits following an exponential
-backoff strategy. This means that after a network outage, it may take a long
-time before the session can be re-established. Setting this option allows
-the timeout to happen at a shorter interval.
+retransmit times out. The system normally attempts many TCP retransmits
+following an exponential backoff strategy. This means that after a network
+outage, it may take a long time before the session can be re-established.
+Setting this option allows the timeout to happen at a shorter interval.
 
 [horizontal]
 Option value type:: int

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1102,31 +1102,6 @@ Option value unit:: boolean
 Default value:: 1 (true)
 Applicable socket types:: all, when using TCP transports.
 
-ZMQ_TCP_RECV_BUFFER: Size of the TCP receive buffer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_TCP_RECV_BUFFER' specifies the maximum number of bytes which can
-be received by an individual syscall to receive data from the TCP socket.
-The default value is 8192.
-
-
-[horizontal]
-Option value type:: int
-Option value unit:: >0
-Default value:: 8192
-Applicable socket types:: all, when using TCP transport
-
-ZMQ_TCP_SEND_BUFFER: Size of the TCP receive buffer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_TCP_SEND_BUFFER' specifies the maximum number of bytes which can
-be sent by an individual syscall to transmit data to the TCP socket.
-The default value is 8192.
-
-
-[horizontal]
-Option value type:: int
-Option value unit:: >0
-Default value:: 8192
-Applicable socket types:: all, when using TCP transport
 
 ZMQ_VMCI_BUFFER_SIZE: Set buffer size of the VMCI socket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -339,8 +339,6 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_CONNECT_TIMEOUT 79
 #define ZMQ_TCP_MAXRT 80
 #define ZMQ_THREAD_SAFE 81
-#define ZMQ_TCP_RECV_BUFFER 82
-#define ZMQ_TCP_SEND_BUFFER 83
 #define ZMQ_MULTICAST_MAXTPDU 84
 #define ZMQ_VMCI_BUFFER_SIZE 85
 #define ZMQ_VMCI_BUFFER_MIN_SIZE 86

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -325,6 +325,8 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_HANDSHAKE_IVL 66
 #define ZMQ_SOCKS_PROXY 68
 #define ZMQ_XPUB_NODROP 69
+//  All options after this is for version 4.2 and still *draft*
+//  Subject to arbitrary change without notice
 #define ZMQ_BLOCKY 70
 #define ZMQ_XPUB_MANUAL 71
 #define ZMQ_XPUB_WELCOME_MSG 72
@@ -335,7 +337,7 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_HEARTBEAT_TIMEOUT 77
 #define ZMQ_XPUB_VERBOSE_UNSUBSCRIBE 78
 #define ZMQ_CONNECT_TIMEOUT 79
-#define ZMQ_TCP_RETRANSMIT_TIMEOUT 80
+#define ZMQ_TCP_MAXRT 80
 #define ZMQ_THREAD_SAFE 81
 #define ZMQ_TCP_RECV_BUFFER 82
 #define ZMQ_TCP_SEND_BUFFER 83

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -335,7 +335,7 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_HEARTBEAT_IVL 75
 #define ZMQ_HEARTBEAT_TTL 76
 #define ZMQ_HEARTBEAT_TIMEOUT 77
-#define ZMQ_XPUB_VERBOSE_UNSUBSCRIBE 78
+#define ZMQ_XPUB_VERBOSER 78
 #define ZMQ_CONNECT_TIMEOUT 79
 #define ZMQ_TCP_MAXRT 80
 #define ZMQ_THREAD_SAFE 81

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -185,13 +185,13 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 /*  0MQ infrastructure (a.k.a. context) initialisation & termination.         */
 /******************************************************************************/
 
-/*  New API                                                                   */
 /*  Context options                                                           */
 #define ZMQ_IO_THREADS  1
 #define ZMQ_MAX_SOCKETS 2
 #define ZMQ_SOCKET_LIMIT 3
 #define ZMQ_THREAD_PRIORITY 3
 #define ZMQ_THREAD_SCHED_POLICY 4
+#define ZMQ_MAX_MSGSZ 5
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT  1

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include <limits>
+#include <climits>
 #include <new>
 #include <string.h>
 
@@ -79,6 +80,7 @@ zmq::ctx_t::ctx_t () :
     slot_count (0),
     slots (NULL),
     max_sockets (clipped_maxsocket (ZMQ_MAX_SOCKETS_DFLT)),
+    max_msgsz (INT_MAX),
     io_thread_count (ZMQ_IO_THREADS_DFLT),
     blocky (true),
     ipv6 (false),
@@ -251,18 +253,24 @@ int zmq::ctx_t::set (int option_, int optval_)
     if (option_ == ZMQ_THREAD_PRIORITY && optval_ >= 0) {
         opt_sync.lock();
         thread_priority = optval_;
-        opt_sync.unlock();
+        opt_sync.unlock ();
     }
     else
     if (option_ == ZMQ_THREAD_SCHED_POLICY && optval_ >= 0) {
         opt_sync.lock();
         thread_sched_policy = optval_;
-        opt_sync.unlock();
+        opt_sync.unlock ();
     }
     else
     if (option_ == ZMQ_BLOCKY && optval_ >= 0) {
         opt_sync.lock ();
         blocky = (optval_ != 0);
+        opt_sync.unlock ();
+    }
+    else
+    if (option_ == ZMQ_MAX_MSGSZ && optval_ >= 0) {
+        opt_sync.lock ();
+        max_msgsz = optval_ < INT_MAX? optval_: INT_MAX;
         opt_sync.unlock ();
     }
     else {
@@ -289,6 +297,9 @@ int zmq::ctx_t::get (int option_)
     else
     if (option_ == ZMQ_BLOCKY)
         rc = blocky;
+    else
+    if (option_ == ZMQ_MAX_MSGSZ)
+        rc = max_msgsz;
     else {
         errno = EINVAL;
         rc = -1;

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -199,6 +199,9 @@ namespace zmq
         //  Maximum number of sockets that can be opened at the same time.
         int max_sockets;
 
+        //  Maximum allowed message size
+        int max_msgsz;
+
         //  Number of I/O threads to launch.
         int io_thread_count;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -42,8 +42,8 @@ zmq::options_t::options_t () :
     recovery_ivl (10000),
     multicast_hops (1),
     multicast_maxtpdu (1500),
-    sndbuf (-1),
-    rcvbuf (-1),
+    sndbuf (8192),
+    rcvbuf (8192),
     tos (0),
     type (-1),
     linger (-1),
@@ -66,8 +66,6 @@ zmq::options_t::options_t () :
     tcp_keepalive_cnt (-1),
     tcp_keepalive_idle (-1),
     tcp_keepalive_intvl (-1),
-    tcp_recv_buffer_size (8192),
-    tcp_send_buffer_size (8192),
     mechanism (ZMQ_NULL),
     as_server (0),
     gss_plaintext (false),
@@ -294,20 +292,6 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
         case ZMQ_TCP_KEEPALIVE_INTVL:
             if (is_int && (value == -1 || value >= 0)) {
                 tcp_keepalive_intvl = value;
-                return 0;
-            }
-            break;
-
-        case ZMQ_TCP_RECV_BUFFER:
-            if (is_int && (value > 0) ) {
-                tcp_recv_buffer_size = static_cast<unsigned int>(value);
-                return 0;
-            }
-            break;
-
-        case ZMQ_TCP_SEND_BUFFER:
-            if (is_int && (value > 0) ) {
-                tcp_send_buffer_size = static_cast<unsigned int>(value);
                 return 0;
             }
             break;
@@ -862,20 +846,6 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
         case ZMQ_TCP_KEEPALIVE_INTVL:
             if (is_int) {
                 *value = tcp_keepalive_intvl;
-                return 0;
-            }
-            break;
-
-        case ZMQ_TCP_SEND_BUFFER:
-            if (is_int) {
-                *value = tcp_send_buffer_size;
-                return 0;
-            }
-            break;
-
-        case ZMQ_TCP_RECV_BUFFER:
-            if (is_int) {
-                *value = tcp_recv_buffer_size;
                 return 0;
             }
             break;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -48,7 +48,7 @@ zmq::options_t::options_t () :
     type (-1),
     linger (-1),
     connect_timeout (0),
-    tcp_retransmit_timeout (0),
+    tcp_maxrt (0),
     reconnect_ivl (100),
     reconnect_ivl_max (0),
     backlog (100),
@@ -178,9 +178,9 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             }
             break;
 
-        case ZMQ_TCP_RETRANSMIT_TIMEOUT:
+        case ZMQ_TCP_MAXRT:
             if (is_int && value >= 0) {
-                tcp_retransmit_timeout = value;
+                tcp_maxrt = value;
                 return 0;
             }
             break;
@@ -745,9 +745,9 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
             }
             break;
 
-        case ZMQ_TCP_RETRANSMIT_TIMEOUT:
+        case ZMQ_TCP_MAXRT:
             if (is_int) {
-                *value = tcp_retransmit_timeout;
+                *value = tcp_maxrt;
                 return 0;
             }
             break;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -160,10 +160,6 @@ namespace zmq
         typedef std::vector <tcp_address_mask_t> tcp_accept_filters_t;
         tcp_accept_filters_t tcp_accept_filters;
 
-        // TCP buffer sizes
-        unsigned int tcp_recv_buffer_size;
-        unsigned int tcp_send_buffer_size;
-
         // IPC accept() filters
 #       if defined ZMQ_HAVE_SO_PEERCRED || defined ZMQ_HAVE_LOCAL_PEERCRED
         bool zap_ipc_creds;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -104,7 +104,7 @@ namespace zmq
         //  Maximum interval in milliseconds beyond which TCP will timeout
         //  retransmitted packets.
         //  Default 0 (unused)
-        int tcp_retransmit_timeout;
+        int tcp_maxrt;
 
         //  Minimum interval between attempts to reconnect, in milliseconds.
         //  Default 100ms

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -245,7 +245,7 @@ namespace zmq
         void update_pipe_options(int option_);
 
         //  Socket's mailbox object.
-        i_mailbox* mailbox;
+        i_mailbox *mailbox;
 
         //  List of attached pipes.
         typedef array_t <pipe_t, 3> pipes_t;

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -203,10 +203,10 @@ void zmq::stream_engine_t::plug (io_thread_t *io_thread_,
 
     if (options.raw_socket) {
         // no handshaking for raw sock, instantiate raw encoder and decoders
-        encoder = new (std::nothrow) raw_encoder_t (options.tcp_send_buffer_size);
+        encoder = new (std::nothrow) raw_encoder_t (options.sndbuf);
         alloc_assert (encoder);
 
-        decoder = new (std::nothrow) raw_decoder_t (options.tcp_recv_buffer_size);
+        decoder = new (std::nothrow) raw_decoder_t (options.rcvbuf);
         alloc_assert (decoder);
 
         // disable handshaking for raw socket
@@ -385,12 +385,12 @@ void zmq::stream_engine_t::out_event ()
         outpos = NULL;
         outsize = encoder->encode (&outpos, 0);
 
-        while (outsize < options.tcp_send_buffer_size) {
+        while (outsize < (size_t) options.sndbuf) {
             if ((this->*next_msg) (&tx_msg) == -1)
                 break;
             encoder->load_msg (&tx_msg);
             unsigned char *bufptr = outpos + outsize;
-            size_t n = encoder->encode (&bufptr, options.tcp_send_buffer_size - outsize);
+            size_t n = encoder->encode (&bufptr, options.sndbuf - outsize);
             zmq_assert (n > 0);
             if (outpos == NULL)
                 outpos = bufptr;
@@ -587,10 +587,10 @@ bool zmq::stream_engine_t::handshake ()
            return false;
         }
 
-        encoder = new (std::nothrow) v1_encoder_t (options.tcp_send_buffer_size);
+        encoder = new (std::nothrow) v1_encoder_t (options.sndbuf);
         alloc_assert (encoder);
 
-        decoder = new (std::nothrow) v1_decoder_t (options.tcp_recv_buffer_size, options.maxmsgsize);
+        decoder = new (std::nothrow) v1_decoder_t (options.rcvbuf, options.maxmsgsize);
         alloc_assert (decoder);
 
         //  We have already sent the message header.
@@ -635,11 +635,11 @@ bool zmq::stream_engine_t::handshake ()
         }
 
         encoder = new (std::nothrow) v1_encoder_t (
-           options.tcp_send_buffer_size);
+           options.sndbuf);
         alloc_assert (encoder);
 
         decoder = new (std::nothrow) v1_decoder_t (
-            options.tcp_recv_buffer_size, options.maxmsgsize);
+            options.rcvbuf, options.maxmsgsize);
         alloc_assert (decoder);
     }
     else
@@ -650,19 +650,19 @@ bool zmq::stream_engine_t::handshake ()
            return false;
         }
 
-        encoder = new (std::nothrow) v2_encoder_t (options.tcp_send_buffer_size);
+        encoder = new (std::nothrow) v2_encoder_t (options.sndbuf);
         alloc_assert (encoder);
 
         decoder = new (std::nothrow) v2_decoder_t (
-            options.tcp_recv_buffer_size, options.maxmsgsize);
+            options.rcvbuf, options.maxmsgsize);
         alloc_assert (decoder);
     }
     else {
-        encoder = new (std::nothrow) v2_encoder_t (options.tcp_send_buffer_size);
+        encoder = new (std::nothrow) v2_encoder_t (options.sndbuf);
         alloc_assert (encoder);
 
         decoder = new (std::nothrow) v2_decoder_t (
-                options.tcp_recv_buffer_size, options.maxmsgsize);
+                options.rcvbuf, options.maxmsgsize);
         alloc_assert (decoder);
 
         if (options.mechanism == ZMQ_NULL

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -84,7 +84,7 @@ void zmq::set_tcp_send_buffer (fd_t sockfd_, int bufsize_)
 void zmq::set_tcp_receive_buffer (fd_t sockfd_, int bufsize_)
 {
     const int rc = setsockopt (sockfd_, SOL_SOCKET, SO_RCVBUF,
-        (char*) &bufsize_, sizeof bufsize_);
+        (char *) &bufsize_, sizeof bufsize_);
 #ifdef ZMQ_HAVE_WINDOWS
     wsa_assert (rc != SOCKET_ERROR);
 #else

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -153,7 +153,7 @@ void zmq::tune_tcp_keepalives (fd_t s_, int keepalive_, int keepalive_cnt_, int 
 #endif // ZMQ_HAVE_WINDOWS
 }
 
-void zmq::tune_tcp_retransmit_timeout (fd_t sockfd_, int timeout_)
+void zmq::tune_tcp_maxrt (fd_t sockfd_, int timeout_)
 {
     if (timeout_ <= 0)
         return;

--- a/src/tcp.hpp
+++ b/src/tcp.hpp
@@ -47,8 +47,8 @@ namespace zmq
     //  Tunes TCP keep-alives
     void tune_tcp_keepalives (fd_t s_, int keepalive_, int keepalive_cnt_, int keepalive_idle_, int keepalive_intvl_);
 
-    //  Tunes TCP retransmit timeout
-    void tune_tcp_retransmit_timeout (fd_t sockfd_, int timeout_);
+    //  Tunes TCP max retransmit timeout
+    void tune_tcp_maxrt (fd_t sockfd_, int timeout_);
 
     //  Writes data to the socket. Returns the number of bytes actually
     //  written (even zero is to be considered to be a success). In case

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -146,7 +146,7 @@ void zmq::tcp_connecter_t::out_event ()
 
     tune_tcp_socket (fd);
     tune_tcp_keepalives (fd, options.tcp_keepalive, options.tcp_keepalive_cnt, options.tcp_keepalive_idle, options.tcp_keepalive_intvl);
-    tune_tcp_retransmit_timeout (fd, options.tcp_retransmit_timeout);
+    tune_tcp_maxrt (fd, options.tcp_maxrt);
 
     // remember our fd for ZMQ_SRCFD in messages
     socket->set_fd (fd);

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -100,7 +100,7 @@ void zmq::tcp_listener_t::in_event ()
 
     tune_tcp_socket (fd);
     tune_tcp_keepalives (fd, options.tcp_keepalive, options.tcp_keepalive_cnt, options.tcp_keepalive_idle, options.tcp_keepalive_intvl);
-    tune_tcp_retransmit_timeout (fd, options.tcp_retransmit_timeout);
+    tune_tcp_maxrt (fd, options.tcp_maxrt);
 
     // remember our fd for ZMQ_SRCFD in messages
     socket->set_fd(fd);

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -133,19 +133,23 @@ void zmq::xpub_t::xwrite_activated (pipe_t *pipe_)
 int zmq::xpub_t::xsetsockopt (int option_, const void *optval_,
     size_t optvallen_)
 {
-    if (option_ == ZMQ_XPUB_VERBOSE || option_ == ZMQ_XPUB_VERBOSE_UNSUBSCRIBE ||
-        option_ == ZMQ_XPUB_NODROP || option_ == ZMQ_XPUB_MANUAL)
-    {
+    if (option_ == ZMQ_XPUB_VERBOSE
+     || option_ == ZMQ_XPUB_VERBOSER
+     || option_ == ZMQ_XPUB_NODROP
+     || option_ == ZMQ_XPUB_MANUAL) {
         if (optvallen_ != sizeof(int) || *static_cast <const int*> (optval_) < 0) {
             errno = EINVAL;
             return -1;
         }
-
-        if (option_ == ZMQ_XPUB_VERBOSE)
+        if (option_ == ZMQ_XPUB_VERBOSE) {
             verbose_subs = (*static_cast <const int*> (optval_) != 0);
+            verbose_unsubs = 0;
+        }
         else
-        if (option_ == ZMQ_XPUB_VERBOSE_UNSUBSCRIBE)
-            verbose_unsubs = (*static_cast <const int*> (optval_) != 0);
+        if (option_ == ZMQ_XPUB_VERBOSER) {
+            verbose_subs = (*static_cast <const int*> (optval_) != 0);
+            verbose_unsubs = verbose_subs;
+        }
         else
         if (option_ == ZMQ_XPUB_NODROP)
             lossy = (*static_cast <const int*> (optval_) == 0);
@@ -155,15 +159,13 @@ int zmq::xpub_t::xsetsockopt (int option_, const void *optval_,
     }
     else
     if (option_ == ZMQ_SUBSCRIBE && manual) {
-        if (last_pipe != NULL) {
-            subscriptions.add((unsigned char *)optval_, optvallen_, last_pipe);
-        }
+        if (last_pipe != NULL)
+            subscriptions.add ((unsigned char *)optval_, optvallen_, last_pipe);
     }
     else
     if (option_ == ZMQ_UNSUBSCRIBE && manual) {
-        if (last_pipe != NULL) {
-            subscriptions.rm((unsigned char *)optval_, optvallen_, last_pipe);
-        }
+        if (last_pipe != NULL)
+            subscriptions.rm ((unsigned char *)optval_, optvallen_, last_pipe);
     }
     else
     if (option_ == ZMQ_XPUB_WELCOME_MSG) {

--- a/tests/test_setsockopt.cpp
+++ b/tests/test_setsockopt.cpp
@@ -1,106 +1,105 @@
 #include "testutil.hpp"
 
-void test_setsockopt_tcp_recv_buffer()
+void test_setsockopt_tcp_recv_buffer (void)
 {
     int rc;
-    void *ctx = zmq_ctx_new();
-    void *socket = zmq_socket(ctx, ZMQ_PUSH);
+    void *ctx = zmq_ctx_new ();
+    void *socket = zmq_socket (ctx, ZMQ_PUSH);
 
     int val = 0;
-    size_t placeholder = sizeof(val);
+    size_t placeholder = sizeof (val);
 
-    rc = zmq_getsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, &placeholder);
-    assert(rc == 0);
-    assert(val == 8192);
+    rc = zmq_getsockopt (socket, ZMQ_RCVBUF, &val, &placeholder);
+    assert (rc == 0);
+    assert (val == 8192);
 
-    rc = zmq_setsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, sizeof(val));
-    assert(rc == 0);
-    assert(val == 8192);
+    rc = zmq_setsockopt (socket, ZMQ_RCVBUF, &val, sizeof (val));
+    assert (rc == 0);
+    assert (val == 8192);
 
-    rc = zmq_getsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, &placeholder);
-    assert(rc == 0);
-    assert(val == 8192);
+    rc = zmq_getsockopt (socket, ZMQ_RCVBUF, &val, &placeholder);
+    assert (rc == 0);
+    assert (val == 8192);
 
     val = 16384;
 
-    rc = zmq_setsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, sizeof(val));
-    assert(rc == 0);
-    assert(val == 16384);
+    rc = zmq_setsockopt (socket, ZMQ_RCVBUF, &val, sizeof (val));
+    assert (rc == 0);
+    assert (val == 16384);
 
-    rc = zmq_getsockopt(socket, ZMQ_TCP_RECV_BUFFER, &val, &placeholder);
-    assert(rc == 0);
-    assert(val == 16384);
+    rc = zmq_getsockopt (socket, ZMQ_RCVBUF, &val, &placeholder);
+    assert (rc == 0);
+    assert (val == 16384);
 
-    zmq_close(socket);
-    zmq_ctx_term(ctx);
+    zmq_close (socket);
+    zmq_ctx_term (ctx);
 }
 
-void test_setsockopt_tcp_send_buffer()
+void test_setsockopt_tcp_send_buffer (void)
 {
     int rc;
-    void *ctx = zmq_ctx_new();
-    void *socket = zmq_socket(ctx, ZMQ_PUSH);
+    void *ctx = zmq_ctx_new ();
+    void *socket = zmq_socket (ctx, ZMQ_PUSH);
 
     int val = 0;
-    size_t placeholder = sizeof(val);
+    size_t placeholder = sizeof (val);
 
-    rc = zmq_getsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, &placeholder);
-    assert(rc == 0);
-    assert(val == 8192);
+    rc = zmq_getsockopt (socket, ZMQ_SNDBUF, &val, &placeholder);
+    assert (rc == 0);
+    assert (val == 8192);
 
-    rc = zmq_setsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, sizeof(val));
-    assert(rc == 0);
-    assert(val == 8192);
+    rc = zmq_setsockopt (socket, ZMQ_SNDBUF, &val, sizeof (val));
+    assert (rc == 0);
+    assert (val == 8192);
 
-    rc = zmq_getsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, &placeholder);
-    assert(rc == 0);
-    assert(val == 8192);
+    rc = zmq_getsockopt (socket, ZMQ_SNDBUF, &val, &placeholder);
+    assert (rc == 0);
+    assert (val == 8192);
 
     val = 16384;
 
-    rc = zmq_setsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, sizeof(val));
-    assert(rc == 0);
-    assert(val == 16384);
+    rc = zmq_setsockopt (socket, ZMQ_SNDBUF, &val, sizeof (val));
+    assert (rc == 0);
+    assert (val == 16384);
 
-    rc = zmq_getsockopt(socket, ZMQ_TCP_SEND_BUFFER, &val, &placeholder);
-    assert(rc == 0);
-    assert(val == 16384);
+    rc = zmq_getsockopt (socket, ZMQ_SNDBUF, &val, &placeholder);
+    assert (rc == 0);
+    assert (val == 16384);
 
-    zmq_close(socket);
-    zmq_ctx_term(ctx);
+    zmq_close (socket);
+    zmq_ctx_term (ctx);
 }
 
-void test_setsockopt_use_fd()
+void test_setsockopt_use_fd ()
 {
     int rc;
-    void *ctx = zmq_ctx_new();
-    void *socket = zmq_socket(ctx, ZMQ_PUSH);
+    void *ctx = zmq_ctx_new ();
+    void *socket = zmq_socket (ctx, ZMQ_PUSH);
 
     int val = 0;
-    size_t placeholder = sizeof(val);
+    size_t placeholder = sizeof (val);
 
-    rc = zmq_getsockopt(socket, ZMQ_USE_FD, &val, &placeholder);
+    rc = zmq_getsockopt (socket, ZMQ_USE_FD, &val, &placeholder);
     assert(rc == 0);
     assert(val == -1);
 
     val = 3;
 
-    rc = zmq_setsockopt(socket, ZMQ_USE_FD, &val, sizeof(val));
+    rc = zmq_setsockopt (socket, ZMQ_USE_FD, &val, sizeof(val));
     assert(rc == 0);
     assert(val == 3);
 
-    rc = zmq_getsockopt(socket, ZMQ_USE_FD, &val, &placeholder);
+    rc = zmq_getsockopt (socket, ZMQ_USE_FD, &val, &placeholder);
     assert(rc == 0);
     assert(val == 3);
 
-    zmq_close(socket);
-    zmq_ctx_term(ctx);
+    zmq_close (socket);
+    zmq_ctx_term (ctx);
 }
 
-
-int main()
+int main (void)
 {
-    test_setsockopt_tcp_recv_buffer();
-    test_setsockopt_tcp_send_buffer();
-    test_setsockopt_use_fd();
+    test_setsockopt_tcp_recv_buffer ();
+    test_setsockopt_tcp_send_buffer ();
+    test_setsockopt_use_fd ();
 }


### PR DESCRIPTION
@minrk I've also noticed the large message test freezes my laptop for a few seconds. Since we're now implementing a maximum message size, I've made this configurable via zmq_ctx_set(). This was long overdue I think. Needs a little help to be fully working.