### PR TITLE
Problem: use of libsodium vs. tweetnacl is confused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,8 @@ test_udp
 test_large_msg
 test_use_fd_ipc
 test_use_fd_tcp
+test_pre_allocated_fd_ipc
+test_pre_allocated_fd_tcp
 tests/test*.log
 tests/test*.trs
 src/platform.hpp*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,334 +1,353 @@
 # CMake build script for ZeroMQ
 
-cmake_minimum_required(VERSION 2.8.12)
-project(ZeroMQ)
+cmake_minimum_required (VERSION 2.8.12)
+project (ZeroMQ)
 
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}")
+list (INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}")
 
-option(WITH_OPENPGM "Build with support for OpenPGM" OFF)
-option(WITH_VMCI "Build with support for VMware VMCI socket" OFF)
+option (WITH_OPENPGM "Build with support for OpenPGM" OFF)
+option (WITH_VMCI "Build with support for VMware VMCI socket" OFF)
 
-if(APPLE)
-  option(ZMQ_BUILD_FRAMEWORK "Build as OS X framework" ON)
-endif()
+if (APPLE)
+    option (ZMQ_BUILD_FRAMEWORK "Build as OS X framework" ON)
+endif ()
 
-option(WITH_SODIUM "Build with libsodium" ON)
-option(WITH_TWEETNACL "Build with tweetnacl" ON)
+# Select curve encryption library, defaults to tweetnacl
+# To use libsodium instead, use --with-libsodium (must be installed)
+# To disable curve, use --disable-curve
 
-if(WITH_SODIUM)
-  find_package(Sodium)
-  if(SODIUM_FOUND)
-    add_definitions(-DHAVE_LIBSODIUM)
-    include_directories(${SODIUM_INCLUDE_DIRS})
-  endif()
-endif()
+option (WITH_LIBSODIUM "Use libsodium instead of built-in tweetnacl" OFF)
+option (ENABLE_CURVE "Enable CURVE security" ON)
 
-if(WITH_TWEETNACL)
-  message(STATUS "Building with TweetNaCL")
-  set(USE_TWEETNACL ON)
-  add_definitions(-DHAVE_TWEETNACL)
-  include_directories(
-    tweetnacl/contrib/randombytes
-    tweetnacl/src
-    )
+if (NOT ENABLE_CURVE)
+    message (STATUS "CURVE security is disabled")
 
-  set(TWEETNACL_SOURCES
-    tweetnacl/src/tweetnacl.c
-    )
+elseif (WITH_SODIUM)
+    find_package (Sodium)
+    if (SODIUM_FOUND)
+        message (STATUS "Using libsodium for CURVE security")
+        add_definitions (-DZMQ_HAVE_CURVE -DHAVE_LIBSODIUM)
+        include_directories (${SODIUM_INCLUDE_DIRS})
 
-  if(WIN32)
-    list(APPEND TWEETNACL_SOURCES tweetnacl/contrib/randombytes/winrandom.c)
-  else()
-    list(APPEND TWEETNACL_SOURCES tweetnacl/contrib/randombytes/devurandom.c)
-  endif()
-endif()
+        # On Solaris, libsodium depends on libssp
+        if (${CMAKE_SYSTEM_NAME} matches "SunOS")
+            target_link_libraries (libzmq ssp)
+        endif ()
+    else ()
+        message (FATAL_ERROR
+            "libsodium is not installed. Install it, then run CMake again")
+    endif ()
 
-set(POLLER "" CACHE STRING "Choose polling system. valid values are
+else ()
+    message (STATUS "Using tweetnacl for CURVE security")
+    add_definitions (-DZMQ_HAVE_CURVE -DHAVE_TWEETNACL)
+    include_directories (tweetnacl/contrib/randombytes tweetnacl/src)
+    list (APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/tweetnacl/src/tweetnacl.c)
+    #   TODO: this should be a single coherent source file
+    if (WIN32)
+        list (APPEND sources
+            ${CMAKE_CURRENT_SOURCE_DIR}/tweetnacl/contrib/randombytes/winrandom.c)
+    else ()
+        list (APPEND sources
+            ${CMAKE_CURRENT_SOURCE_DIR}/tweetnacl/contrib/randombytes/devurandom.c)
+    endif ()
+endif ()
+
+set (POLLER "" CACHE STRING "Choose polling system. valid values are
                             kqueue, epoll, devpoll, poll or select [default=autodetect]")
 
-include(CheckFunctionExists)
-include(CheckTypeSize)
-if(POLLER STREQUAL "")
-    set(CMAKE_REQUIRED_INCLUDES sys/event.h)
-    check_function_exists(kqueue HAVE_KQUEUE)
-    set(CMAKE_REQUIRED_INCLUDES )
-    if(HAVE_KQUEUE)
-        set(POLLER "kqueue")
-    else()
-        set(CMAKE_REQUIRED_INCLUDES sys/epoll.h)
-        check_function_exists(epoll_create HAVE_EPOLL)
-        set(CMAKE_REQUIRED_INCLUDES )
-        if(HAVE_EPOLL)
-            set(POLLER "epoll")
-        else()
-            set(CMAKE_REQUIRED_INCLUDES sys/devpoll.h)
-            check_type_size("struct pollfd" DEVPOLL)
-            set(CMAKE_REQUIRED_INCLUDES )
-            if(HAVE_DEVPOLL)
-                set(POLLER "devpoll")
-            else()
-                set(CMAKE_REQUIRED_INCLUDES poll.h)
-                check_function_exists(poll HAVE_POLL)
-                set(CMAKE_REQUIRED_INCLUDES )
-                if(HAVE_POLL)
-                    set(POLLER "poll")
-                else()
-                    if(WIN32)
-                        set(CMAKE_REQUIRED_INCLUDES winsock2.h)
-                        set(HAVE_SELECT 1)
-                    else()
-                        set(CMAKE_REQUIRED_INCLUDES sys/select.h)
-                        check_function_exists(select HAVE_SELECT)
-                    endif()
-                    set(CMAKE_REQUIRED_INCLUDES )
-                    if(HAVE_SELECT)
-                        set(POLLER "select")
-                    else()
-                        message(FATAL_ERROR
-                            "Could not autodetect polling method")
-                    endif()
-                endif()
-            endif()
-        endif()
+include (CheckFunctionExists)
+include (CheckTypeSize)
+
+if (POLLER STREQUAL "")
+    set (CMAKE_REQUIRED_INCLUDES sys/event.h)
+    check_function_exists (kqueue HAVE_KQUEUE)
+    set (CMAKE_REQUIRED_INCLUDES)
+    if (HAVE_KQUEUE)
+        set (POLLER "kqueue")
     endif()
-endif()
+endif ()
 
-if(     NOT POLLER STREQUAL "kqueue"
-    AND NOT POLLER STREQUAL "epoll"
-    AND NOT POLLER STREQUAL "devpoll"
-    AND NOT POLLER STREQUAL "poll"
-    AND NOT POLLER STREQUAL "select")
-  message(FATAL_ERROR "Invalid polling method")
-endif()
+if (POLLER STREQUAL "")
+    set (CMAKE_REQUIRED_INCLUDES sys/epoll.h)
+    check_function_exists (epoll_create HAVE_EPOLL)
+    set (CMAKE_REQUIRED_INCLUDES)
+    if (HAVE_EPOLL)
+        set (POLLER "epoll")
+    endif ()
+endif ()
 
-if(NOT ${POLLER} STREQUAL "")
-  string(TOUPPER ${POLLER} UPPER_POLLER)
-  set(ZMQ_USE_${UPPER_POLLER} 1)
-endif()
+if (POLLER STREQUAL "")
+    set (CMAKE_REQUIRED_INCLUDES sys/devpoll.h)
+    check_type_size ("struct pollfd" DEVPOLL)
+    set (CMAKE_REQUIRED_INCLUDES)
+    if (HAVE_DEVPOLL)
+        set (POLLER "devpoll")
+    endif ()
+endif ()
 
-set(ZMQ_CMAKE_MODULES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/Modules)
-list(APPEND CMAKE_MODULE_PATH ${ZMQ_CMAKE_MODULES_DIR})
+if (POLLER STREQUAL "")
+    set (CMAKE_REQUIRED_INCLUDES poll.h)
+    check_function_exists (poll HAVE_POLL)
+    set (CMAKE_REQUIRED_INCLUDES)
+    if (HAVE_POLL)
+        set (POLLER "poll")
+    endif ()
+endif ()
 
-include(TestZMQVersion)
-include(ZMQSourceRunChecks)
-include(CheckIncludeFiles)
-include(CheckLibraryExists)
-include(CheckCCompilerFlag)
-include(CheckCXXCompilerFlag)
-include(CheckCSourceCompiles)
-include(CheckCSourceRuns)
-include(CMakeDependentOption)
-include(CheckCXXSymbolExists)
+if (POLLER STREQUAL "")
+    if (WIN32)
+        set (CMAKE_REQUIRED_INCLUDES winsock2.h)
+        set (HAVE_SELECT 1)
+    else ()
+        set (CMAKE_REQUIRED_INCLUDES sys/select.h)
+        check_function_exists (select HAVE_SELECT)
+        set (CMAKE_REQUIRED_INCLUDES)
+    endif ()
+    if (HAVE_SELECT)
+        set (POLLER "select")
+    else ()
+        message (FATAL_ERROR
+            "Could not autodetect polling method")
+    endif ()
+endif ()
 
-check_include_files(ifaddrs.h ZMQ_HAVE_IFADDRS)
-check_include_files(windows.h ZMQ_HAVE_WINDOWS)
-check_include_files(sys/uio.h ZMQ_HAVE_UIO)
-check_include_files(sys/eventfd.h ZMQ_HAVE_EVENTFD)
+if (POLLER STREQUAL "kqueue"
+ OR POLLER STREQUAL "epoll"
+ OR POLLER STREQUAL "devpoll"
+ OR POLLER STREQUAL "poll"
+ OR POLLER STREQUAL "select")
+    message (STATUS "Detected ${POLLER} polling method")
+    string (TOUPPER ${POLLER} UPPER_POLLER)
+    set (ZMQ_USE_${UPPER_POLLER} 1)
+else ()
+    message (FATAL_ERROR "Invalid polling method")
+endif ()
 
-check_library_exists(ws2_32 fopen "" HAVE_WS2_32) # TODO: Why doesn't something logical like WSAStartup work?
-check_library_exists(ws2 fopen "" HAVE_WS2)
-check_library_exists(rpcrt4 fopen "" HAVE_RPCRT4) # UuidCreateSequential
-check_library_exists(iphlpapi fopen "" HAVE_IPHLAPI) # GetAdaptersAddresses
+set (ZMQ_CMAKE_MODULES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/Modules)
+list (APPEND CMAKE_MODULE_PATH ${ZMQ_CMAKE_MODULES_DIR})
 
-check_cxx_symbol_exists(SO_PEERCRED sys/socket.h ZMQ_HAVE_SO_PEERCRED)
-check_cxx_symbol_exists(LOCAL_PEERCRED sys/socket.h ZMQ_HAVE_LOCAL_PEERCRED)
+include (TestZMQVersion)
+include (ZMQSourceRunChecks)
+include (CheckIncludeFiles)
+include (CheckLibraryExists)
+include (CheckCCompilerFlag)
+include (CheckCXXCompilerFlag)
+include (CheckCSourceCompiles)
+include (CheckCSourceRuns)
+include (CMakeDependentOption)
+include (CheckCXXSymbolExists)
 
-find_library(RT_LIBRARY rt)
+check_include_files (ifaddrs.h ZMQ_HAVE_IFADDRS)
+check_include_files (windows.h ZMQ_HAVE_WINDOWS)
+check_include_files (sys/uio.h ZMQ_HAVE_UIO)
+check_include_files (sys/eventfd.h ZMQ_HAVE_EVENTFD)
 
-find_package(Threads)
+check_library_exists (ws2_32 fopen "" HAVE_WS2_32) # TODO: Why doesn't something logical like WSAStartup work?
+check_library_exists (ws2 fopen "" HAVE_WS2)
+check_library_exists (rpcrt4 fopen "" HAVE_RPCRT4) # UuidCreateSequential
+check_library_exists (iphlpapi fopen "" HAVE_IPHLAPI) # GetAdaptersAddresses
 
+check_cxx_symbol_exists (SO_PEERCRED sys/socket.h ZMQ_HAVE_SO_PEERCRED)
+check_cxx_symbol_exists (LOCAL_PEERCRED sys/socket.h ZMQ_HAVE_LOCAL_PEERCRED)
 
-if(WIN32 AND NOT CYGWIN)
-  if(NOT HAVE_WS2_32 AND NOT HAVE_WS2)
-    message(FATAL_ERROR "Cannot link to ws2_32 or ws2")
-  endif()
+find_library (RT_LIBRARY rt)
 
-  if(NOT HAVE_RPCRT4)
-    message(FATAL_ERROR "Cannot link to rpcrt4")
-  endif()
-
-  if(NOT HAVE_IPHLAPI)
-    message(FATAL_ERROR "Cannot link to iphlapi")
-  endif()
-endif()
-
-set(CMAKE_REQUIRED_LIBRARIES rt)
-check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
-set(CMAKE_REQUIRED_LIBRARIES )
-
-set(CMAKE_REQUIRED_INCLUDES unistd.h)
-check_function_exists(fork HAVE_FORK)
-set(CMAKE_REQUIRED_INCLUDES )
-
-set(CMAKE_REQUIRED_INCLUDES sys/time.h)
-check_function_exists(gethrtime HAVE_GETHRTIME)
-set(CMAKE_REQUIRED_INCLUDES )
-
-add_definitions(-D_REENTRANT -D_THREAD_SAFE)
-add_definitions(-DZMQ_USING_CMAKE)
-
-option(ENABLE_EVENTFD "Enable/disable eventfd" ZMQ_HAVE_EVENTFD)
-
-macro(zmq_check_cxx_flag_prepend flag)
-  check_cxx_compiler_flag("${flag}" HAVE_FLAG_${flag})
-
-  if(HAVE_FLAG_${flag})
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-  endif()
-endmacro()
-
-
-if(MSVC)
-  zmq_check_cxx_flag_prepend("/W3")
-
-  if(MSVC_IDE)
-    set(MSVC_TOOLSET "-${CMAKE_VS_PLATFORM_TOOLSET}")
-  else()
-    set(MSVC_TOOLSET "")
-  endif()
-else()
-  zmq_check_cxx_flag_prepend("-Wall")
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  zmq_check_cxx_flag_prepend("-Wextra")
-endif()
-
-zmq_check_cxx_flag_prepend("-Wno-long-long")
-zmq_check_cxx_flag_prepend("-Wno-uninitialized")
-
-option(LIBZMQ_PEDANTIC "" ON)
-option(LIBZMQ_WERROR "" OFF)
-
-if(LIBZMQ_PEDANTIC)
-  zmq_check_cxx_flag_prepend("-pedantic")
-
-  if(${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
-    zmq_check_cxx_flag_prepend("-strict-ansi")
-  endif()
-
-  if(${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
-    zmq_check_cxx_flag_prepend("-compat=5")
-  endif()
-endif()
-
-if(LIBZMQ_WERROR)
-  zmq_check_cxx_flag_prepend("-Werror")
-  zmq_check_cxx_flag_prepend("-errwarn=%all")
-endif()
+find_package (Threads)
 
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^sparc")
-  zmq_check_cxx_flag_prepend("-mcpu=v9")
-endif()
+if (WIN32 AND NOT CYGWIN)
+  if (NOT HAVE_WS2_32 AND NOT HAVE_WS2)
+    message (FATAL_ERROR "Cannot link to ws2_32 or ws2")
+  endif ()
 
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
-  zmq_check_cxx_flag_prepend("-features=zla")
-endif()
+  if (NOT HAVE_RPCRT4)
+    message (FATAL_ERROR "Cannot link to rpcrt4")
+  endif ()
+
+  if (NOT HAVE_IPHLAPI)
+    message (FATAL_ERROR "Cannot link to iphlapi")
+  endif ()
+endif ()
+
+set (CMAKE_REQUIRED_LIBRARIES rt)
+check_function_exists (clock_gettime HAVE_CLOCK_GETTIME)
+set (CMAKE_REQUIRED_LIBRARIES)
+
+set (CMAKE_REQUIRED_INCLUDES unistd.h)
+check_function_exists (fork HAVE_FORK)
+set (CMAKE_REQUIRED_INCLUDES)
+
+set (CMAKE_REQUIRED_INCLUDES sys/time.h)
+check_function_exists (gethrtime HAVE_GETHRTIME)
+set (CMAKE_REQUIRED_INCLUDES)
+
+add_definitions (-D_REENTRANT -D_THREAD_SAFE)
+add_definitions (-DZMQ_USING_CMAKE)
+
+option (ENABLE_EVENTFD "Enable/disable eventfd" ZMQ_HAVE_EVENTFD)
+
+macro (zmq_check_cxx_flag_prepend flag)
+  check_cxx_compiler_flag ("${flag}" HAVE_FLAG_${flag})
+
+  if (HAVE_FLAG_${flag})
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+  endif ()
+endmacro ()
 
 
-if(CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD")
-  message(STATUS "Checking whether atomic operations can be used")
-  check_c_source_compiles(
+if (MSVC)
+  zmq_check_cxx_flag_prepend ("/W3")
+
+  if (MSVC_IDE)
+    set (MSVC_TOOLSET "-${CMAKE_VS_PLATFORM_TOOLSET}")
+  else ()
+    set (MSVC_TOOLSET "")
+  endif ()
+else ()
+  zmq_check_cxx_flag_prepend ("-Wall")
+endif ()
+
+if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  zmq_check_cxx_flag_prepend ("-Wextra")
+endif ()
+
+#   TODO: why is -Wno-long-long defined differently than in configure.ac?
+zmq_check_cxx_flag_prepend ("-Wno-long-long")
+zmq_check_cxx_flag_prepend ("-Wno-uninitialized")
+
+option (LIBZMQ_PEDANTIC "" ON)
+option (LIBZMQ_WERROR "" OFF)
+
+if (LIBZMQ_PEDANTIC)
+  zmq_check_cxx_flag_prepend ("-pedantic")
+
+  if (${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
+    zmq_check_cxx_flag_prepend ("-strict-ansi")
+  endif ()
+
+  if (${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
+    zmq_check_cxx_flag_prepend ("-compat=5")
+  endif ()
+endif ()
+
+if (LIBZMQ_WERROR)
+  zmq_check_cxx_flag_prepend ("-Werror")
+  zmq_check_cxx_flag_prepend ("-errwarn=%all")
+endif ()
+
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^sparc")
+  zmq_check_cxx_flag_prepend ("-mcpu=v9")
+endif ()
+
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
+  zmq_check_cxx_flag_prepend ("-features=zla")
+endif ()
+
+
+if (CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+  message (STATUS "Checking whether atomic operations can be used")
+  check_c_source_compiles (
   "
    #include <atomic.h>
 
-    int main()
+    int main ()
     {
       uint32_t value;
-      atomic_cas_32(&value, 0, 0);
+      atomic_cas_32 (&value, 0, 0);
       return 0;
     }
     "
     HAVE_ATOMIC_H)
 
-  if(NOT HAVE_ATOMIC_H)
-    set(ZMQ_FORCE_MUTEXES 1)
-  endif()
-endif()
+  if (NOT HAVE_ATOMIC_H)
+    set (ZMQ_FORCE_MUTEXES 1)
+  endif ()
+endif ()
 
 
 #-----------------------------------------------------------------------------
-zmq_check_sock_cloexec()
-zmq_check_so_keepalive()
-zmq_check_tcp_keepcnt()
-zmq_check_tcp_keepidle()
-zmq_check_tcp_keepintvl()
-zmq_check_tcp_keepalive()
+zmq_check_sock_cloexec ()
+zmq_check_so_keepalive ()
+zmq_check_tcp_keepcnt ()
+zmq_check_tcp_keepidle ()
+zmq_check_tcp_keepintvl ()
+zmq_check_tcp_keepalive ()
 
 
-if(    CMAKE_SYSTEM_NAME MATCHES "Linux"
+if (    CMAKE_SYSTEM_NAME MATCHES "Linux"
     OR CMAKE_SYSTEM_NAME MATCHES "GNU/kFreeBSD"
     OR CMAKE_SYSTEM_NAME MATCHES "GNU/Hurd"
     OR CYGWIN)
-  add_definitions(-D_GNU_SOURCE)
-elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-  add_definitions(-D__BSD_VISIBLE)
-elseif(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
-  add_definitions(-D_NETBSD_SOURCE)
-elseif(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
-  add_definitions(-D_OPENBSD_SOURCE)
-elseif(CMAKE_SYSTEM_NAME MATCHES "SunOS")
-  add_definitions(-D_PTHREADS)
-elseif(CMAKE_SYSTEM_NAME MATCHES "HP-UX")
-  add_definitions(-D_POSIX_C_SOURCE=200112L)
-  zmq_check_cxx_flag_prepend(-Ae)
-elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  add_definitions(-D_DARWIN_C_SOURCE)
-endif()
+  add_definitions (-D_GNU_SOURCE)
+elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+  add_definitions (-D__BSD_VISIBLE)
+elseif (CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+  add_definitions (-D_NETBSD_SOURCE)
+elseif (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  add_definitions (-D_OPENBSD_SOURCE)
+elseif (CMAKE_SYSTEM_NAME MATCHES "SunOS")
+  add_definitions (-D_PTHREADS)
+elseif (CMAKE_SYSTEM_NAME MATCHES "HP-UX")
+  add_definitions (-D_POSIX_C_SOURCE=200112L)
+  zmq_check_cxx_flag_prepend (-Ae)
+elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  add_definitions (-D_DARWIN_C_SOURCE)
+endif ()
 
-set(CMAKE_PYTHON_VERSION 2.7 2.6 2.5 2.4)
-find_package(PythonInterp)
-find_package(AsciiDoc)
+set (CMAKE_PYTHON_VERSION 2.7 2.6 2.5 2.4)
+find_package (PythonInterp)
+find_package (AsciiDoc)
 
-cmake_dependent_option(WITH_DOC "Build Reference Guide documentation(requires DocBook)" ON
+cmake_dependent_option (WITH_DOC "Build Reference Guide documentation (requires DocBook)" ON
                        "PYTHON_FOUND;ASCIIDOC_FOUND" OFF)
 
-if(MSVC)
-  if(WITH_OPENPGM)
-    #   set(OPENPGM_ROOT "" CACHE PATH "Location of OpenPGM")
-    set(OPENPGM_VERSION_MAJOR 5)
-    set(OPENPGM_VERSION_MINOR 2)
-    set(OPENPGM_VERSION_MICRO 122)
-    if(CMAKE_CL_64)
-      find_path(OPENPGM_ROOT include/pgm/pgm.h
+if (MSVC)
+  if (WITH_OPENPGM)
+    #   set (OPENPGM_ROOT "" CACHE PATH "Location of OpenPGM")
+    set (OPENPGM_VERSION_MAJOR 5)
+    set (OPENPGM_VERSION_MINOR 2)
+    set (OPENPGM_VERSION_MICRO 122)
+    if (CMAKE_CL_64)
+      find_path (OPENPGM_ROOT include/pgm/pgm.h
                 PATHS
                 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
                 NO_DEFAULT_PATH
-                )
-      message(STATUS "OpenPGM x64 detected - ${OPENPGM_ROOT}")
-    else()
-      find_path(OPENPGM_ROOT include/pgm/pgm.h
+               )
+      message (STATUS "OpenPGM x64 detected - ${OPENPGM_ROOT}")
+    else ()
+      find_path (OPENPGM_ROOT include/pgm/pgm.h
                 PATHS
                 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
                 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
                 NO_DEFAULT_PATH
-                )
-      message(STATUS "OpenPGM x86 detected - ${OPENPGM_ROOT}")
-    endif(CMAKE_CL_64)
-    set(OPENPGM_INCLUDE_DIRS ${OPENPGM_ROOT}/include)
-    set(OPENPGM_LIBRARY_DIRS ${OPENPGM_ROOT}/lib)
-    set(OPENPGM_LIBRARIES
+               )
+      message (STATUS "OpenPGM x86 detected - ${OPENPGM_ROOT}")
+    endif (CMAKE_CL_64)
+    set (OPENPGM_INCLUDE_DIRS ${OPENPGM_ROOT}/include)
+    set (OPENPGM_LIBRARY_DIRS ${OPENPGM_ROOT}/lib)
+    set (OPENPGM_LIBRARIES
       optimized libpgm${MSVC_TOOLSET}-mt-${OPENPGM_VERSION_MAJOR}_${OPENPGM_VERSION_MINOR}_${OPENPGM_VERSION_MICRO}.lib
       debug libpgm${MSVC_TOOLSET}-mt-gd-${OPENPGM_VERSION_MAJOR}_${OPENPGM_VERSION_MINOR}_${OPENPGM_VERSION_MICRO}.lib)
-  endif()
-else()
-  if(WITH_OPENPGM)
-    message(FATAL_ERROR "WITH_OPENPGM not implemented")
+  endif ()
+else ()
+  if (WITH_OPENPGM)
+    message (FATAL_ERROR "WITH_OPENPGM not implemented")
     # DSO symbol visibility for openpgm
-    if(HAVE_FLAG_VISIBILITY_HIDDEN)
+    if (HAVE_FLAG_VISIBILITY_HIDDEN)
 
-    elseif(HAVE_FLAG_LDSCOPE_HIDDEN)
-    endif()
-  endif()
-endif()
+    elseif (HAVE_FLAG_LDSCOPE_HIDDEN)
+    endif ()
+  endif ()
+endif ()
 
 
 #-----------------------------------------------------------------------------
 # force off-tree build
 
-if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
-message(FATAL_ERROR "CMake generation is not allowed within the source directory!
+if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+message (FATAL_ERROR "CMake generation is not allowed within the source directory!
 Remove the CMakeCache.txt file and try again from another folder, e.g.:
 
    rm CMakeCache.txt
@@ -336,50 +355,50 @@ Remove the CMakeCache.txt file and try again from another folder, e.g.:
    cd cmake-make
    cmake ..
 ")
-endif()
+endif ()
 
 #-----------------------------------------------------------------------------
 # default to Release build
 
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   # CMAKE_BUILD_TYPE is not used for multi-configuration generators like Visual Studio/XCode
   # which instead use CMAKE_CONFIGURATION_TYPES
-  set(CMAKE_BUILD_TYPE Release CACHE STRING
+  set (CMAKE_BUILD_TYPE Release CACHE STRING
       "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
       FORCE)
-endif()
+endif ()
 
-set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
-set(LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set (EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
+set (LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 #-----------------------------------------------------------------------------
 # platform specifics
 
 if (WIN32)
-  # NB: May require tweaking for highly connected applications.
-  add_definitions (-DFD_SETSIZE=4096)
-  add_definitions (-D_CRT_SECURE_NO_WARNINGS)
+    #   Socket limit is 4K (can be raised arbitrarily)
+    add_definitions (-DFD_SETSIZE=4096)
+    add_definitions (-D_CRT_SECURE_NO_WARNINGS)
 endif ()
 
-if(MSVC)
+if (MSVC)
   # Parallel make.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
   # Optimization flags.
   # http://msdn.microsoft.com/en-us/magazine/cc301698.aspx
-  if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GL")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LTCG")
-    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /LTCG")
-  endif()
-endif()
+  if (NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GL")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LTCG")
+    set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /LTCG")
+  endif ()
+endif ()
 
 
 #-----------------------------------------------------------------------------
 # source files
 
-set(cxx-sources
+set (cxx-sources
         address.cpp
         client.cpp
         clock.cpp
@@ -464,22 +483,22 @@ set(cxx-sources
         udp_engine.cpp
         udp_address.cpp)
 
-set(rc-sources version.rc)
+set (rc-sources version.rc)
 
-if(MINGW)
+if (MINGW)
   # Generate the right type when using -m32 or -m64
-  macro(set_rc_arch rc_target)
-    set(CMAKE_RC_COMPILER_INIT windres)
-    enable_language(RC)
-    set(CMAKE_RC_COMPILE_OBJECT
+  macro (set_rc_arch rc_target)
+    set (CMAKE_RC_COMPILER_INIT windres)
+    enable_language (RC)
+    set (CMAKE_RC_COMPILE_OBJECT
         "<CMAKE_RC_COMPILER> <FLAGS> -O coff --target=${rc_target} <DEFINES> -i <SOURCE> -o <OBJECT>")
-  endmacro()
+  endmacro ()
 
-  if (NOT CMAKE_SYSTEM_PROCESSOR )
-    set (CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR} )
+  if (NOT CMAKE_SYSTEM_PROCESSOR)
+    set (CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
   endif ()
 
-  if(    CMAKE_SYSTEM_PROCESSOR MATCHES "i386"
+  if (    CMAKE_SYSTEM_PROCESSOR MATCHES "i386"
       OR CMAKE_SYSTEM_PROCESSOR MATCHES "i486"
       OR CMAKE_SYSTEM_PROCESSOR MATCHES "i586"
       OR CMAKE_SYSTEM_PROCESSOR MATCHES "i686"
@@ -488,18 +507,18 @@ if(MINGW)
       OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64"
       OR CMAKE_SYSTEM_PROCESSOR MATCHES "amd64")
 
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set_rc_arch("pe-x86-64")
-    else()
-      set_rc_arch("pe-i386")
-    endif()
-  endif()
-endif()
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+      set_rc_arch ("pe-x86-64")
+    else ()
+      set_rc_arch ("pe-i386")
+    endif ()
+  endif ()
+endif ()
 
-include_directories(include ${CMAKE_CURRENT_BINARY_DIR})
-set(public_headers include/zmq.h)
+include_directories (include ${CMAKE_CURRENT_BINARY_DIR})
+set (public_headers include/zmq.h)
 
-set(readme-docs AUTHORS
+set (readme-docs AUTHORS
                 COPYING
                 COPYING.LESSER
                 MAINTAINERS
@@ -508,57 +527,51 @@ set(readme-docs AUTHORS
 #-----------------------------------------------------------------------------
 # optional modules
 
-if(WITH_OPENPGM)
-  add_definitions(-DZMQ_HAVE_OPENPGM)
-  include_directories(${OPENPGM_INCLUDE_DIRS})
-  link_directories(${OPENPGM_LIBRARY_DIRS})
-  set(OPTIONAL_LIBRARIES ${OPENPGM_LIBRARIES})
-endif(WITH_OPENPGM)
+if (WITH_OPENPGM)
+  add_definitions (-DZMQ_HAVE_OPENPGM)
+  include_directories (${OPENPGM_INCLUDE_DIRS})
+  link_directories (${OPENPGM_LIBRARY_DIRS})
+  set (OPTIONAL_LIBRARIES ${OPENPGM_LIBRARIES})
+endif (WITH_OPENPGM)
 
-if(WITH_VMCI)
-    add_definitions(-DZMQ_HAVE_VMCI)
-    include_directories(${VMCI_INCLUDE_DIRS})
-    list(APPEND cxx-sources vmci_address.cpp vmci_connecter.cpp vmci_listener.cpp vmci.cpp)
-endif(WITH_VMCI)
+if (WITH_VMCI)
+    add_definitions (-DZMQ_HAVE_VMCI)
+    include_directories (${VMCI_INCLUDE_DIRS})
+    list (APPEND cxx-sources vmci_address.cpp vmci_connecter.cpp vmci_listener.cpp vmci.cpp)
+endif (WITH_VMCI)
 
 #-----------------------------------------------------------------------------
 # source generators
 
-foreach(source ${cxx-sources})
-  list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/src/${source})
-endforeach()
+foreach (source ${cxx-sources})
+  list (APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/src/${source})
+endforeach ()
 
-if(USE_TWEETNACL)
-  foreach(source ${TWEETNACL_SOURCES})
-    list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/${source})
-  endforeach()
-endif()
+foreach (source ${rc-sources})
+  list (APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/${source})
+  configure_file (${CMAKE_CURRENT_SOURCE_DIR}/src/${source}.in ${CMAKE_CURRENT_BINARY_DIR}/${source})
+endforeach ()
 
-foreach(source ${rc-sources})
-  list(APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/${source})
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/${source}.in ${CMAKE_CURRENT_BINARY_DIR}/${source})
-endforeach()
+configure_file (${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/platform.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
+list (APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/platform.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
-list(APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
+configure_file (${CMAKE_CURRENT_SOURCE_DIR}/src/libzmq.pc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc @ONLY)
+set (zmq-pkgconfig ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/libzmq.pc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc @ONLY)
-set(zmq-pkgconfig ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc)
-
-if(NOT ZMQ_BUILD_FRAMEWORK)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc DESTINATION lib/pkgconfig)
-endif()
+if (NOT ZMQ_BUILD_FRAMEWORK)
+  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc DESTINATION lib/pkgconfig)
+endif ()
 
 
 
-if(MSVC)
-  if(CMAKE_CL_64)
-    set(nsis-template ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/NSIS.template64.in)
-  else()
-    set(nsis-template ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/NSIS.template32.in)
-  endif()
+if (MSVC)
+  if (CMAKE_CL_64)
+    set (nsis-template ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/NSIS.template64.in)
+  else ()
+    set (nsis-template ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/NSIS.template32.in)
+  endif ()
 
-  add_custom_command(
+  add_custom_command (
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in
     COMMAND ${CMAKE_COMMAND}
     ARGS -E
@@ -566,16 +579,16 @@ if(MSVC)
     ${nsis-template}
     ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in
     DEPENDS ${nsis-template})
-endif()
+endif ()
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc)
-file(GLOB docs RELATIVE ${CMAKE_CURRENT_BINARY_DIR}/ "${CMAKE_CURRENT_SOURCE_DIR}/doc/*.txt")
-set(html-docs)
-foreach(txt ${docs})
-  string(REGEX REPLACE ".*/(.*)\\.txt" "\\1.html" html ${txt})
-  set(src ${txt})
-  set(dst doc/${html})
-  add_custom_command(
+file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc)
+file (GLOB docs RELATIVE ${CMAKE_CURRENT_BINARY_DIR}/ "${CMAKE_CURRENT_SOURCE_DIR}/doc/*.txt")
+set (html-docs)
+foreach (txt ${docs})
+  string (REGEX REPLACE ".*/ (.*)\\.txt" "\\1.html" html ${txt})
+  set (src ${txt})
+  set (dst doc/${html})
+  add_custom_command (
     OUTPUT  ${dst}
     COMMAND ${PYTHON_EXECUTABLE}
     ARGS    -x
@@ -589,303 +602,303 @@ foreach(txt ${docs})
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${src}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Generating ${html}")
-  if(WITH_DOC)
-    list(APPEND html-docs ${CMAKE_CURRENT_BINARY_DIR}/${dst})
-  endif()
-endforeach()
+  if (WITH_DOC)
+    list (APPEND html-docs ${CMAKE_CURRENT_BINARY_DIR}/${dst})
+  endif ()
+endforeach ()
 
-if(ZMQ_BUILD_FRAMEWORK)
-  add_custom_command(
+if (ZMQ_BUILD_FRAMEWORK)
+  add_custom_command (
     TARGET libzmq
     POST_BUILD
     COMMAND ${CMAKE_COMMAND}
     ARGS -E make_directory "${CMAKE_LIBRARY_OUTPUT_PATH}/ZeroMQ.framework/Versions/${ZMQ_VERSION}/MacOS"
     COMMENT "Perf tools")
-endif()
+endif ()
 
 
 #-----------------------------------------------------------------------------
 # output
 
-if(MSVC)
-  add_library(libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in)
-  target_link_libraries(libzmq ${OPTIONAL_LIBRARIES})
-  set_target_properties(libzmq PROPERTIES
+if (MSVC)
+  add_library (libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in)
+  target_link_libraries (libzmq ${OPTIONAL_LIBRARIES})
+  set_target_properties (libzmq PROPERTIES
     PUBLIC_HEADER "${public_headers}"
     RELEASE_POSTFIX "${MSVC_TOOLSET}-mt-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
     RELWITHDEBINFO_POSTFIX "${MSVC_TOOLSET}-mt-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
     DEBUG_POSTFIX "${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
     COMPILE_DEFINITIONS "DLL_EXPORT")
-  add_library(libzmq-static STATIC ${sources})
-  set_target_properties(libzmq-static PROPERTIES
+  add_library (libzmq-static STATIC ${sources})
+  set_target_properties (libzmq-static PROPERTIES
     PUBLIC_HEADER "${public_headers}"
     RELEASE_POSTFIX "${MSVC_TOOLSET}-mt-s-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
     RELWITHDEBINFO_POSTFIX "${MSVC_TOOLSET}-mt-s-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
     DEBUG_POSTFIX "${MSVC_TOOLSET}-mt-sgd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
     COMPILE_FLAGS "/D ZMQ_STATIC"
     OUTPUT_NAME "libzmq-static")
-else()
-    add_library(libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig})
-    set_target_properties(libzmq PROPERTIES
+else ()
+    add_library (libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig})
+    set_target_properties (libzmq PROPERTIES
                           COMPILE_DEFINITIONS "DLL_EXPORT"
                           PUBLIC_HEADER "${public_headers}"
                           VERSION ${ZMQ_VERSION}
                           SOVERSION "${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.0"
                           OUTPUT_NAME "libzmq"
                           PREFIX "")
-    if(ZMQ_BUILD_FRAMEWORK)
-      set_target_properties(libzmq PROPERTIES
+    if (ZMQ_BUILD_FRAMEWORK)
+      set_target_properties (libzmq PROPERTIES
                             FRAMEWORK TRUE
                             MACOSX_FRAMEWORK_IDENTIFIER "org.zeromq.libzmq"
                             MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${ZMQ_VERSION}
                             MACOSX_FRAMEWORK_BUNDLE_VERSION ${ZMQ_VERSION})
-      set_source_files_properties(${html-docs} PROPERTIES
+      set_source_files_properties (${html-docs} PROPERTIES
                                   MACOSX_PACKAGE_LOCATION doc)
-      set_source_files_properties(${readme-docs} PROPERTIES
+      set_source_files_properties (${readme-docs} PROPERTIES
                                   MACOSX_PACKAGE_LOCATION etc)
-      set_source_files_properties(${zmq-pkgconfig} PROPERTIES
+      set_source_files_properties (${zmq-pkgconfig} PROPERTIES
                                   MACOSX_PACKAGE_LOCATION lib/pkgconfig)
-    endif()
-    add_library(libzmq-static STATIC ${sources} ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig})
-    set_target_properties(libzmq-static PROPERTIES
+    endif ()
+    add_library (libzmq-static STATIC ${sources} ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig})
+    set_target_properties (libzmq-static PROPERTIES
       PUBLIC_HEADER "${public_headers}"
       COMPILE_DEFINITIONS "ZMQ_STATIC"
       OUTPUT_NAME "libzmq-static"
       PREFIX "")
-endif()
+endif ()
 
-target_link_libraries(libzmq ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries (libzmq ${CMAKE_THREAD_LIBS_INIT})
 
-if(SODIUM_FOUND)
-  target_link_libraries(libzmq ${SODIUM_LIBRARIES})
-endif()
-if(HAVE_WS2_32)
-  target_link_libraries(libzmq ws2_32)
-elseif(HAVE_WS2)
-  target_link_libraries(libzmq ws2)
-endif()
+if (SODIUM_FOUND)
+  target_link_libraries (libzmq ${SODIUM_LIBRARIES})
+endif ()
+if (HAVE_WS2_32)
+  target_link_libraries (libzmq ws2_32)
+elseif (HAVE_WS2)
+  target_link_libraries (libzmq ws2)
+endif ()
 
-if(HAVE_RPCRT4)
-  target_link_libraries(libzmq rpcrt4)
-endif()
+if (HAVE_RPCRT4)
+  target_link_libraries (libzmq rpcrt4)
+endif ()
 
-if(HAVE_IPHLAPI)
-  target_link_libraries(libzmq iphlpapi)
-endif()
+if (HAVE_IPHLAPI)
+  target_link_libraries (libzmq iphlpapi)
+endif ()
 
-if(RT_LIBRARY)
-  target_link_libraries(libzmq ${RT_LIBRARY})
-endif()
+if (RT_LIBRARY)
+  target_link_libraries (libzmq ${RT_LIBRARY})
+endif ()
 
-set(perf-tools local_lat
+set (perf-tools local_lat
                remote_lat
                local_thr
                remote_thr
                inproc_lat
                inproc_thr)
 
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug") # Why?
-option(WITH_PERF_TOOL "Build with perf-tools" ON)
-else()
-option(WITH_PERF_TOOL "Build with perf-tools" OFF)
-endif()
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug") # Why?
+option (WITH_PERF_TOOL "Build with perf-tools" ON)
+else ()
+option (WITH_PERF_TOOL "Build with perf-tools" OFF)
+endif ()
 
-if(WITH_PERF_TOOL)
-  foreach(perf-tool ${perf-tools})
-    add_executable(${perf-tool} perf/${perf-tool}.cpp)
-    target_link_libraries(${perf-tool} libzmq)
+if (WITH_PERF_TOOL)
+  foreach (perf-tool ${perf-tools})
+    add_executable (${perf-tool} perf/${perf-tool}.cpp)
+    target_link_libraries (${perf-tool} libzmq)
 
-    if(RT_LIBRARY)
-      target_link_libraries(${perf-tool} ${RT_LIBRARY})
-    endif()
+    if (RT_LIBRARY)
+      target_link_libraries (${perf-tool} ${RT_LIBRARY})
+    endif ()
 
-    if(ZMQ_BUILD_FRAMEWORK)
+    if (ZMQ_BUILD_FRAMEWORK)
       # Copy perf-tools binaries into Framework
-      add_custom_command(
+      add_custom_command (
         TARGET libzmq ${perf-tool}
         POST_BUILD
         COMMAND ${CMAKE_COMMAND}
         ARGS -E copy "$<TARGET_FILE:${perf-tool}>" "${LIBRARY_OUTPUT_PATH}/ZeroMQ.framework/Versions/${ZMQ_VERSION_STRING}/MacOS/${perf-tool}"
         VERBATIM
         COMMENT "Perf tools")
-    else()
-      install(TARGETS ${perf-tool}
+    else ()
+      install (TARGETS ${perf-tool}
               RUNTIME DESTINATION bin
               COMPONENT PerfTools)
-    endif()
-  endforeach()
-endif()
+    endif ()
+  endforeach ()
+endif ()
 
 #-----------------------------------------------------------------------------
 # tests
 
-set(ZMQ_BUILD_TESTS ON CACHE BOOL "Build the tests for ZeroMQ")
+set (ZMQ_BUILD_TESTS ON CACHE BOOL "Build the tests for ZeroMQ")
 
-if(ZMQ_BUILD_TESTS)
-  enable_testing() # Enable testing only works in root scope
-  ADD_SUBDIRECTORY(tests)
-endif()
+if (ZMQ_BUILD_TESTS)
+  enable_testing () # Enable testing only works in root scope
+  ADD_SUBDIRECTORY (tests)
+endif ()
 
 #-----------------------------------------------------------------------------
 # installer
 
-if(MSVC)
-  install(TARGETS libzmq libzmq-static
+if (MSVC)
+  install (TARGETS libzmq libzmq-static
           ARCHIVE DESTINATION lib
           LIBRARY DESTINATION lib
           PUBLIC_HEADER DESTINATION include
           COMPONENT SDK)
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    install(TARGETS libzmq libzmq-static
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    install (TARGETS libzmq libzmq-static
             RUNTIME DESTINATION bin
             ARCHIVE DESTINATION lib
             PUBLIC_HEADER DESTINATION include
             COMPONENT SDK)
-    if(NOT CMAKE_PDB_OUTPUT_DIRECTORY)
-      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}.pdb DESTINATION lib
+    if (NOT CMAKE_PDB_OUTPUT_DIRECTORY)
+      install (FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}.pdb DESTINATION lib
             COMPONENT SDK)
-    endif()
-  else()
-    install(TARGETS libzmq
+    endif ()
+  else ()
+    install (TARGETS libzmq
             RUNTIME DESTINATION bin
             PUBLIC_HEADER DESTINATION include
             COMPONENT Runtime)
-  endif()
-else()
-  install(TARGETS libzmq libzmq-static
+  endif ()
+else ()
+  install (TARGETS libzmq libzmq-static
           RUNTIME DESTINATION bin
           ARCHIVE DESTINATION lib
           LIBRARY DESTINATION lib
           FRAMEWORK DESTINATION "Library/Frameworks"
           PUBLIC_HEADER DESTINATION include)
-endif()
+endif ()
 
-# install(FILES ${public_headers}
+# install (FILES ${public_headers}
 #          DESTINATION include
 #          COMPONENT SDK)
 
-#if(NOT ZMQ_BUILD_FRAMEWORK)
-#  file(GLOB private_headers "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp")
-#  install(FILES ${sources} ${private_headers} DESTINATION src/zmq
+#if (NOT ZMQ_BUILD_FRAMEWORK)
+#  file (GLOB private_headers "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp")
+#  install (FILES ${sources} ${private_headers} DESTINATION src/zmq
 #          COMPONENT SourceCode)
-#endif()
+#endif ()
 
-foreach(readme ${readme-docs})
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${readme} ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt)
+foreach (readme ${readme-docs})
+  configure_file (${CMAKE_CURRENT_SOURCE_DIR}/${readme} ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt)
 
-  if(NOT ZMQ_BUILD_FRAMEWORK)
-    if(MSVC)
-      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION .)
-    else()
-      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION share/zmq)
-    endif()
-  endif()
-endforeach()
+  if (NOT ZMQ_BUILD_FRAMEWORK)
+    if (MSVC)
+      install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION .)
+    else ()
+      install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION share/zmq)
+    endif ()
+  endif ()
+endforeach ()
 
-if(WITH_DOC)
-  if(NOT ZMQ_BUILD_FRAMEWORK)
-    install(FILES ${html-docs} DESTINATION doc/zmq COMPONENT RefGuide)
-  endif()
-endif()
+if (WITH_DOC)
+  if (NOT ZMQ_BUILD_FRAMEWORK)
+    install (FILES ${html-docs} DESTINATION doc/zmq COMPONENT RefGuide)
+  endif ()
+endif ()
 
 
-if(MSVC)
-  include(InstallRequiredSystemLibraries)
+if (MSVC)
+  include (InstallRequiredSystemLibraries)
 
-  if(CMAKE_CL_64)
-    set(arch_name "x64")
-  else()
-    set(arch_name "x86")
-  endif()
+  if (CMAKE_CL_64)
+    set (arch_name "x64")
+  else ()
+    set (arch_name "x86")
+  endif ()
 
-  set(CPACK_NSIS_DISPLAY_NAME "ZeroMQ ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}(${arch_name})")
-  set(CPACK_PACKAGE_FILE_NAME "ZeroMQ-${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}-${arch_name}")
+  set (CPACK_NSIS_DISPLAY_NAME "ZeroMQ ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH} (${arch_name})")
+  set (CPACK_PACKAGE_FILE_NAME "ZeroMQ-${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}-${arch_name}")
 
   # TODO: I think this part was intended to be used when running cpack
   # separately from cmake but I don't know how that works.
   #
-  # macro(add_crt_version version)
-  #   set(rel_dir "${CMAKE_CURRENT_BINARY_DIR}/build/${arch_name}/${version};ZeroMQ;ALL;/")
-  #   set(debug_dir "${CMAKE_CURRENT_BINARY_DIR}/debug/${arch_name}/${version};ZeroMQ;ALL;/")
-  #   if(EXISTS ${rel_dir})
-  #     list(APPEND CPACK_INSTALL_CMAKE_PROJECTS ${rel_dir})
-  #   endif()
+  # macro (add_crt_version version)
+  #   set (rel_dir "${CMAKE_CURRENT_BINARY_DIR}/build/${arch_name}/${version};ZeroMQ;ALL;/")
+  #   set (debug_dir "${CMAKE_CURRENT_BINARY_DIR}/debug/${arch_name}/${version};ZeroMQ;ALL;/")
+  #   if (EXISTS ${rel_dir})
+  #     list (APPEND CPACK_INSTALL_CMAKE_PROJECTS ${rel_dir})
+  #   endif ()
 
-  #   if(EXISTS ${debug_dir})
-  #     list(APPEND CPACK_INSTALL_CMAKE_PROJECTS ${rel_dir})
-  #   endmacro()
-  # endmacro()
+  #   if (EXISTS ${debug_dir})
+  #     list (APPEND CPACK_INSTALL_CMAKE_PROJECTS ${rel_dir})
+  #   endmacro ()
+  # endmacro ()
 
-  # add_crt_version(v110)
-  # add_crt_version(v100)
-  # add_crt_version(v90)
+  # add_crt_version (v110)
+  # add_crt_version (v100)
+  # add_crt_version (v90)
 
-  set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}")
-  set(CPACK_GENERATOR "NSIS")
-  set(CPACK_PACKAGE_NAME "ZeroMQ")
-  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ZeroMQ lightweight messaging kernel")
-  set(CPACK_PACKAGE_VENDOR "Miru")
-  set(CPACK_NSIS_CONTACT "Steven McCoy <Steven.McCoy@miru.hk>")
-  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_BINARY_DIR}\\\\COPYING.txt")
-#  set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_BINARY_DIR}\\\\README.txt")
-#  set(CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_BINARY_DIR}\\\\WELCOME.txt")
+  set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}")
+  set (CPACK_GENERATOR "NSIS")
+  set (CPACK_PACKAGE_NAME "ZeroMQ")
+  set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "ZeroMQ lightweight messaging kernel")
+  set (CPACK_PACKAGE_VENDOR "Miru")
+  set (CPACK_NSIS_CONTACT "Steven McCoy <Steven.McCoy@miru.hk>")
+  set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_BINARY_DIR}\\\\COPYING.txt")
+#  set (CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_BINARY_DIR}\\\\README.txt")
+#  set (CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_BINARY_DIR}\\\\WELCOME.txt")
   # There is a bug in NSI that does not handle full unix paths properly. Make
-  # sure there is at least one set of four(4) backslashes.
-  set(CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\installer.ico")
-  set(CPACK_NSIS_MUI_UNIICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\installer.ico")
+  # sure there is at least one set of four (4) backslashes.
+  set (CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\installer.ico")
+  set (CPACK_NSIS_MUI_UNIICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\installer.ico")
 
-  set(CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\branding.bmp")
-  set(CPACK_NSIS_COMPRESSOR "/SOLID lzma")
-  set(CPACK_PACKAGE_VERSION ${ZMQ_VERSION})
-  set(CPACK_PACKAGE_VERSION_MAJOR ${ZMQ_VERSION_MAJOR})
-  set(CPACK_PACKAGE_VERSION_MINOR ${ZMQ_VERSION_MINOR})
-  set(CPACK_PACKAGE_VERSION_PATCH ${ZMQ_VERSION_PATCH})
-#  set(CPACK_PACKAGE_INSTALL_DIRECTORY "ZMQ Install Directory")
-#  set(CPACK_TEMPORARY_DIRECTORY "ZMQ Temporary CPack Directory")
+  set (CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\branding.bmp")
+  set (CPACK_NSIS_COMPRESSOR "/SOLID lzma")
+  set (CPACK_PACKAGE_VERSION ${ZMQ_VERSION})
+  set (CPACK_PACKAGE_VERSION_MAJOR ${ZMQ_VERSION_MAJOR})
+  set (CPACK_PACKAGE_VERSION_MINOR ${ZMQ_VERSION_MINOR})
+  set (CPACK_PACKAGE_VERSION_PATCH ${ZMQ_VERSION_PATCH})
+#  set (CPACK_PACKAGE_INSTALL_DIRECTORY "ZMQ Install Directory")
+#  set (CPACK_TEMPORARY_DIRECTORY "ZMQ Temporary CPack Directory")
 
-  include(CPack)
+  include (CPack)
 
-  cpack_add_component_group(Development
+  cpack_add_component_group (Development
     DISPLAY_NAME "ZeroMQ software development kit"
     EXPANDED)
-  cpack_add_component(PerfTools
+  cpack_add_component (PerfTools
     DISPLAY_NAME "ZeroMQ performance tools"
     INSTALL_TYPES FullInstall DevInstall)
-  cpack_add_component(SourceCode
+  cpack_add_component (SourceCode
     DISPLAY_NAME "ZeroMQ source code"
     DISABLED
     INSTALL_TYPES FullInstall)
-  cpack_add_component(SDK
+  cpack_add_component (SDK
     DISPLAY_NAME "ZeroMQ headers and libraries"
     INSTALL_TYPES FullInstall DevInstall
     GROUP Development)
-  if(WITH_DOC)
-    cpack_add_component(RefGuide
+  if (WITH_DOC)
+    cpack_add_component (RefGuide
       DISPLAY_NAME "ZeroMQ reference guide"
       INSTALL_TYPES FullInstall DevInstall
       GROUP Development)
-  endif()
-  cpack_add_component(Runtime
+  endif ()
+  cpack_add_component (Runtime
     DISPLAY_NAME "ZeroMQ runtime files"
     REQUIRED
     INSTALL_TYPES FullInstall DevInstall MinInstall)
-  cpack_add_install_type(FullInstall
+  cpack_add_install_type (FullInstall
     DISPLAY_NAME "Full install, including source code")
-  cpack_add_install_type(DevInstall
+  cpack_add_install_type (DevInstall
     DISPLAY_NAME "Developer install, headers and libraries")
-  cpack_add_install_type(MinInstall
+  cpack_add_install_type (MinInstall
     DISPLAY_NAME "Minimal install, runtime only")
-endif()
+endif ()
 
 # Export this for library to help build this as a sub-project
-set(ZEROMQ_LIBRARY libzmq CACHE STRING "ZeroMQ library")
+set (ZEROMQ_LIBRARY libzmq CACHE STRING "ZeroMQ library")
 
 # Workaround for MSVS10 to avoid the Dialog Hell
 # FIXME: This could be removed with future version of CMake.
-if(MSVC_VERSION EQUAL 1600)
-  set(ZMQ_SLN_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/ZeroMQ.sln")
-  if(EXISTS "${ZMQ_SLN_FILENAME}")
-    file(APPEND "${ZMQ_SLN_FILENAME}" "\n# This should be regenerated!\n")
-  endif()
-endif()
+if (MSVC_VERSION EQUAL 1600)
+  set (ZMQ_SLN_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/ZeroMQ.sln")
+  if (EXISTS "${ZMQ_SLN_FILENAME}")
+    file (APPEND "${ZMQ_SLN_FILENAME}" "\n# This should be regenerated!\n")
+  endif ()
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,6 +552,9 @@ foreach (source ${rc-sources})
   configure_file (${CMAKE_CURRENT_SOURCE_DIR}/src/${source}.in ${CMAKE_CURRENT_BINARY_DIR}/${source})
 endforeach ()
 
+#   Delete any src/platform.hpp left by configure
+file (REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/src/platform.hpp)
+
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/platform.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
 list (APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -269,11 +269,6 @@ src_libzmq_la_CPPFLAGS =
 src_libzmq_la_CXXFLAGS = @LIBZMQ_EXTRA_CXXFLAGS@
 src_libzmq_la_LIBADD =
 
-if HAVE_SODIUM
-src_libzmq_la_CPPFLAGS += ${sodium_CFLAGS}
-src_libzmq_la_LIBADD += ${sodium_LIBS}
-endif
-
 if USE_TWEETNACL
 src_libzmq_la_SOURCES += \
     tweetnacl/src/tweetnacl.c \
@@ -281,6 +276,11 @@ src_libzmq_la_SOURCES += \
 src_libzmq_la_CXXFLAGS += \
     -I$(top_builddir)/tweetnacl/contrib/randombytes \
     -I$(top_builddir)/tweetnacl/src
+endif
+
+if USE_LIBSODIUM
+src_libzmq_la_CPPFLAGS += ${sodium_CFLAGS}
+src_libzmq_la_LIBADD += ${sodium_LIBS}
 endif
 
 if HAVE_PGM

--- a/configure.ac
+++ b/configure.ac
@@ -67,8 +67,6 @@ LIBZMQ_CHECK_ENABLE_DEBUG
 # Check wheter to enable code coverage
 LIBZMQ_WITH_GCOV
 
-
-
 AC_MSG_CHECKING([if TIPC is available and supports nonblocking connect])
 
 AC_RUN_IFELSE(
@@ -102,7 +100,6 @@ AC_RUN_IFELSE(
     [libzmq_tipc_support=no])
 
 AC_MSG_RESULT([$libzmq_tipc_support])
-
 
 AC_ARG_WITH([relaxed],
     [AS_HELP_STRING([--with-relaxed],
@@ -423,58 +420,49 @@ if test "x$require_libgssapi_krb5_ext" != "xno"; then
         AC_MSG_ERROR(libgssapi_krb5 is needed for GSSAPI security))
 fi
 
-# build using libsodium
-have_sodium_library="no"
+# Select curve encryption library, defaults to tweetnacl
+# To use libsodium instead, use --with-libsodium (must be installed)
+# To disable curve, use --disable-curve
 
-AC_ARG_WITH([libsodium], [AS_HELP_STRING([--with-libsodium],
-    [require libzmq build with libsodium crypto library. Requires pkg-config [default=check]])],
-    [require_libsodium_ext=$withval],
-    [require_libsodium_ext=check])
+AC_ARG_WITH([libsodium],
+    AS_HELP_STRING([--with-libsodium], [Use libsodium instead of built-in tweetnacl [default=no]]))
 
-AC_ARG_WITH([tweetnacl], [AS_HELP_STRING([--with-tweetnacl],
-    [build libzmq  with bundled tweetnacl crypto library [default=no]])],
-    [require_libsodium_ext=no
-     with_tweetnacl=yes
-     AC_MSG_CHECKING(for sodium)
-     AC_MSG_RESULT(tweetnacl)],
-    [with_tweetnacl=check])
-
-# conditionally require libsodium package
-if test "x$require_libsodium_ext" != "xno"; then
-  PKG_CHECK_MODULES([sodium], [libsodium],
-    [
-      have_sodium_library=yes
-      with_tweetnacl=no
-    ],
-    [
-      if test "x$require_libsodium_ext" == "xyes"; then
-        AC_MSG_ERROR(libsodium has been requested but not found)
-      else
-        AC_MSG_RESULT([             libsodium not found, using tweetnacl])
-        have_sodium_library=no
-        with_tweetnacl=yes
-      fi
+AS_IF([test "x$with_libsodium" = "xyes"], [
+    PKG_CHECK_MODULES([sodium], [libsodium], [libsodium_found=yes], [
+        AC_MSG_ERROR(libsodium is not installed. Install it, then run configure again)
     ])
-fi
+])
 
-if test "x$have_sodium_library" != "xno"; then
-    AC_DEFINE(HAVE_LIBSODIUM, 1, [The libsodium library is to be used.])
+AC_ARG_ENABLE([curve],
+    AS_HELP_STRING([--disable-curve], [Disable CURVE security [default=no]]))
 
-    # ssp library is required for libsodium on Solaris-like systems
+if test "x$enable_curve" == "xno"; then
+    curve_library=""
+    AC_MSG_NOTICE([CURVE security is disabled])
+
+elif test "x$with_libsodium" == "xyes"; then
+    AC_MSG_NOTICE([Using libsodium for CURVE security])
+    AC_DEFINE(ZMQ_HAVE_CURVE, [1], [Using curve encryption])
+    AC_DEFINE(HAVE_LIBSODIUM, [1], [Using libsodium for curve encryption])
+    curve_library="libsodium"
+
+    # On Solaris, libsodium depends on libssp
     case "${host_os}" in
         *solaris*)
             LDFLAGS="-lssp $LDFLAGS"
-            CPPFLAGS="$CPPFLAGS -Wno-long-long"
+            CPPFLAGS="-Wno-long-long $CPPFLAGS"
         ;;
     esac
-elif test "x$with_tweetnacl" != "xno"; then
-    AC_DEFINE(HAVE_LIBSODIUM, 1, [Sodium is provided by tweetnacl.])
-    AC_DEFINE(HAVE_TWEETNACL, 1, [Using tweetnacl.])
-    libzmq_pedantic="no"
+else
+    AC_MSG_NOTICE([Using tweetnacl for CURVE security])
+    AC_DEFINE(ZMQ_HAVE_CURVE, [1], [Using curve encryption])
+    AC_DEFINE(HAVE_TWEETNACL, [1], [Using tweetnacl for curve encryption])
+    curve_library="tweetnacl"
+    libzmq_pedantic="no"    #   Disable pedantic warnings
 fi
 
-AM_CONDITIONAL(HAVE_SODIUM, test "x$have_sodium_library" != "xno")
-AM_CONDITIONAL(USE_TWEETNACL, test "x$with_tweetnacl" != "xno")
+AM_CONDITIONAL(USE_LIBSODIUM, test "$curve_library" == "sodium")
+AM_CONDITIONAL(USE_TWEETNACL, test "$curve_library" == "tweetnacl")
 
 # build using pgm
 have_pgm_library="no"
@@ -506,8 +494,6 @@ AC_ARG_WITH([norm],
         [build libzmq with NORM protocol extension, optionally specifying norm path [default=no]])],
     [with_norm_ext=$withval],
     [with_norm_ext=no])
-
-
 
 AC_MSG_CHECKING("with_norm_ext = ${with_norm_ext}")
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -48,12 +48,10 @@
 #include "err.hpp"
 #include "msg.hpp"
 
-#ifdef HAVE_LIBSODIUM
-#ifdef HAVE_TWEETNACL
-#include "randombytes.h"
-#else
-#include "sodium.h"
-#endif
+#if defined (HAVE_TWEETNACL)
+#   include "randombytes.h"
+#elif defined (HAVE_LIBSODIUM)
+#   include "sodium.h"
 #endif
 
 #ifdef ZMQ_HAVE_VMCI
@@ -63,7 +61,7 @@
 #define ZMQ_CTX_TAG_VALUE_GOOD 0xabadcafe
 #define ZMQ_CTX_TAG_VALUE_BAD  0xdeadbeef
 
-int clipped_maxsocket(int max_requested)
+int clipped_maxsocket (int max_requested)
 {
     if (max_requested >= zmq::poller_t::max_fds () && zmq::poller_t::max_fds () != -1)
         // -1 because we need room for the reaper mailbox.
@@ -127,8 +125,8 @@ zmq::ctx_t::~ctx_t ()
 
     //  If we've done any Curve encryption, we may have a file handle
     //  to /dev/urandom open that needs to be cleaned up.
-#ifdef HAVE_LIBSODIUM
-    randombytes_close();
+#ifdef ZMQ_HAVE_CURVE
+    randombytes_close ();
 #endif
 
     //  Remove the tag, so that the object is considered dead.

--- a/src/curve_client.cpp
+++ b/src/curve_client.cpp
@@ -29,7 +29,7 @@
 
 #include "platform.hpp"
 
-#ifdef HAVE_LIBSODIUM
+#ifdef ZMQ_HAVE_CURVE
 
 #ifdef ZMQ_HAVE_WINDOWS
 #include "windows.hpp"

--- a/src/curve_client.hpp
+++ b/src/curve_client.hpp
@@ -30,15 +30,16 @@
 #ifndef __ZMQ_CURVE_CLIENT_HPP_INCLUDED__
 #define __ZMQ_CURVE_CLIENT_HPP_INCLUDED__
 
+#ifdef ZMQ_HAVE_CURVE
+
 #include "platform.hpp"
 #include "mutex.hpp"
 
-#ifdef HAVE_LIBSODIUM
-#ifdef HAVE_TWEETNACL
-#include "tweetnacl_base.h"
-#include "randombytes.h"
-#else
-#include "sodium.h"
+#if defined (HAVE_TWEETNACL)
+#   include "tweetnacl_base.h"
+#   include "randombytes.h"
+#elif defined (HAVE_LIBSODIUM)
+#   include "sodium.h"
 #endif
 
 #if crypto_box_NONCEBYTES != 24 \
@@ -46,7 +47,7 @@
 ||  crypto_box_SECRETKEYBYTES != 32 \
 ||  crypto_box_ZEROBYTES != 32 \
 ||  crypto_box_BOXZEROBYTES != 16
-#error "libsodium not built properly"
+#   error "libsodium not built properly"
 #endif
 
 #include "mechanism.hpp"

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -29,7 +29,7 @@
 
 #include "platform.hpp"
 
-#ifdef HAVE_LIBSODIUM
+#ifdef ZMQ_HAVE_CURVE
 
 #ifdef ZMQ_HAVE_WINDOWS
 #include "windows.hpp"

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -30,15 +30,17 @@
 #ifndef __ZMQ_CURVE_SERVER_HPP_INCLUDED__
 #define __ZMQ_CURVE_SERVER_HPP_INCLUDED__
 
+#ifdef ZMQ_HAVE_CURVE
+
 #include "platform.hpp"
 
-#ifdef HAVE_LIBSODIUM
-#ifdef HAVE_TWEETNACL
-#include "tweetnacl_base.h"
-#include "randombytes.h"
-#else
-#include "sodium.h"
+#if defined (HAVE_TWEETNACL)
+#   include "tweetnacl_base.h"
+#   include "randombytes.h"
+#elif defined (HAVE_LIBSODIUM)
+#   include "sodium.h"
 #endif
+
 #if crypto_box_NONCEBYTES != 24 \
 ||  crypto_box_PUBLICKEYBYTES != 32 \
 ||  crypto_box_SECRETKEYBYTES != 32 \
@@ -47,7 +49,7 @@
 ||  crypto_secretbox_NONCEBYTES != 24 \
 ||  crypto_secretbox_ZEROBYTES != 32 \
 ||  crypto_secretbox_BOXZEROBYTES != 16
-#error "libsodium not built properly"
+#   error "libsodium not built properly"
 #endif
 
 #include "mechanism.hpp"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -320,7 +320,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             }
             break;
 
-#       if defined ZMQ_HAVE_SO_PEERCRED || defined ZMQ_HAVE_LOCAL_PEERCRED
+#if defined ZMQ_HAVE_SO_PEERCRED || defined ZMQ_HAVE_LOCAL_PEERCRED
         case ZMQ_IPC_FILTER_UID:
             if (optvallen_ == 0 && optval_ == NULL) {
                 ipc_uid_accept_filters.clear ();
@@ -344,9 +344,9 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
-#       endif
+#endif
 
-#       if defined ZMQ_HAVE_SO_PEERCRED
+#if defined ZMQ_HAVE_SO_PEERCRED
         case ZMQ_IPC_FILTER_PID:
             if (optvallen_ == 0 && optval_ == NULL) {
                 ipc_pid_accept_filters.clear ();
@@ -358,7 +358,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
-#       endif
+#endif
 
         case ZMQ_PLAIN_SERVER:
             if (is_int && (value == 0 || value == 1)) {
@@ -403,8 +403,8 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             }
             break;
 
-        //  If libsodium isn't installed, these options provoke EINVAL
-#       ifdef HAVE_LIBSODIUM
+        //  If curve encryption isn't built, these options provoke EINVAL
+#ifdef ZMQ_HAVE_CURVE
         case ZMQ_CURVE_SERVER:
             if (is_int && (value == 0 || value == 1)) {
                 as_server = value;
@@ -496,7 +496,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 }
             }
             break;
-#       endif
+#endif
 
         case ZMQ_CONFLATE:
             if (is_int && (value == 0 || value == 1)) {
@@ -506,7 +506,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             break;
 
         //  If libgssapi isn't installed, these options provoke EINVAL
-#       ifdef HAVE_LIBGSSAPI_KRB5
+#ifdef HAVE_LIBGSSAPI_KRB5
         case ZMQ_GSSAPI_SERVER:
             if (is_int && (value == 0 || value == 1)) {
                 as_server = value;
@@ -538,7 +538,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
-#       endif
+#endif
 
         case ZMQ_HANDSHAKE_IVL:
             if (is_int && value >= 0) {
@@ -577,7 +577,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
             }
             break;
 
-#       ifdef ZMQ_HAVE_VMCI
+#ifdef ZMQ_HAVE_VMCI
         case ZMQ_VMCI_BUFFER_SIZE:
             if (optvallen_ == sizeof (uint64_t)) {
                 vmci_buffer_size = *((uint64_t*) optval_);
@@ -605,7 +605,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
-#       endif
+#endif
 
         case ZMQ_USE_FD:
             if (is_int && value >= -1) {
@@ -888,8 +888,8 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
             }
             break;
 
-        //  If libsodium isn't installed, these options provoke EINVAL
-#       ifdef HAVE_LIBSODIUM
+        //  If curve encryption isn't built, these options provoke EINVAL
+#ifdef ZMQ_HAVE_CURVE
         case ZMQ_CURVE_SERVER:
             if (is_int) {
                 *value = as_server && mechanism == ZMQ_CURVE;
@@ -932,7 +932,7 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
                 return 0;
             }
             break;
-#       endif
+#endif
 
         case ZMQ_CONFLATE:
             if (is_int) {
@@ -942,7 +942,7 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
             break;
 
         //  If libgssapi isn't installed, these options provoke EINVAL
-#       ifdef HAVE_LIBGSSAPI_KRB5
+#ifdef HAVE_LIBGSSAPI_KRB5
         case ZMQ_GSSAPI_SERVER:
             if (is_int) {
                 *value = as_server && mechanism == ZMQ_GSSAPI;

--- a/src/poller.hpp
+++ b/src/poller.hpp
@@ -39,20 +39,20 @@
 #endif
 
 #if defined ZMQ_USE_KQUEUE
-#include "kqueue.hpp"
+#   include "kqueue.hpp"
 #elif defined ZMQ_USE_EPOLL
-#include "epoll.hpp"
+#   include "epoll.hpp"
 #elif defined ZMQ_USE_DEVPOLL
-#include "devpoll.hpp"
+#   include "devpoll.hpp"
 #elif defined ZMQ_USE_POLL
-#include "poll.hpp"
+#   include "poll.hpp"
 #elif defined ZMQ_USE_SELECT
-#include "select.hpp"
+#   include "select.hpp"
 #elif defined ZMQ_HAVE_GNU
-#define ZMQ_USE_POLL
-#include "poll.hpp"
+#   define ZMQ_USE_POLL
+#   include "poll.hpp"
 #else
-#error None of the ZMQ_USE_* macros defined
+#   error None of the ZMQ_USE_* macros defined
 #endif
 
 #if defined ZMQ_USE_SELECT

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -682,7 +682,7 @@ bool zmq::stream_engine_t::handshake ()
                     plain_client_t (options);
             alloc_assert (mechanism);
         }
-#ifdef HAVE_LIBSODIUM
+#ifdef ZMQ_HAVE_CURVE
         else
         if (options.mechanism == ZMQ_CURVE
         &&  memcmp (greeting_recv + 12, "CURVE\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 20) == 0) {

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1211,7 +1211,8 @@ int zmq_poller_wait (void *poller_, zmq_poller_event_t *event, long timeout_)
         return -1;
     }
 
-    zmq::socket_poller_t::event_t e = {};
+    zmq::socket_poller_t::event_t e;
+    memset (&e, 0, sizeof (e));
 
     int rc = ((zmq::socket_poller_t*)poller_)->wait (&e, timeout_);
 
@@ -1360,7 +1361,7 @@ int zmq_has (const char *capability)
     if (strcmp (capability, "norm") == 0)
         return true;
 #endif
-#if defined (HAVE_LIBSODIUM)
+#if defined (ZMQ_HAVE_CURVE)
     if (strcmp (capability, "curve") == 0)
         return true;
 #endif

--- a/tests/test_capabilities.cpp
+++ b/tests/test_capabilities.cpp
@@ -55,7 +55,7 @@ int main (void)
     assert (!zmq_has ("norm"));
 #endif
     
-#if defined (HAVE_LIBSODIUM)
+#if defined (ZMQ_HAVE_CURVE)
     assert (zmq_has ("curve"));
 #else
     assert (!zmq_has ("curve"));

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -102,11 +102,10 @@ static void zap_handler (void *handler)
 
 int main (void)
 {
-#ifndef HAVE_LIBSODIUM
-    printf ("libsodium not installed, skipping CURVE test\n");
+#ifndef ZMQ_HAVE_CURVE
+    printf ("CURVE encryption not installed, skipping test\n");
     return 0;
 #endif
-
     //  Generate new keypairs for this test
     int rc = zmq_curve_keypair (client_public, client_secret);
     assert (rc == 0);


### PR DESCRIPTION
It's unclear which we need and in the source code, conditional code
treats tweetnacl as a subclass of libsodium, which is inaccurate.

Solution: redesign the configure/cmake API for this:

* tweetnacl is present by default and cannot be enabled
* libsodium can be enabled using --with-libsodium, which replaces
  the built-in tweetnacl
* CURVE encryption can be disabled entirely using --enable-curve=no

The macros we define in platform.hpp are:

    ZMQ_HAVE_CURVE    1        //  When CURVE is enabled
    HAVE_LIBSODIUM    1        //  When we are using libsodium
    HAVE_TWEETNACL    1        //  When we're using tweetnacl (default)

As of this patch, the default build of libzmq always has CURVE
security, and always uses tweetnacl.