### PR TITLE
Problem: autotools platform.hpp is not compatible with CMake

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -781,20 +781,17 @@ dnl # LIBZMQ_CHECK_POLLER_KQUEUE([action-if-found], [action-if-not-found])      
 dnl # Checks kqueue polling system                                                 #
 dnl ################################################################################
 AC_DEFUN([LIBZMQ_CHECK_POLLER_KQUEUE], [{
-    AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM(
-        [
+    AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([
 #include <sys/types.h>
 #include <sys/event.h>
 #include <sys/time.h>
-        ],
-[[
+        ],[[
 struct kevent t_kev;
 kqueue();
-]]
-        )],
-        [libzmq_cv_have_poller_kqueue="yes" ; $1],
-        [libzmq_cv_have_poller_kqueue="no" ; $2])
+        ]])],
+        [$1], [$2]
+    )
 }])
 
 dnl ################################################################################
@@ -803,35 +800,27 @@ dnl # Checks epoll polling system can actually run #
 dnl # For cross-compile, only requires that epoll can link #
 dnl ################################################################################
 AC_DEFUN([LIBZMQ_CHECK_POLLER_EPOLL], [{
-    AC_RUN_IFELSE(
-        [AC_LANG_PROGRAM(
-        [
+    AC_RUN_IFELSE([
+        AC_LANG_PROGRAM([
 #include <sys/epoll.h>
-        ],
-[[
+        ],[[
 struct epoll_event t_ev;
 int r;
 r = epoll_create(10);
 return(r < 0);
-]]
-        )],
-        [libzmq_cv_have_poller_epoll="yes" ; $1],
-        [libzmq_cv_have_poller_epoll="no" ; $2],
-        [
-          AC_LINK_IFELSE(
-              [AC_LANG_PROGRAM(
-              [
+        ]])],
+        [$1],[$2],[
+            AC_LINK_IFELSE([
+                AC_LANG_PROGRAM([
 #include <sys/epoll.h>
-              ],
-      [[
-      struct epoll_event t_ev;
-      epoll_create(10);
-      ]]
-              )],
-              [libzmq_cv_have_poller_epoll="yes" ; $1],
-              [libzmq_cv_have_poller_epoll="no" ; $2])
-
-        ])
+                ],[[
+struct epoll_event t_ev;
+epoll_create(10);
+                ]])],
+                [$1], [$2]
+            )
+        ]
+    )
 }])
 
 dnl ################################################################################
@@ -839,18 +828,15 @@ dnl # LIBZMQ_CHECK_POLLER_DEVPOLL([action-if-found], [action-if-not-found])     
 dnl # Checks devpoll polling system                                                #
 dnl ################################################################################
 AC_DEFUN([LIBZMQ_CHECK_POLLER_DEVPOLL], [{
-    AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM(
-        [
+    AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([
 #include <sys/devpoll.h>
-        ],
-[[
+        ],[[
 struct pollfd t_devpoll;
 int fd = open("/dev/poll", O_RDWR);
-]]
-        )],
-        [libzmq_cv_have_poller_devpoll="yes" ; $1],
-        [libzmq_cv_have_poller_devpoll="no" ; $2])
+        ]])],
+        [$1], [$2]
+    )
 }])
 
 dnl ################################################################################
@@ -858,18 +844,15 @@ dnl # LIBZMQ_CHECK_POLLER_POLL([action-if-found], [action-if-not-found])        
 dnl # Checks poll polling system                                                   #
 dnl ################################################################################
 AC_DEFUN([LIBZMQ_CHECK_POLLER_POLL], [{
-    AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM(
-        [
+    AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([
 #include <poll.h>
-        ],
-[[
+        ],[[
 struct pollfd t_poll;
 poll(&t_poll, 1, 1);
-]]
-        )],
-        [libzmq_cv_have_poller_poll="yes" ; $1],
-        [libzmq_cv_have_poller_poll="no" ; $2])
+        ]])],
+        [$1], [$2]
+    )
 }])
 
 dnl ################################################################################
@@ -877,9 +860,8 @@ dnl # LIBZMQ_CHECK_POLLER_SELECT([action-if-found], [action-if-not-found])      
 dnl # Checks select polling system                                                 #
 dnl ################################################################################
 AC_DEFUN([LIBZMQ_CHECK_POLLER_SELECT], [{
-    AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM(
-        [
+    AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([
 #ifdef ZMQ_HAVE_WINDOWS
 #include "winsock2.h"
 #elif defined ZMQ_HAVE_OPENVMS
@@ -888,79 +870,84 @@ AC_DEFUN([LIBZMQ_CHECK_POLLER_SELECT], [{
 #else
 #include <sys/select.h>
 #endif
-        ],
-[[
+        ],[[
 fd_set t_rfds;
 struct timeval tv;
-
 FD_ZERO(&t_rfds);
 FD_SET(0, &t_rfds);
-
 tv.tv_sec = 5;
 tv.tv_usec = 0;
-
 select(1, &t_rfds, NULL, NULL, &tv);
-]]
-        )],
-        [libzmq_cv_have_poller_select="yes" ; $1],
-        [libzmq_cv_have_poller_select="no" ; $2])
+        ]])],
+        [$1],[$2]
+    )
 }])
 
 dnl ################################################################################
 dnl # LIBZMQ_CHECK_POLLER([action-if-found], [action-if-not-found])                #
 dnl # Choose polling system                                                        #
 dnl ################################################################################
+
 AC_DEFUN([LIBZMQ_CHECK_POLLER], [{
-
     # Allow user to override poller autodetection
-    AC_ARG_WITH([poller], [AS_HELP_STRING([--with-poller],
-                [choose polling system manually. valid values are kqueue, epoll, devpoll, poll or select [default=autodetect]])])
+    AC_ARG_WITH([poller],
+        [AS_HELP_STRING([--with-poller],
+        [choose polling system manually. Valid values are 'kqueue', 'epoll', 'devpoll', 'poll', 'select', or 'auto'. [default=auto]])])
 
-    case "${with_poller}" in
-        kqueue|epoll|devpoll|poll|select)
-            # User has chosen polling system
-            AC_MSG_CHECKING([for suitable polling system skipped for preselect])
-            libzmq_cv_poller="${with_poller}"
-        ;;
+    if test "x$with_poller" == "x"; then
+        pollers=auto
+    else
+        pollers=$with_poller
+    fi
+    if test "$pollers" == "auto"; then
+        # We search for pollers in this order
+        pollers="kqueue epoll devpoll poll select"
+    fi
 
-        *)
-            # try to find suitable polling system. the order of testing is:
-            # kqueue -> epoll -> devpoll -> poll -> select
-            AC_MSG_CHECKING([for suitable polling system])
-            for subsystem in kqueue epoll devpoll poll select; do
-
-                case "${subsystem}" in
-                    kqueue)
-                        LIBZMQ_CHECK_POLLER_KQUEUE([libzmq_cv_poller=$subsystem], [])
-                    ;;
-
-                    epoll)
-                        LIBZMQ_CHECK_POLLER_EPOLL([libzmq_cv_poller=$subsystem], [])
-                    ;;
-
-                    devpoll)
-                        LIBZMQ_CHECK_POLLER_DEVPOLL([libzmq_cv_poller=$subsystem], [])
-                    ;;
-
-                    poll)
-                        LIBZMQ_CHECK_POLLER_POLL([libzmq_cv_poller=$subsystem], [])
-                    ;;
-
-                    select)
-                        LIBZMQ_CHECK_POLLER_SELECT([libzmq_cv_poller=$subsystem], [])
-                    ;;
-                esac
-
-                if test "x${libzmq_cv_poller}" != "x"; then
-                    break
-                fi
-            done
-      ;;
-    esac
-
-    libzmq_cv_poller_flag=`echo "ZMQ_USE_${libzmq_cv_poller}" | tr a-z A-Z`
-
-    AS_IF([test "x${libzmq_cv_poller}" != "x"],
-          [AC_MSG_RESULT([using $libzmq_cv_poller]) ; $1], [AC_MSG_RESULT(no suitable polling system found) ; $2])
+    # try to find suitable polling system. the order of testing is:
+    AC_MSG_NOTICE([Choosing polling system from '$pollers'...])
+    poller_found=0
+    for poller in $pollers; do
+        case "$poller" in
+            kqueue)
+                LIBZMQ_CHECK_POLLER_KQUEUE([
+                    AC_MSG_NOTICE([Using 'kqueue' polling system])
+                    AC_DEFINE(ZMQ_USE_KQUEUE, 1, [Use 'kqueue' polling system])
+                    poller_found=1
+                ])
+            ;;
+            epoll)
+                LIBZMQ_CHECK_POLLER_EPOLL([
+                    AC_MSG_NOTICE([Using 'epoll' polling system])
+                    AC_DEFINE(ZMQ_USE_EPOLL, 1, [Use 'epoll' polling system])
+                    poller_found=1
+                ])
+            ;;
+            devpoll)
+                LIBZMQ_CHECK_POLLER_DEVPOLL([
+                    AC_MSG_NOTICE([Using 'devpoll' polling system])
+                    AC_DEFINE(ZMQ_USE_DEVPOLL, 1, [Use 'devpoll' polling system])
+                    poller_found=1
+                ])
+            ;;
+            poll)
+                LIBZMQ_CHECK_POLLER_POLL([
+                    AC_MSG_NOTICE([Using 'poll' polling system])
+                    AC_DEFINE(ZMQ_USE_POLL, 1, [Use 'poll' polling system])
+                    poller_found=1
+                ])
+            ;;
+            select)
+                LIBZMQ_CHECK_POLLER_SELECT([
+                    AC_MSG_NOTICE([Using 'select' polling system])
+                    AC_DEFINE(ZMQ_USE_SELECT, 1, [Use 'select' polling system])
+                    poller_found=1
+                ])
+            ;;
+        esac
+        test $poller_found -eq 1 && break
+    done
+    if test $poller_found -eq 0; then
+        AC_MSG_ERROR([None of '$pollers' are valid pollers on this platform])
+    fi
 }])
-

--- a/configure.ac
+++ b/configure.ac
@@ -320,9 +320,8 @@ esac
 # Check whether to build docs / install man pages
 LIBZMQ_CHECK_DOC_BUILD
 
-# Check polling system
-LIBZMQ_CHECK_POLLER([CPPFLAGS="${CPPFLAGS} -D${libzmq_cv_poller_flag}"],
-    [AC_MSG_ERROR([Unable to continue without polling system])])
+# Check polling system, set appropriate macro in src/platform.hpp
+LIBZMQ_CHECK_POLLER
 
 # Checks for header files.
 AC_HEADER_STDC
@@ -498,6 +497,7 @@ AC_ARG_WITH([norm],
 AC_MSG_CHECKING("with_norm_ext = ${with_norm_ext}")
 
 if test "x$with_norm_ext" != "xno"; then
+    AC_MSG_RESULT([yes])
     AC_DEFINE(ZMQ_HAVE_NORM, 1, [Have NORM protocol extension])
 
     if test "x$with_norm_ext" != "xyes"; then
@@ -505,8 +505,9 @@ if test "x$with_norm_ext" != "xno"; then
         LIBZMQ_EXTRA_CXXFLAGS="-I${norm_path}/include ${LIBZMQ_EXTRA_CXXFLAGS}"
         LIBZMQ_EXTRA_LDFLAGS="-I${norm_path}/include ${LIBZMQ_EXTRA_LDFLAGS}"
     fi
-
     LIBS="-lnorm $LIBS"
+else
+    AC_MSG_RESULT([no])
 fi
 
 # build using vmci


### PR DESCRIPTION
Specifically, the poller detection code does not set macros in
platform.hpp. The configure script passed them as -D on the command
line.

Solution: rewrite the poller detection code.