### PR TITLE
Problem: typo in CMake platform.hpp breaks build

### DIFF
--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -31,7 +31,7 @@
 #cmakedefine ZMQ_MAKE_VALGRIND_HAPPY
 
 #cmakedefine ZMQ_HAVE_CURVE
-#cmakedefine HAVE_TWEETNACL
+#cmakedefine ZMQ_USE_TWEETNACL
 #cmakedefine HAVE_LIBSODIUM
 
 #ifdef _AIX


### PR DESCRIPTION
Solution: use ZMQ_USE_TWEETNACL as a define as expected instead of
HAVE_TWEETNACL


With this, the build is 100% unborken. Yay! :-)