### PR TITLE
Problem: tests don't build on Windows

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -10,4 +10,4 @@ Note that testutil.hpp includes platform.h. Do not include it yourself as it cha
 
 All sources must contain the correct header. Please copy from test_system.cpp if you're not certain.
 
-
+Please use only ANSI C99 in test cases, no C++. This is to make the code more reusable.

--- a/tests/test_filter_ipc.cpp
+++ b/tests/test_filter_ipc.cpp
@@ -27,12 +27,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <string.h>
-#include <sys/types.h>
-
-#include <string>
-#include <sstream>
-
 #include "testutil.hpp"
 
 static void bounce_fail (void *server, void *client)
@@ -78,9 +72,9 @@ static void run_test (int opt, T optval, int expected_error, int bounce_test)
         if (expected_error) {
             assert (rc == -1);
             assert (zmq_errno () == expected_error);
-        } else {
-            assert (rc == 0);
         }
+        else
+            assert (rc == 0);
     }
 
     void *sc = zmq_socket (ctx, ZMQ_DEALER);
@@ -113,7 +107,6 @@ static void run_test (int opt, T optval, int expected_error, int bounce_test)
         else
             bounce_fail (sb, sc);
     }
-
     close_zero_linger (sc);
     close_zero_linger (sb);
 
@@ -123,6 +116,7 @@ static void run_test (int opt, T optval, int expected_error, int bounce_test)
 
 int main (void)
 {
+#if !defined (ZMQ_HAVE_WINDOWS)
     setup_test_environment();
 
     // No filters
@@ -166,6 +160,7 @@ int main (void)
     run_test<pid_t> (ZMQ_IPC_FILTER_PID, 0, EINVAL, 0);
 #endif // defined ZMQ_HAVE_SO_PEERCRED || defined ZMQ_HAVE_LOCAL_PEERCRED
 
+#endif
     return 0 ;
 }
 

--- a/tests/test_fork.cpp
+++ b/tests/test_fork.cpp
@@ -35,6 +35,7 @@ const char *address = "tcp://127.0.0.1:6571";
 
 int main (void)
 {
+#if !defined (ZMQ_HAVE_WINDOWS)
     setup_test_environment ();
     void *ctx = zmq_ctx_new ();
     assert (ctx);
@@ -87,5 +88,6 @@ int main (void)
         }
         exit (0);
     }
+#endif
     return 0;
 }

--- a/tests/test_heartbeats.cpp
+++ b/tests/test_heartbeats.cpp
@@ -24,10 +24,7 @@
 #   include <stdexcept>
 #   define close closesocket
 #else
-#   include <sys/socket.h>
-#   include <netinet/in.h>
 #   include <arpa/inet.h>
-#   include <unistd.h>
 #endif
 
 //  Read one event off the monitor socket; return value and address
@@ -184,8 +181,8 @@ test_heartbeat_timeout (void)
     int s;
 
     ip4addr.sin_family = AF_INET;
-    ip4addr.sin_port = htons(5556);
-#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
+    ip4addr.sin_port = htons (5556);
+#if defined (ZMQ_HAVE_WINDOWS) && (_WIN32_WINNT < 0x0600)
     ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
 #else
     inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);

--- a/tests/test_router_mandatory_hwm.cpp
+++ b/tests/test_router_mandatory_hwm.cpp
@@ -95,7 +95,7 @@ int main (void)
     // This should fail after one message but kernel buffering could
     // skew results
     assert (i < 10);
-    sleep(1);
+    msleep (1000);
     // Send second batch of messages
     for(; i < 100000; ++i) {
         if (TRACE_ENABLED) fprintf(stderr, "Sending message %d (part 2) ...\n", i);

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -244,7 +244,7 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons (9998);
-#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
+#if defined (ZMQ_HAVE_WINDOWS) && (_WIN32_WINNT < 0x0600)
     ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
 #else
     inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);

--- a/tests/test_security_null.cpp
+++ b/tests/test_security_null.cpp
@@ -158,7 +158,7 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons(9003);
-#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
+#if defined (ZMQ_HAVE_WINDOWS) && (_WIN32_WINNT < 0x0600)
     ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
 #else
     inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);

--- a/tests/test_security_plain.cpp
+++ b/tests/test_security_plain.cpp
@@ -164,10 +164,10 @@ int main (void)
 
     ip4addr.sin_family = AF_INET;
     ip4addr.sin_port = htons (9998);
-#if (ZMQ_HAVE_WINDOWS and _WIN32_WINNT < 0x0600)
+#if defined (ZMQ_HAVE_WINDOWS) && (_WIN32_WINNT < 0x0600)
     ip4addr.sin_addr.s_addr = inet_addr ("127.0.0.1");
 #else
-    inet_pton(AF_INET, "127.0.0.1", &ip4addr.sin_addr);
+    inet_pton (AF_INET, "127.0.0.1", &ip4addr.sin_addr);
 #endif
 
     s = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);

--- a/tests/test_stream_exceeds_buffer.cpp
+++ b/tests/test_stream_exceeds_buffer.cpp
@@ -52,7 +52,7 @@ int main()
     int server_sock = socket(AF_INET, SOCK_STREAM, 0);
     assert(server_sock!=-1);
     int enable = 1;
-    int rc = setsockopt(server_sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+    int rc = setsockopt (server_sock, SOL_SOCKET, SO_REUSEADDR, (char *) &enable, sizeof(enable));
     assert(rc!=-1);
 
     struct sockaddr_in saddr;


### PR DESCRIPTION
There were numerous small issues with test cases:

- some lacked the right source file header
- some were not portable at all
- some were using internal libzmq APIs (headers)

Solution: fixed and cleaned up.