### PR TITLE
Problem: curve keys getsockopt uninitialised read

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -78,6 +78,9 @@ zmq::options_t::options_t () :
     heartbeat_timeout (-1),
     use_fd (-1)
 {
+    memset (curve_public_key, 0, CURVE_KEYSIZE);
+    memset (curve_secret_key, 0, CURVE_KEYSIZE);
+    memset (curve_server_key, 0, CURVE_KEYSIZE);
 #if defined ZMQ_HAVE_VMCI
     vmci_buffer_size = 0;
     vmci_buffer_min_size = 0;


### PR DESCRIPTION
Solution: always initialised zmq::options_t class variables arrays to
avoid reading uninitialised data when CURVE is not yet configured and
a getsockopt ZMQ_CURVE_{SERVER | PUBLIC | SECRET]KEY is issued.