### PR TITLE
Problem:  Windows build script requires edit for DevStudio version

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -111,6 +111,7 @@ Hardeep Singh
 André Caron 
 Tim Mossbarger 
 Doron Somech
+Osiris Pedroso
 
 Credits
 =======

--- a/INSTALL
+++ b/INSTALL
@@ -14,6 +14,11 @@ If you clone the Git repository then you should start by running the
 command `./autogen.sh`. This is not necessary if you get the source
 packages.
 
+Windows Builds
+==============
+
+For Windows building, see the libzmq\builds\msvc\readme.txt file.
+
 Basic Installation
 ==================
 

--- a/builds/msvc/build/buildall.bat
+++ b/builds/msvc/build/buildall.bat
@@ -1,7 +1,17 @@
 @ECHO OFF
+@setlocal
+::
+:: uses the environment from the DevStudio CMD window to figure out which version to build
+::
 
-CALL buildbase.bat ..\vs2015\libzmq.sln 14
-ECHO.
+set VSVER=%VSINSTALLDIR:~-5,2%
+set DIRVER=%VSVER%
+if %VSVER% gtr 10 set /a DIRVER = DIRVER + 1
+
+CALL buildbase.bat ..\vs20%DIRVER%\libzmq.sln %VSVER%
+
+:- CALL buildbase.bat ..\vs2015\libzmq.sln 14
+:- ECHO.
 :- CALL buildbase.bat ..\vs2013\libzmq.sln 12
 :- ECHO.
 :- CALL buildbase.bat ..\vs2012\libzmq.sln 11
@@ -9,4 +19,5 @@ ECHO.
 :- CALL buildbase.bat ..\vs2010\libzmq.sln 10
 :- ECHO.
 
+@endlocal
 PAUSE

--- a/builds/msvc/readme.txt
+++ b/builds/msvc/readme.txt
@@ -13,3 +13,12 @@ The vs2015/vs2013/vs2012/vs2010 solution and project files differ only in versio
 More info here:
 
 http://en.wikipedia.org/wiki/Visual_C%2B%2B
+
+
+For building Windows, use the buildall.bat script in this directory.
+
+It requires that the CMD.EXE be created using the DevStudio Tools link to create a CMD.EXE windo.
+
+If multiple DevStudio versions are installed on the machine, you can run buildall.bat on separate windows that each were created by the desired DevStudio target.
+
+If you prefer to build all versions (or several) at the same time, you should uncomment the specific version desired in buildall.bat to build them from a single window.


### PR DESCRIPTION
Solution: Use CMD.EXE environment variable to extract DevStudio version
number and build using it. This even supports machines with multiple
DevStudio versions installed, as long as the build for each version is
done on a separate window with the correct environment.
If multiple version builds are desired from a single CMD.EXE, edit the
buildall.bat file to uncomment the build statements for each specific
version desired.