### PR TITLE
Deprecate zmq_utils.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,7 +509,8 @@ if (MINGW)
 endif ()
 
 include_directories (include ${CMAKE_CURRENT_BINARY_DIR})
-set (public_headers include/zmq.h)
+set (public_headers include/zmq.h
+                    include/zmq_utils.h)
 
 set (readme-docs AUTHORS
                 COPYING

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,8 @@ AM_CPPFLAGS = \
 lib_LTLIBRARIES = src/libzmq.la
 
 include_HEADERS = \
-	include/zmq.h 
+	include/zmq.h \
+	include/zmq_utils.h
 
 src_libzmq_la_SOURCES = \
 	src/address.cpp \

--- a/include/zmq_utils.h
+++ b/include/zmq_utils.h
@@ -28,3 +28,5 @@
 */
 
 /*  This file is deprecated, and all its functionality provided by zmq.h     */
+
+#warning zmq_utils.h is deprecated. All its functionality is provided by zmq.h.

--- a/packaging/redhat/zeromq.spec.in
+++ b/packaging/redhat/zeromq.spec.in
@@ -120,6 +120,7 @@ This package contains ZeroMQ related development libraries and header files.
 %files devel
 %defattr(-,root,root,-)
 %{_includedir}/zmq.h
+%{_includedir}/zmq_utils.h
 
 %{_libdir}/libzmq.la
 %{_libdir}/libzmq.a


### PR DESCRIPTION
instead of removing it, which breaks downstream builds.