### PR TITLE
Problem: VC++ gives warnings on inet_addr

### DIFF
--- a/builds/gyp/project.gyp
+++ b/builds/gyp/project.gyp
@@ -26,7 +26,8 @@
           'ZMQ_HAVE_WINDOWS',
           'ZMQ_STATIC',
           'FD_SETSIZE=16384',
-          '_CRT_SECURE_NO_WARNINGS'
+          '_CRT_SECURE_NO_WARNINGS',
+          '_WINSOCK_DEPRECATED_NO_WARNINGS'
         ],
         'libraries': [
           'ws2_32',


### PR DESCRIPTION
Solution: in project.gyp, define _WINSOCK_DEPRECATED_NO_WARNINGS