### PR TITLE
Problem: tweetnacl gives many warnings on MSVC

### DIFF
--- a/src/tweetnacl.c
+++ b/src/tweetnacl.c
@@ -30,7 +30,13 @@
 #include "platform.hpp"
 #if defined (ZMQ_USE_TWEETNACL)
 
-#pragma GCC diagnostic ignored "-Wsign-compare"
+//  Disable warnings for this source only, rather than for the whole
+//  codebase
+#ifdef __GNUC__
+#   pragma GCC diagnostic ignored "-Wsign-compare"
+#elif defined _MSC_VER
+#   pragma warning (disable:4018 4244 4146)
+#endif
 
 #include "tweetnacl.h"
 


### PR DESCRIPTION
Solution: disable the warnings on this file only

We use pragmas wrapped in compiler conditionals. This will need
extending to non-gcc/msvc compilers. We could also fix the warnings
in the code, though I suspect it's not really possible.