### PR TITLE
Problem: Visual Studio Toolset was incorrectly set in VCXPROJ files

### DIFF
--- a/builds/msvc/vs2010/inproc_lat/inproc_lat.vcxproj
+++ b/builds/msvc/vs2010/inproc_lat/inproc_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6FF7436F-B3F6-4AE9-A3AC-CFDE8A3872A0}</ProjectGuid>
     <ProjectName>inproc_lat</ProjectName>

--- a/builds/msvc/vs2010/inproc_thr/inproc_thr.vcxproj
+++ b/builds/msvc/vs2010/inproc_thr/inproc_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1077E977-95DD-4E73-A692-74647DD0CC1E}</ProjectGuid>
     <ProjectName>inproc_thr</ProjectName>

--- a/builds/msvc/vs2010/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2010/libzmq/libzmq.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{641C5F36-32EE-4323-B740-992B651CF9D6}</ProjectGuid>
     <ProjectName>libzmq</ProjectName>

--- a/builds/msvc/vs2010/local_lat/local_lat.vcxproj
+++ b/builds/msvc/vs2010/local_lat/local_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4FDB8C73-9D4A-4D87-A4A9-A7FC06DFEA57}</ProjectGuid>
     <ProjectName>local_lat</ProjectName>

--- a/builds/msvc/vs2010/local_thr/local_thr.vcxproj
+++ b/builds/msvc/vs2010/local_thr/local_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8EF2DF6B-6646-460F-8032-913B70FE0E94}</ProjectGuid>
     <ProjectName>local_thr</ProjectName>

--- a/builds/msvc/vs2010/remote_lat/remote_lat.vcxproj
+++ b/builds/msvc/vs2010/remote_lat/remote_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9C20A37C-5D9F-4C4C-A2D9-E6EE91A077D1}</ProjectGuid>
     <ProjectName>remote_lat</ProjectName>

--- a/builds/msvc/vs2010/remote_thr/remote_thr.vcxproj
+++ b/builds/msvc/vs2010/remote_thr/remote_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B15E059C-0CBB-4A82-8C42-6567FB650802}</ProjectGuid>
     <ProjectName>remote_thr</ProjectName>

--- a/builds/msvc/vs2012/inproc_lat/inproc_lat.vcxproj
+++ b/builds/msvc/vs2012/inproc_lat/inproc_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6FF7436F-B3F6-4AE9-A3AC-CFDE8A3872A0}</ProjectGuid>
     <ProjectName>inproc_lat</ProjectName>

--- a/builds/msvc/vs2012/inproc_thr/inproc_thr.vcxproj
+++ b/builds/msvc/vs2012/inproc_thr/inproc_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1077E977-95DD-4E73-A692-74647DD0CC1E}</ProjectGuid>
     <ProjectName>inproc_thr</ProjectName>

--- a/builds/msvc/vs2012/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2012/libzmq/libzmq.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{641C5F36-32EE-4323-B740-992B651CF9D6}</ProjectGuid>
     <ProjectName>libzmq</ProjectName>

--- a/builds/msvc/vs2012/local_lat/local_lat.vcxproj
+++ b/builds/msvc/vs2012/local_lat/local_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4FDB8C73-9D4A-4D87-A4A9-A7FC06DFEA57}</ProjectGuid>
     <ProjectName>local_lat</ProjectName>

--- a/builds/msvc/vs2012/local_thr/local_thr.vcxproj
+++ b/builds/msvc/vs2012/local_thr/local_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8EF2DF6B-6646-460F-8032-913B70FE0E94}</ProjectGuid>
     <ProjectName>local_thr</ProjectName>

--- a/builds/msvc/vs2012/remote_lat/remote_lat.vcxproj
+++ b/builds/msvc/vs2012/remote_lat/remote_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9C20A37C-5D9F-4C4C-A2D9-E6EE91A077D1}</ProjectGuid>
     <ProjectName>remote_lat</ProjectName>

--- a/builds/msvc/vs2012/remote_thr/remote_thr.vcxproj
+++ b/builds/msvc/vs2012/remote_thr/remote_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B15E059C-0CBB-4A82-8C42-6567FB650802}</ProjectGuid>
     <ProjectName>remote_thr</ProjectName>

--- a/builds/msvc/vs2013/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2013/libzmq/libzmq.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{641C5F36-32EE-4323-B740-992B651CF9D6}</ProjectGuid>
     <ProjectName>libzmq</ProjectName>

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -36,6 +36,7 @@
 #include "platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
+#define WIN32_LEAN_AND_MEAN		// speeds up compilation by removing rarely used windows definitions from headers
 #include "windows.hpp"
 #else
 #include <unistd.h>


### PR DESCRIPTION
Solution: Corrected Toolset setting where needed and inprove compilation speed
by adding defintion of WIN32_LEAN_AND_MEAN prior to any Windows specific
include files, which skips non-essential definitions during compilation.