### PR TITLE
Problem: Several problems found by Coverity Static Analyzer

### DIFF
--- a/builds/msvc/vs2010/inproc_lat/inproc_lat.vcxproj
+++ b/builds/msvc/vs2010/inproc_lat/inproc_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6FF7436F-B3F6-4AE9-A3AC-CFDE8A3872A0}</ProjectGuid>
     <ProjectName>inproc_lat</ProjectName>

--- a/builds/msvc/vs2010/inproc_thr/inproc_thr.vcxproj
+++ b/builds/msvc/vs2010/inproc_thr/inproc_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1077E977-95DD-4E73-A692-74647DD0CC1E}</ProjectGuid>
     <ProjectName>inproc_thr</ProjectName>

--- a/builds/msvc/vs2010/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2010/libzmq/libzmq.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{641C5F36-32EE-4323-B740-992B651CF9D6}</ProjectGuid>
     <ProjectName>libzmq</ProjectName>

--- a/builds/msvc/vs2010/local_lat/local_lat.vcxproj
+++ b/builds/msvc/vs2010/local_lat/local_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4FDB8C73-9D4A-4D87-A4A9-A7FC06DFEA57}</ProjectGuid>
     <ProjectName>local_lat</ProjectName>

--- a/builds/msvc/vs2010/local_thr/local_thr.vcxproj
+++ b/builds/msvc/vs2010/local_thr/local_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8EF2DF6B-6646-460F-8032-913B70FE0E94}</ProjectGuid>
     <ProjectName>local_thr</ProjectName>

--- a/builds/msvc/vs2010/remote_lat/remote_lat.vcxproj
+++ b/builds/msvc/vs2010/remote_lat/remote_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9C20A37C-5D9F-4C4C-A2D9-E6EE91A077D1}</ProjectGuid>
     <ProjectName>remote_lat</ProjectName>

--- a/builds/msvc/vs2010/remote_thr/remote_thr.vcxproj
+++ b/builds/msvc/vs2010/remote_thr/remote_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B15E059C-0CBB-4A82-8C42-6567FB650802}</ProjectGuid>
     <ProjectName>remote_thr</ProjectName>

--- a/builds/msvc/vs2012/inproc_lat/inproc_lat.vcxproj
+++ b/builds/msvc/vs2012/inproc_lat/inproc_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6FF7436F-B3F6-4AE9-A3AC-CFDE8A3872A0}</ProjectGuid>
     <ProjectName>inproc_lat</ProjectName>

--- a/builds/msvc/vs2012/inproc_thr/inproc_thr.vcxproj
+++ b/builds/msvc/vs2012/inproc_thr/inproc_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1077E977-95DD-4E73-A692-74647DD0CC1E}</ProjectGuid>
     <ProjectName>inproc_thr</ProjectName>

--- a/builds/msvc/vs2012/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2012/libzmq/libzmq.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{641C5F36-32EE-4323-B740-992B651CF9D6}</ProjectGuid>
     <ProjectName>libzmq</ProjectName>

--- a/builds/msvc/vs2012/local_lat/local_lat.vcxproj
+++ b/builds/msvc/vs2012/local_lat/local_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4FDB8C73-9D4A-4D87-A4A9-A7FC06DFEA57}</ProjectGuid>
     <ProjectName>local_lat</ProjectName>

--- a/builds/msvc/vs2012/local_thr/local_thr.vcxproj
+++ b/builds/msvc/vs2012/local_thr/local_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8EF2DF6B-6646-460F-8032-913B70FE0E94}</ProjectGuid>
     <ProjectName>local_thr</ProjectName>

--- a/builds/msvc/vs2012/remote_lat/remote_lat.vcxproj
+++ b/builds/msvc/vs2012/remote_lat/remote_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9C20A37C-5D9F-4C4C-A2D9-E6EE91A077D1}</ProjectGuid>
     <ProjectName>remote_lat</ProjectName>

--- a/builds/msvc/vs2012/remote_thr/remote_thr.vcxproj
+++ b/builds/msvc/vs2012/remote_thr/remote_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B15E059C-0CBB-4A82-8C42-6567FB650802}</ProjectGuid>
     <ProjectName>remote_thr</ProjectName>

--- a/builds/msvc/vs2013/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2013/libzmq/libzmq.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{641C5F36-32EE-4323-B740-992B651CF9D6}</ProjectGuid>
     <ProjectName>libzmq</ProjectName>

--- a/builds/msvc/vs2015/inproc_lat/inproc_lat.vcxproj
+++ b/builds/msvc/vs2015/inproc_lat/inproc_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{6FF7436F-B3F6-4AE9-A3AC-CFDE8A3872A0}</ProjectGuid>
     <ProjectName>inproc_lat</ProjectName>

--- a/builds/msvc/vs2015/inproc_thr/inproc_thr.vcxproj
+++ b/builds/msvc/vs2015/inproc_thr/inproc_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1077E977-95DD-4E73-A692-74647DD0CC1E}</ProjectGuid>
     <ProjectName>inproc_thr</ProjectName>

--- a/builds/msvc/vs2015/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2015/libzmq/libzmq.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{641C5F36-32EE-4323-B740-992B651CF9D6}</ProjectGuid>
     <ProjectName>libzmq</ProjectName>

--- a/builds/msvc/vs2015/local_lat/local_lat.vcxproj
+++ b/builds/msvc/vs2015/local_lat/local_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4FDB8C73-9D4A-4D87-A4A9-A7FC06DFEA57}</ProjectGuid>
     <ProjectName>local_lat</ProjectName>

--- a/builds/msvc/vs2015/local_thr/local_thr.vcxproj
+++ b/builds/msvc/vs2015/local_thr/local_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{8EF2DF6B-6646-460F-8032-913B70FE0E94}</ProjectGuid>
     <ProjectName>local_thr</ProjectName>

--- a/builds/msvc/vs2015/remote_lat/remote_lat.vcxproj
+++ b/builds/msvc/vs2015/remote_lat/remote_lat.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{9C20A37C-5D9F-4C4C-A2D9-E6EE91A077D1}</ProjectGuid>
     <ProjectName>remote_lat</ProjectName>

--- a/builds/msvc/vs2015/remote_thr/remote_thr.vcxproj
+++ b/builds/msvc/vs2015/remote_thr/remote_thr.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B15E059C-0CBB-4A82-8C42-6567FB650802}</ProjectGuid>
     <ProjectName>remote_thr</ProjectName>

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -108,6 +108,8 @@ f_compatible_get_tick_count64 init_compatible_get_tick_count64()
   if (func == NULL)
     func = compatible_get_tick_count64;
 
+  ::FreeLibrary(module);
+
   return func;
 }
 

--- a/src/dish.cpp
+++ b/src/dish.cpp
@@ -332,13 +332,15 @@ int zmq::dish_session_t::pull_msg (msg_t *msg_)
         int offset;
 
         if (msg_->is_join ()) {
-            command.init_size (group_length + 5);
-            offset = 5;
+            rc = command.init_size (group_length + 5);
+			errno_assert(rc == 0);
+			offset = 5;
             memcpy (command.data (), "\4JOIN", 5);
         }
         else {
-            command.init_size (group_length + 6);
-            offset = 6;
+            rc = command.init_size (group_length + 6);
+			errno_assert(rc == 0);
+			offset = 6;
             memcpy (command.data (), "\5LEAVE", 6);
         }
 
@@ -349,7 +351,7 @@ int zmq::dish_session_t::pull_msg (msg_t *msg_)
         memcpy (command_data + offset, msg_->group (), group_length);
 
         //  Close the join message
-        int rc = msg_->close ();
+        rc = msg_->close ();
         errno_assert (rc == 0);
 
         *msg_ = command;

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -58,6 +58,10 @@ namespace zmq
 
         inline encoder_base_t (size_t bufsize_) :
             bufsize (bufsize_),
+			write_pos(0),
+			to_write(0),
+			next(nullptr),
+			new_msg_flag(false),
             in_progress (NULL)
         {
             buf = (unsigned char*) malloc (bufsize_);

--- a/src/null_mechanism.cpp
+++ b/src/null_mechanism.cpp
@@ -157,7 +157,7 @@ int zmq::null_mechanism_t::process_handshake_command (msg_t *msg_)
     }
 
     if (rc == 0) {
-        int rc = msg_->close ();
+        rc = msg_->close ();
         errno_assert (rc == 0);
         rc = msg_->init ();
         errno_assert (rc == 0);

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -92,6 +92,7 @@ zmq::pipe_t::pipe_t (object_t *parent_, upipe_t *inpipe_, upipe_t *outpipe_,
     sink (NULL),
     state (active),
     delay (true),
+	routing_id(0),
     conflate (conflate_)
 {
 }

--- a/src/poller_base.cpp
+++ b/src/poller_base.cpp
@@ -53,7 +53,7 @@ void zmq::poller_base_t::adjust_load (int amount_)
         load.add (amount_);
     else
     if (amount_ < 0)
-        load.sub (-amount_);
+        bool reset = load.sub (-amount_);
 }
 
 void zmq::poller_base_t::add_timer (int timeout_, i_poll_events *sink_, int id_)

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -227,8 +227,9 @@ int zmq::radio_session_t::pull_msg (msg_t *msg_)
         int length = (int) strlen (group);
 
         //  First frame is the group
-        msg_->init_size (length);
-        msg_->set_flags (msg_t::more);
+        rc = msg_->init_size (length);
+		errno_assert(rc == 0);
+		msg_->set_flags(msg_t::more);
         memcpy (msg_->data (), group, length);
 
         //  Next status is the body

--- a/src/reaper.cpp
+++ b/src/reaper.cpp
@@ -36,6 +36,7 @@
 zmq::reaper_t::reaper_t (class ctx_t *ctx_, uint32_t tid_) :
     object_t (ctx_, tid_),
     sockets (0),
+	mailbox_handle(NULL),
     terminating (false)
 {
     poller = new (std::nothrow) poller_t (*ctx_);

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -155,9 +155,9 @@ void zmq::router_t::xpipe_terminated (pipe_t *pipe_)
     if (it != anonymous_pipes.end ())
         anonymous_pipes.erase (it);
     else {
-        outpipes_t::iterator it = outpipes.find (pipe_->get_identity ());
-        zmq_assert (it != outpipes.end ());
-        outpipes.erase (it);
+        outpipes_t::iterator iter = outpipes.find (pipe_->get_identity ());
+        zmq_assert (iter != outpipes.end ());
+        outpipes.erase (iter);
         fq.pipe_terminated (pipe_);
         if (pipe_ == current_out)
             current_out = NULL;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -122,7 +122,7 @@ int zmq::server_t::xsend (msg_t *msg_)
     bool ok = it->second.pipe->write (msg_);
     if (unlikely (!ok)) {
         // Message failed to send - we must close it ourselves.
-        int rc = msg_->close ();
+        rc = msg_->close ();
         errno_assert (rc == 0);
     }
     else

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -539,7 +539,8 @@ int zmq::signaler_t::make_fdpair (fd_t *r_, fd_t *w_)
         saved_errno = WSAGetLastError ();
 
     //  We don't need the listening socket anymore. Close it.
-    closesocket (listener);
+    rc = closesocket (listener);
+	wsa_assert(rc != SOCKET_ERROR);
 
     if (sync != NULL) {
         //  Exit the critical section.

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -34,12 +34,20 @@
 zmq::socket_poller_t::socket_poller_t () :
     tag (0xCAFEBABE),
     need_rebuild (true),
+	poll_size(0),
+	maxfd(0),
     use_signaler (false)
 #if defined ZMQ_POLL_BASED_ON_POLL
     ,
     pollfds (NULL)
 #endif
 {
+#if defined ZMQ_POLL_BASED_ON_SELECT
+	memset(&pollset_in, 0, sizeof(pollset_in));
+	memset(&pollset_out, 0, sizeof(pollset_in));
+	memset(&pollset_err, 0, sizeof(pollset_in));
+	maxfd = 0;
+#endif
 }
 
 zmq::socket_poller_t::~socket_poller_t ()

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -63,6 +63,9 @@ zmq::socks_connecter_t::socks_connecter_t (class io_thread_t *io_thread_,
     s (retired_fd),
     delayed_start (delayed_start_),
     session (session_),
+	handle(NULL),
+	handle_valid(false),
+	timer_started(false),
     current_reconnect_ivl (options.reconnect_ivl)
 {
     zmq_assert (addr);
@@ -113,13 +116,13 @@ void zmq::socks_connecter_t::in_event ()
              && status != waiting_for_reconnect_time);
 
     if (status == waiting_for_choice) {
-        const int rc = choice_decoder.input (s);
+        int rc = choice_decoder.input (s);
         if (rc == 0 || rc == -1)
             error ();
         else
         if (choice_decoder.message_ready ()) {
              const socks_choice_t choice = choice_decoder.decode ();
-             const int rc = process_server_response (choice);
+             rc = process_server_response (choice);
              if (rc == -1)
                  error ();
              else {
@@ -139,13 +142,13 @@ void zmq::socks_connecter_t::in_event ()
     }
     else
     if (status == waiting_for_response) {
-        const int rc = response_decoder.input (s);
+        int rc = response_decoder.input (s);
         if (rc == 0 || rc == -1)
             error ();
         else
         if (response_decoder.message_ready ()) {
             const socks_response_t response = response_decoder.decode ();
-            const int rc = process_server_response (response);
+            rc = process_server_response (response);
             if (rc == -1)
                 error ();
             else {

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -87,6 +87,8 @@ zmq::stream_engine_t::stream_engine_t (fd_t fd_, const options_t &options_,
     has_timeout_timer (false),
     has_heartbeat_timer (false),
     heartbeat_timeout (0),
+	as_server(false),
+	handle(NULL),
     socket (NULL)
 {
     int rc = tx_msg.init ();
@@ -1018,8 +1020,9 @@ int zmq::stream_engine_t::produce_ping_message(msg_t * msg_)
     zmq_assert (mechanism != NULL);
 
     // 16-bit TTL + \4PING == 7
-    msg_->init_size(7);
-    msg_->set_flags(msg_t::command);
+    rc = msg_->init_size(7);
+	errno_assert(rc == 0);
+	msg_->set_flags(msg_t::command);
     // Copy in the command message
     memcpy(msg_->data(), "\4PING", 5);
 
@@ -1040,8 +1043,9 @@ int zmq::stream_engine_t::produce_pong_message(msg_t * msg_)
     int rc = 0;
     zmq_assert (mechanism != NULL);
 
-    msg_->init_size(5);
-    msg_->set_flags(msg_t::command);
+    rc = msg_->init_size(5);
+	errno_assert(rc == 0);
+	msg_->set_flags(msg_t::command);
 
     memcpy(msg_->data(), "\4PONG", 5);
 

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -72,6 +72,7 @@ zmq::tcp_connecter_t::tcp_connecter_t (class io_thread_t *io_thread_,
     connect_timer_started (false),
     reconnect_timer_started (false),
     session (session_),
+	handle(NULL),
     current_reconnect_ivl (options.reconnect_ivl)
 {
     zmq_assert (addr);

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -65,6 +65,7 @@ zmq::tcp_listener_t::tcp_listener_t (io_thread_t *io_thread_,
     own_t (io_thread_, options_),
     io_object_t (io_thread_),
     s (retired_fd),
+	handle(NULL),
     socket (socket_)
 {
 }

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -55,6 +55,9 @@ namespace zmq
     public:
 
         inline thread_t ()
+			: tfn(nullptr)
+			, arg(nullptr)
+			, descriptor(NULL)
         {
         }
 

--- a/src/udp_address.cpp
+++ b/src/udp_address.cpp
@@ -48,6 +48,7 @@
 #endif
 
 zmq::udp_address_t::udp_address_t ()
+	: is_mutlicast(false)
 {
     memset (&bind_address, 0, sizeof bind_address);
     memset (&dest_address, 0, sizeof dest_address);

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -48,6 +48,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 zmq::udp_engine_t::udp_engine_t() :
     plugged (false),
+	fd(NULL),
+	address(nullptr),
+	send_enabled(false),
+	recv_enabled(false),
+	handle(NULL),
     session(NULL)
 {
 }
@@ -122,7 +127,7 @@ void zmq::udp_engine_t::plug (io_thread_t* io_thread_, session_base_t *session_)
             struct ip_mreq mreq;
             mreq.imr_multiaddr = address->resolved.udp_addr->multicast_ip ();
             mreq.imr_interface = address->resolved.udp_addr->interface_ip ();
-            int rc = setsockopt (fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*) &mreq, sizeof (mreq));
+            rc = setsockopt (fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*) &mreq, sizeof (mreq));
 #ifdef ZMQ_HAVE_WINDOWS
             wsa_assert (rc != SOCKET_ERROR);
 #else

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -173,7 +173,8 @@ int zmq::xpub_t::xsetsockopt (int option_, const void *optval_,
         welcome_msg.close();
 
         if (optvallen_ > 0) {
-            welcome_msg.init_size(optvallen_);
+            int rc = welcome_msg.init_size(optvallen_);
+			errno_assert(rc == 0);
 
             unsigned char *data = (unsigned char*)welcome_msg.data();
             memcpy(data, optval_, optvallen_);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -925,12 +925,9 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
     //  file descriptors.
     zmq_assert (nitems_ <= FD_SETSIZE);
 
-    fd_set pollset_in;
-    FD_ZERO (&pollset_in);
-    fd_set pollset_out;
-    FD_ZERO (&pollset_out);
-    fd_set pollset_err;
-    FD_ZERO (&pollset_err);
+	fd_set pollset_in  = { 0 };
+	fd_set pollset_out = { 0 };
+	fd_set pollset_err = { 0 };
 
     zmq::fd_t maxfd = 0;
 


### PR DESCRIPTION
Solution: The Coverity Static Code Analyzer was used on libzmq code and found
many issues with uninitialized member variables, some redefinition of variables
hidding previous instances of same variable name and a couple of functions
where return values were not checked, even though all other occurrences were
checked (e.g. init_size() return).