### PR TITLE
Problem: build borken

### DIFF
--- a/src/dish.cpp
+++ b/src/dish.cpp
@@ -333,14 +333,14 @@ int zmq::dish_session_t::pull_msg (msg_t *msg_)
 
         if (msg_->is_join ()) {
             rc = command.init_size (group_length + 5);
-			errno_assert(rc == 0);
-			offset = 5;
+            errno_assert(rc == 0);
+            offset = 5;
             memcpy (command.data (), "\4JOIN", 5);
         }
         else {
             rc = command.init_size (group_length + 6);
-			errno_assert(rc == 0);
-			offset = 6;
+            errno_assert(rc == 0);
+            offset = 6;
             memcpy (command.data (), "\5LEAVE", 6);
         }
 

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -57,11 +57,11 @@ namespace zmq
     public:
 
         inline encoder_base_t (size_t bufsize_) :
-            bufsize (bufsize_),
             write_pos(0),
             to_write(0),
             next(nullptr),
             new_msg_flag(false),
+            bufsize (bufsize_),
             in_progress (NULL)
         {
             buf = (unsigned char*) malloc (bufsize_);

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -58,10 +58,10 @@ namespace zmq
 
         inline encoder_base_t (size_t bufsize_) :
             bufsize (bufsize_),
-			write_pos(0),
-			to_write(0),
-			next(nullptr),
-			new_msg_flag(false),
+            write_pos(0),
+            to_write(0),
+            next(nullptr),
+            new_msg_flag(false),
             in_progress (NULL)
         {
             buf = (unsigned char*) malloc (bufsize_);

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -59,7 +59,7 @@ namespace zmq
         inline encoder_base_t (size_t bufsize_) :
             write_pos(0),
             to_write(0),
-            next(nullptr),
+            next(NULL),
             new_msg_flag(false),
             bufsize (bufsize_),
             in_progress (NULL)

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -92,7 +92,7 @@ zmq::pipe_t::pipe_t (object_t *parent_, upipe_t *inpipe_, upipe_t *outpipe_,
     sink (NULL),
     state (active),
     delay (true),
-	routing_id(0),
+    routing_id(0),
     conflate (conflate_)
 {
 }

--- a/src/poller_base.cpp
+++ b/src/poller_base.cpp
@@ -53,7 +53,7 @@ void zmq::poller_base_t::adjust_load (int amount_)
         load.add (amount_);
     else
     if (amount_ < 0)
-        bool reset = load.sub (-amount_);
+        load.sub (-amount_);
 }
 
 void zmq::poller_base_t::add_timer (int timeout_, i_poll_events *sink_, int id_)

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -228,8 +228,8 @@ int zmq::radio_session_t::pull_msg (msg_t *msg_)
 
         //  First frame is the group
         rc = msg_->init_size (length);
-		errno_assert(rc == 0);
-		msg_->set_flags(msg_t::more);
+        errno_assert(rc == 0);
+        msg_->set_flags(msg_t::more);
         memcpy (msg_->data (), group, length);
 
         //  Next status is the body

--- a/src/reaper.cpp
+++ b/src/reaper.cpp
@@ -35,8 +35,8 @@
 
 zmq::reaper_t::reaper_t (class ctx_t *ctx_, uint32_t tid_) :
     object_t (ctx_, tid_),
-    sockets (0),
     mailbox_handle(NULL),
+    sockets (0),
     terminating (false)
 {
     poller = new (std::nothrow) poller_t (*ctx_);

--- a/src/reaper.cpp
+++ b/src/reaper.cpp
@@ -36,7 +36,7 @@
 zmq::reaper_t::reaper_t (class ctx_t *ctx_, uint32_t tid_) :
     object_t (ctx_, tid_),
     sockets (0),
-	mailbox_handle(NULL),
+    mailbox_handle(NULL),
     terminating (false)
 {
     poller = new (std::nothrow) poller_t (*ctx_);

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -540,7 +540,7 @@ int zmq::signaler_t::make_fdpair (fd_t *r_, fd_t *w_)
 
     //  We don't need the listening socket anymore. Close it.
     rc = closesocket (listener);
-	wsa_assert(rc != SOCKET_ERROR);
+    wsa_assert(rc != SOCKET_ERROR);
 
     if (sync != NULL) {
         //  Exit the critical section.

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -191,8 +191,8 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_, uint32_t tid_, int sid_, bool
     monitor_socket (NULL),
     monitor_events (0),
     thread_safe (thread_safe_),
-	poller(nullptr),
-	handle(NULL),
+    poller(nullptr),
+    handle(NULL),
     reaper_signaler (NULL)
 {
     options.socket_id = sid_;
@@ -454,7 +454,7 @@ int zmq::socket_base_t::getsockopt (int option_, void *optval_,
             EXIT_MUTEX ();
             return -1;
         }
-		strncpy(static_cast <char *> (optval_), last_endpoint.c_str(), last_endpoint.size() + 1);
+        strncpy(static_cast <char *> (optval_), last_endpoint.c_str(), last_endpoint.size() + 1);
         *optvallen_ = last_endpoint.size () + 1;
         EXIT_MUTEX ();
         return 0;
@@ -1504,9 +1504,9 @@ void zmq::socket_base_t::in_event ()
         reaper_signaler->recv();
 
     int rc = process_commands (0, false);
-	EXIT_MUTEX();
-	errno_assert(rc == 0);
-	check_destroy();
+    EXIT_MUTEX();
+    errno_assert(rc == 0);
+    check_destroy();
 }
 
 void zmq::socket_base_t::out_event ()

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -184,7 +184,7 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_, uint32_t tid_, int sid_, bool
     tag (0xbaddecaf),
     ctx_terminated (false),
     destroyed (false),
-    poller(nullptr),
+    poller(NULL),
     handle(NULL),
     last_tsc (0),
     ticks (0),

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1503,9 +1503,8 @@ void zmq::socket_base_t::in_event ()
     if (thread_safe)
         reaper_signaler->recv();
 
-    int rc = process_commands (0, false);
+    process_commands (0, false);
     EXIT_MUTEX();
-    errno_assert(rc == 0);
     check_destroy();
 }
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -184,6 +184,8 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_, uint32_t tid_, int sid_, bool
     tag (0xbaddecaf),
     ctx_terminated (false),
     destroyed (false),
+    poller(nullptr),
+    handle(NULL),
     last_tsc (0),
     ticks (0),
     rcvmore (false),
@@ -191,8 +193,6 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_, uint32_t tid_, int sid_, bool
     monitor_socket (NULL),
     monitor_events (0),
     thread_safe (thread_safe_),
-    poller(nullptr),
-    handle(NULL),
     reaper_signaler (NULL)
 {
     options.socket_id = sid_;

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -34,14 +34,14 @@
 zmq::socket_poller_t::socket_poller_t () :
     tag (0xCAFEBABE),
     need_rebuild (true),
-    poll_size(0),
-#if defined ZMQ_POLL_BASED_ON_SELECT
-    maxfd(0),
-#endif
-    use_signaler (false)
+    use_signaler (false),
+    poll_size(0)
 #if defined ZMQ_POLL_BASED_ON_POLL
     ,
     pollfds (NULL)
+#elif defined ZMQ_POLL_BASED_ON_SELECT
+    ,
+    maxfd(0)
 #endif
 {
 #if defined ZMQ_POLL_BASED_ON_SELECT

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -35,7 +35,9 @@ zmq::socket_poller_t::socket_poller_t () :
     tag (0xCAFEBABE),
     need_rebuild (true),
     poll_size(0),
+#if defined ZMQ_POLL_BASED_ON_SELECT
     maxfd(0),
+#endif
     use_signaler (false)
 #if defined ZMQ_POLL_BASED_ON_POLL
     ,
@@ -46,7 +48,6 @@ zmq::socket_poller_t::socket_poller_t () :
     memset(&pollset_in, 0, sizeof(pollset_in));
     memset(&pollset_out, 0, sizeof(pollset_in));
     memset(&pollset_err, 0, sizeof(pollset_in));
-    maxfd = 0;
 #endif
 }
 

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -34,8 +34,8 @@
 zmq::socket_poller_t::socket_poller_t () :
     tag (0xCAFEBABE),
     need_rebuild (true),
-	poll_size(0),
-	maxfd(0),
+    poll_size(0),
+    maxfd(0),
     use_signaler (false)
 #if defined ZMQ_POLL_BASED_ON_POLL
     ,
@@ -43,10 +43,10 @@ zmq::socket_poller_t::socket_poller_t () :
 #endif
 {
 #if defined ZMQ_POLL_BASED_ON_SELECT
-	memset(&pollset_in, 0, sizeof(pollset_in));
-	memset(&pollset_out, 0, sizeof(pollset_in));
-	memset(&pollset_err, 0, sizeof(pollset_in));
-	maxfd = 0;
+    memset(&pollset_in, 0, sizeof(pollset_in));
+    memset(&pollset_out, 0, sizeof(pollset_in));
+    memset(&pollset_err, 0, sizeof(pollset_in));
+    maxfd = 0;
 #endif
 }
 

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -61,11 +61,11 @@ zmq::socks_connecter_t::socks_connecter_t (class io_thread_t *io_thread_,
     proxy_addr (proxy_addr_),
     status (unplugged),
     s (retired_fd),
-    delayed_start (delayed_start_),
-    session (session_),
     handle(NULL),
     handle_valid(false),
+    delayed_start (delayed_start_),
     timer_started(false),
+    session (session_),
     current_reconnect_ivl (options.reconnect_ivl)
 {
     zmq_assert (addr);

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -63,9 +63,9 @@ zmq::socks_connecter_t::socks_connecter_t (class io_thread_t *io_thread_,
     s (retired_fd),
     delayed_start (delayed_start_),
     session (session_),
-	handle(NULL),
-	handle_valid(false),
-	timer_started(false),
+    handle(NULL),
+    handle_valid(false),
+    timer_started(false),
     current_reconnect_ivl (options.reconnect_ivl)
 {
     zmq_assert (addr);

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -61,6 +61,8 @@
 zmq::stream_engine_t::stream_engine_t (fd_t fd_, const options_t &options_,
                                        const std::string &endpoint_) :
     s (fd_),
+    as_server(false),
+    handle(NULL),
     inpos (NULL),
     insize (0),
     decoder (NULL),
@@ -87,8 +89,6 @@ zmq::stream_engine_t::stream_engine_t (fd_t fd_, const options_t &options_,
     has_timeout_timer (false),
     has_heartbeat_timer (false),
     heartbeat_timeout (0),
-    as_server(false),
-    handle(NULL),
     socket (NULL)
 {
     int rc = tx_msg.init ();

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -87,8 +87,8 @@ zmq::stream_engine_t::stream_engine_t (fd_t fd_, const options_t &options_,
     has_timeout_timer (false),
     has_heartbeat_timer (false),
     heartbeat_timeout (0),
-	as_server(false),
-	handle(NULL),
+    as_server(false),
+    handle(NULL),
     socket (NULL)
 {
     int rc = tx_msg.init ();
@@ -1021,8 +1021,8 @@ int zmq::stream_engine_t::produce_ping_message(msg_t * msg_)
 
     // 16-bit TTL + \4PING == 7
     rc = msg_->init_size(7);
-	errno_assert(rc == 0);
-	msg_->set_flags(msg_t::command);
+    errno_assert(rc == 0);
+    msg_->set_flags(msg_t::command);
     // Copy in the command message
     memcpy(msg_->data(), "\4PING", 5);
 
@@ -1044,8 +1044,8 @@ int zmq::stream_engine_t::produce_pong_message(msg_t * msg_)
     zmq_assert (mechanism != NULL);
 
     rc = msg_->init_size(5);
-	errno_assert(rc == 0);
-	msg_->set_flags(msg_t::command);
+    errno_assert(rc == 0);
+    msg_->set_flags(msg_t::command);
 
     memcpy(msg_->data(), "\4PONG", 5);
 

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -72,7 +72,7 @@ zmq::tcp_connecter_t::tcp_connecter_t (class io_thread_t *io_thread_,
     connect_timer_started (false),
     reconnect_timer_started (false),
     session (session_),
-	handle(NULL),
+    handle(NULL),
     current_reconnect_ivl (options.reconnect_ivl)
 {
     zmq_assert (addr);

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -67,12 +67,12 @@ zmq::tcp_connecter_t::tcp_connecter_t (class io_thread_t *io_thread_,
     io_object_t (io_thread_),
     addr (addr_),
     s (retired_fd),
+    handle(NULL),
     handle_valid (false),
     delayed_start (delayed_start_),
     connect_timer_started (false),
     reconnect_timer_started (false),
     session (session_),
-    handle(NULL),
     current_reconnect_ivl (options.reconnect_ivl)
 {
     zmq_assert (addr);

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -65,7 +65,7 @@ zmq::tcp_listener_t::tcp_listener_t (io_thread_t *io_thread_,
     own_t (io_thread_, options_),
     io_object_t (io_thread_),
     s (retired_fd),
-	handle(NULL),
+    handle(NULL),
     socket (socket_)
 {
 }

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -57,7 +57,6 @@ namespace zmq
         inline thread_t ()
             : tfn(nullptr)
             , arg(nullptr)
-            , descriptor(NULL)
         {
         }
 

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -55,9 +55,9 @@ namespace zmq
     public:
 
         inline thread_t ()
-			: tfn(nullptr)
-			, arg(nullptr)
-			, descriptor(NULL)
+            : tfn(nullptr)
+            , arg(nullptr)
+            , descriptor(NULL)
         {
         }
 

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -55,8 +55,8 @@ namespace zmq
     public:
 
         inline thread_t ()
-            : tfn(nullptr)
-            , arg(nullptr)
+            : tfn(NULL)
+            , arg(NULL)
         {
         }
 

--- a/src/udp_address.cpp
+++ b/src/udp_address.cpp
@@ -48,7 +48,7 @@
 #endif
 
 zmq::udp_address_t::udp_address_t ()
-	: is_mutlicast(false)
+        : is_mutlicast(false)
 {
     memset (&bind_address, 0, sizeof bind_address);
     memset (&dest_address, 0, sizeof dest_address);

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -49,11 +49,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 zmq::udp_engine_t::udp_engine_t() :
     plugged (false),
     fd(NULL),
+    session(NULL),
+    handle(NULL),
     address(nullptr),
     send_enabled(false),
-    recv_enabled(false),
-    handle(NULL),
-    session(NULL)
+    recv_enabled(false)
 {
 }
 

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -48,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 zmq::udp_engine_t::udp_engine_t() :
     plugged (false),
-    fd(NULL),
+    fd(-1),
     session(NULL),
     handle(NULL),
     address(nullptr),

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -51,7 +51,7 @@ zmq::udp_engine_t::udp_engine_t() :
     fd(-1),
     session(NULL),
     handle(NULL),
-    address(nullptr),
+    address(NULL),
     send_enabled(false),
     recv_enabled(false)
 {

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -48,11 +48,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 zmq::udp_engine_t::udp_engine_t() :
     plugged (false),
-	fd(NULL),
-	address(nullptr),
-	send_enabled(false),
-	recv_enabled(false),
-	handle(NULL),
+    fd(NULL),
+    address(nullptr),
+    send_enabled(false),
+    recv_enabled(false),
+    handle(NULL),
     session(NULL)
 {
 }

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -174,7 +174,7 @@ int zmq::xpub_t::xsetsockopt (int option_, const void *optval_,
 
         if (optvallen_ > 0) {
             int rc = welcome_msg.init_size(optvallen_);
-			errno_assert(rc == 0);
+            errno_assert(rc == 0);
 
             unsigned char *data = (unsigned char*)welcome_msg.data();
             memcpy(data, optval_, optvallen_);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -925,9 +925,9 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
     //  file descriptors.
     zmq_assert (nitems_ <= FD_SETSIZE);
 
-	fd_set pollset_in  = { 0 };
-	fd_set pollset_out = { 0 };
-	fd_set pollset_err = { 0 };
+    fd_set pollset_in  = { 0 };
+    fd_set pollset_out = { 0 };
+    fd_set pollset_err = { 0 };
 
     zmq::fd_t maxfd = 0;
 


### PR DESCRIPTION
Solution: unbork it

Whitespace fix (tab => 4 spaces), class variable initialization order, assert where it should not.
Fixes #1824 

@opedroso - if Coverity complains about unused return values, we can cast them to (void) to silence it where it makes sense not to check :-)