### PR TITLE
include sys/ucred.h for struct ucred

### DIFF
--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -50,10 +50,12 @@
 #include <fcntl.h>
 #include <sys/un.h>
 
-#if defined ZMQ_HAVE_SO_PEERCRED || defined ZMQ_HAVE_LOCAL_PEERCRED
+#ifdef ZMQ_HAVE_LOCAL_PEERCRED
 #   include <sys/types.h>
+#   include <sys/ucred.h>
 #endif
 #ifdef ZMQ_HAVE_SO_PEERCRED
+#   include <sys/types.h>
 #   include <pwd.h>
 #   include <grp.h>
 #   if defined ZMQ_HAVE_OPENBSD

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -42,6 +42,9 @@
 #if defined ZMQ_HAVE_SO_PEERCRED || defined ZMQ_HAVE_LOCAL_PEERCRED
 #include <sys/types.h>
 #endif
+#ifdef ZMQ_HAVE_LOCAL_PEERCRED
+#include <sys/ucred.h>
+#endif
 
 //  Normal base 256 key is 32 bytes
 #define CURVE_KEYSIZE       32


### PR DESCRIPTION
Platforms that have struct ucred, for LOCAL_PEERCRED, typically declare it in sys/ucred.h

I'm not sure how libzmq compiles on regular FreeBSD without this #include.  This was noticed on Debian GNU/kFreeBSD, please see https://bugs.debian.org/815495

Thanks!
