### PR TITLE
Problem: Fix build with Heimdal krb5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -407,7 +407,8 @@ AC_ARG_WITH([libgssapi_krb5], [AS_HELP_STRING([--with-libgssapi_krb5],
 
 # conditionally require libgssapi_krb5
 if test "x$require_libgssapi_krb5_ext" != "xno"; then
-    AC_CHECK_LIB([gssapi_krb5], [gss_init_sec_context],,
+    AC_CHECK_HEADERS(gssapi/gssapi_generic.h)
+    AC_SEARCH_LIBS([gss_init_sec_context], [gssapi_krb5 gssapi],,
         AC_MSG_ERROR(libgssapi_krb5 is needed for GSSAPI security))
 fi
 

--- a/src/gssapi_mechanism_base.hpp
+++ b/src/gssapi_mechanism_base.hpp
@@ -34,7 +34,7 @@
 
 #ifdef HAVE_LIBGSSAPI_KRB5
 
-#if !defined(ZMQ_HAVE_FREEBSD) && !defined(ZMQ_HAVE_DRAGONFLY)
+#if HAVE_GSSAPI_GSSAPI_GENERIC_H
 #include <gssapi/gssapi_generic.h>
 #endif
 #include <gssapi/gssapi_krb5.h>


### PR DESCRIPTION
Solution:
* Check gssapi/gssapi_generic.h header file, it is not in Heimdal.
* Check libgssapi too, libgssapi_krb5 is not separated in Heimdal.