### PR TITLE
Problem: Added "make clean" to Windows build scripts

### DIFF
--- a/builds/msvc/build/buildall.bat
+++ b/builds/msvc/build/buildall.bat
@@ -1,5 +1,20 @@
 @ECHO OFF
+:: Usage: buildall.bat [Clean]
 @setlocal
+
+:: validate environment
+if "%VSINSTALLDIR%" == "" @echo Error: Attempt to build without proper DevStudio environment.&@goto :done
+
+:: record starting time
+set STARTTIME=%DATE% %TIME%
+@echo Start Time: %STARTTIME%
+
+
+:: validate optional argument (and make sure it is spelled "Clean")
+set MAKECLEAN=%%1
+if NOT "%%1" == "" if /I "%%1" == "clean" set MAKECLEAN=Clean
+
+
 ::
 :: uses the environment from the DevStudio CMD window to figure out which version to build
 ::
@@ -8,16 +23,22 @@ set VSVER=%VSINSTALLDIR:~-5,2%
 set DIRVER=%VSVER%
 if %VSVER% gtr 10 set /a DIRVER = DIRVER + 1
 
-CALL buildbase.bat ..\vs20%DIRVER%\libzmq.sln %VSVER%
+CALL buildbase.bat ..\vs20%DIRVER%\libzmq.sln %VSVER% %MAKECLEAN%
 
-:- CALL buildbase.bat ..\vs2015\libzmq.sln 14
+:- CALL buildbase.bat ..\vs2015\libzmq.sln 14 %MAKECLEAN%
 :- ECHO.
-:- CALL buildbase.bat ..\vs2013\libzmq.sln 12
+:- CALL buildbase.bat ..\vs2013\libzmq.sln 12 %MAKECLEAN%
 :- ECHO.
-:- CALL buildbase.bat ..\vs2012\libzmq.sln 11
+:- CALL buildbase.bat ..\vs2012\libzmq.sln 11 %MAKECLEAN%
 :- ECHO.
-:- CALL buildbase.bat ..\vs2010\libzmq.sln 10
+:- CALL buildbase.bat ..\vs2010\libzmq.sln 10 %MAKECLEAN%
 :- ECHO.
 
+set STOPTIME=%DATE% %TIME%
+@echo Stop  Time: %STOPTIME%
+@echo Start Time: %STARTTIME%
+
+:done
 @endlocal
+
 PAUSE

--- a/builds/msvc/build/buildbase.bat
+++ b/builds/msvc/build/buildbase.bat
@@ -1,8 +1,15 @@
 @ECHO OFF
-REM Usage: [buildbase.bat ..\vs2013\mysolution.sln 12]
+@setlocal
+REM Usage: [buildbase.bat ..\vs2013\mysolution.sln 12 [Clean]]
 
 SET solution=%1
 SET version=%2
+
+:: supports passing in Clean as third argument if "make clean" behavior is desired
+SET target=%3
+SET ACTION=Building
+if NOT "%target%" == "" set target=/t:%target%&set ACTION=Cleaning
+
 SET log=build_%version%.log
 SET tools=Microsoft Visual Studio %version%.0\VC\vcvarsall.bat
 SET environment="%programfiles(x86)%\%tools%"
@@ -15,56 +22,45 @@ IF EXIST "..\..\..\..\libsodium\builds/msvc/vs2015\libsodium.import.props" (
     IF errorlevel 1 GOTO error
     SET packages=%packages% /p:HAVE_LIBSODIUM=1
 ) ELSE (
-    ECHO Building without libsodium
+    ECHO %ACTION% without libsodium
 )
 
-ECHO Building %solution%... (%packages%)
 
-CALL %environment% x86 > nul
-ECHO Platform=x86
+@ECHO %ACTION% %solution%... (%packages%)
+
+CALL %environment% x86 >%SystemDrive%\nul 2>&1
+ECHO Platform=x86 2> %log%
 
 ECHO Configuration=DynDebug
-msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=Win32 %packages% %solution% > %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=Win32 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=DynRelease
-msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=Win32 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=Win32 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=LtcgDebug
-msbuild /m /v:n /p:Configuration=LtcgDebug /p:Platform=Win32 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=LtcgDebug /p:Platform=Win32 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=LtcgRelease
-msbuild /m /v:n /p:Configuration=LtcgRelease /p:Platform=Win32 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=LtcgRelease /p:Platform=Win32 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=StaticDebug
-msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=Win32 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=Win32 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=StaticRelease
-msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=Win32 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=Win32 %packages% %solution% %target%>> %log% || GOTO error
 
-CALL %environment% x86_amd64 > nul
+CALL %environment% x86_amd64 >%SystemDrive%\nul 2>&1
 ECHO Platform=x64
 
 ECHO Configuration=DynDebug
-msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=x64 %packages% %solution% > %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=x64 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=DynRelease
-msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=x64 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=DynRelease /p:Platform=x64 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=LtcgDebug
-msbuild /m /v:n /p:Configuration=LtcgDebug /p:Platform=x64 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=LtcgDebug /p:Platform=x64 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=LtcgRelease
-msbuild /m /v:n /p:Configuration=LtcgRelease /p:Platform=x64 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=LtcgRelease /p:Platform=x64 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=StaticDebug
-msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=x64 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=x64 %packages% %solution% %target%>> %log% || GOTO error
 ECHO Configuration=StaticRelease
-msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=x64 %packages% %solution% >> %log%
-IF errorlevel 1 GOTO error
+msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=x64 %packages% %solution% %target%>> %log% || GOTO error
 
-ECHO Complete: %solution%
+ECHO %ACTION% complete: %solution%
 GOTO end
 
 :error
@@ -75,4 +71,4 @@ GOTO end
 ECHO *** ERROR, build tools not found: %tools%
 
 :end
-
+@endlocal


### PR DESCRIPTION
Solution: Added ability to do equivalent of a "make clean" by executing:

O:\git\libzmq\builds\msvc\build>buildall.bat clean
Start Time: Fri 03/04/2016 14:33:56.50
Cleaning without libsodium
Cleaning ..\vs2013\libzmq.sln... ()
Platform=x86
Configuration=DynDebug
Configuration=DynRelease
Configuration=LtcgDebug
Configuration=LtcgRelease
Configuration=StaticDebug
Configuration=StaticRelease
Platform=x64
Configuration=DynDebug
Configuration=DynRelease
Configuration=LtcgDebug
Configuration=LtcgRelease
Configuration=StaticDebug
Configuration=StaticRelease
Cleaning complete: ..\vs2013\libzmq.sln

Stop  Time: Fri 03/04/2016 14:34:01.84
Start Time: Fri 03/04/2016 14:33:56.50

A clean takes ~5 secs to complete.