### PR TITLE
Problem: IPC wildcard test broken on OSX

### DIFF
--- a/tests/test_term_endpoint.cpp
+++ b/tests/test_term_endpoint.cpp
@@ -29,7 +29,7 @@
 
 #include "testutil.hpp"
 
-#define BUF_SIZE 32
+#define BUF_SIZE 73
 
 int main (void)
 {


### PR DESCRIPTION
Solution: increase path buffer length to 73

Apparently temporary paths on OSX are ridiculously long!