### PR TITLE
Fix usage of IPv6 addresses

### DIFF
--- a/src/select.cpp
+++ b/src/select.cpp
@@ -435,6 +435,7 @@ bool zmq::select_t::is_retired_fd (const fd_entry_t &entry)
 #if defined ZMQ_HAVE_WINDOWS
 u_short zmq::select_t::get_fd_family (fd_t fd_)
 {
+	// Use sockaddr_storage instead of sockaddr to accomodate differect structure sizes
 	sockaddr_storage addr = { 0 };
 	int addr_size = sizeof addr;
 

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -435,14 +435,15 @@ bool zmq::select_t::is_retired_fd (const fd_entry_t &entry)
 #if defined ZMQ_HAVE_WINDOWS
 u_short zmq::select_t::get_fd_family (fd_t fd_)
 {
-    sockaddr addr = { 0 };
-    int addr_size = sizeof addr;
-    int rc = getsockname (fd_, &addr, &addr_size);
+	sockaddr_storage addr = { 0 };
+	int addr_size = sizeof addr;
+
+    int rc = getsockname (fd_, (sockaddr *)&addr, &addr_size);
 
     //  AF_INET and AF_INET6 can be mixed in select
     //  TODO: If proven otherwise, should simply return addr.sa_family
     if (rc != SOCKET_ERROR)
-        return addr.sa_family == AF_INET6 ? AF_INET : addr.sa_family;
+        return addr.ss_family == AF_INET6 ? AF_INET : addr.ss_family;
     else
         return AF_UNSPEC;
 }


### PR DESCRIPTION
I've noticed recent changes in "select.cpp" file that caused getsockname function to return "Bad address" error due invalid size of the sockaddr structure.

It's better to use sockaddr_storage which uses 128 bytes instead of 16 bytes for sockaddr (IPv4).

Please correct me if the behavior of getsockname function is diffent of other platforms.

Source:
https://msdn.microsoft.com/en-us/library/windows/desktop/ms740496(v=vs.85).aspx 