### PR TITLE
zeromq-4.1.4/src/tcp_address.cpp : fix relaxed use of sizeof() without parenthesis

### DIFF
--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -133,10 +133,10 @@ int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_
     struct ifreq ifr;
 
     //  Copy interface name for ioctl get.
-    strncpy (ifr.ifr_name, nic_, sizeof ifr.ifr_name);
+    strncpy (ifr.ifr_name, nic_, sizeof (ifr.ifr_name) );
 
     //  Fetch interface address.
-    const int rc = ioctl (sd, SIOCGIFADDR, (caddr_t) &ifr, sizeof ifr);
+    const int rc = ioctl (sd, SIOCGIFADDR, (caddr_t) &ifr, sizeof (ifr) );
 
     //  Clean up.
     close (sd);
@@ -244,23 +244,23 @@ int zmq::tcp_address_t::resolve_interface (const char *interface_, bool ipv6_, b
     //  with the address.
     if (ipv6_) {
         sockaddr_in6 ip6_addr;
-        memset (&ip6_addr, 0, sizeof ip6_addr);
+        memset (&ip6_addr, 0, sizeof (ip6_addr) );
         ip6_addr.sin6_family = AF_INET6;
-        memcpy (&ip6_addr.sin6_addr, &in6addr_any, sizeof in6addr_any);
-        out_addrlen = sizeof ip6_addr;
+        memcpy (&ip6_addr.sin6_addr, &in6addr_any, sizeof (in6addr_any) );
+        out_addrlen = sizeof (ip6_addr);
         memcpy (out_addr, &ip6_addr, out_addrlen);
     }
     else {
         sockaddr_in ip4_addr;
-        memset (&ip4_addr, 0, sizeof ip4_addr);
+        memset (&ip4_addr, 0, sizeof (ip4_addr) );
         ip4_addr.sin_family = AF_INET;
         ip4_addr.sin_addr.s_addr = htonl (INADDR_ANY);
-        out_addrlen = sizeof ip4_addr;
+        out_addrlen = sizeof (ip4_addr);
         memcpy (out_addr, &ip4_addr, out_addrlen);
     }
     //  "*" resolves to INADDR_ANY or in6addr_any.
     if (strcmp (interface_, "*") == 0) {
-        zmq_assert (out_addrlen <= sizeof address);
+        zmq_assert (out_addrlen <= sizeof (address) );
         if (is_src_)
             memcpy (&source_address, out_addr, out_addrlen);
         else
@@ -281,7 +281,7 @@ int zmq::tcp_address_t::resolve_interface (const char *interface_, bool ipv6_, b
     addrinfo *res = NULL;
     addrinfo req;
 #endif
-    memset (&req, 0, sizeof req);
+    memset (&req, 0, sizeof (req) );
 
     //  Choose IPv4 or IPv6 protocol family. Note that IPv6 allows for
     //  IPv4-in-IPv6 addresses.
@@ -314,7 +314,7 @@ int zmq::tcp_address_t::resolve_interface (const char *interface_, bool ipv6_, b
 
     //  Use the first result.
     zmq_assert (res != NULL);
-    zmq_assert ((size_t) res->ai_addrlen <= sizeof address);
+    zmq_assert ((size_t) res->ai_addrlen <= sizeof (address) );
     if (is_src_)
         memcpy (&source_address, res->ai_addr, res->ai_addrlen);
     else
@@ -334,7 +334,7 @@ int zmq::tcp_address_t::resolve_hostname (const char *hostname_, bool ipv6_, boo
 #else
     addrinfo req;
 #endif
-    memset (&req, 0, sizeof req);
+    memset (&req, 0, sizeof (req) );
 
     //  Choose IPv4 or IPv6 protocol family. Note that IPv6 allows for
     //  IPv4-in-IPv6 addresses.
@@ -375,7 +375,7 @@ int zmq::tcp_address_t::resolve_hostname (const char *hostname_, bool ipv6_, boo
     }
 
     //  Copy first result to output addr with hostname and service.
-    zmq_assert ((size_t) res->ai_addrlen <= sizeof address);
+    zmq_assert ((size_t) res->ai_addrlen <= sizeof (address) );
     if (is_src_)
         memcpy (&source_address, res->ai_addr, res->ai_addrlen);
     else
@@ -389,8 +389,8 @@ int zmq::tcp_address_t::resolve_hostname (const char *hostname_, bool ipv6_, boo
 zmq::tcp_address_t::tcp_address_t () :
     _has_src_addr (false)
 {
-    memset (&address, 0, sizeof address);
-    memset (&source_address, 0, sizeof source_address);
+    memset (&address, 0, sizeof (address) );
+    memset (&source_address, 0, sizeof (source_address) );
 }
 
 zmq::tcp_address_t::tcp_address_t (const sockaddr *sa, socklen_t sa_len) :
@@ -398,13 +398,13 @@ zmq::tcp_address_t::tcp_address_t (const sockaddr *sa, socklen_t sa_len) :
 {
     zmq_assert (sa && sa_len > 0);
 
-    memset (&address, 0, sizeof address);
-    memset (&source_address, 0, sizeof source_address);
-    if (sa->sa_family == AF_INET && sa_len >= (socklen_t) sizeof address.ipv4)
-        memcpy (&address.ipv4, sa, sizeof address.ipv4);
+    memset (&address, 0, sizeof (address) );
+    memset (&source_address, 0, sizeof (source_address) );
+    if (sa->sa_family == AF_INET && sa_len >= (socklen_t) sizeof (address.ipv4) )
+        memcpy (&address.ipv4, sa, sizeof (address.ipv4) );
     else
-    if (sa->sa_family == AF_INET6 && sa_len >= (socklen_t) sizeof address.ipv6)
-        memcpy (&address.ipv6, sa, sizeof address.ipv6);
+    if (sa->sa_family == AF_INET6 && sa_len >= (socklen_t) sizeof (address.ipv6) )
+        memcpy (&address.ipv6, sa, sizeof (address.ipv6) );
 }
 
 zmq::tcp_address_t::~tcp_address_t ()
@@ -514,7 +514,7 @@ int zmq::tcp_address_t::to_string (std::string &addr_)
     //  Not using service resolving because of
     //  https://github.com/zeromq/libzmq/commit/1824574f9b5a8ce786853320e3ea09fe1f822bc4
     char hbuf [NI_MAXHOST];
-    int rc = getnameinfo (addr (), addrlen (), hbuf, sizeof hbuf, NULL, 0, NI_NUMERICHOST);
+    int rc = getnameinfo (addr (), addrlen (), hbuf, sizeof (hbuf), NULL, 0, NI_NUMERICHOST);
     if (rc != 0) {
         addr_.clear ();
         return rc;
@@ -541,9 +541,9 @@ const sockaddr *zmq::tcp_address_t::addr () const
 socklen_t zmq::tcp_address_t::addrlen () const
 {
     if (address.generic.sa_family == AF_INET6)
-        return (socklen_t) sizeof address.ipv6;
+        return (socklen_t) sizeof (address.ipv6);
     else
-        return (socklen_t) sizeof address.ipv4;
+        return (socklen_t) sizeof (address.ipv4);
 }
 
 const sockaddr *zmq::tcp_address_t::src_addr () const
@@ -554,9 +554,9 @@ const sockaddr *zmq::tcp_address_t::src_addr () const
 socklen_t zmq::tcp_address_t::src_addrlen () const
 {
     if (address.generic.sa_family == AF_INET6)
-        return (socklen_t) sizeof source_address.ipv6;
+        return (socklen_t) sizeof (source_address.ipv6);
     else
-        return (socklen_t) sizeof source_address.ipv4;
+        return (socklen_t) sizeof (source_address.ipv4);
 }
 
 bool zmq::tcp_address_t::has_src_addr () const
@@ -646,7 +646,7 @@ int zmq::tcp_address_mask_t::to_string (std::string &addr_)
     }
 
     char hbuf [NI_MAXHOST];
-    int rc = getnameinfo (addr (), addrlen (), hbuf, sizeof hbuf, NULL, 0, NI_NUMERICHOST);
+    int rc = getnameinfo (addr (), addrlen (), hbuf, sizeof (hbuf), NULL, 0, NI_NUMERICHOST);
     if (rc != 0) {
         addr_.clear ();
         return rc;


### PR DESCRIPTION
Still compiles on Linux. Newly compiles on Solaris (specifically OpenIndiana userland). Both with gcc ;)