### PR TITLE
Problem: CURVE mechanism is unusable with chroot()

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -93,6 +93,17 @@ zmq::ctx_t::ctx_t () :
     vmci_fd = -1;
     vmci_family = -1;
 #endif
+
+    crypto_sync.lock ();
+#if defined (ZMQ_USE_TWEETNACL)
+    // allow opening of /dev/urandom
+    unsigned char tmpbytes[4];
+    randombytes(tmpbytes, 4);
+#else
+    int rc = sodium_init ();
+    zmq_assert (rc != -1);
+#endif
+    crypto_sync.unlock ();
 }
 
 bool zmq::ctx_t::check_tag ()

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -233,6 +233,8 @@ namespace zmq
         int vmci_family;
         mutex_t vmci_sync;
 #endif
+
+        mutex_t crypto_sync;
     };
 
 }

--- a/src/curve_client.cpp
+++ b/src/curve_client.cpp
@@ -47,22 +47,12 @@ zmq::curve_client_t::curve_client_t (const options_t &options_) :
     mechanism_t (options_),
     state (send_hello),
     cn_nonce(1),
-    cn_peer_nonce(1),
-    sync()
+    cn_peer_nonce(1)
 {
     int rc;
     memcpy (public_key, options_.curve_public_key, crypto_box_PUBLICKEYBYTES);
     memcpy (secret_key, options_.curve_secret_key, crypto_box_SECRETKEYBYTES);
     memcpy (server_key, options_.curve_server_key, crypto_box_PUBLICKEYBYTES);
-    scoped_lock_t lock (sync);
-#if defined (ZMQ_USE_TWEETNACL)
-    // allow opening of /dev/urandom
-    unsigned char tmpbytes[4];
-    randombytes(tmpbytes, 4);
-#else
-    rc = sodium_init ();
-    zmq_assert (rc != -1);
-#endif
 
     //  Generate short-term key pair
     rc = crypto_box_keypair (cn_public, cn_secret);

--- a/src/curve_client.hpp
+++ b/src/curve_client.hpp
@@ -33,7 +33,6 @@
 #ifdef ZMQ_HAVE_CURVE
 
 #include "platform.hpp"
-#include "mutex.hpp"
 
 #if defined (ZMQ_USE_TWEETNACL)
 #   include "tweetnacl.h"
@@ -119,7 +118,6 @@ namespace zmq
         int produce_initiate (msg_t *msg_);
         int process_ready (const uint8_t *cmd_data, size_t data_size);
         int process_error (const uint8_t *cmd_data, size_t data_size);
-        mutex_t sync;
     };
 
 }

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -51,21 +51,11 @@ zmq::curve_server_t::curve_server_t (session_base_t *session_,
     peer_address (peer_address_),
     state (expect_hello),
     cn_nonce (1),
-    cn_peer_nonce(1),
-    sync()
+    cn_peer_nonce(1)
 {
     int rc;
     //  Fetch our secret key from socket options
     memcpy (secret_key, options_.curve_secret_key, crypto_box_SECRETKEYBYTES);
-    scoped_lock_t lock (sync);
-#if defined (ZMQ_USE_TWEETNACL)
-    // allow opening of /dev/urandom
-    unsigned char tmpbytes[4];
-    randombytes (tmpbytes, 4);
-#else
-    rc = sodium_init ();
-    zmq_assert (rc != -1);
-#endif
 
     //  Generate short-term key pair
     rc = crypto_box_keypair (cn_public, cn_secret);

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -129,7 +129,6 @@ namespace zmq
 
         void send_zap_request (const uint8_t *key);
         int receive_and_process_zap_reply ();
-        mutex_t sync;
     };
 
 }


### PR DESCRIPTION
libsodium calls abort() when /dev/urandom can't be found
even if one creates ZeroMQ context before calling chroot()[1].

This happens because crypto gets initialized on handshake,
and at that moment the process is already chroot'ed.

Solution: initialize cryptographic libraries in ctx

randombytes_close() is already there in the destructor.

[1] https://download.libsodium.org/doc/usage/index.html