### PR TITLE
Tweaks to building libzmq

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -99,7 +99,7 @@ zmq::ctx_t::ctx_t () :
     // allow opening of /dev/urandom
     unsigned char tmpbytes[4];
     randombytes(tmpbytes, 4);
-#elif defined (HAVE_LIBSODIUM)
+#elif defined (ZMQ_USE_SODIUM)
     int rc = sodium_init ();
     zmq_assert (rc != -1);
 #endif


### PR DESCRIPTION
- ZMQ_USE_LIBSODIUM macro
- clarified build instructions for msvc