### PR TITLE
Windows XP compatability fixes

### DIFF
--- a/builds/msvc/properties/Common.props
+++ b/builds/msvc/properties/Common.props
@@ -18,4 +18,11 @@
     </ClCompile>
   </ItemDefinitionGroup>
 
+  <!-- When using a tool set to target Windows XP, define a pre-processor definition and modify the target Windows version -->
+  <ItemDefinitionGroup Condition="$(PlatformToolset.Contains('_xp'))">
+    <ClCompile>
+      <PreprocessorDefinitions>ZMQ_HAVE_WINDOWS_TARGET_XP;_WIN32_WINNT=0x0501;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
 </Project>

--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -450,13 +450,23 @@ int zmq::tcp_address_t::resolve (const char *name_, bool local_, bool ipv6_, boo
         std::string if_str = addr_str.substr(pos + 1);
         addr_str = addr_str.substr(0, pos);
         if (isalpha (if_str.at (0)))
+#if !defined ZMQ_HAVE_WINDOWS_TARGET_XP
             zone_id = if_nametoindex(if_str.c_str());
+#else
+            // The function 'if_nametoindex' is not supported on Windows XP.
+            // If we are targeting XP using a vxxx_xp toolset then fail.
+            // This is brutal as this code could be run on later windows clients
+            // meaning the IPv6 zone_id cannot have an interface name.
+            // This could be fixed with a runtime check.
+            zone_id = 0;
+#endif
         else
             zone_id = (uint32_t) atoi (if_str.c_str ());
         if (zone_id == 0) {
             errno = EINVAL;
             return -1;
         }
+
     }
 
     //  Allow 0 specifically, to detect invalid port error in atoi if not


### PR DESCRIPTION
A Visual Studio build from master (commit id: dac5b45dfb224ff184a7aed39c5859ae5bac3803) using the v140_xp toolset yields a binary that is not XP compatible.

Two libraries contain exports that cannot be found:
 -  IPHLPAPI.DLL : if_nametoindex
 - KERNEL32.DLL : InitializeConditionVariable

The latter export is already dealt with in the file './src/condition_variable.hpp'; however this requires setting the _WIN32_WINNT pre-processor definition.
I am not experienced enough to figure a work around for the 'if_nametoindex' method, so I have created a new pre-processor definition 'ZMQ_HAVE_WINDOWS_TARGET_XP' and removed the calling of the function; with the limitation that these builds cannot handle a IPv6 address with an adapter name.

To make it easier for people targeting XP with an MSVC build I have modified the MSBuild property file to add/modify the pre-processor definitions if they are building using a XP targeting tool set; such as v140_xp.

I added a comment to the original commit that broke the compatability here: https://github.com/zeromq/libzmq/commit/7cfa93352ebe5b92a5c3ff7ccce5ddff6c3e0e00#commitcomment-16896696

I would appreciate a discussion on the suitability of the fix.