### PR TITLE
Fixed ZMQ_REQ_CORRELATE (see pull request #1730)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -732,8 +732,7 @@ check_PROGRAMS = ${test_apps}
 
 #  Run the test cases
 TESTS = $(test_apps)
-XFAIL_TESTS = tests/test_req_correlate \
-		tests/test_req_relaxed
+XFAIL_TESTS =
 
 if !ON_LINUX
 XFAIL_TESTS += tests/test_abstract_ipc

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -279,6 +279,21 @@ int zmq::req_session_t::push_msg (msg_t *msg_)
 {
     switch (state) {
     case bottom:
+        if (msg_->flags () == msg_t::more) {
+            //  In case option ZMQ_CORRELATE is on, allow request_id to be
+            //  transfered as first frame (would be too cumbersome to check
+            //  whether the option is actually on or not).
+            if (msg_->size () == sizeof (uint32_t)) {
+                state = request_id;
+                return session_base_t::push_msg (msg_);
+            }
+            else if (msg_->size () == 0) {
+                state = body;
+                return session_base_t::push_msg (msg_);
+            }
+        }
+        break;
+    case request_id:
         if (msg_->flags () == msg_t::more && msg_->size () == 0) {
             state = body;
             return session_base_t::push_msg (msg_);

--- a/src/req.hpp
+++ b/src/req.hpp
@@ -108,6 +108,7 @@ namespace zmq
 
         enum {
             bottom,
+            request_id,
             body
         } state;
 

--- a/tests/test_req_correlate.cpp
+++ b/tests/test_req_correlate.cpp
@@ -93,58 +93,7 @@ int main (void)
     // Receive the rest.
     s_recv_seq (router, 0, "ABC", "DEF", SEQ_END);
 
-    // Send back a bad reply: correct req id
-    zmq_msg_copy (&msg, &peer_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    zmq_msg_copy (&msg, &req_id_msg);
-    rc = zmq_msg_send (&msg, router, 0);
-    assert (rc != -1);
-
-    // Send back a bad reply: wrong req id
-    zmq_msg_copy (&msg, &peer_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
     uint32_t bad_req_id = req_id + 1;
-    zmq_msg_init_data (&msg, &bad_req_id, sizeof (uint32_t), NULL, NULL);
-    rc = zmq_msg_send (&msg, router, 0);
-    assert (rc != -1);
-
-    // Send back a bad reply: correct req id, 0
-    zmq_msg_copy (&msg, &peer_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    zmq_msg_copy (&msg, &req_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    s_send_seq (router, 0, SEQ_END);
-
-    // Send back a bad reply: correct req id, garbage
-    zmq_msg_copy (&msg, &peer_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    zmq_msg_copy (&msg, &req_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    s_send_seq (router, "FOO", SEQ_END);
-
-    // Send back a bad reply: wrong req id, 0
-    zmq_msg_copy (&msg, &peer_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    zmq_msg_init_data (&msg, &bad_req_id, sizeof (uint32_t), NULL, NULL);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    s_send_seq (router, 0, SEQ_END);
-
-    // Send back a bad reply: correct req id, garbage, data
-    zmq_msg_copy (&msg, &peer_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    zmq_msg_copy (&msg, &req_id_msg);
-    rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
-    assert (rc != -1);
-    s_send_seq (router, "FOO", "DATA", SEQ_END);
 
     // Send back a bad reply: wrong req id, 0, data
     zmq_msg_copy (&msg, &peer_id_msg);
@@ -155,7 +104,7 @@ int main (void)
     assert (rc != -1);
     s_send_seq (router, 0, "DATA", SEQ_END);
 
-    // Send back a good reply.
+    // Send back a good reply: good req id, 0, data
     zmq_msg_copy (&msg, &peer_id_msg);
     rc = zmq_msg_send (&msg, router, ZMQ_SNDMORE);
     assert (rc != -1);
@@ -164,7 +113,7 @@ int main (void)
     assert (rc != -1);
     s_send_seq (router, 0, "GHI", SEQ_END);
 
-    // Receive reply. If any of the other messages got through, we wouldn't see
+    // Receive reply. If bad reply got through, we wouldn't see
     // this particular data.
     s_recv_seq (req, "GHI", SEQ_END);
 

--- a/tests/test_req_relaxed.cpp
+++ b/tests/test_req_relaxed.cpp
@@ -32,7 +32,7 @@
 static void bounce (void *socket)
 {
     int more;
-    size_t more_size = sizeof(more);
+    size_t more_size = sizeof (more);
     do {
         zmq_msg_t recv_part, sent_part;
         int rc = zmq_msg_init (&recv_part);
@@ -50,13 +50,13 @@ static void bounce (void *socket)
         rc = zmq_msg_send (&sent_part, socket, more ? ZMQ_SNDMORE : 0);
         assert (rc != -1);
 
-        zmq_msg_close(&recv_part);
+        zmq_msg_close (&recv_part);
     } while (more);
 }
 
 int main (void)
 {
-    setup_test_environment();
+    setup_test_environment ();
     void *ctx = zmq_ctx_new ();
     assert (ctx);
 
@@ -68,10 +68,6 @@ int main (void)
     assert (rc == 0);
 
     rc = zmq_setsockopt (req, ZMQ_REQ_CORRELATE, &enabled, sizeof (int));
-    assert (rc == 0);
-
-    int rcvtimeo = 100;
-    rc = zmq_setsockopt (req, ZMQ_RCVTIMEO, &rcvtimeo, sizeof (int));
     assert (rc == 0);
 
     rc = zmq_bind (req, "tcp://127.0.0.1:5555");
@@ -127,7 +123,7 @@ int main (void)
     s_recv_seq (rep [3], "H", SEQ_END);
     s_send_seq (rep [3], "BAD", SEQ_END);
 
-    // Wait for message to be there.
+    //  Wait for message to be there.
     msleep (SETTLE_TIME);
 
     //  Without receiving that reply, send another request on the REQ socket
@@ -142,8 +138,8 @@ int main (void)
     //  communication pipes. For example pipe from req to rep[0] should not be
     //  closed after executing Case 1. So rep[0] should be the next to receive,
     //  not rep[1].
-    s_send_seq(req, "J", SEQ_END);
-    s_recv_seq(rep [0], "J", SEQ_END);
+    s_send_seq (req, "J", SEQ_END);
+    s_recv_seq (rep [0], "J", SEQ_END);
 
     close_zero_linger (req);
     for (size_t peer = 0; peer < services; peer++)
@@ -171,18 +167,14 @@ int main (void)
 
     //  Setup ROUTER socket as server but do not bind it just yet
     void *router = zmq_socket (ctx, ZMQ_ROUTER);
-    assert(router);
-
-    int timeout = 1000;
-    rc = zmq_setsockopt (router, ZMQ_RCVTIMEO, &timeout, sizeof(int));
-    assert (rc == 0);
+    assert (router);
 
     //  Send two requests
     s_send_seq (req, "TO_BE_DISCARDED", SEQ_END);
     s_send_seq (req, "TO_BE_ANSWERED", SEQ_END);
 
     //  Bind server allowing it to receive messages
-    rc = zmq_bind(router, "tcp://127.0.0.1:5555");
+    rc = zmq_bind (router, "tcp://127.0.0.1:5555");
     assert (rc == 0);
 
     //  Read the two messages and send them back as is


### PR DESCRIPTION
**Commit Comment**
Problem: Since pull request #1730 was merged, protocol for REQ socket is checked at the session level and this check does not take into account the possibility of a request_id being part of the message. Thus the option `ZMQ_REQ_CORRELATE` would no longer work.
This is now fixed: the possiblity of a 4 bytes integer being present before the delimiter frame is taken into account (whether or not this breaks the REQ/REP RFC is another issue).

**Work done**

- Added a possible state `request_id` in the protocol of the REQ socket

- Removed the timers in `test_req_relaxed` as they were there only to make the tests fail fast

- Removed the tests in `test_req_correlate` that were testing that invalid REQ messages were silently ignored. This is no longer the case: malformed messages now trigger the closing of the peer that sent them.

**Comments**

- The protocol for an incoming message accepted by the REQ is now either `0|payload` or` request_id|0|payload`. I did not bother checking whether the `ZMQ_REQ_CORRELATE` was on or not as I found too cumbersome to check this at the session level (would have to pass the option from the socket to the session). I do not think that this is too much of a problem: we may accept invalid message in some cases but then they would be silently ignored at the socket level.

- As discussed on pull request #1730, an alternative solution would have been to remove the checks done at the session level and keep the checking mechanism done at the socket level. But the libzmq project team advised against it.

- As the checks of the REQ protocol are now done at the session level, the same should probably be done for the REP socket (indeed why would the REQ socket be the only socket checking that its protocol is valid at the session level when the REP has exactly the same protocol and does its checking as the socket level?)

- There is still the question of the REQREP RFC (the possibility of a request_id as a first frame of the REQREP protocol is not described in the RFC).

- As I mentionned in defect #1695, I came to believe that ZMQ_REQ_CORRELATE and ZMQ_REQ_RELAXED serve very little purpose but generate a lot of line of codes in libzmq. If at some point in a given workflow, someone needs to send two messages in a row from a REQ socket, the easiest thing to do is to close the socket and re-opening it prior to sending the second message, the REQREP mechanism would then make sure that the correct response is received without the need for such a sophisticated mechanism. From a performance perspective, it is slower to close and reopen a socket but in the workflow I have in mind where you need to send two messages in a row, this is usually in response to a rare event (such as not getting your first message answer in due time), so the performance impact would be negligeable. So maybe obsoleting/removing these options would be a good thing (do you have a way of asking the community about it?).


