### PR TITLE
Fix NetBSD thread scheduling problem.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -138,6 +138,10 @@ void zmq::thread_t::setSchedulingParameters(int priority_, int schedulingPolicy_
         policy = schedulingPolicy_;
     }
 
+#ifdef __NetBSD__
+    if(policy == SCHED_OTHER) param.sched_priority = -1;
+#endif
+
     rc = pthread_setschedparam(descriptor, policy, &param);
     posix_assert (rc);
 #endif


### PR DESCRIPTION
Defining thread priority for SCHED_OTHER is implementation defined.
Some platforms like NetBSD cannot reassign it as they are dynamic.

<http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_getschedparam.html>

Credit goes to <kamil@netbsd.org> and <riastradh@netbsd.org> for finding this
solution.