### PR TITLE
Problem: zmq_bind IPv4 fallback still tries IPv6

### DIFF
--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -184,13 +184,13 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
 #endif
 
     //  IPv6 address family not supported, try automatic downgrade to IPv4.
-    if (address.family () == AF_INET6
+    if (s == -1 && address.family () == AF_INET6
     && errno == EAFNOSUPPORT
     && options.ipv6) {
-        rc = address.resolve (addr_, true, true);
+        rc = address.resolve (addr_, true, false);
         if (rc != 0)
             return rc;
-        s = ::socket (address.family (), SOCK_STREAM, IPPROTO_TCP);
+        s = open_socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     }
 
 #ifdef ZMQ_HAVE_WINDOWS

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -178,10 +178,6 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
 
     //  Create a listening socket.
     s = open_socket (address.family (), SOCK_STREAM, IPPROTO_TCP);
-#ifdef ZMQ_HAVE_WINDOWS
-    if (s == INVALID_SOCKET)
-        errno = wsa_error_to_errno (WSAGetLastError ());
-#endif
 
     //  IPv6 address family not supported, try automatic downgrade to IPv4.
     if (s == -1 && address.family () == AF_INET6


### PR DESCRIPTION
Solution: fix fallback in tcp_listener and add it in tcp_connecter. With these changes, if you try to bind/connect to an IPv4 endpoint when zmq_ipv6 is enabled but there's no support for IPv6, the connection works.

Fixes #1887