### PR TITLE
Fix return value of zmq_poller_wait when used on empty poller

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1209,6 +1209,8 @@ int zmq_poller_wait (void *poller_, zmq_poller_event_t *event, long timeout_)
         return -1;
     }
 
+    zmq_assert (event != NULL);
+
     zmq::socket_poller_t::event_t e;
     memset (&e, 0, sizeof (e));
 

--- a/tests/test_poller.cpp
+++ b/tests/test_poller.cpp
@@ -60,6 +60,14 @@ int main (void)
 
     //  Set up poller
     void* poller = zmq_poller_new ();
+    zmq_poller_event_t event;
+
+    // waiting on poller with no registered sockets should report error
+    rc = zmq_poller_wait(poller, &event, 0);
+    assert (rc == -1);
+    assert (errno == ETIMEDOUT);
+
+    // register sink
     rc = zmq_poller_add (poller, sink, sink, ZMQ_POLLIN);
     assert (rc == 0);
     
@@ -69,7 +77,6 @@ int main (void)
     assert (rc == 1);   
 
     //  We expect a message only on the sink
-    zmq_poller_event_t event;
     rc = zmq_poller_wait (poller, &event, -1);
     assert (rc == 0);
     assert (event.socket == sink);


### PR DESCRIPTION
Problem: tricky return value from zmq::socket_poller_t::wait when poller is empty

Solution: return -1 (no event) instead of 0 (event)

For some reason, this just returns 0 if there are no sockets registered
on the poller. Usually this would mean there has been an event. So the
caller would have to check the return value AND the event, or write code
that takes the number of registered sockets into consideration.

By returning -1 and setting errno = ETIMEDOUT like in the usual timeout
cases, it's more consistent and convenient.

Test case included.