### PR TITLE
Problem: build broken on Solaris 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,10 @@ set (CMAKE_REQUIRED_INCLUDES sys/time.h)
 check_function_exists (gethrtime HAVE_GETHRTIME)
 set (CMAKE_REQUIRED_INCLUDES)
 
+set (CMAKE_REQUIRED_INCLUDES stdlib.h)
+check_function_exists (mkdtemp HAVE_MKDTEMP)
+set (CMAKE_REQUIRED_INCLUDES)
+
 add_definitions (-D_REENTRANT -D_THREAD_SAFE)
 add_definitions (-DZMQ_CUSTOM_PLATFORM_HPP)
 

--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -12,6 +12,7 @@
 #cmakedefine HAVE_FORK
 #cmakedefine HAVE_CLOCK_GETTIME
 #cmakedefine HAVE_GETHRTIME
+#cmakedefine HAVE_MKDTEMP
 #cmakedefine ZMQ_HAVE_UIO
 
 #cmakedefine ZMQ_HAVE_EVENTFD

--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ case "${host_os}" in
         ;;
     *solaris*)
         # Define on Solaris to enable all library features
-        CPPFLAGS="-D_PTHREADS $CPPFLAGS"
+        CPPFLAGS="-Wno-sign-compare -D_PTHREADS $CPPFLAGS"
         AC_DEFINE(ZMQ_HAVE_SOLARIS, 1, [Have Solaris OS])
         AC_CHECK_LIB(socket, socket)
         AC_CHECK_LIB(nsl, gethostbyname)

--- a/configure.ac
+++ b/configure.ac
@@ -561,7 +561,7 @@ AC_LANG_POP([C++])
 
 # Checks for library functions.
 AC_TYPE_SIGNAL
-AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs fork posix_memalign)
+AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs fork posix_memalign mkdtemp)
 AC_CHECK_HEADERS([alloca.h])
 
 LIBZMQ_CHECK_SOCK_CLOEXEC([

--- a/configure.ac
+++ b/configure.ac
@@ -446,6 +446,8 @@ elif test "x$with_libsodium" = "xyes"; then
     case "${host_os}" in
         *solaris*)
             LDFLAGS="-lssp $LDFLAGS"
+            libzmq_pedantic="no"
+            libzmq_werror="no"
         ;;
     esac
 else

--- a/src/condition_variable.hpp
+++ b/src/condition_variable.hpp
@@ -165,9 +165,9 @@ namespace zmq
                 timeout.tv_sec += timeout_ / 1000;
                 timeout.tv_nsec += (timeout_ % 1000) * 1000000;
 
-                if (timeout.tv_nsec > 1E9) {
+                if (timeout.tv_nsec > 1000000000) {
                     timeout.tv_sec++;
-                    timeout.tv_nsec -= 1E9;
+                    timeout.tv_nsec -= 1000000000;
                 }
 
                 rc = pthread_cond_timedwait (&cond, mutex_->get_mutex (), &timeout);

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -71,7 +71,8 @@ const char *zmq::ipc_listener_t::tmp_env_vars[] = {
   0  // Sentinel
 };
 
-int zmq::ipc_listener_t::create_wildcard_address(std::string& path_)
+int zmq::ipc_listener_t::create_wildcard_address(std::string& path_,
+        std::string& file_)
 {
     std::string tmp_path;
 
@@ -101,6 +102,7 @@ int zmq::ipc_listener_t::create_wildcard_address(std::string& path_)
     std::vector<char> buffer(tmp_path.length()+1);
     strcpy(buffer.data(), tmp_path.c_str());
 
+#ifdef HAVE_MKDTEMP
     // Create the directory.  POSIX requires that mkdtemp() creates the
     // directory with 0700 permissions, meaning the only possible race
     // with socket creation could be the same user.  However, since
@@ -112,6 +114,18 @@ int zmq::ipc_listener_t::create_wildcard_address(std::string& path_)
     }
 
     path_.assign(buffer.data());
+    file_.assign (path_ + "/socket");
+#else
+    // Silence -Wunused-parameter. #pragma and __attribute__((unused)) are not
+    // very portable unfortunately...
+    (void) path_;
+    int fd = mkstemp (buffer.data());
+    if (fd == -1)
+         return -1;
+    ::close (fd);
+
+    file_.assign (buffer.data());
+#endif
 
     return 0;
 }
@@ -201,15 +215,9 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
 
     //  Allow wildcard file
     if (addr [0] == '*') {
-        std::string tmp_path;
-
-        if ( create_wildcard_address(tmp_path) < 0 ) {
+        if ( create_wildcard_address(tmp_socket_dirname, addr) < 0 ) {
             return -1;
         }
-
-        tmp_socket_dirname.assign(tmp_path);
-
-        addr.assign (tmp_path + "/socket");
     }
 
     //  Get rid of the file associated with the UNIX domain socket that

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -214,7 +214,7 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
     std::string addr (addr_);
 
     //  Allow wildcard file
-    if (addr [0] == '*') {
+    if (options.use_fd == -1 && addr [0] == '*') {
         if ( create_wildcard_address(tmp_socket_dirname, addr) < 0 ) {
             return -1;
         }

--- a/src/ipc_listener.hpp
+++ b/src/ipc_listener.hpp
@@ -74,7 +74,8 @@ namespace zmq
         int close ();
 
         // Create wildcard path address
-        static int create_wildcard_address(std::string& path_);
+        static int create_wildcard_address(std::string& path_,
+                std::string& file_);
 
         //  Filter new connections if the OS provides a mechanism to get
         //  the credentials of the peer process.  Called from accept().

--- a/src/tweetnacl.c
+++ b/src/tweetnacl.c
@@ -32,9 +32,9 @@
 
 /*
     Disable warnings for this source only, rather than for the whole
-    codebase when building with C99 or with Microsoft's compiler
+    codebase when building with C99 (gcc >= 4.2) or with Microsoft's compiler
 */
-#if defined __GNUC__ && __STDC_VERSION__ < 201112L
+#if defined __GNUC__ && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)) && __STDC_VERSION__ < 201112L
 #   pragma GCC diagnostic ignored "-Wsign-compare"
 #elif defined _MSC_VER
 #   pragma warning (disable:4018 4244 4146)

--- a/tests/test_use_fd_tcp.cpp
+++ b/tests/test_use_fd_tcp.cpp
@@ -35,8 +35,17 @@
 void pre_allocate_sock (void *zmq_socket, const char *address,
         const char *port)
 {
-    struct addrinfo *addr;
-    int rc = getaddrinfo (address, port, NULL, &addr);
+    struct addrinfo *addr, hint;
+    hint.ai_flags=0;
+    hint.ai_family=AF_INET;
+    hint.ai_socktype=SOCK_STREAM;
+    hint.ai_protocol=IPPROTO_TCP;
+    hint.ai_addrlen=0;
+    hint.ai_canonname=NULL;
+    hint.ai_addr=NULL;
+    hint.ai_next=NULL;
+
+    int rc = getaddrinfo (address, port, &hint, &addr);
     assert (rc == 0);
 
     int s_pre = socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);


### PR DESCRIPTION
Solution: see commits

Note that this is a partial solution for #1866, there is one more fix to be able to build 4.2 on Solaris, but I'm not sure whether we should add it.

The problem is that we have started using C++11 features - which is great IMHO, but this also means dropping support for older platforms where GCC is just too old, like Solaris 10.
In my opinion at this point it would be acceptable to declare that 4.1 is the last release that supports compilers without C++11.

@hintjens (and any other contributor of course) what do you think?