### PR TITLE
Problem: can't unbind with bound addr with IPv6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ matrix:
        os: osx
     -  env: BUILD_TYPE=valgrind CURVE=tweetnacl
        os: osx
+  include:
+    -  env: BUILD_TYPE=default CURVE=tweetnacl IPv6=ON
+       os: linux
+       dist: precise
+       sudo: false
 
 sudo: required
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1029,8 +1029,38 @@ int zmq::socket_base_t::term_endpoint (const char *addr_)
         return 0;
     }
 
+    std::string resolved_addr = std::string (addr_);
+    std::pair <endpoints_t::iterator, endpoints_t::iterator> range;
+
+    // The resolved last_endpoint is used as a key in the endpoints map.
+    // The address passed by the user might not match in the TCP case due to
+    // IPv4-in-IPv6 mapping (EG: tcp://[::ffff:127.0.0.1]:9999), so try to
+    // resolve before giving up. Given at this stage we don't know whether a
+    // socket is connected or bound, try with both.
+    if (protocol == "tcp") {
+        range = endpoints.equal_range (resolved_addr);
+        if (range.first == range.second) {
+            tcp_address_t *tcp_addr = new (std::nothrow) tcp_address_t ();
+            alloc_assert (tcp_addr);
+            rc = tcp_addr->resolve (address.c_str (), false, options.ipv6);
+
+            if (rc == 0) {
+                tcp_addr->to_string (resolved_addr);
+                range = endpoints.equal_range (resolved_addr);
+
+                if (range.first == range.second) {
+                    rc = tcp_addr->resolve (address.c_str (), true, options.ipv6);
+                    if (rc == 0) {
+                        tcp_addr->to_string (resolved_addr);
+                    }
+                }
+            }
+            LIBZMQ_DELETE(tcp_addr);
+        }
+    }
+
     //  Find the endpoints range (if any) corresponding to the addr_ string.
-    std::pair <endpoints_t::iterator, endpoints_t::iterator> range = endpoints.equal_range (std::string (addr_));
+    range = endpoints.equal_range (resolved_addr);
     if (range.first == range.second) {
         errno = ENOENT;
         EXIT_MUTEX ();

--- a/tests/test_unbind_wildcard.cpp
+++ b/tests/test_unbind_wildcard.cpp
@@ -22,11 +22,16 @@
 int main (void)
 {
     setup_test_environment();
+    int ipv6 = is_ipv6_available ();
     void *ctx = zmq_ctx_new ();
     assert (ctx);
 
+    /* Address wildcard, IPv6 disabled */
     void *sb = zmq_socket (ctx, ZMQ_REP);
     assert (sb);
+    void *sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+
     int rc = zmq_bind (sb, "tcp://*:5555");
     assert (rc == 0);
 
@@ -35,11 +40,234 @@ int main (void)
     rc = zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, endpoint, &endpoint_len);
     assert (rc == 0);
 
+    rc = zmq_connect (sc, endpoint);
+    assert (rc == 0);
+
+    bounce (sb, sc);
+
+    rc = zmq_disconnect (sc, endpoint);
+    assert (rc == 0);
     rc = zmq_unbind (sb, endpoint);
     assert (rc == 0);
 
+    rc = zmq_close (sc);
+    assert (rc == 0);
     rc = zmq_close (sb);
     assert (rc == 0);
+
+    /* Address wildcard, IPv6 enabled */
+    sb = zmq_socket (ctx, ZMQ_REP);
+    assert (sb);
+    sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+
+    rc = zmq_setsockopt (sb, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_setsockopt (sc, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+
+    rc = zmq_bind (sb, "tcp://*:5556");
+    assert (rc == 0);
+
+    endpoint_len = sizeof (endpoint);
+    memset(endpoint, 0, endpoint_len);
+    rc = zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, endpoint, &endpoint_len);
+    assert (rc == 0);
+
+    rc = zmq_connect (sc, endpoint);
+    assert (rc == 0);
+
+    bounce (sb, sc);
+
+    rc = zmq_disconnect (sc, endpoint);
+    assert (rc == 0);
+    rc = zmq_unbind (sb, endpoint);
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    /* Port wildcard, IPv4 address, IPv6 disabled */
+    sb = zmq_socket (ctx, ZMQ_REP);
+    assert (sb);
+    sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+
+    rc = zmq_bind (sb, "tcp://127.0.0.1:*");
+    assert (rc == 0);
+
+    endpoint_len = sizeof (endpoint);
+    memset(endpoint, 0, endpoint_len);
+    rc = zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, endpoint, &endpoint_len);
+    assert (rc == 0);
+
+    rc = zmq_connect (sc, endpoint);
+    assert (rc == 0);
+
+    bounce (sb, sc);
+
+    rc = zmq_disconnect (sc, endpoint);
+    assert (rc == 0);
+    rc = zmq_unbind (sb, endpoint);
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    /* Port wildcard, IPv4 address, IPv6 enabled */
+    sb = zmq_socket (ctx, ZMQ_REP);
+    assert (sb);
+    sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+
+    rc = zmq_setsockopt (sb, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_setsockopt (sc, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+
+    rc = zmq_bind (sb, "tcp://127.0.0.1:*");
+    assert (rc == 0);
+
+    endpoint_len = sizeof (endpoint);
+    memset(endpoint, 0, endpoint_len);
+    rc = zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, endpoint, &endpoint_len);
+    assert (rc == 0);
+
+    rc = zmq_connect (sc, endpoint);
+    assert (rc == 0);
+
+    bounce (sb, sc);
+
+    rc = zmq_disconnect (sc, endpoint);
+    assert (rc == 0);
+    rc = zmq_unbind (sb, endpoint);
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    if (ipv6) {
+        /* Port wildcard, IPv6 address, IPv6 enabled */
+        sb = zmq_socket (ctx, ZMQ_REP);
+        assert (sb);
+        sc = zmq_socket (ctx, ZMQ_REQ);
+        assert (sc);
+
+        rc = zmq_setsockopt (sb, ZMQ_IPV6, &ipv6, sizeof (int));
+        assert (rc == 0);
+        rc = zmq_setsockopt (sc, ZMQ_IPV6, &ipv6, sizeof (int));
+        assert (rc == 0);
+
+        rc = zmq_bind (sb, "tcp://[::1]:*");
+        assert (rc == 0);
+
+        endpoint_len = sizeof (endpoint);
+        memset(endpoint, 0, endpoint_len);
+        rc = zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, endpoint, &endpoint_len);
+        assert (rc == 0);
+
+        rc = zmq_connect (sc, endpoint);
+        assert (rc == 0);
+
+        bounce (sb, sc);
+
+        rc = zmq_disconnect (sc, endpoint);
+        assert (rc == 0);
+        rc = zmq_unbind (sb, endpoint);
+        assert (rc == 0);
+
+        rc = zmq_close (sc);
+        assert (rc == 0);
+        rc = zmq_close (sb);
+        assert (rc == 0);
+    }
+
+    /* No wildcard, IPv4 address, IPv6 disabled */
+    sb = zmq_socket (ctx, ZMQ_REP);
+    assert (sb);
+    sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+
+    rc = zmq_bind (sb, "tcp://127.0.0.1:5557");
+    assert (rc == 0);
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5557");
+    assert (rc == 0);
+
+    bounce (sb, sc);
+
+    rc = zmq_disconnect (sc, "tcp://127.0.0.1:5557");
+    assert (rc == 0);
+    rc = zmq_unbind (sb, "tcp://127.0.0.1:5557");
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    /* No wildcard, IPv4 address, IPv6 enabled */
+    sb = zmq_socket (ctx, ZMQ_REP);
+    assert (sb);
+    sc = zmq_socket (ctx, ZMQ_REQ);
+    assert (sc);
+
+    rc = zmq_setsockopt (sb, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+    rc = zmq_setsockopt (sc, ZMQ_IPV6, &ipv6, sizeof (int));
+    assert (rc == 0);
+
+    rc = zmq_bind (sb, "tcp://127.0.0.1:5558");
+    assert (rc == 0);
+    rc = zmq_connect (sc, "tcp://127.0.0.1:5558");
+    assert (rc == 0);
+
+    bounce (sb, sc);
+
+    rc = zmq_disconnect (sc, "tcp://127.0.0.1:5558");
+    assert (rc == 0);
+    rc = zmq_unbind (sb, "tcp://127.0.0.1:5558");
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    if (ipv6) {
+        /* No wildcard, IPv6 address, IPv6 enabled */
+        sb = zmq_socket (ctx, ZMQ_REP);
+        assert (sb);
+        sc = zmq_socket (ctx, ZMQ_REQ);
+        assert (sc);
+
+        rc = zmq_setsockopt (sb, ZMQ_IPV6, &ipv6, sizeof (int));
+        assert (rc == 0);
+        rc = zmq_setsockopt (sc, ZMQ_IPV6, &ipv6, sizeof (int));
+        assert (rc == 0);
+
+        rc = zmq_bind (sb, "tcp://[::1]:5559");
+        assert (rc == 0);
+        rc = zmq_connect (sc, "tcp://[::1]:5559");
+        assert (rc == 0);
+
+        bounce (sb, sc);
+
+        rc = zmq_disconnect (sc, "tcp://[::1]:5559");
+        assert (rc == 0);
+        rc = zmq_unbind (sb, "tcp://[::1]:5559");
+        assert (rc == 0);
+
+        rc = zmq_close (sc);
+        assert (rc == 0);
+        rc = zmq_close (sb);
+        assert (rc == 0);
+    }
 
     rc = zmq_ctx_term (ctx);
     assert (rc == 0);

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -51,6 +51,7 @@
 #include <string.h>
 
 #if defined _WIN32
+#   include "windows.hpp"
 #   if defined _MSC_VER
 #       include <crtdbg.h>
 #       pragma warning(disable:4996)
@@ -61,6 +62,9 @@
 #   include <signal.h>
 #   include <stdlib.h>
 #   include <sys/wait.h>
+#   include <sys/socket.h>
+#   include <netinet/in.h>
+#   include <arpa/inet.h>
 #endif
 
 //  Bounce a message from client to server and back
@@ -318,5 +322,53 @@ msleep (int milliseconds)
 #endif
 }
 
+// check if IPv6 is available (0/false if not, 1/true if it is)
+// only way to reliably check is to actually open a socket and try to bind it
+int
+is_ipv6_available(void)
+{
+    int rc, ipv6 = 1;
+    struct sockaddr_in6 test_addr;
+
+    memset (&test_addr, 0, sizeof (test_addr));
+    test_addr.sin6_family = AF_INET6;
+    inet_pton (AF_INET6, "::1", &(test_addr.sin6_addr));
+
+#ifdef ZMQ_HAVE_WINDOWS
+    SOCKET fd = socket (AF_INET6, SOCK_STREAM, IPPROTO_IP);
+    if (fd == INVALID_SOCKET)
+        ipv6 = 0;
+    else {
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char *)&ipv6, sizeof(int));
+        rc = setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (const char *)&ipv6, sizeof(int));
+        if (rc == SOCKET_ERROR)
+            ipv6 = 0;
+        else {
+            rc = bind (fd, (struct sockaddr *)&test_addr, sizeof (test_addr));
+            if (rc == SOCKET_ERROR)
+                ipv6 = 0;
+        }
+        closesocket (fd);
+    }
+#else
+    int fd = socket (AF_INET6, SOCK_STREAM, IPPROTO_IP);
+    if (fd == -1)
+        ipv6 = 0;
+    else {
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &ipv6, sizeof(int));
+        rc = setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6, sizeof(int));
+        if (rc != 0)
+            ipv6 = 0;
+        else {
+            rc = bind (fd, (struct sockaddr *)&test_addr, sizeof (test_addr));
+            if (rc != 0)
+                ipv6 = 0;
+        }
+        close (fd);
+    }
+#endif
+
+    return ipv6;
+}
 
 #endif


### PR DESCRIPTION
Solution: un-break un-binding a socket with the same endpoint string that was used to bind it when IPv6 is enabled. The breakage was caused by using the actual last_endpoint as a key instead of the string passed by the user, which is necessary in the wildcard case. But it broke the normal case with IPv6, since even if the address is an IPv4 one it will be saved in IPv6 format, so it doesn't match anymore. This is the culprit: https://github.com/zeromq/libzmq/commit/09e7416ee9588f131493e29491b46cc09a9560b5

My solution is a liiitle bit of a hack - basically I try to use the used-provided endpoint string and resolve it, just like it's used in connect/bind case, and see if that succeeds before giving up. At least it should be future-proof, and if more changes are done to the connect/bind they should be picked up in the unbind/disconnect. And the existing API for wildcard sockets is maintained, nothing is broken.

Also added a bunch of tests for various combinations of TCP sockets endpoints. Note that Travis on Precise (legacy) or Trusty does not support IPv6, so I added a test run on the container-based environment which is the only one that has a loopback interface with ::1 bound on it, so IPv6 test cases can run there. Note that I can't test this on Windows - I think it should work as I've used the same options as in existing part of the library.

Fixes https://github.com/zeromq/zeromq4-1/issues/114