### PR TITLE
Problem: Linker search path warnings on OS X

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,7 +131,10 @@ foreach(test ${tests})
     # it will only link correctly for DEBUG builds in Windows (I don't know how to specify the target and target library in CMake)
     SET_TARGET_PROPERTIES( ${test} PROPERTIES LINK_FLAGS "/LIBPATH:../bin/Win32/Debug/v120/dynamic" )
   else()
-    link_directories(${test} PRIVATE "${CMAKE_SOURCE_DIR}/../lib")
+    # per-test directories not generated on OS X / Darwin
+    if (NOT APPLE)
+        link_directories(${test} PRIVATE "${CMAKE_SOURCE_DIR}/../lib")
+    endif()
   endif()
 
   if(RT_LIBRARY)


### PR DESCRIPTION
**Problem:**
A per-test Linker search path was added in commit a911fa4 to `tests/CMakeLists.txt` as part of fixing Windows builds. Whilst this is silently ignored by `ld(1)` on Linux, it does not settle well with OS X. Spurious warnings are generated about missing directories, which unnecessarily convolutes the build logs.

**Solution:**
Make per-Test `LINK_DIRECTORIES()` call to be conditional for non-Apple platforms.