### PR TITLE
Problem: ZMQ_SRCFD test does not work on Windows

### DIFF
--- a/tests/test_srcfd.cpp
+++ b/tests/test_srcfd.cpp
@@ -105,8 +105,13 @@ int main (void)
 
     // getting name from closed socket will fail
     rc = getpeername (srcFd, (struct sockaddr*) &ss, &addrlen);
+#ifdef ZMQ_HAVE_WINDOWS
+    assert (rc == SOCKET_ERROR);
+    assert (WSAGetLastError() == WSAENOTSOCK);
+#else
     assert (rc == -1);
     assert (errno == EBADF);
+#endif
 
     rc = zmq_ctx_term (ctx);
     assert (rc == 0);


### PR DESCRIPTION
**Solution:**
* Add Winsock specific assertions, since [getpeername()](https://msdn.microsoft.com/en-us/library/windows/desktop/ms738533(v=vs.85).aspx) will return `SOCKET_ERROR` (-1) and `WSAGetLastError()` will return last error as `WSAENOTSOCK`.

**Notes:**
* The issue has been around since the initial commit of `tests/test_srcfd.cpp`
* Please wait until AppVeyor build is complete before merging this into base

**Issues affected:**
* #1903