### PR TITLE
Problem: LD search path warnings if using Clang

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,7 +137,7 @@ foreach(test ${tests})
     SET_TARGET_PROPERTIES( ${test} PROPERTIES LINK_FLAGS "/LIBPATH:../bin/Win32/Debug/v120/dynamic" )
   else()
     # per-test directories not generated on OS X / Darwin
-    if (NOT APPLE)
+    if (NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang.*")
         link_directories(${test} PRIVATE "${CMAKE_SOURCE_DIR}/../lib")
     endif()
   endif()


### PR DESCRIPTION
Solution: PR #1906 did not solve the problem entirely; subsequent Travis CI builds indicated that the issue happens due to Clang/LLVM, naturally, so make sure to fix the issue by detecting if CMake is using Clang for building the tests.