### PR TITLE
Problem: assertion in test_xpub_manual is swapped

### DIFF
--- a/tests/test_xpub_manual.cpp
+++ b/tests/test_xpub_manual.cpp
@@ -230,7 +230,7 @@ int test_xpub_proxy_unsubscribe_on_disconnect()
 
 int test_missing_subscriptions(const char *frontend, const char *backend)
 {
-    assert (!frontend && !backend);
+    assert (frontend && backend);
 
     const char* topic1 = "1";
     const char* topic2 = "2";


### PR DESCRIPTION
Solution: check that both pointers passed as arguments to
test_missing_subscription are non-NULL, instead of the opposite.