### PR TITLE
Naos Ltd license grant/quitclaim

### DIFF
--- a/RELICENSE/README.md
+++ b/RELICENSE/README.md
@@ -1,0 +1,22 @@
+# Permission to Relicense under MPLV2
+
+This directory collects grants from individuals and firms that hold
+copyrights in ZeroMQ to permit licensing the ZeroMQ code under
+the [Mozilla Public License, version
+2](https://www.mozilla.org/en-US/MPL/2.0/).  See [GitHub Pull
+Request #1917](https://github.com/zeromq/libzmq/pull/1917) and
+[original iMatix zeromq-dev license
+grant](http://lists.zeromq.org/pipermail/zeromq-dev/2016-April/030288.html)
+for some background information.
+
+Please create a separate file in this directory for each individual
+or firm holding copyright in ZeroMQ, named after the individual or
+firm holding the copyright.
+
+Each patch must be made with a GitHub handle that is clearly
+associated with the copyright owner, to guarantee the identity of
+the signatory.  Please avoid changing the files created by other
+individuals or firms granting a copyright license over their
+copyrights (if rewording is required contact them and ask them to
+submit an updated version).  This makes it easier to verify that
+the license grant was made by an authorized GitHub account.

--- a/RELICENSE/naos_ltd.md
+++ b/RELICENSE/naos_ltd.md
@@ -1,0 +1,19 @@
+## Naos Ltd (a New Zealand company)
+
+This is a statement by Naos Ltd (Naos) that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under
+the Mozilla Public License v2 (MPLv2).
+
+The port of libzmq to run on the z/OS Mainframe ([GitHub Pull
+request #1136](https://github.com/zeromq/libzmq/pull/1136), [GitHub Pull
+request #1138](https://github.com/zeromq/libzmq/pull/1138), and
+[GitHub Pull request #1139](https://github.com/zeromq/libzmq/pull/1139))
+was performed as work for hire under contract to iMatix Corporation
+sprl, itself under contract to a client.  Thus copyright in that
+portability work does not belong to Naos Ltd, and Naos Ltd hereby
+releases any claim to the copyright in the z/OS Mainframe portability
+work identified by the above three GitHub pull requests.
+
+Ewen McNeill  
+Managing Director, Naos Ltd  
+2016-04-25


### PR DESCRIPTION
Problem: Naos Ltd potentially has copyright on ZeroMQ

Solution: Grant license under MPLv2, and quitclaim license over z/OS port (performed as work for hire).