### PR TITLE
Problem: tune_tcp_keepalives signature more than 80 chars on a line

### DIFF
--- a/src/tcp.hpp
+++ b/src/tcp.hpp
@@ -45,7 +45,8 @@ namespace zmq
     void set_tcp_receive_buffer (fd_t sockfd_, int bufsize_);
 
     //  Tunes TCP keep-alives
-    void tune_tcp_keepalives (fd_t s_, int keepalive_, int keepalive_cnt_, int keepalive_idle_, int keepalive_intvl_);
+    void tune_tcp_keepalives (fd_t s_, int keepalive_, int keepalive_cnt_,
+                              int keepalive_idle_, int keepalive_intvl_);
 
     //  Tunes TCP max retransmit timeout
     void tune_tcp_maxrt (fd_t sockfd_, int timeout_);


### PR DESCRIPTION
**Solution:**
Fix it.