### PR TITLE
[WIP] Enable UDP transport support for CLIENT and SERVER protocols

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -572,7 +572,7 @@ void zmq::session_base_t::start_connecting (bool wait_)
 #endif
 
 if (addr->protocol == "udp") {
-    zmq_assert (options.type == ZMQ_DISH || options.type == ZMQ_RADIO);
+    zmq_assert (options.type == ZMQ_DISH || options.type == ZMQ_RADIO || options.type == ZMQ_CLIENT || options.type == ZMQ_SERVER);
 
     udp_engine_t* engine = new (std::nothrow) udp_engine_t ();
     alloc_assert (engine);
@@ -586,6 +586,10 @@ if (addr->protocol == "udp") {
     }
     else if (options.type == ZMQ_DISH) {
         send = false;
+        recv = true;
+    }
+    else if (options.type == ZMQ_CLIENT || options.type == ZMQ_SERVER) {
+        send = true;
         recv = true;
     }
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -308,7 +308,9 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_)
 #endif
 
     if (protocol_ == "udp" && (options.type != ZMQ_DISH &&
-                               options.type != ZMQ_RADIO)) {
+                               options.type != ZMQ_RADIO &&
+                               options.type != ZMQ_CLIENT &&
+                               options.type != ZMQ_SERVER)) {
         errno = ENOCOMPATPROTO;
         return -1;
     }
@@ -882,7 +884,7 @@ int zmq::socket_base_t::connect (const char *addr_)
 if (protocol  == "udp") {
     paddr->resolved.udp_addr = new (std::nothrow) udp_address_t ();
     alloc_assert (paddr->resolved.udp_addr);
-    rc = paddr->resolved.udp_addr->resolve (address.c_str(), options.type == ZMQ_DISH);
+    rc = paddr->resolved.udp_addr->resolve (address.c_str(), (options.type == ZMQ_DISH || options.type == ZMQ_CLIENT || options.type == ZMQ_SERVER));
     if (rc != 0) {
         LIBZMQ_DELETE(paddr);
         EXIT_MUTEX ();


### PR DESCRIPTION
I'm trying to add UDP transport support for CLIENT/SERVER connections, based on the previous RADIO/DISH work by @somdoron (thanks a lot for it), as it would be useful for me (should scratch my own itch, right ?).

So far, I have only changed what seems obvious, but there is some specific code on radio.hpp and radio.cpp to handle UDP pipes that I don't quite understand. 

Could you point me what still needs to be changed for this to work ?

Sorry for possibly weird English and thanks in advice.