### PR TITLE
Problem: zmq_setsockopt(3) man page formatting

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -493,7 +493,7 @@ Applicable socket types:: all, when using TCP transport
 
 
 ZMQ_USE_FD: Set the pre-allocated socket file descriptor
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When set to a positive integer value before zmq_bind is called on the socket,
 the socket shall use the corresponding file descriptor for connections over
 TCP or IPC instead of allocating a new file descriptor.
@@ -869,7 +869,7 @@ Applicable socket types:: all, when using TCP transports.
 
 
 ZMQ_TCP_MAXRT: Set TCP Maximum Retransmit Timeout
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 On OSes where it is supported, sets how long before an unacknowledged TCP
 retransmit times out. The system normally attempts many TCP retransmits
 following an exponential backoff strategy. This means that after a network


### PR DESCRIPTION
**Solution:**
- Update formatting and remove redundant parts from `ZMQ_PROBE_ROUTER`, `ZMQ_USE_FD`, `ZMQ_TCP_MAXRT`, `ZMQ_TCP_TOS`
- Only cosmetic changes to the content
- These changes already merged to <http://api.zeromq.org> by me

**Hat-tip:**
@hintjens 