### PR TITLE
problem: no way to disable draft when compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ test_scatter_gather
 test_socketopt_hwm
 test_use_fd_ipc
 test_use_fd_tcp
+test_pub_invert_matching
 tests/test*.log
 tests/test*.trs
 src/platform.hpp*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,19 @@ os:
 dist: trusty
 
 env:
-- BUILD_TYPE=default CURVE=tweetnacl
+- BUILD_TYPE=default CURVE=tweetnacl DRAFT=enabled
 - BUILD_TYPE=android CURVE=tweetnacl
 - BUILD_TYPE=cmake CURVE=tweetnacl
 - BUILD_TYPE=default CURVE=libsodium
 - BUILD_TYPE=default
-- BUILD_TYPE=coverage CURVE=tweetnacl
-- BUILD_TYPE=valgrind CURVE=tweetnacl
+- BUILD_TYPE=coverage CURVE=tweetnacl DRAFT=enabled
+- BUILD_TYPE=valgrind CURVE=tweetnacl DRAFT=enabled
 
 matrix:
   exclude:
-    -  env: BUILD_TYPE=coverage CURVE=tweetnacl
+    -  env: BUILD_TYPE=coverage CURVE=tweetnacl DRAFT=enabled
        os: osx
-    -  env: BUILD_TYPE=valgrind CURVE=tweetnacl
+    -  env: BUILD_TYPE=valgrind CURVE=tweetnacl DRAFT=enabled
        os: osx
   include:
     -  env: BUILD_TYPE=default CURVE=tweetnacl IPv6=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,20 @@ else ()
     set (ZMQ_HAVE_CURVE 1)
 endif ()
 
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
+if (EXISTS "${SOURCE_DIR}/.git")
+    OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" ON)
+else ()
+    OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" OFF)
+endif ()
+IF (ENABLE_DRAFTS)
+    ADD_DEFINITIONS (-DZMQ_BUILD_DRAFT_API)
+    set (pkg_config_defines "-DZMQ_BUILD_DRAFT_API=1")
+ELSE (ENABLE_DRAFTS)
+    set (pkg_config_defines "")
+ENDIF (ENABLE_DRAFTS)
+
 set (POLLER "" CACHE STRING "Choose polling system. valid values are
                             kqueue, epoll, devpoll, poll or select [default=autodetect]")
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -394,7 +394,6 @@ test_apps = \
 	tests/test_sockopt_hwm \
 	tests/test_heartbeats \
 	tests/test_stream_exceeds_buffer \
-	tests/test_scatter_gather \
 	tests/test_pub_invert_matching
 
 tests_test_system_SOURCES = tests/test_system.cpp
@@ -594,9 +593,6 @@ tests_test_heartbeats_LDADD = src/libzmq.la
 tests_test_stream_exceeds_buffer_SOURCES = tests/test_stream_exceeds_buffer.cpp
 tests_test_stream_exceeds_buffer_LDADD = src/libzmq.la
 
-tests_test_scatter_gather_SOURCES = tests/test_scatter_gather.cpp
-tests_test_scatter_gather_LDADD = src/libzmq.la
-
 tests_test_pub_invert_matching_SOURCES = tests/test_pub_invert_matching.cpp
 tests_test_pub_invert_matching_LDADD = src/libzmq.la
 
@@ -722,7 +718,8 @@ test_apps += tests/test_poller \
 	tests/test_thread_safe \
 	tests/test_timers \
 	tests/test_radio_dish \
-	tests/test_udp
+	tests/test_udp \
+	tests/test_scatter_gather
 
 tests_test_poller_SOURCES = tests/test_poller.cpp
 tests_test_poller_LDADD = src/libzmq.la
@@ -741,6 +738,9 @@ tests_test_radio_dish_LDADD = src/libzmq.la
 
 tests_test_udp_SOURCES = tests/test_udp.cpp
 tests_test_udp_LDADD = src/libzmq.la
+
+tests_test_scatter_gather_SOURCES = tests/test_scatter_gather.cpp
+tests_test_scatter_gather_LDADD = src/libzmq.la
 endif
 
 check_PROGRAMS = ${test_apps}

--- a/Makefile.am
+++ b/Makefile.am
@@ -391,8 +391,6 @@ test_apps = \
 	tests/test_xpub_manual \
 	tests/test_xpub_welcome_msg \
 	tests/test_atomics \
-	tests/test_client_server \
-	tests/test_thread_safe \
 	tests/test_sockopt_hwm \
 	tests/test_heartbeats \
 	tests/test_stream_exceeds_buffer \
@@ -588,12 +586,6 @@ tests_test_xpub_welcome_msg_LDADD = src/libzmq.la
 tests_test_atomics_SOURCES = tests/test_atomics.cpp
 tests_test_atomics_LDADD = src/libzmq.la
 
-tests_test_client_server_SOURCES = tests/test_client_server.cpp
-tests_test_client_server_LDADD = src/libzmq.la
-
-tests_test_thread_safe_SOURCES = tests/test_thread_safe.cpp
-tests_test_thread_safe_LDADD = src/libzmq.la
-
 tests_test_sockopt_hwm_SOURCES = tests/test_sockopt_hwm.cpp
 tests_test_sockopt_hwm_LDADD = src/libzmq.la
 
@@ -741,7 +733,14 @@ test_reqrep_vmci_CXXFLAGS = @LIBZMQ_VMCI_CXXFLAGS@
 endif
 
 if ENABLE_DRAFTS
-test_apps +=
+test_apps += tests/test_client_server \
+	tests/test_thread_safe
+
+tests_test_client_server_SOURCES = tests/test_client_server.cpp
+tests_test_client_server_LDADD = src/libzmq.la
+
+tests_test_thread_safe_SOURCES = tests/test_thread_safe.cpp
+tests_test_thread_safe_LDADD = src/libzmq.la
 endif
 
 check_PROGRAMS = ${test_apps}

--- a/Makefile.am
+++ b/Makefile.am
@@ -394,7 +394,6 @@ test_apps = \
 	tests/test_sockopt_hwm \
 	tests/test_heartbeats \
 	tests/test_stream_exceeds_buffer \
-	tests/test_timers \
 	tests/test_radio_dish \
 	tests/test_udp \
 	tests/test_scatter_gather \
@@ -597,9 +596,6 @@ tests_test_heartbeats_LDADD = src/libzmq.la
 tests_test_stream_exceeds_buffer_SOURCES = tests/test_stream_exceeds_buffer.cpp
 tests_test_stream_exceeds_buffer_LDADD = src/libzmq.la
 
-tests_test_timers_SOURCES = tests/test_timers.cpp
-tests_test_timers_LDADD = src/libzmq.la
-
 tests_test_radio_dish_SOURCES = tests/test_radio_dish.cpp
 tests_test_radio_dish_LDADD = src/libzmq.la
 
@@ -731,7 +727,8 @@ endif
 if ENABLE_DRAFTS
 test_apps += tests/test_poller \
 	tests/test_client_server \
-	tests/test_thread_safe
+	tests/test_thread_safe \
+	tests/test_timers
 
 tests_test_poller_SOURCES = tests/test_poller.cpp
 tests_test_poller_LDADD = src/libzmq.la
@@ -741,6 +738,9 @@ tests_test_client_server_LDADD = src/libzmq.la
 
 tests_test_thread_safe_SOURCES = tests/test_thread_safe.cpp
 tests_test_thread_safe_LDADD = src/libzmq.la
+
+tests_test_timers_SOURCES = tests/test_timers.cpp
+tests_test_timers_LDADD = src/libzmq.la
 endif
 
 check_PROGRAMS = ${test_apps}

--- a/Makefile.am
+++ b/Makefile.am
@@ -394,7 +394,6 @@ test_apps = \
 	tests/test_sockopt_hwm \
 	tests/test_heartbeats \
 	tests/test_stream_exceeds_buffer \
-	tests/test_poller \
 	tests/test_timers \
 	tests/test_radio_dish \
 	tests/test_udp \
@@ -598,9 +597,6 @@ tests_test_heartbeats_LDADD = src/libzmq.la
 tests_test_stream_exceeds_buffer_SOURCES = tests/test_stream_exceeds_buffer.cpp
 tests_test_stream_exceeds_buffer_LDADD = src/libzmq.la
 
-tests_test_poller_SOURCES = tests/test_poller.cpp
-tests_test_poller_LDADD = src/libzmq.la
-
 tests_test_timers_SOURCES = tests/test_timers.cpp
 tests_test_timers_LDADD = src/libzmq.la
 
@@ -733,8 +729,12 @@ test_reqrep_vmci_CXXFLAGS = @LIBZMQ_VMCI_CXXFLAGS@
 endif
 
 if ENABLE_DRAFTS
-test_apps += tests/test_client_server \
+test_apps += tests/test_poller \
+	tests/test_client_server \
 	tests/test_thread_safe
+
+tests_test_poller_SOURCES = tests/test_poller.cpp
+tests_test_poller_LDADD = src/libzmq.la
 
 tests_test_client_server_SOURCES = tests/test_client_server.cpp
 tests_test_client_server_LDADD = src/libzmq.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -394,8 +394,6 @@ test_apps = \
 	tests/test_sockopt_hwm \
 	tests/test_heartbeats \
 	tests/test_stream_exceeds_buffer \
-	tests/test_radio_dish \
-	tests/test_udp \
 	tests/test_scatter_gather \
 	tests/test_pub_invert_matching
 
@@ -596,12 +594,6 @@ tests_test_heartbeats_LDADD = src/libzmq.la
 tests_test_stream_exceeds_buffer_SOURCES = tests/test_stream_exceeds_buffer.cpp
 tests_test_stream_exceeds_buffer_LDADD = src/libzmq.la
 
-tests_test_radio_dish_SOURCES = tests/test_radio_dish.cpp
-tests_test_radio_dish_LDADD = src/libzmq.la
-
-tests_test_udp_SOURCES = tests/test_udp.cpp
-tests_test_udp_LDADD = src/libzmq.la
-
 tests_test_scatter_gather_SOURCES = tests/test_scatter_gather.cpp
 tests_test_scatter_gather_LDADD = src/libzmq.la
 
@@ -728,7 +720,9 @@ if ENABLE_DRAFTS
 test_apps += tests/test_poller \
 	tests/test_client_server \
 	tests/test_thread_safe \
-	tests/test_timers
+	tests/test_timers \
+	tests/test_radio_dish \
+	tests/test_udp
 
 tests_test_poller_SOURCES = tests/test_poller.cpp
 tests_test_poller_LDADD = src/libzmq.la
@@ -741,6 +735,12 @@ tests_test_thread_safe_LDADD = src/libzmq.la
 
 tests_test_timers_SOURCES = tests/test_timers.cpp
 tests_test_timers_LDADD = src/libzmq.la
+
+tests_test_radio_dish_SOURCES = tests/test_radio_dish.cpp
+tests_test_radio_dish_LDADD = src/libzmq.la
+
+tests_test_udp_SOURCES = tests/test_udp.cpp
+tests_test_udp_LDADD = src/libzmq.la
 endif
 
 check_PROGRAMS = ${test_apps}

--- a/Makefile.am
+++ b/Makefile.am
@@ -740,6 +740,10 @@ test_reqrep_vmci_CXXFLAGS = @LIBZMQ_VMCI_CXXFLAGS@
 
 endif
 
+if ENABLE_DRAFTS
+test_apps +=
+endif
+
 check_PROGRAMS = ${test_apps}
 
 #  Run the test cases

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -23,6 +23,12 @@ if [ $BUILD_TYPE == "default" ]; then
         ( cd libsodium; ./autogen.sh; ./configure --prefix=$BUILD_PREFIX; make check; make install)
     fi
 
+    if [ -z $DRAFT ] || [ $DRAFT == "disabled" ]; then
+        CONFIG_OPTS+=("--enable-drafts=no")
+    elif [ $DRAFT == "enabled" ]; then
+        CONFIG_OPTS+=("--enable-drafts=yes")
+    fi
+
     #   Build and check this project
     (
         ./autogen.sh &&

--- a/configure.ac
+++ b/configure.ac
@@ -605,6 +605,33 @@ LIBZMQ_CHECK_TCP_KEEPALIVE([
 
 AM_CONDITIONAL(HAVE_FORK, test "x$ac_cv_func_fork" = "xyes")
 
+if test "x$cross_compiling" = "xyes"; then
+    #   Enable draft by default when cross-compiling
+    defaultval=yes
+else
+    # enable draft API by default if we're in a git repository
+    # else disable it by default; then allow --enable-drafts=yes/no override
+    AC_CHECK_FILE($srcdir/.git, [defaultval=yes], [defaultval=no])
+fi
+
+AC_ARG_ENABLE([drafts],
+    AS_HELP_STRING([--enable-drafts],
+        [Build and install draft classes and methods [default=yes]]),
+    [enable_drafts=$enableval],
+    [enable_drafts=$defaultval])
+
+AM_CONDITIONAL([ENABLE_DRAFTS], [test x$enable_drafts != xno])
+
+if test "x$enable_drafts" = "xyes"; then
+    AC_MSG_NOTICE([Building stable and legacy API + draft API])
+    AC_DEFINE(ZMQ_BUILD_DRAFT_API, 1, [Provide draft classes and methods])
+    AC_SUBST(pkg_config_defines, "-DZMQ_BUILD_DRAFT_API=1")
+#    CPPFLAGS="-DZMQ_BUILD_DRAFT_API=1 $CPPFLAGS"
+else
+    AC_MSG_NOTICE([Building stable and legacy API (no draft API)])
+    AC_SUBST(pkg_config_defines, "")
+fi
+
 # Subst LIBZMQ_EXTRA_CFLAGS & CXXFLAGS & LDFLAGS
 AC_SUBST(LIBZMQ_EXTRA_CFLAGS)
 AC_SUBST(LIBZMQ_EXTRA_CXXFLAGS)

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -260,8 +260,6 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_XPUB 9
 #define ZMQ_XSUB 10
 #define ZMQ_STREAM 11
-#define ZMQ_GATHER 16
-#define ZMQ_SCATTER 17
 
 /*  Deprecated aliases                                                        */
 #define ZMQ_XREQ ZMQ_DEALER
@@ -529,6 +527,8 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_CLIENT 13
 #define ZMQ_RADIO 14
 #define ZMQ_DISH 15
+#define ZMQ_GATHER 16
+#define ZMQ_SCATTER 17
 
 /*  DRAFT Socket events.                                                      */
 ZMQ_EXPORT int zmq_join (void *s, const char *group);

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -575,6 +575,16 @@ ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn* func, void* arg);
 ZMQ_EXPORT void zmq_threadclose (void* thread);
 
 
+/******************************************************************************/
+/*  These functions are DRAFT and disabled in stable releases, and subject to */
+/*  change at ANY time until declared stable.                                 */
+/******************************************************************************/
+
+#ifdef ZMQ_BUILD_DRAFT_API
+
+#endif // ZMQ_BUILD_DRAFT_API
+
+
 #undef ZMQ_EXPORT
 
 #ifdef __cplusplus

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -438,42 +438,6 @@ typedef struct zmq_pollitem_t
 ZMQ_EXPORT int  zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
 
 /******************************************************************************/
-/*  Poller polling on sockets,fd and thread-safe sockets                      */
-/******************************************************************************/
-
-#define ZMQ_HAVE_POLLER
-
-typedef struct zmq_poller_event_t
-{
-    void *socket;
-#if defined _WIN32
-    SOCKET fd;
-#else
-    int fd;
-#endif
-    void *user_data;
-    short events;
-} zmq_poller_event_t;
-
-ZMQ_EXPORT void *zmq_poller_new (void);
-ZMQ_EXPORT int  zmq_poller_destroy (void **poller_p);
-ZMQ_EXPORT int  zmq_poller_add (void *poller, void *socket, void *user_data, short events);
-ZMQ_EXPORT int  zmq_poller_modify (void *poller, void *socket, short events);
-ZMQ_EXPORT int  zmq_poller_remove (void *poller, void *socket);
-ZMQ_EXPORT int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
-
-#if defined _WIN32
-ZMQ_EXPORT int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, SOCKET fd, short events);
-ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, SOCKET fd);
-#else
-ZMQ_EXPORT int zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
-ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
-#endif
-
-/******************************************************************************/
-/*  Scheduling timers                                                         */
 /******************************************************************************/
 
 #define ZMQ_HAVE_TIMERS
@@ -583,6 +547,41 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 /*  DRAFT Socket types.                                                       */
 #define ZMQ_SERVER 12
 #define ZMQ_CLIENT 13
+
+/******************************************************************************/
+/*  Poller polling on sockets,fd and thread-safe sockets                      */
+/******************************************************************************/
+
+#define ZMQ_HAVE_POLLER
+
+typedef struct zmq_poller_event_t
+{
+    void *socket;
+#if defined _WIN32
+    SOCKET fd;
+#else
+    int fd;
+#endif
+    void *user_data;
+    short events;
+} zmq_poller_event_t;
+
+ZMQ_EXPORT void *zmq_poller_new (void);
+ZMQ_EXPORT int  zmq_poller_destroy (void **poller_p);
+ZMQ_EXPORT int  zmq_poller_add (void *poller, void *socket, void *user_data, short events);
+ZMQ_EXPORT int  zmq_poller_modify (void *poller, void *socket, short events);
+ZMQ_EXPORT int  zmq_poller_remove (void *poller, void *socket);
+ZMQ_EXPORT int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
+
+#if defined _WIN32
+ZMQ_EXPORT int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);
+ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, SOCKET fd, short events);
+ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, SOCKET fd);
+#else
+ZMQ_EXPORT int zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
+ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
+ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
+#endif
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -260,8 +260,6 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_XPUB 9
 #define ZMQ_XSUB 10
 #define ZMQ_STREAM 11
-#define ZMQ_RADIO 14
-#define ZMQ_DISH 15
 #define ZMQ_GATHER 16
 #define ZMQ_SCATTER 17
 
@@ -408,8 +406,6 @@ ZMQ_EXPORT int zmq_send (void *s, const void *buf, size_t len, int flags);
 ZMQ_EXPORT int zmq_send_const (void *s, const void *buf, size_t len, int flags);
 ZMQ_EXPORT int zmq_recv (void *s, void *buf, size_t len, int flags);
 ZMQ_EXPORT int zmq_socket_monitor (void *s, const char *addr, int events);
-ZMQ_EXPORT int zmq_join (void *s, const char *group);
-ZMQ_EXPORT int zmq_leave (void *s, const char *group);
 
 
 /******************************************************************************/
@@ -531,6 +527,12 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 /*  DRAFT Socket types.                                                       */
 #define ZMQ_SERVER 12
 #define ZMQ_CLIENT 13
+#define ZMQ_RADIO 14
+#define ZMQ_DISH 15
+
+/*  DRAFT Socket events.                                                      */
+ZMQ_EXPORT int zmq_join (void *s, const char *group);
+ZMQ_EXPORT int zmq_leave (void *s, const char *group);
 
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -260,8 +260,6 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_XPUB 9
 #define ZMQ_XSUB 10
 #define ZMQ_STREAM 11
-#define ZMQ_SERVER 12
-#define ZMQ_CLIENT 13
 #define ZMQ_RADIO 14
 #define ZMQ_DISH 15
 #define ZMQ_GATHER 16
@@ -581,6 +579,10 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 /******************************************************************************/
 
 #ifdef ZMQ_BUILD_DRAFT_API
+
+/*  DRAFT Socket types.                                                       */
+#define ZMQ_SERVER 12
+#define ZMQ_CLIENT 13
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -438,22 +438,6 @@ typedef struct zmq_pollitem_t
 ZMQ_EXPORT int  zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
 
 /******************************************************************************/
-/******************************************************************************/
-
-#define ZMQ_HAVE_TIMERS
-
-typedef void (zmq_timer_fn)(int timer_id, void *arg);
-
-ZMQ_EXPORT void *zmq_timers_new (void);
-ZMQ_EXPORT int   zmq_timers_destroy (void **timers_p);
-ZMQ_EXPORT int   zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
-ZMQ_EXPORT int   zmq_timers_cancel (void *timers, int timer_id);
-ZMQ_EXPORT int   zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
-ZMQ_EXPORT int   zmq_timers_reset (void *timers, int timer_id);
-ZMQ_EXPORT long  zmq_timers_timeout (void *timers);
-ZMQ_EXPORT int   zmq_timers_execute (void *timers);
-
-/******************************************************************************/
 /*  Message proxying                                                          */
 /******************************************************************************/
 
@@ -582,6 +566,23 @@ ZMQ_EXPORT int zmq_poller_add_fd (void *poller, int fd, void *user_data, short e
 ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
 ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
 #endif
+
+/******************************************************************************/
+/*  Scheduling timers                                                         */
+/******************************************************************************/
+
+#define ZMQ_HAVE_TIMERS
+
+typedef void (zmq_timer_fn)(int timer_id, void *arg);
+
+ZMQ_EXPORT void *zmq_timers_new (void);
+ZMQ_EXPORT int   zmq_timers_destroy (void **timers_p);
+ZMQ_EXPORT int   zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
+ZMQ_EXPORT int   zmq_timers_cancel (void *timers, int timer_id);
+ZMQ_EXPORT int   zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
+ZMQ_EXPORT int   zmq_timers_reset (void *timers, int timer_id);
+ZMQ_EXPORT long  zmq_timers_timeout (void *timers);
+ZMQ_EXPORT int   zmq_timers_execute (void *timers);
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/src/libzmq.pc.cmake.in
+++ b/src/libzmq.pc.cmake.in
@@ -8,4 +8,4 @@ Description: 0MQ c++ library
 Version: @ZMQ_VERSION_MAJOR@.@ZMQ_VERSION_MINOR@.@ZMQ_VERSION_PATCH@
 Libs: -L${libdir} -lzmq
 Libs.private: -lstdc++
-Cflags: -I${includedir}
+Cflags: -I${includedir} @pkg_config_defines@

--- a/src/libzmq.pc.in
+++ b/src/libzmq.pc.in
@@ -8,4 +8,4 @@ Description: 0MQ c++ library
 Version: @VERSION@
 Libs: -L${libdir} -lzmq
 Libs.private: -lstdc++
-Cflags: -I${includedir}
+Cflags: -I${includedir} @pkg_config_defines@

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -138,10 +138,12 @@
 #include <string>
 #include <vector>
 
+#endif // _MSC_VER
+
 
 // 0MQ definitions and exported functions
+#include "platform.hpp"
 #include "../include/zmq.h"
 
-#endif // _MSC_VER
 
 #endif //ifndef __ZMQ_PRECOMPILED_HPP_INCLUDED__

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -152,6 +152,10 @@
 
 #ifndef ZMQ_BUILD_DRAFT_API
 
+/*  DRAFT Socket types.                                                       */
+#define ZMQ_SERVER 12
+#define ZMQ_CLIENT 13
+
 #endif // ZMQ_BUILD_DRAFT_API
 
 #endif //ifndef __ZMQ_PRECOMPILED_HPP_INCLUDED__

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -155,6 +155,8 @@
 /*  DRAFT Socket types.                                                       */
 #define ZMQ_SERVER 12
 #define ZMQ_CLIENT 13
+#define ZMQ_RADIO 14
+#define ZMQ_DISH 15
 
 /*  DRAFT Socket events.                                                      */
 int zmq_join (void *s, const char *group);

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -157,6 +157,8 @@
 #define ZMQ_CLIENT 13
 #define ZMQ_RADIO 14
 #define ZMQ_DISH 15
+#define ZMQ_GATHER 16
+#define ZMQ_SCATTER 17
 
 /*  DRAFT Socket events.                                                      */
 int zmq_join (void *s, const char *group);

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -145,5 +145,13 @@
 #include "platform.hpp"
 #include "../include/zmq.h"
 
+/******************************************************************************/
+/*  These functions are DRAFT and disabled in stable releases, and subject to */
+/*  change at ANY time until declared stable.                                 */
+/******************************************************************************/
+
+#ifndef ZMQ_BUILD_DRAFT_API
+
+#endif // ZMQ_BUILD_DRAFT_API
 
 #endif //ifndef __ZMQ_PRECOMPILED_HPP_INCLUDED__

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -195,6 +195,23 @@ int zmq_poller_modify_fd (void *poller, int fd, short events);
 int zmq_poller_remove_fd (void *poller, int fd);
 #endif
 
+/******************************************************************************/
+/*  Scheduling timers                                                         */
+/******************************************************************************/
+
+#define ZMQ_HAVE_TIMERS
+
+typedef void (zmq_timer_fn)(int timer_id, void *arg);
+
+void *zmq_timers_new (void);
+int   zmq_timers_destroy (void **timers_p);
+int   zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
+int   zmq_timers_cancel (void *timers, int timer_id);
+int   zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
+int   zmq_timers_reset (void *timers, int timer_id);
+long  zmq_timers_timeout (void *timers);
+int   zmq_timers_execute (void *timers);
+
 #endif // ZMQ_BUILD_DRAFT_API
 
 #endif //ifndef __ZMQ_PRECOMPILED_HPP_INCLUDED__

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -156,6 +156,45 @@
 #define ZMQ_SERVER 12
 #define ZMQ_CLIENT 13
 
+/*  DRAFT Socket events.                                                      */
+int zmq_join (void *s, const char *group);
+int zmq_leave (void *s, const char *group);
+
+/******************************************************************************/
+/*  Poller polling on sockets,fd and thread-safe sockets                      */
+/******************************************************************************/
+
+#define ZMQ_HAVE_POLLER
+
+typedef struct zmq_poller_event_t
+{
+    void *socket;
+#if defined _WIN32
+    SOCKET fd;
+#else
+    int fd;
+#endif
+    void *user_data;
+    short events;
+} zmq_poller_event_t;
+
+void *zmq_poller_new (void);
+int  zmq_poller_destroy (void **poller_p);
+int  zmq_poller_add (void *poller, void *socket, void *user_data, short events);
+int  zmq_poller_modify (void *poller, void *socket, short events);
+int  zmq_poller_remove (void *poller, void *socket);
+int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
+
+#if defined _WIN32
+int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);
+int zmq_poller_modify_fd (void *poller, SOCKET fd, short events);
+int zmq_poller_remove_fd (void *poller, SOCKET fd);
+#else
+int zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
+int zmq_poller_modify_fd (void *poller, int fd, short events);
+int zmq_poller_remove_fd (void *poller, int fd);
+#endif
+
 #endif // ZMQ_BUILD_DRAFT_API
 
 #endif //ifndef __ZMQ_PRECOMPILED_HPP_INCLUDED__

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,6 @@ set(tests
         test_setsockopt
         test_sockopt_hwm
         test_heartbeats
-        test_poller
         test_atomics
         test_bind_src_address
         test_capabilities
@@ -118,6 +117,7 @@ endif()
 
 IF (ENABLE_DRAFTS)
     list(APPEND tests
+        test_poller
         test_thread_safe
         test_client_server
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,8 +52,6 @@ set(tests
         test_connect_rid
         test_xpub_nodrop
         test_pub_invert_matching
-        test_thread_safe
-        test_client_server
         test_setsockopt
         test_sockopt_hwm
         test_heartbeats
@@ -120,6 +118,8 @@ endif()
 
 IF (ENABLE_DRAFTS)
     list(APPEND tests
+        test_thread_safe
+        test_client_server
     )
 ENDIF (ENABLE_DRAFTS)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,8 +64,6 @@ set(tests
         test_stream_timeout
         test_xpub_manual
         test_xpub_welcome_msg
-        test_radio_dish
-        test_udp
         test_scatter_gather
 )
 if(NOT WIN32)
@@ -120,6 +118,8 @@ IF (ENABLE_DRAFTS)
         test_thread_safe
         test_client_server
         test_timers
+        test_radio_dish
+        test_udp
     )
 ENDIF (ENABLE_DRAFTS)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,7 +64,6 @@ set(tests
         test_stream_timeout
         test_xpub_manual
         test_xpub_welcome_msg
-        test_timers
         test_radio_dish
         test_udp
         test_scatter_gather
@@ -120,6 +119,7 @@ IF (ENABLE_DRAFTS)
         test_poller
         test_thread_safe
         test_client_server
+        test_timers
     )
 ENDIF (ENABLE_DRAFTS)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,12 @@ if(WITH_VMCI)
   )
 endif()
 
+
+IF (ENABLE_DRAFTS)
+    list(APPEND tests
+    )
+ENDIF (ENABLE_DRAFTS)
+
 # add location of platform.hpp for Windows builds
 if(WIN32)
     add_definitions(-DZMQ_CUSTOM_PLATFORM_HPP)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,7 +64,6 @@ set(tests
         test_stream_timeout
         test_xpub_manual
         test_xpub_welcome_msg
-        test_scatter_gather
 )
 if(NOT WIN32)
   list(APPEND tests
@@ -120,6 +119,7 @@ IF (ENABLE_DRAFTS)
         test_timers
         test_radio_dish
         test_udp
+        test_scatter_gather
     )
 ENDIF (ENABLE_DRAFTS)
 

--- a/tests/test_poller.cpp
+++ b/tests/test_poller.cpp
@@ -50,6 +50,7 @@ int main (void)
     void *bowl = zmq_socket (ctx, ZMQ_PULL);
     assert (bowl);
 
+#if defined(ZMQ_SERVER) && defined(ZMQ_CLIENT)
     void *server = zmq_socket (ctx, ZMQ_SERVER);
     assert (server);
     rc = zmq_bind (server, "tcp://127.0.0.1:55557");
@@ -57,6 +58,7 @@ int main (void)
 
     void *client = zmq_socket (ctx, ZMQ_CLIENT);
     assert (client);
+#endif
 
     //  Set up poller
     void* poller = zmq_poller_new ();
@@ -116,6 +118,7 @@ int main (void)
     assert (event.user_data == bowl);
     zmq_poller_remove_fd (poller, fd);
 
+#if defined(ZMQ_SERVER) && defined(ZMQ_CLIENT)
     //  Polling on thread safe sockets
     rc = zmq_poller_add (poller, server, NULL, ZMQ_POLLIN);
     assert (rc == 0);
@@ -138,6 +141,7 @@ int main (void)
     assert (event.socket == server);
     assert (event.user_data == NULL);
     assert (event.events == ZMQ_POLLOUT);
+#endif
 
     //  Destory poller, sockets and ctx
     rc = zmq_poller_destroy (&poller);
@@ -148,10 +152,12 @@ int main (void)
     assert (rc == 0);
     rc = zmq_close (bowl);
     assert (rc == 0);
+#if defined(ZMQ_SERVER) && defined(ZMQ_CLIENT)
     rc = zmq_close (server);
     assert (rc == 0);
     rc = zmq_close (client);
     assert (rc == 0);
+#endif
     rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 

--- a/tests/test_use_fd_ipc.cpp
+++ b/tests/test_use_fd_ipc.cpp
@@ -124,6 +124,7 @@ void test_pair ()
 
 void test_client_server ()
 {
+#if defined(ZMQ_SERVER) && defined(ZMQ_CLIENT)
     void *ctx = zmq_ctx_new ();
     assert (ctx);
 
@@ -200,6 +201,7 @@ void test_client_server ()
 
     rc = unlink ("/tmp/tester");
     assert (rc == 0);
+#endif
 }
 
 int main (void)

--- a/tests/test_use_fd_tcp.cpp
+++ b/tests/test_use_fd_tcp.cpp
@@ -130,6 +130,7 @@ void test_pair ()
 
 void test_client_server ()
 {
+#if defined(ZMQ_SERVER) && defined(ZMQ_CLIENT)
     void *ctx = zmq_ctx_new ();
     assert (ctx);
 
@@ -203,6 +204,7 @@ void test_client_server ()
 
     rc = zmq_ctx_term (ctx);
     assert (rc == 0);
+#endif
 }
 
 int main (void)

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -30,13 +30,13 @@
 #ifndef __TESTUTIL_HPP_INCLUDED__
 #define __TESTUTIL_HPP_INCLUDED__
 
-#include "../include/zmq.h"
-#include "../src/stdint.hpp"
 #if defined ZMQ_CUSTOM_PLATFORM_HPP
 #   include "platform.hpp"
 #else
 #   include "../src/platform.hpp"
 #endif
+#include "../include/zmq.h"
+#include "../src/stdint.hpp"
 
 //  This defines the settle time used in tests; raise this if we
 //  get test failures on slower systems due to binds/connects not


### PR DESCRIPTION
Solution: add DRAFT option to CMake and Autotools (see commits).
Fixes #1942 

Need help from the Windows gurus for VS201X and others :-)
Changed half the test runs to build with drafts, left some without to make sure we don't break anything.

Also tested building CZMQ against both with and without drafts, all looks good. Next, we need a way in zproject to support enable/disable of drafts in dependencies for CI jobs.

Besides zmq_pollers*/timers*/client/server/radio/dish/scatter/gather, other APIs that should be under DRAFT?