### PR TITLE
Problem: supported protocols comment is stale

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -381,7 +381,7 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 /*  0MQ socket events and monitoring                                          */
 /******************************************************************************/
 
-/*  Socket transport events (TCP and IPC only)                                */
+/*  Socket transport events (TCP, IPC and TIPC only)                          */
 
 #define ZMQ_EVENT_CONNECTED         0x0001
 #define ZMQ_EVENT_CONNECT_DELAYED   0x0002


### PR DESCRIPTION
**Solution:**
Fix it by aligning with the documentation; [zmq_socket_monitor(3)](http://api.zeromq.org/4-0:zmq-socket-monitor) outlines that ZeroMQ socket monitoring is supported for TCP, IPC and TIPC.