### PR TITLE
Problem: ZMQ_HAVE_TIPC option for CMake is broken

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,7 @@ endif (WITH_VMCI)
 
 if (ZMQ_HAVE_TIPC)
     add_definitions (-DZMQ_HAVE_TIPC)
-    list (APPEND cxx-source tipc_address.cpp tipc_connecter.cpp tipc_listener.cpp)
+    list (APPEND cxx-sources tipc_address.cpp tipc_connecter.cpp tipc_listener.cpp)
 endif (ZMQ_HAVE_TIPC)
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
**Solution:**
Fix it - there was a typo in the source list variable; it should be `cpp-sources` and not `cpp-source`.