### PR TITLE
Problem: No CMake option to set ZMQ_ACT_MILITANT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,11 @@ ELSE (ENABLE_DRAFTS)
     set (pkg_config_defines "")
 ENDIF (ENABLE_DRAFTS)
 
+option (WITH_MILITANT "Enable militant assertions" OFF)
+if (WITH_MILITANT)
+    add_definitions(-DZMQ_ACT_MILITANT)
+endif()
+
 set (POLLER "" CACHE STRING "Choose polling system. valid values are
                             kqueue, epoll, devpoll, poll or select [default=autodetect]")
 


### PR DESCRIPTION
**Solution:**
Add CMake option called `WITH_MILITANT` so that it aligns with the Autotools build infrastructure; enabling this option defines `ZMQ_ACT_MILITANT`, which enables assertions should malformed requests make their way into zmq_setsockopt(3) or zmq_getsockopt(3).