### PR TITLE
Problem: Not all ancillary API methods tested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ autom4te.cache
 .dirstamp
 .libs
 curve_keygen
+test_ancillaries
 test_heartbeats
 test_msg_ffn
 test_sockopt_hwm

--- a/Makefile.am
+++ b/Makefile.am
@@ -332,6 +332,7 @@ endif
 # tests
 #
 test_apps = \
+	tests/test_ancillaries \
 	tests/test_system \
 	tests/test_pair_inproc \
 	tests/test_pair_tcp \
@@ -396,6 +397,9 @@ test_apps = \
 	tests/test_heartbeats \
 	tests/test_stream_exceeds_buffer \
 	tests/test_pub_invert_matching
+
+tests_test_ancillaries_SOURCES = tests/test_ancillaries.cpp
+tests_test_ancillaries_LDADD = src/libzmq.la
 
 tests_test_system_SOURCES = tests/test_system.cpp
 tests_test_system_LDADD = src/libzmq.la

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION "2.8.1")
 PROJECT(tests)
 
 set(tests
+        test_ancillaries
         test_system
         test_pair_inproc
         test_pair_tcp

--- a/tests/test_ancillaries.cpp
+++ b/tests/test_ancillaries.cpp
@@ -1,0 +1,51 @@
+/*
+    Copyright (c) 2007-2016 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+ * File for adding tests for ancillary API methods and other miscellaenous
+ * API internals. Please ensure that when adding such tests into this file,
+ * that they are short-lived so they do not trigger timeouts in the
+ * CI build environments.
+ */
+
+#include "testutil.hpp"
+
+int main (void)
+{
+    int major, minor, patch;
+
+    zmq_version (&major, &minor, &patch);
+    assert (major == ZMQ_VERSION_MAJOR &&
+            minor == ZMQ_VERSION_MINOR &&
+            patch == ZMQ_VERSION_PATCH);
+
+    assert (zmq_strerror (EINVAL));
+
+    return 0;
+}


### PR DESCRIPTION
**Solution:**
- Add file for testing ancillary API methods and any misc internal machinery
- Add tests for zmq_version(3) and zmq_strerror(3)
- Add test file into gitignore, Autotools and CMake build files
- Increase test coverage

**Note:**
MSVC solution files not updated.