### PR TITLE
Problem: Deploying release artifacts to github is a manual process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,15 @@ env:
 
 matrix:
   exclude:
-    -  env: BUILD_TYPE=coverage CURVE=tweetnacl DRAFT=enabled
-       os: osx
-    -  env: BUILD_TYPE=valgrind CURVE=tweetnacl DRAFT=enabled
-       os: osx
+  - env: BUILD_TYPE=coverage CURVE=tweetnacl DRAFT=enabled
+    os: osx
+  - env: BUILD_TYPE=valgrind CURVE=tweetnacl DRAFT=enabled
+    os: osx
   include:
-    -  env: BUILD_TYPE=default CURVE=tweetnacl IPv6=ON
-       os: linux
-       dist: precise
-       sudo: false
+  - env: BUILD_TYPE=default CURVE=tweetnacl IPv6=ON
+    os: linux
+    dist: precise
+    sudo: false
 
 sudo: required
 
@@ -49,3 +49,19 @@ before_script:
 
 # Build and check this project according to the BUILD_TYPE
 script: ./ci_build.sh
+
+# Deploy tags
+before_deploy:
+- . ./ci_deploy.sh
+deploy:
+  provider: releases
+  api_key:
+    secure: vGB5E+A8wxm2J1GJZzmIgT9PrjEzvd9gE8iui8FyxSbxAsW9vFZFGZC/21sTtpVcmRarwQCHH1UEbtg+nJwN2iD9YzMRnSVks8xqP+b709YW+VXaMuhZgTzWa74IorQku7NuvLibvQk72/OSgdwPGaNJ6f5AX9pnWVWbEoW1svE=
+  file_glob: true
+  file: ${LIBZMQ_DEPLOYMENT}
+  skip_cleanup: true
+  on:
+    repo: zeromq/libzmq
+    branch: master
+    tags: true
+    condition: "$TRAVIS_OS_NAME =~ (linux) && $BUILD_TYPE =~ (default) && $CURVE =~ (libsodium) && -z $DRAFT"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -x
+set -e
 
 if [ $BUILD_TYPE == "default" ]; then
     mkdir tmp
@@ -29,7 +30,7 @@ if [ $BUILD_TYPE == "default" ]; then
         CONFIG_OPTS+=("--enable-drafts=yes")
     fi
 
-    #   Build and check this project
+    # Build and check this project
     (
         ./autogen.sh &&
         ./configure "${CONFIG_OPTS[@]}" &&

--- a/ci_deploy.sh
+++ b/ci_deploy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+
+if [[ $BUILD_TYPE == "default" && $CURVE == "libsodium" && -z $DRAFT ]]; then
+    # Tell travis to deploy all files in dist
+    mkdir dist
+    export LIBZMQ_DEPLOYMENT=dist/*
+    # Move archives to dist
+    mv *.tar.gz dist
+    mv *.zip dist
+    # Generate hash sums
+    cd dist
+    md5sum *.zip *.tar.gz > MD5SUMS
+    sha1sum *.zip *.tar.gz > SHA1SUMS
+    cd -
+else
+    export LIBZMQ_DEPLOYMENT=""
+fi


### PR DESCRIPTION
Solution: Use travis to deploy these artifacts automatically.

The deployment is triggered by tagging on the zeromq/libzmq repository.
Of the many builds travis is checking only the default one with
libsodium and drafts disabled is used for deployment.

For now the results of `make distcheck` are deployed as well as their
md5 and sha1 hash sums. Further changes may upload a generated
Changelog as well.