### PR TITLE
Problem: Coverage option broken with LLVM GCOV Frontend

### DIFF
--- a/m4/ax_code_coverage.m4
+++ b/m4/ax_code_coverage.m4
@@ -143,7 +143,14 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 		CODE_COVERAGE_CPPFLAGS="-DNDEBUG"
 		CODE_COVERAGE_CFLAGS="-O0 -g -fprofile-arcs -ftest-coverage"
 		CODE_COVERAGE_CXXFLAGS="-O0 -g -fprofile-arcs -ftest-coverage"
-		CODE_COVERAGE_LDFLAGS="-lgcov"
+
+		dnl Libgcov is not required for the LLVM GCOV frontend
+		case "`$GCOV -version`" in
+			*LLVM*)
+				CODE_COVERAGE_LDFLAGS="";;
+			*)
+				CODE_COVERAGE_LDFLAGS="-lgcov";;
+		esac
 
 		AC_SUBST([CODE_COVERAGE_CPPFLAGS])
 		AC_SUBST([CODE_COVERAGE_CFLAGS])


### PR DESCRIPTION
**Solution:**
This is an issue with the imported Autoconf M4 macro package for standardised code coverage builds, i.e. when using  `./configure --enable-code-coverage`.

The simplest way that I could find is to add a case statement that checks if the output of running `gcov -version` contains the "LLVM" keyword; if that is true then do not link with LIBGCOV as its neither required nor supported when using the GCOV frontend for LLVM; least not on Mac OS X. The case statement
would also be the most portable.

Moreover, using "-version" instead of "-v" for `$GCOV` seems to be the best bet as that is supported by the normal GCOV and the LLVM GCOV frontend.

**Upstream candidate** - this solution should be improved by Autoconf M4 macro overlords and applied to the upstream M4 package; I could not find a suitable way to detect if LLVM GCOV is being used, except for the solution herein; this should also work on *BSD too.