### PR TITLE
tipc: add support for address domain suffix

### DIFF
--- a/src/tipc_address.cpp
+++ b/src/tipc_address.cpp
@@ -59,8 +59,16 @@ int zmq::tipc_address_t::resolve (const char *name)
     unsigned int type = 0;
     unsigned int lower = 0;
     unsigned int upper = 0;
-
+    unsigned int z = 1, c = 0, n = 0;
+    char eof;
+    const char *domain;
     const int res = sscanf (name, "{%u,%u,%u}", &type, &lower, &upper);
+
+    /* Fetch optional domain suffix. */
+    if ((domain = strchr(name, '@'))) {
+        if (sscanf(domain, "@%u.%u.%u%c", &z, &c, &n, &eof) != 3)
+            return EINVAL;
+    }
     if (res == 3)
         goto nameseq;
     else
@@ -69,10 +77,7 @@ int zmq::tipc_address_t::resolve (const char *name)
         address.addrtype = TIPC_ADDR_NAME;
         address.addr.name.name.type = type;
         address.addr.name.name.instance = lower;
-        /* Since we can't specify lookup domain when connecting
-         * (and we're not sure that we want it to be configurable)
-         * Change from 'closest first' approach, to search entire zone */
-        address.addr.name.domain = tipc_addr (1, 0, 0);
+        address.addr.name.domain = tipc_addr (z, c, n);
         address.scope = 0;
         return 0;
     }

--- a/tests/test_connect_delay_tipc.cpp
+++ b/tests/test_connect_delay_tipc.cpp
@@ -60,10 +60,10 @@ int main (void)
     val = 0;
     zmq_setsockopt (from, ZMQ_LINGER, &val, sizeof (val));
     // This pipe will not connect
-    rc = zmq_connect (from, "tipc://{5556,0}");
+    rc = zmq_connect (from, "tipc://{5556,0}@0.0.0");
     assert (rc == 0);
     // This pipe will
-    rc = zmq_connect (from, "tipc://{6555,0}");
+    rc = zmq_connect (from, "tipc://{6555,0}@0.0.0");
     assert (rc == 0);
 
     // We send 10 messages, 5 should just get stuck in the queue
@@ -130,10 +130,10 @@ int main (void)
     assert (rc == 0);
 
     // Connect to the invalid socket
-    rc = zmq_connect (from, "tipc://{5561,0}");
+    rc = zmq_connect (from, "tipc://{5561,0}@0.0.0");
     assert (rc == 0);
     // Connect to the valid socket
-    rc = zmq_connect (from, "tipc://{5560,0}");
+    rc = zmq_connect (from, "tipc://{5560,0}@0.0.0");
     assert (rc == 0);
 
     // Send 10 messages, all should be routed to the connected pipe
@@ -185,7 +185,7 @@ int main (void)
     assert (rc == 0);
     rc = zmq_bind (backend, "tipc://{5560,0,0}");
     assert (rc == 0);
-    rc = zmq_connect (frontend, "tipc://{5560,0}");
+    rc = zmq_connect (frontend, "tipc://{5560,0}@0.0.0");
     assert (rc == 0);
 
     //  Ping backend to frontend so we know when the connection is up

--- a/tests/test_pair_tipc.cpp
+++ b/tests/test_pair_tipc.cpp
@@ -44,7 +44,7 @@ int main (void)
 
     void *sc = zmq_socket (ctx, ZMQ_PAIR);
     assert (sc);
-    rc = zmq_connect (sc, "tipc://{5560,0}");
+    rc = zmq_connect (sc, "tipc://{5560,0}@0.0.0");
     assert (rc == 0);
 
     bounce (sb, sc);

--- a/tests/test_reqrep_device_tipc.cpp
+++ b/tests/test_reqrep_device_tipc.cpp
@@ -49,13 +49,13 @@ int main (void)
     //  Create a worker.
     void *rep = zmq_socket (ctx, ZMQ_REP);
     assert (rep);
-    rc = zmq_connect (rep, "tipc://{5560,0}");
+    rc = zmq_connect (rep, "tipc://{5560,0}@0.0.0");
     assert (rc == 0);
 
     //  Create a client.
     void *req = zmq_socket (ctx, ZMQ_REQ);
     assert (req);
-    rc = zmq_connect (req, "tipc://{5561,0}");
+    rc = zmq_connect (req, "tipc://{5561,0}@0.0.0");
     assert (rc == 0);
 
     //  Send a request.

--- a/tests/test_reqrep_tipc.cpp
+++ b/tests/test_reqrep_tipc.cpp
@@ -43,7 +43,7 @@ int main (void)
 
     void *sc = zmq_socket (ctx, ZMQ_REQ);
     assert (sc);
-    rc = zmq_connect (sc, "tipc://{5560,0}");
+    rc = zmq_connect (sc, "tipc://{5560,0}@0.0.0");
     assert (rc == 0);
 
     bounce (sb, sc);

--- a/tests/test_shutdown_stress_tipc.cpp
+++ b/tests/test_shutdown_stress_tipc.cpp
@@ -37,7 +37,7 @@ extern "C"
     {
         int rc;
 
-        rc = zmq_connect (s, "tipc://{5560,0}");
+        rc = zmq_connect (s, "tipc://{5560,0}@0.0.0");
         assert (rc == 0);
 
         //  Start closing the socket while the connecting process is underway.

--- a/tests/test_sub_forward_tipc.cpp
+++ b/tests/test_sub_forward_tipc.cpp
@@ -49,13 +49,13 @@ int main (void)
     //  Create a publisher.
     void *pub = zmq_socket (ctx, ZMQ_PUB);
     assert (pub);
-    rc = zmq_connect (pub, "tipc://{5561,0}");
+    rc = zmq_connect (pub, "tipc://{5561,0}@0.0.0");
     assert (rc == 0);
 
     //  Create a subscriber.
     void *sub = zmq_socket (ctx, ZMQ_SUB);
     assert (sub);
-    rc = zmq_connect (sub, "tipc://{5560,0}");
+    rc = zmq_connect (sub, "tipc://{5560,0}@0.0.0");
     assert (rc == 0);
 
     //  Subscribe for all messages.

--- a/tests/test_term_endpoint_tipc.cpp
+++ b/tests/test_term_endpoint_tipc.cpp
@@ -34,7 +34,7 @@ int main (void)
     int rc;
     char buf[32];
     const char *ep = "tipc://{5560,0,0}";
-    const char *name = "tipc://{5560,0}";
+    const char *name = "tipc://{5560,0}@0.0.0";
 
     fprintf (stderr, "unbind endpoint test running...\n");
 


### PR DESCRIPTION
The TIPC protocol bindings in ZeroMQ defaults to a lookup domain
of 1.0.0 to prevent 'closest first' search, and instead always
do round robin if several sockets in the network or node have
the same name published. In retrospect, this might have been a
bad idea because it won't work on standalone configurations.
We solve this by allowing an optional domain suffix to be provided
in the address, and 0.0.0 should be used in that case, or if the
TIPC address range in the cluster configuration is defined to some
other value. Domain suffixes are only relevant for connecting
addresses.

Signed-off-by: Erik Hugne <erik.hugne@gmail.com>