### PR TITLE
Problem: scheduling parameters unused on OSX

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -28,6 +28,7 @@
 */
 
 #include "precompiled.hpp"
+#include "macros.hpp"
 #include "thread.hpp"
 #include "err.hpp"
 #include "platform.hpp"
@@ -73,6 +74,8 @@ void zmq::thread_t::stop ()
 void zmq::thread_t::setSchedulingParameters(int priority_, int schedulingPolicy_)
 {
     // not implemented
+    LIBZMQ_UNUSED (priority_);
+    LIBZMQ_UNUSED (schedulingPolicy_);
 }
 
 #else
@@ -144,12 +147,11 @@ void zmq::thread_t::setSchedulingParameters(int priority_, int schedulingPolicy_
 
     rc = pthread_setschedparam(descriptor, policy, &param);
     posix_assert (rc);
+#else
+
+    LIBZMQ_UNUSED (priority_);
+    LIBZMQ_UNUSED (schedulingPolicy_);
 #endif
 }
 
 #endif
-
-
-
-
-


### PR DESCRIPTION
**Solution:**
* Mark them with LIBZMQ_UNUSED macro as per convention; although in future the appropriate pthread code should be updated to support thread scheduling priorities.

* Removed some stray trailing whitespace as well.