### PR TITLE
Problem: No coverage for ctx termination errors

### DIFF
--- a/tests/test_ctx_destroy.cpp
+++ b/tests/test_ctx_destroy.cpp
@@ -50,7 +50,13 @@ void test_ctx_destroy()
     // Close the socket
     rc = zmq_close (socket);
     assert (rc == 0);
-    
+
+    // Test error - API has multiple ways to kill Contexts
+    rc = zmq_ctx_term (NULL);
+    assert (rc == -1 && errno == EFAULT);
+    rc = zmq_term (NULL);
+    assert (rc == -1 && errno == EFAULT);
+
     // Destroy the context
     rc = zmq_ctx_destroy (ctx);
     assert (rc == 0);
@@ -72,6 +78,10 @@ void test_ctx_shutdown()
 
     // Wait for thread to start up and block
     msleep (SETTLE_TIME);
+
+    // Test error - Shutdown context
+    rc = zmq_ctx_shutdown (NULL);
+    assert (rc == -1 && errno == EFAULT);
 
     // Shutdown context, if we used destroy here we would deadlock.
     rc = zmq_ctx_shutdown (ctx);


### PR DESCRIPTION
**Solution:**
- Add error state coverage for `zmq_ctx_term()`, `zmq_term()` and `zmq_ctx_shutdown()`; `zmq_ctx_destroy()` is already covered since it only calls `zmq_ctx_term()`
- Add coverage for `zmq_term()`