### PR TITLE
Problem: test send count too high for AppVeyor CI environment

### DIFF
--- a/tests/test_thread_safe.cpp
+++ b/tests/test_thread_safe.cpp
@@ -33,7 +33,7 @@
 void client_thread (void *client)
 {
     char data = 0;
-    for (int count = 0; count < 100000; count++) {
+    for (int count = 0; count < 15000; count++) {
         int rc = zmq_send (client, &data, 1, 0);
         assert (rc == 1);
     }


### PR DESCRIPTION
**Solution:**
Reduce send count in CLIENT/SERVER thread-safe socket test, so that it does not timeout on AppVeyor CI environment and older Windows boxes. The former is slow, uni-processor and resource constrained.