### PR TITLE
Problem: zmq_poller_destroy can segfault

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1110,8 +1110,9 @@ void *zmq_poller_new (void)
 
 int zmq_poller_destroy (void **poller_p_)
 {
-    void *poller = *poller_p_;
-    if (!poller || !((zmq::socket_poller_t*) poller)->check_tag ()) {
+    void *poller;
+    if (!poller_p_ || !(poller = *poller_p_) ||
+            !((zmq::socket_poller_t*) poller)->check_tag ()) {
         errno = EFAULT;
         return -1;
     }

--- a/tests/test_poller.cpp
+++ b/tests/test_poller.cpp
@@ -156,7 +156,15 @@ int main (void)
     rc = zmq_close (client);
     assert (rc == 0);
 #endif
-    rc = zmq_poller_destroy(&poller);
+
+    // Test error - null poller pointers
+    rc = zmq_poller_destroy (NULL);
+    assert (rc == -1 && errno == EFAULT);
+    void *null_poller = NULL;
+    rc = zmq_poller_destroy (&null_poller);
+    assert (rc == -1 && errno == EFAULT);
+
+    rc = zmq_poller_destroy (&poller);
     assert(rc == 0);
     rc = zmq_ctx_term (ctx);
     assert (rc == 0);


### PR DESCRIPTION
**Solution:**
- Add checks for `**poller_p_` parameter to ensure that the function does not segfault when either it or the value within it are NULL
- Add tests for the above and increase error state coverage