### PR TITLE
Problem: no function to derive public key from curve secret.

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -465,9 +465,13 @@ ZMQ_EXPORT char *zmq_z85_encode (char *dest, const uint8_t *data, size_t size);
 /*  Decode data with Z85 encoding. Returns decoded data                       */
 ZMQ_EXPORT uint8_t *zmq_z85_decode (uint8_t *dest, const char *string);
 
-/*  Generate z85-encoded public and private keypair with libsodium.           */
+/*  Generate z85-encoded public and private keypair with tweetnacl/libsodium. */
 /*  Returns 0 on success.                                                     */
 ZMQ_EXPORT int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key);
+
+/*  Derive the z85-encoded public key from the z85-encoded secret key.        */
+/*  Returns 0 on success.                                                     */
+ZMQ_EXPORT int zmq_curve_public (char *z85_public_key, const char *z85_secret_key);
 
 /******************************************************************************/
 /*  Atomic utility methods                                                    */

--- a/src/tweetnacl.h
+++ b/src/tweetnacl.h
@@ -60,6 +60,7 @@ int crypto_box_open_afternm(u8 *m,const u8 *c,u64 d,const u8 *n,const u8 *k);
 int crypto_box(u8 *c,const u8 *m,u64 d,const u8 *n,const u8 *y,const u8 *x);
 int crypto_box_open(u8 *m,const u8 *c,u64 d,const u8 *n,const u8 *y,const u8 *x);
 int crypto_box_beforenm(u8 *k,const u8 *y,const u8 *x);
+int crypto_scalarmult_base(u8 *q,const u8 *n);
 int crypto_secretbox(u8 *c,const u8 *m,u64 d,const u8 *n,const u8 *k);
 int crypto_secretbox_open(u8 *m,const u8 *c,u64 d,const u8 *n,const u8 *k);
 #ifdef __cplusplus


### PR DESCRIPTION
The lack of a public function to derive the public key from a curve secret key requires that both keys be preserved together indefinitely. This is a "truth in two places" problem when it comes to configuration, especially if one is not using "certificate" files. Making matters worse, there is no straightforward way to validate that a given public key correctly corresponds to a given secret key. This change allows a secret key to be retained alone and for an application to derive the corresponding public key as needed.