### PR TITLE
Windows Subsystem for Linux compatibility fix

### DIFF
--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -183,6 +183,14 @@ int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_
     //  Get the addresses.
     ifaddrs *ifa = NULL;
     const int rc = getifaddrs (&ifa);
+    if (rc != 0 && errno == EINVAL) {
+        // Windows Subsystem for Linux compatibility
+        LIBZMQ_UNUSED (nic_);
+        LIBZMQ_UNUSED (ipv6_);
+
+        errno = ENODEV;
+        return -1;
+    }
     errno_assert (rc == 0);
     zmq_assert (ifa != NULL);
 


### PR DESCRIPTION
On systems where getifaddrs() exists but isn't implemented, behave as if 'resolve_nic_name()' were entirely unsupported.

This is a fix for jupyter/notebook#1331 and a workaround for Microsoft/BashOnWindows#185 .  It's not exactly a beautiful solution, and it's probable that the Bash-on-Windows folks will have fixed the root cause of this problem before they next pull in the latest build of ZeroMQ.  I certainly wouldn't object if you declined this PR on those grounds.  But I wrote the fix, and it works, so I figure I might as well share it.