### PR TITLE
[RFC] Problem: there is no fine grained way to setup unix sockets in libzmq

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -298,6 +298,11 @@ src_libzmq_la_CPPFLAGS += ${pgm_CFLAGS}
 src_libzmq_la_LIBADD += ${pgm_LIBS}
 endif
 
+if HAVE_SYSTEMD
+src_libzmq_la_CPPFLAGS += ${libsystemd_CFLAGS}
+src_libzmq_la_LIBADD += ${libsystemd_LIBS}
+endif
+
 if ENABLE_PERF
 noinst_PROGRAMS = \
 	perf/local_lat \

--- a/configure.ac
+++ b/configure.ac
@@ -530,6 +530,26 @@ fi
 
 AM_CONDITIONAL(HAVE_VMCI, test "x$have_vmci_ext" != "xno")
 
+# build with libsystemd support
+have_systemd_library="no"
+AC_ARG_WITH([systemd], [AS_HELP_STRING([--with-systemd],
+            [build libzmq with systemd socket activation (experimental) [default=no]])],
+            [with_systemd_ext=$withval],
+            [with_systemd_ext=no])
+
+# conditionally require libsystemd package
+if test "x$with_systemd_ext" != "xno"; then
+    PKG_CHECK_MODULES([libsystemd], [libsystemd >= 200], [ have_systemd_library="yes" ],
+        AC_MSG_ERROR(libsystemd is not installed. Install it, then run configure again)
+        ])
+fi
+
+if test "x$have_systemd_library" = "xyes"; then
+    AC_DEFINE(ZMQ_HAVE_SYSTEMD, [1], [Have systemd support])
+fi
+
+AM_CONDITIONAL(HAVE_SYSTEMD, test "x$have_systemd_library" = "xyes")
+
 # Set -Wall, -Werror and -pedantic
 AC_LANG_PUSH([C++])
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -77,6 +77,10 @@
 #include "pgm_socket.hpp"
 #endif
 
+#if defined ZMQ_HAVE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #include "pair.hpp"
 #include "pub.hpp"
 #include "sub.hpp"
@@ -503,6 +507,30 @@ int zmq::socket_base_t::add_signaler(signaler_t *s_)
     return 0;
 }
 
+#if defined ZMQ_HAVE_SYSTEMD
+static int s_open_socket_sd (int domain_, int type_, int protocol_)
+{
+
+    static int listen_fds = -1;
+    static int fd = SD_LISTEN_FDS_START;
+
+    if (listen_fds == -1)
+        listen_fds = sd_listen_fds (1);
+
+    errno_assert (listen_fds >= 0);
+
+    // we don't have LISTEN_FDS or we run out of created sockets
+    if (listen_fds == 0 || fd >= (SD_LISTEN_FDS_START + listen_fds))
+        return 0;
+
+    //TODO: check more properties of the socket??
+    if (sd_is_socket (fd, domain_, type_, -1) <= 0)
+        return -1;
+
+    return fd++;
+}
+#endif
+
 int zmq::socket_base_t::remove_signaler(signaler_t *s_)
 {
     ENTER_MUTEX ();
@@ -543,6 +571,24 @@ int zmq::socket_base_t::bind (const char *addr_)
         EXIT_MUTEX ();
         return -1;
     }
+
+#if defined ZMQ_HAVE_SYSTEMD
+    //  Aquire listening socket from systemd - unless use_fd is already specified
+    if (options.use_fd == -1 && protocol == "ipc") {
+
+       int fd = s_open_socket_sd (AF_UNIX, SOCK_STREAM, 0);
+       // TODO: do we want to call sd_is function to check if the socket is the expected one?
+       if (fd > 0) {
+           int r = setsockopt (ZMQ_USE_FD, &fd, sizeof (fd));
+           errno_assert (r != -1);
+       }
+       else
+       if (fd == -1) {
+           EXIT_MUTEX ();
+           return -1;
+       }
+    }
+#endif
 
     if (protocol == "inproc") {
         const endpoint_t endpoint = { this, options };


### PR DESCRIPTION
Solution: use systemd socket activation to solve the problem at least on
Linux with systemd.

The support is limited to ipc transport atm.

Inspiration comes from zeromq-devel Setting privileges on a UNIX socket

Tested on malamute broker (ROUTER socket + ipc transport)