### PR TITLE
Problem: std:vector.data breaks compat with C++98

### DIFF
--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -100,7 +100,7 @@ int zmq::ipc_listener_t::create_wildcard_address(std::string& path_,
 
     // We need room for tmp_path + trailing NUL
     std::vector<char> buffer(tmp_path.length()+1);
-    strcpy(buffer.data(), tmp_path.c_str());
+    strcpy (&buffer[0], tmp_path.c_str ());
 
 #ifdef HAVE_MKDTEMP
     // Create the directory.  POSIX requires that mkdtemp() creates the
@@ -109,22 +109,22 @@ int zmq::ipc_listener_t::create_wildcard_address(std::string& path_,
     // each socket is created in a directory created by mkdtemp(), and
     // mkdtemp() guarantees a unique directory name, there will be no
     // collision.
-    if ( mkdtemp(buffer.data()) == 0 ) {
+    if (mkdtemp (&buffer[0]) == 0) {
         return -1;
     }
 
-    path_.assign(buffer.data());
+    path_.assign (&buffer[0]);
     file_.assign (path_ + "/socket");
 #else
     // Silence -Wunused-parameter. #pragma and __attribute__((unused)) are not
     // very portable unfortunately...
     (void) path_;
-    int fd = mkstemp (buffer.data());
+    int fd = mkstemp (&buffer[0]);
     if (fd == -1)
          return -1;
     ::close (fd);
 
-    file_.assign (buffer.data());
+    file_.assign (&buffer[0]);
 #endif
 
     return 0;


### PR DESCRIPTION
Solution: use buffer address instead

@somdoron - as we discussed on Saturday, this fixes the build with compilers that don't support C++11, for example on Solaris.