### PR TITLE
Poll() implementation for Windows Vista+

### DIFF
--- a/builds/msvc/vs2015/libzmq/libzmq.props
+++ b/builds/msvc/vs2015/libzmq/libzmq.props
@@ -21,13 +21,15 @@
       <EnablePREfast>false</EnablePREfast>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>precompiled.hpp</PrecompiledHeaderFile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;FD_SETSIZE=16384;WIN32_LEAN_AND_MEAN;ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;FD_SETSIZE=16384;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-tweet)' == 'true'">ZMQ_USE_TWEETNACL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-sodium)' == 'true'">ZMQ_USE_LIBSODIUM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-tweet)' == 'true' Or '$(Option-sodium)' == 'true'">ZMQ_HAVE_CURVE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-openpgm)' == 'true'">ZMQ_HAVE_OPENPGM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-gssapi)' == 'true'">HAVE_LIBGSSAPI_KRB5;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Option-draftapi)' == 'true'">ZMQ_BUILD_DRAFT_API;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Option-usepoll)' == 'true'">ZMQ_USE_POLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Option-usepoll)' != 'true'">ZMQ_USE_SELECT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'StaticLibrary'">ZMQ_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -64,6 +66,7 @@
     <Message Text="Option-openpgm    : $(Option-openpgm)" Importance="high"/>
     <Message Text="Option-gssapi     : $(Option-gssapi)" Importance="high"/>
     <Message Text="Option-draftapi   : $(Option-draftapi)" Importance="high"/>
+    <Message Text="Option-usepoll    : $(Option-usepoll)" Importance="high"/>
   </Target>
 
   <Target Name="LinkageInfo" BeforeTargets="PrepareForBuild">

--- a/builds/msvc/vs2015/libzmq/libzmq.xml
+++ b/builds/msvc/vs2015/libzmq/libzmq.xml
@@ -7,6 +7,7 @@
       <Category Name="openpgm" DisplayName="openpgm" />
       <Category Name="gssapi" DisplayName="gssapi" />
       <Category Name="draftapi" DisplayName="draftapi" />
+      <Category Name="usepoll" DisplayName="usepoll" />
     </Rule.Categories>
     <Rule.DataSource>
       <DataSource Persistence="ProjectFile" ItemType="" />
@@ -28,6 +29,10 @@
       <EnumValue Name="true" DisplayName="Yes" />
     </EnumProperty>
     <EnumProperty Name="Option-draftapi" DisplayName="Enable Draft API" Description="Enable Draft API build option" Category="draftapi">
+      <EnumValue Name="" DisplayName="No" />
+      <EnumValue Name="true" DisplayName="Yes" />
+    </EnumProperty>
+    <EnumProperty Name="Option-usepoll" DisplayName="Enable poll() usage (Vista+ only)" Description="Use poll() instead of select() for waiting on incoming data. Increases performance, but the binary will only run on Windows Vista or later." Category="usepoll">
       <EnumValue Name="" DisplayName="No" />
       <EnumValue Name="true" DisplayName="Yes" />
     </EnumProperty>

--- a/src/poll.cpp
+++ b/src/poll.cpp
@@ -94,25 +94,25 @@ void zmq::poll_t::rm_fd (handle_t handle_)
 
 void zmq::poll_t::set_pollin (handle_t handle_)
 {
-    int index = fd_table [handle_].index;
+    fd_t index = fd_table [handle_].index;
     pollset [index].events |= POLLIN;
 }
 
 void zmq::poll_t::reset_pollin (handle_t handle_)
 {
-    int index = fd_table [handle_].index;
+    fd_t index = fd_table [handle_].index;
     pollset [index].events &= ~((short) POLLIN);
 }
 
 void zmq::poll_t::set_pollout (handle_t handle_)
 {
-    int index = fd_table [handle_].index;
+    fd_t index = fd_table [handle_].index;
     pollset [index].events |= POLLOUT;
 }
 
 void zmq::poll_t::reset_pollout (handle_t handle_)
 {
-    int index = fd_table [handle_].index;
+    fd_t index = fd_table [handle_].index;
     pollset [index].events &= ~((short) POLLOUT);
 }
 

--- a/src/poll.cpp
+++ b/src/poll.cpp
@@ -32,8 +32,10 @@
 #if defined ZMQ_USE_POLL
 
 #include <sys/types.h>
+#if !defined ZMQ_HAVE_WINDOWS
 #include <sys/time.h>
 #include <poll.h>
+#endif
 #include <algorithm>
 
 #include "poll.hpp"

--- a/src/poll.hpp
+++ b/src/poll.hpp
@@ -34,7 +34,9 @@
 #include "poller.hpp"
 #if defined ZMQ_USE_POLL
 
+#if !defined ZMQ_HAVE_WINDOWS
 #include <poll.h>
+#endif
 #include <stddef.h>
 #include <vector>
 

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -37,7 +37,7 @@
 //  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'
 //  instead of 'events' and 'revents' and defines macros to map from POSIX-y
 //  names to AIX-specific names).
-#if defined ZMQ_POLL_BASED_ON_POLL
+#if defined ZMQ_POLL_BASED_ON_POLL && !defined ZMQ_HAVE_WINDOWS
 #include <poll.h>
 #endif
 

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -35,7 +35,9 @@
 //  instead of 'events' and 'revents' and defines macros to map from POSIX-y
 //  names to AIX-specific names).
 #if defined ZMQ_POLL_BASED_ON_POLL
+#if !defined ZMQ_HAVE_WINDOWS
 #include <poll.h>
+#endif
 #elif defined ZMQ_POLL_BASED_ON_SELECT
 #if defined ZMQ_HAVE_WINDOWS
 #elif defined ZMQ_HAVE_HPUX

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -32,7 +32,7 @@
 
 #include "poller.hpp"
 
-#if defined ZMQ_POLL_BASED_ON_POLL
+#if defined ZMQ_POLL_BASED_ON_POLL && !defined ZMQ_HAVE_WINDOWS
 #include <poll.h>
 #endif
 

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -79,6 +79,10 @@ struct tcp_keepalive {
 #include <process.h>
 #endif
 
+#if ZMQ_USE_POLL
+static inline int poll(struct pollfd *pfd, unsigned long nfds, int timeout) { return WSAPoll(pfd, nfds, timeout); }
+#endif
+
 //  In MinGW environment AI_NUMERICSERV is not defined.
 #ifndef AI_NUMERICSERV
 #define AI_NUMERICSERV 0x0400

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -36,7 +36,7 @@
 //  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'
 //  instead of 'events' and 'revents' and defines macros to map from POSIX-y
 //  names to AIX-specific names).
-#if defined ZMQ_POLL_BASED_ON_POLL
+#if defined ZMQ_POLL_BASED_ON_POLL && !defined ZMQ_HAVE_WINDOWS
 #include <poll.h>
 #endif
 


### PR DESCRIPTION
Provide poll() for Windows as well. This is a build option that defaults to off as the resulting binary will only run on Windows Vista or newer.

This is not tested with alternative Winsock service providers like VMCI, but the documentation for WSAPoll does not mention limitations.

On my local machine, throughput improves by ~10 % (20 simultaneous remote_thr workes to one local_thr, 10 byte messages), while latency improves by ~30 % (measured with remote/local_lat).