### PR TITLE
Copy instead of reference to a vector that gets reallocated.

### DIFF
--- a/src/select.cpp
+++ b/src/select.cpp
@@ -312,7 +312,7 @@ void zmq::select_t::loop ()
 
             //  Size is cached to avoid iteration through recently added descriptors.
             for (fd_entries_t::size_type i = 0, size = family_entry.fd_entries.size (); i < size && rc > 0; ++i) {
-                fd_entry_t& fd_entry = family_entry.fd_entries [i];
+                fd_entry_t fd_entry = family_entry.fd_entries [i];
 
                 if (fd_entry.fd == retired_fd)
                     continue;


### PR DESCRIPTION
One more time, with a clean history.

`family_entry.fd_entries` is a `std::vector`. The code was taking a reference to the ith element, which wouldn't be so bad, except that sometimes the vector is full. A few lines down `fd_entry.events->in_event ();` can add an element to `fd_entries`. If it's full, then the whole vector is re-allocated. If the new vector isn't on the same address as the original the reference refers to invalid memory.

I changed the code so `fd_entry` is a copy of the ith element and it will be valid throughout the for loop.