### PR TITLE
Send manual unsubscriptions on pipe termination in XPUB

### DIFF
--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -79,6 +79,9 @@ namespace zmq
         //  List of all subscriptions mapped to corresponding pipes.
         mtrie_t subscriptions;
 
+        //  List of manual subscriptions mapped to corresponding pipes.
+        mtrie_t manual_subscriptions;
+
         //  Distributor of messages holding the list of outbound pipes.
         dist_t dist;
 


### PR DESCRIPTION
Currently unsubscriptions sent by XPUB in manual mode on pipe termination are in terms of topics, which is different from explicit unsubscriptions sent by client (some custom format). This change stores manual subscriptions in XPUB and sends them on pipe termination to make behaviour consistent.