### PR TITLE
Problem: parameter %1 set hard to build target and prevents the skipp…

### DIFF
--- a/builds/msvc/build/build.bat
+++ b/builds/msvc/build/build.bat
@@ -31,8 +31,3 @@ set STOPTIME=%DATE% %TIME%
 
 :done
 @endlocal
-
-if NOT %1 == "" if /I %1 == "skip_pause" goto :quit
-
-PAUSE
-:quit


### PR DESCRIPTION
 Problem: parameter %1 set hard to build target and prevents the skipping of Pause

Solution: removed Pause, because it is not necessary and original code remains
 