### PR TITLE
Problem: getifaddrs can fail with ECONNREFUSED

### DIFF
--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -182,7 +182,16 @@ int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_
 {
     //  Get the addresses.
     ifaddrs *ifa = NULL;
-    const int rc = getifaddrs (&ifa);
+    int rc;
+    const int max_attempts = 10;
+    const int backoff_msec = 1;
+    for (int i = 0; i < max_attempts; i++) {
+        rc = getifaddrs (&ifa);
+        if (rc == 0 || (rc < 0 && errno != ECONNREFUSED))
+            break;
+        usleep ((backoff_msec << i) * 1000);
+    }
+
     if (rc != 0 && errno == EINVAL) {
         // Windows Subsystem for Linux compatibility
         LIBZMQ_UNUSED (nic_);


### PR DESCRIPTION
getifaddrs() can fail transiently with ECONNREFUSED on Linux.
This has been observed with Linux 3.10 when multiple processes
call zmq::tcp_address_t::resolve_nic_name() simultaneously.

Before asserting in this case, make 10 attempts, with exponential
backoff, given by (1 msec * 2^i), where i is the attempt number.

Fixes #2051