### PR TITLE
Problem: Travis CI OSX builds are broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ addons:
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" ] ; then brew update; brew install binutils ; fi
+# workaround for Travis OSX CI bug, hasn't been fixed in a month so time for a hack
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then brew uninstall libtool && brew install libtool ; fi
 
 before_script:
 # ZMQ stress tests need more open socket (files) than the usual default


### PR DESCRIPTION
Solution: add a workaround to reinstall libtool. Travis hasn't fixed
the issue in a month, so time for a little hack until they sort it.