### PR TITLE
Avoid race condition with accept4 where available (ticket #956)

### DIFF
--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -273,7 +273,11 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
 #else
     socklen_t ss_len = sizeof (ss);
 #endif
+#if defined ZMQ_HAVE_SOCK_CLOEXEC
+    fd_t sock = ::accept4 (s, (struct sockaddr *) &ss, &ss_len, SOCK_CLOEXEC);
+#else
     fd_t sock = ::accept (s, (struct sockaddr *) &ss, &ss_len);
+#endif
 
 #ifdef ZMQ_HAVE_WINDOWS
     if (sock == INVALID_SOCKET) {
@@ -299,9 +303,9 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
     }
 #endif
 
+#if !defined ZMQ_HAVE_SOCK_CLOEXEC && defined FD_CLOEXEC
     //  Race condition can cause socket not to be closed (if fork happens
     //  between accept and this point).
-#ifdef FD_CLOEXEC
     int rc = fcntl (sock, F_SETFD, FD_CLOEXEC);
     errno_assert (rc != -1);
 #endif


### PR DESCRIPTION
Linux provides accept4(2) which will return a socket with FD_CLOEXEC set
when called with the SOCK_CLOEXEC flag. So call this when available and
fall back to fcntl(..., FD_CLOEXEC) if not.