### PR TITLE
Problem: OBS compress not available on CentOS

### DIFF
--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -72,13 +72,13 @@
     <param name="outfilename">debian.libzmq5.install</param>
   </service>
 
+  <service name="set_version">
+    <param name="basename">zeromq</param>
+  </service>
+
   <service name="recompress">
     <param name="file">*.tar</param>
     <param name="compression">gz</param>
-  </service>
-
-  <service name="set_version">
-    <param name="basename">zeromq</param>
   </service>
 </services>
 

--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -72,8 +72,8 @@
     <param name="outfilename">debian.libzmq5.install</param>
   </service>
 
-  <service name="recompress" mode="buildtime">
-    <param name="file">zeromq-*.tar</param>
+  <service name="recompress">
+    <param name="file">*.tar</param>
     <param name="compression">gz</param>
   </service>
 


### PR DESCRIPTION
Solution: run the obs-service-compress at service time rather than
buildtime