### PR TITLE
Problem: zmq_stream doc is confusing regarding ZMQ_SNDMORE flag

### DIFF
--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -406,11 +406,8 @@ When a connection is made, a zero-length message will be received by the
 application.  Similarly, when the peer disconnects (or the connection is lost),
 a zero-length message will be received by the application.
 
-The ZMQ_SNDMORE flag is ignored on data frames. You must send one identity frame
-followed by one data frame.
-
-Also, please note that omitting the ZMQ_SNDMORE flag will prevent sending further
-data (from any client) on the same socket.
+You must send one identity frame followed by one data frame. The ZMQ_SNDMORE
+flag is required for identity frames but is ignored on data frames.
 
 [horizontal]
 .Summary of ZMQ_STREAM characteristics
@@ -583,12 +580,10 @@ while (1) {
 		"Hello, World!";
 	/* Sends the ID frame followed by the response */
 	zmq_send (socket, id, id_size, ZMQ_SNDMORE);
-	zmq_send (socket, http_response, strlen (http_response), ZMQ_SNDMORE);
+	zmq_send (socket, http_response, strlen (http_response), 0);
 	/* Closes the connection by sending the ID frame followed by a zero response */
 	zmq_send (socket, id, id_size, ZMQ_SNDMORE);
-	zmq_send (socket, 0, 0, ZMQ_SNDMORE);
-	/* NOTE: If we don't use ZMQ_SNDMORE, then we won't be able to send more */
-	/* message to any client */
+	zmq_send (socket, 0, 0, 0);
 }
 zmq_close (socket);
 zmq_ctx_destroy (ctx);


### PR DESCRIPTION
Solution: fix it.

The documentation first states that the ZMQ_SNDMORE flag is ignored on
data frames. Then it states that omitting the ZMQ_SNDMORE flag has
consequences. The example HTTP server code further muddies the situation
with a similar comment.

The implementation of ZMQ_STREAM only accepts two-part messages.
The first part is an identity frame while the second and last part is
the data frame.

As with any multipart message, all parts except the last need the
ZMQ_SNDMORE flag. The second and last part would normally omit the
ZMQ_SNDMORE flag to mark the end of the multipart message.

However, the ZMQ_STREAM implementation ignores the ZMQ_SNDMORE flag on
the data frame rather than requiring that it be omitted. The latter
behaviour would have been more consistent with the other ZeroMQ
sockets.