### PR TITLE
Problem: tests should not create 2 ZMQ contexts

### DIFF
--- a/tests/test_unbind_wildcard.cpp
+++ b/tests/test_unbind_wildcard.cpp
@@ -22,9 +22,9 @@
 int main (void)
 {
     setup_test_environment();
-    int ipv6 = is_ipv6_available ();
     void *ctx = zmq_ctx_new ();
     assert (ctx);
+    int ipv6 = is_ipv6_available ();
 
     /* Address wildcard, IPv6 disabled */
     void *sb = zmq_socket (ctx, ZMQ_REP);

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -339,10 +339,6 @@ is_ipv6_available(void)
     inet_pton (AF_INET6, "::1", &(test_addr.sin6_addr));
 
 #ifdef ZMQ_HAVE_WINDOWS
-    // initialize network stack
-    void *ctx = zmq_ctx_new();
-    assert(ctx);
-
     SOCKET fd = socket (AF_INET6, SOCK_STREAM, IPPROTO_IP);
     if (fd == INVALID_SOCKET)
         ipv6 = 0;
@@ -358,9 +354,6 @@ is_ipv6_available(void)
         }
         closesocket (fd);
     }
-
-    rc = zmq_ctx_term(ctx);
-    assert(rc == 0);
 #else
     int fd = socket (AF_INET6, SOCK_STREAM, IPPROTO_IP);
     if (fd == -1)


### PR DESCRIPTION
Solution: call is_ipv6_available after the context is created to avoid issues on Windows instead of having 2 contexts at the same time