### PR TITLE
[gssapi] memory allocation mismatch on windows

### DIFF
--- a/src/gssapi_mechanism_base.cpp
+++ b/src/gssapi_mechanism_base.cpp
@@ -181,7 +181,7 @@ int zmq::gssapi_mechanism_base_t::decode_message (msg_t *msg_)
     memcpy (msg_->data (), static_cast <char *> (plaintext.value)+1, plaintext.length-1);
 
     gss_release_buffer (&min_stat, &plaintext);
-    gss_release_buffer (&min_stat, &wrapped);
+    free(wrapped.value);
 
     if (bytes_left > 0) {
         errno = EPROTO;


### PR DESCRIPTION
The gssapi has some helper functions gssalloc_malloc()/gssalloc_free()
which on windows doesn't call malloc()/free(). Instead these are
wrappers around HeapAlloc() and HeapFree(). To complicate matters
gssapi doesn't export these helper functions, so you're left using
the allocation method of your choice.

See Here:
https://github.com/krb5/krb5/blob/89683d1f135765e91041f3a239af865b11aaf86b/src/lib/gssapi/generic/gssapi_alloc.h

The zmq gssapi implementation is calling malloc and then calling
gss_release_buffer() to free the memory. gss_release_buffer uses
gssalloc_free() to free this buffer which on windows calls HeapFree()
instead of free(). This causes an access violation on windows.