### PR TITLE
Problem: testutil.hpp fails to build on Windows XP

### DIFF
--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -331,6 +331,9 @@ msleep (int milliseconds)
 int
 is_ipv6_available(void)
 {
+#if defined (ZMQ_HAVE_WINDOWS) && (_WIN32_WINNT < 0x0600)
+    return 0;
+#else
     int rc, ipv6 = 1;
     struct sockaddr_in6 test_addr;
 
@@ -373,6 +376,7 @@ is_ipv6_available(void)
 #endif
 
     return ipv6;
+#endif // _WIN32_WINNT < 0x0600
 }
 
 #endif


### PR DESCRIPTION
Solution: ifdef is_ipv6_available to always return false if building
on Windows XP, as it doesn't support the needed standard libc
functions

Fixes #2091 