### PR TITLE
Problem: CMake build from dist tarball broken

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -786,6 +786,8 @@ EXTRA_DIST = \
 	version.sh	\
 	src/libzmq.pc.cmake.in \
 	src/libzmq.vers \
+	src/version.rc.in \
+	tests/CMakeLists.txt \
 	tools/curve_keygen.cpp
 
 MAINTAINERCLEANFILES = \


### PR DESCRIPTION
Solution: include src/version.rc.in and tests/CMakeLists.txt in the
make dist tarball by adding them to makefile.am EXTRA_DIST list.

Fixes #2096 