### PR TITLE
Problem: Missing newline in printf statement

### DIFF
--- a/tests/test_system.cpp
+++ b/tests/test_system.cpp
@@ -86,9 +86,9 @@ int main (void)
             printf ("W: Only able to create %d sockets on this box\n", count);
             printf ("I: Tune your system to increase maximum allowed file handles\n");
 #if defined (ZMQ_HAVE_OSX)
-            printf ("I: On OS/X, run 'ulimit -n 1200' in bash");
+            printf ("I: On OS/X, run 'ulimit -n 1200' in bash\n");
 #elif defined (ZMQ_HAVE_LINUX)
-            printf ("I: On Linux, run 'ulimit -n 1200' in bash");
+            printf ("I: On Linux, run 'ulimit -n 1200' in bash\n");
 #endif        
             return -1;
         }


### PR DESCRIPTION
Solution: Add "\n" at end of format string.