### PR TITLE
Problem: MinGW cross compile is failed on Linux

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,6 +65,7 @@ Joe Thornber
 Jon Dyte
 Kamil Shakirov
 Ken Steele
+Kouhei Sutou
 Laurent Alebarde
 Leonardo J. Consoni
 Lourens Naudé

--- a/src/tweetnacl.c
+++ b/src/tweetnacl.c
@@ -852,7 +852,7 @@ int crypto_sign_open(u8 *m,u64 *mlen,const u8 *sm,u64 n,const u8 *pk)
 #ifdef ZMQ_HAVE_WINDOWS
 
 #include <windows.h>
-#include <WinCrypt.h>
+#include <wincrypt.h>
 
 #define NCP ((HCRYPTPROV) 0)
 


### PR DESCRIPTION
Solution: Use only lower case for header file name.

We can find "wincrypt.h" by "WinCrypt.h" on Windows because Windows uses
case insensitive file system. But we can't find "wincrypt.h" by
"WinCrypt.h" on Linux Because Linux uses case sensitive file system.