### PR TITLE
Problem: documentation markup unrecognized

### DIFF
--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -465,7 +465,7 @@ Applicable socket types:: all, when using TCP or IPC transports
 
 
 ZMQ_USE_FD: Retrieve the pre-allocated socket file descriptor
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_USE_FD' option shall retrieve the pre-allocated file
 descriptor that has been assigned to a ZMQ socket, if any. -1 shall be
 returned if a pre-allocated file descriptor was not set for the socket.


### PR DESCRIPTION
The effect can be seen on http://api.zeromq.org/4-2:zmq-getsockopt at
options ZMQ_USE_FD and ZMQ_RATE.

Solution: fix length of squiggly line under option title (I guess)