### PR TITLE
Problem: Pub socket crashes on client disconnect. 

### DIFF
--- a/src/select.cpp
+++ b/src/select.cpp
@@ -309,29 +309,28 @@ void zmq::select_t::loop ()
 
             //  Size is cached to avoid iteration through recently added descriptors.
             for (fd_entries_t::size_type i = 0, size = family_entry.fd_entries.size (); i < size && rc > 0; ++i) {
-                fd_entry_t fd_entry = family_entry.fd_entries [i];
 
-                if (fd_entry.fd == retired_fd)
+                if (family_entry.fd_entries[i].fd == retired_fd)
                     continue;
 
-                if (FD_ISSET (fd_entry.fd, &local_fds_set.read)) {
-                    fd_entry.events->in_event ();
+                if (FD_ISSET(family_entry.fd_entries[i].fd, &local_fds_set.read)) {
+                    family_entry.fd_entries[i].events->in_event();
                     --rc;
                 }
 
-                if (fd_entry.fd == retired_fd || rc == 0)
+                if (family_entry.fd_entries[i].fd == retired_fd || rc == 0)
                     continue;
 
-                if (FD_ISSET (fd_entry.fd, &local_fds_set.write)) {
-                    fd_entry.events->out_event ();
+                if (FD_ISSET(family_entry.fd_entries[i].fd, &local_fds_set.write)) {
+                    family_entry.fd_entries[i].events->out_event();
                     --rc;
                 }
 
-                if (fd_entry.fd == retired_fd || rc == 0)
+                if (family_entry.fd_entries[i].fd == retired_fd || rc == 0)
                     continue;
 
-                if (FD_ISSET (fd_entry.fd, &local_fds_set.error)) {
-                    fd_entry.events->in_event ();
+                if (FD_ISSET(family_entry.fd_entries[i].fd, &local_fds_set.error)) {
+                    family_entry.fd_entries[i].events->in_event();
                     --rc;
                 }
             }


### PR DESCRIPTION
 family_entry.fd_entries [i] is modified in zmq::select_t::rm_fd()

Solution: do not copy family_entry.fd_entries [i]