### PR TITLE
Problem: zmq_ctx_term asserts with connect-before-bind and sockets with identity over inproc transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ test_use_fd_tcp
 test_pub_invert_matching
 test_dgram
 test_base85
+test_bind_after_connect_tcp
 test_sodium
 tests/test*.log
 tests/test*.trs

--- a/Makefile.am
+++ b/Makefile.am
@@ -405,6 +405,7 @@ test_apps = \
 	tests/test_stream_exceeds_buffer \
 	tests/test_pub_invert_matching \
 	tests/test_base85 \
+	tests/test_bind_after_connect_tcp \
 	tests/test_sodium
 
 tests_test_ancillaries_SOURCES = tests/test_ancillaries.cpp
@@ -609,6 +610,9 @@ tests_test_stream_exceeds_buffer_LDADD = src/libzmq.la
 
 tests_test_pub_invert_matching_SOURCES = tests/test_pub_invert_matching.cpp
 tests_test_pub_invert_matching_LDADD = src/libzmq.la
+
+tests_test_bind_after_connect_tcp_SOURCES = tests/test_bind_after_connect_tcp.cpp
+tests_test_bind_after_connect_tcp_LDADD = src/libzmq.la
 
 tests_test_base85_SOURCES = tests/test_base85.cpp
 tests_test_base85_LDADD = src/libzmq.la

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -573,7 +573,13 @@ void zmq::ctx_t::connect_inproc_sockets (zmq::socket_base_t *bind_socket_,
     else
         pending_connection_.connect_pipe->send_bind (bind_socket_, pending_connection_.bind_pipe, false);
 
-    if (pending_connection_.endpoint.options.recv_identity) {
+    // When a ctx is terminated all pending inproc connection will be
+    // connected, but the socket will already be closed and the pipe will be
+    // in waiting_for_delimiter state, which means no more writes can be done
+    // and the identity write fails and causes an assert. Check if the socket
+    // is open before sending.
+    if (pending_connection_.endpoint.options.recv_identity &&
+            pending_connection_.endpoint.socket->check_tag ()) {
         msg_t id;
         const int rc = id.init_size (bind_options.identity_size);
         errno_assert (rc == 0);

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -152,6 +152,8 @@ int zmq::ctx_t::terminate ()
     pending_connections_t copy = pending_connections;
     for (pending_connections_t::iterator p = copy.begin (); p != copy.end (); ++p) {
         zmq::socket_base_t *s = create_socket (ZMQ_PAIR);
+        // create_socket might fail eg: out of memory/sockets limit reached
+        zmq_assert (s);
         s->bind (p->first.c_str ());
         s->close ();
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ set(tests
         test_xpub_manual
         test_xpub_welcome_msg
         test_base85
+        test_bind_after_connect_tcp
         test_sodium
 )
 if(NOT WIN32)

--- a/tests/test_bind_after_connect_tcp.cpp
+++ b/tests/test_bind_after_connect_tcp.cpp
@@ -1,0 +1,97 @@
+/*
+    Copyright (c) 2016 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+
+int main (void)
+{
+    setup_test_environment();
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    void *sb = zmq_socket (ctx, ZMQ_DEALER);
+    assert (sb);
+
+    void *sc = zmq_socket (ctx, ZMQ_DEALER);
+    assert (sc);
+
+    int rc = zmq_connect (sc, "tcp://127.0.0.1:7722");
+    assert (rc == 0);
+
+    rc = zmq_send_const (sc, "foobar", 6, 0);
+    assert (rc == 6);
+
+    rc = zmq_send_const (sc, "baz", 3, 0);
+    assert (rc == 3);
+
+    rc = zmq_send_const (sc, "buzz", 4, 0);
+    assert (rc == 4);
+
+    rc = zmq_bind (sb, "tcp://127.0.0.1:7722");
+    assert (rc == 0);
+
+    zmq_msg_t msg;
+    rc = zmq_msg_init (&msg);
+    assert (rc == 0);
+    rc = zmq_msg_recv (&msg, sb, 0);
+    assert (rc == 6);
+    void *data = zmq_msg_data (&msg);
+    assert (memcmp ("foobar", data, 6) == 0);
+    rc = zmq_msg_close(&msg);
+    assert (rc == 0);
+
+    rc = zmq_msg_init (&msg);
+    assert (rc == 0);
+    rc = zmq_msg_recv (&msg, sb, 0);
+    assert (rc == 3);
+    data = zmq_msg_data (&msg);
+    assert (memcmp ("baz", data, 3) == 0);
+    rc = zmq_msg_close(&msg);
+    assert (rc == 0);
+
+    rc = zmq_msg_init (&msg);
+    assert (rc == 0);
+    rc = zmq_msg_recv (&msg, sb, 0);
+    assert (rc == 4);
+    data = zmq_msg_data (&msg);
+    assert (memcmp ("buzz", data, 4) == 0);
+    rc = zmq_msg_close(&msg);
+    assert (rc == 0);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+
+    return 0;
+}

--- a/tests/test_inproc_connect.cpp
+++ b/tests/test_inproc_connect.cpp
@@ -212,6 +212,30 @@ void test_connect_before_bind_pub_sub ()
     assert (rc == 0);
 }
 
+void test_connect_before_bind_ctx_term ()
+{
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    for (int i = 0; i < 20; ++i) {
+        // Connect first
+        void *connectSocket = zmq_socket (ctx, ZMQ_ROUTER);
+        assert (connectSocket);
+
+        char ep[20];
+        sprintf(ep, "inproc://cbbrr%d", i);
+        int rc = zmq_connect (connectSocket, ep);
+        assert (rc == 0);
+
+        // Cleanup
+        rc = zmq_close (connectSocket);
+        assert (rc == 0);
+    }
+
+    int rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+}
+
 void test_multiple_connects ()
 {
     const unsigned int no_of_connects = 10;
@@ -499,6 +523,7 @@ int main (void)
     test_bind_before_connect ();
     test_connect_before_bind ();
     test_connect_before_bind_pub_sub ();
+    test_connect_before_bind_ctx_term ();
     test_multiple_connects ();
     test_multiple_threads ();
     test_simultaneous_connect_bind_threads ();


### PR DESCRIPTION
Solution: check if the connecting inproc socket has been closed
before trying to send the identity.
Otherwise the pipe will be in waiting_for_delimiter state causing
writes to fail and the connect to assert when the context is being
torn down and the pending inproc connects are resolved.
Add test case that covers this behaviour.

Also add a new assert, and a new test case.

Fixes #2117