### PR TITLE
Fix fd_entry may reference invalid object.

### DIFF
--- a/src/select.cpp
+++ b/src/select.cpp
@@ -353,29 +353,27 @@ void zmq::select_t::loop ()
 
         //  Size is cached to avoid iteration through just added descriptors.
         for (fd_entries_t::size_type i = 0, size = fd_entries.size (); i < size && rc > 0; ++i) {
-            fd_entry_t& fd_entry = fd_entries [i];
-
-            if (fd_entry.fd == retired_fd)
+            if (fd_entries [i].fd == retired_fd)
                 continue;
 
-            if (FD_ISSET (fd_entry.fd, &local_fds_set.read)) {
-                fd_entry.events->in_event ();
+            if (FD_ISSET (fd_entries [i].fd, &local_fds_set.read)) {
+                fd_entries [i].events->in_event ();
                 --rc;
             }
 
-            if (fd_entry.fd == retired_fd || rc == 0)
+            if (fd_entries [i].fd == retired_fd || rc == 0)
                 continue;
 
-            if (FD_ISSET (fd_entry.fd, &local_fds_set.write)) {
-                fd_entry.events->out_event ();
+            if (FD_ISSET (fd_entries [i].fd, &local_fds_set.write)) {
+                fd_entries [i].events->out_event ();
                 --rc;
             }
 
-            if (fd_entry.fd == retired_fd || rc == 0)
+            if (fd_entries [i].fd == retired_fd || rc == 0)
                 continue;
 
-            if (FD_ISSET (fd_entry.fd, &local_fds_set.error)) {
-                fd_entry.events->in_event ();
+            if (FD_ISSET (fd_entries [i].fd, &local_fds_set.error)) {
+                fd_entries [i].events->in_event ();
                 --rc;
             }
         }


### PR DESCRIPTION
fd_entries (std::vector) can reallocate underlying storage
which will render reference invalid.