### PR TITLE
	fix bugs of the pollset

### DIFF
--- a/src/pollset.cpp
+++ b/src/pollset.cpp
@@ -252,4 +252,3 @@ void zmq::pollset_t::worker_routine (void *arg_)
 }
 
 #endif
--

--- a/src/pollset.cpp
+++ b/src/pollset.cpp
@@ -135,7 +135,7 @@ void zmq::pollset_t::reset_pollin (handle_t handle_)
     pc.events = 0;
 
     pc.cmd = PS_DELETE;
-       int rc = pollset_ctl (pollset_fd, &pc, 1);
+    int rc = pollset_ctl (pollset_fd, &pc, 1);
     
     if (pe->flag_pollout) {
         pc.events = POLLOUT;
@@ -183,20 +183,7 @@ void zmq::pollset_t::reset_pollout (handle_t handle_)
         pc.events = POLLIN;
         rc = pollset_ctl (pollset_fd, &pc, 1);
         errno_assert (rc != -1);
-    }struct poll_ctl pc;
-    pc.fd     = pe->fd;
-    pc.events = 0;
-
-    if (pe->flag_pollin) {
-        pc.cmd    = PS_DELETE;
-        pc.events = POLLIN;
-        pollset_ctl (pollset_fd, &pc, 1);
     }
-
-    pc.cmd = PS_MOD;
-    int rc = pollset_ctl (pollset_fd, &pc, 1);
-    errno_assert (rc != -1);
-
     pe->flag_pollout = false;
 }
 

--- a/src/pollset.cpp
+++ b/src/pollset.cpp
@@ -81,7 +81,9 @@ zmq::pollset_t::handle_t zmq::pollset_t::add_fd (fd_t fd_, i_poll_events *events
     //  Increase the load metric of the thread.
     adjust_load (1);
 
-    fd_table.resize(fd_ + 1, NULL);
+    if (fd_ >= fd_table.size ()) {
+        fd_table.resize(fd_ + 1, NULL);
+    }
     fd_table [fd_] = pe;
     return pe;
 }
@@ -132,15 +134,15 @@ void zmq::pollset_t::reset_pollin (handle_t handle_)
     pc.fd     = pe->fd;
     pc.events = 0;
 
+    pc.cmd = PS_DELETE;
+       int rc = pollset_ctl (pollset_fd, &pc, 1);
+    
     if (pe->flag_pollout) {
-        pc.cmd    = PS_DELETE;
         pc.events = POLLOUT;
-        pollset_ctl(pollset_fd, &pc, 1);
+        pc.cmd    = PS_MOD;
+        rc = pollset_ctl (pollset_fd, &pc, 1);
+        errno_assert (rc != -1);
     }
-
-    pc.cmd = PS_MOD;
-    int rc = pollset_ctl (pollset_fd, &pc, 1);
-    errno_assert (rc != -1);
 
     pe->flag_pollin = false;
 }
@@ -169,6 +171,19 @@ void zmq::pollset_t::reset_pollout (handle_t handle_)
     }
 
     struct poll_ctl pc;
+    pc.fd     = pe->fd;
+    pc.events = 0;
+
+    pc.cmd = PS_DELETE;
+    int rc = pollset_ctl (pollset_fd, &pc, 1);
+    errno_assert (rc != -1);
+    
+    if (pe->flag_pollin) {
+        pc.cmd    = PS_MOD;
+        pc.events = POLLIN;
+        rc = pollset_ctl (pollset_fd, &pc, 1);
+        errno_assert (rc != -1);
+    }struct poll_ctl pc;
     pc.fd     = pe->fd;
     pc.events = 0;
 
@@ -250,3 +265,4 @@ void zmq::pollset_t::worker_routine (void *arg_)
 }
 
 #endif
+-


### PR DESCRIPTION
1. extend 'fd_table' when fd_ is greater or equal than the size of 'fd_table';
2. delete specific fd from pollset before reset pollin or pollout according the description of AIX document