### PR TITLE
Problem: zmq_poller only signals one event

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -577,6 +577,7 @@ ZMQ_EXPORT int  zmq_poller_add (void *poller, void *socket, void *user_data, sho
 ZMQ_EXPORT int  zmq_poller_modify (void *poller, void *socket, short events);
 ZMQ_EXPORT int  zmq_poller_remove (void *poller, void *socket);
 ZMQ_EXPORT int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
+ZMQ_EXPORT int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events, long timeout);
 
 #if defined _WIN32
 ZMQ_EXPORT int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -75,6 +75,8 @@ namespace zmq
 
         int wait (event_t *event, long timeout);
 
+        inline int size (void) { return items.size (); };
+
         //  Return false if object is not a socket.
         bool check_tag ();
 

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -80,6 +80,7 @@ int  zmq_poller_add (void *poller, void *socket, void *user_data, short events);
 int  zmq_poller_modify (void *poller, void *socket, short events);
 int  zmq_poller_remove (void *poller, void *socket);
 int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
+int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events, long timeout);
 
 #if defined _WIN32
 int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);


### PR DESCRIPTION
Solution: zmq_poller_wait_all signals all events

allows signaling multiple events with one call to zmq_poller_wait_all rather than emitting only one event.

this prepares for zmq_poll being based on zmq_poller, which requires events for all sockets rather than just one.

closes #2108