### PR TITLE
add n_events argument to zmq_poller_wait_all

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -577,7 +577,7 @@ ZMQ_EXPORT int  zmq_poller_add (void *poller, void *socket, void *user_data, sho
 ZMQ_EXPORT int  zmq_poller_modify (void *poller, void *socket, short events);
 ZMQ_EXPORT int  zmq_poller_remove (void *poller, void *socket);
 ZMQ_EXPORT int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
-ZMQ_EXPORT int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events, long timeout);
+ZMQ_EXPORT int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events, int n_events, long timeout);
 
 #if defined _WIN32
 ZMQ_EXPORT int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -380,7 +380,7 @@ int zmq::socket_poller_t::rebuild ()
     return 0;
 }
 
-int zmq::socket_poller_t::wait (zmq::socket_poller_t::event_t *events_, long timeout_)
+int zmq::socket_poller_t::wait (zmq::socket_poller_t::event_t *events_, int n_events_, long timeout_)
 {
     if (need_rebuild)
         if (rebuild () == -1)
@@ -441,7 +441,7 @@ int zmq::socket_poller_t::wait (zmq::socket_poller_t::event_t *events_, long tim
 
         //  Check for the events.
         int i=0;
-        for (items_t::iterator it = items.begin (); it != items.end (); ++i, ++it) {
+        for (items_t::iterator it = items.begin (); it != items.end () && i < n_events_; ++i, ++it) {
 
             events_[i].socket = NULL;
             events_[i].fd = 0;

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -73,7 +73,7 @@ namespace zmq
         int modify_fd (fd_t fd, short events);
         int remove_fd (fd_t fd);
 
-        int wait (event_t *event, long timeout);
+        int wait (event_t *event, int n_events, long timeout);
 
         inline int size (void) { return items.size (); };
 

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -80,7 +80,7 @@ int  zmq_poller_add (void *poller, void *socket, void *user_data, short events);
 int  zmq_poller_modify (void *poller, void *socket, short events);
 int  zmq_poller_remove (void *poller, void *socket);
 int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
-int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events, long timeout);
+int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events, int n_events, long timeout);
 
 #if defined _WIN32
 int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);


### PR DESCRIPTION
avoids unnecessary heap allocations, races on the number of items

follow-up to #2128