### PR TITLE
Problem: pkgconfig file does not support static link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ if(COMPILER_SUPPORTS_C11)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
 endif()
 
+# Will be used to add flags to pkg-config useful when apps want to statically link
+set (pkg_config_requires_private "")
+set (pkg_config_libs_private "")
+
 option (WITH_OPENPGM "Build with support for OpenPGM" OFF)
 option (WITH_VMCI "Build with support for VMware VMCI socket" OFF)
 
@@ -45,6 +49,7 @@ elseif (WITH_LIBSODIUM)
         endif ()
         set (ZMQ_USE_LIBSODIUM 1)
         set (ZMQ_HAVE_CURVE 1)
+        list (APPEND pkg_config_requires_private "libsodium")
     else ()
         message (FATAL_ERROR
             "libsodium is not installed. Install it, then run CMake again")

--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,10 @@ libzmq_on_gnu="no"
 # Set some default features required by ZeroMQ code
 CPPFLAGS="-D_REENTRANT -D_THREAD_SAFE -Wno-long-long $CPPFLAGS"
 
+# Will be used to add flags to pkg-config useful when apps want to statically link
+PKGCFG_REQUIRES_PRIVATE=""
+PKGCFG_LIBS_PRIVATE=""
+
 # For host type checks
 AC_CANONICAL_HOST
 
@@ -450,6 +454,8 @@ elif test "x$with_libsodium" = "xyes"; then
             libzmq_werror="no"
         ;;
     esac
+
+    PKGCFG_REQUIRES_PRIVATE="$PKGCFG_REQUIRES_PRIVATE libsodium"
 else
     AC_MSG_NOTICE([Using tweetnacl for CURVE security])
     AC_DEFINE(ZMQ_HAVE_CURVE, [1], [Using curve encryption])
@@ -471,9 +477,14 @@ AC_ARG_WITH([pgm], [AS_HELP_STRING([--with-pgm],
 
 # conditionally require pgm package
 if test "x$with_pgm_ext" != "xno"; then
-    PKG_CHECK_MODULES([pgm], [openpgm-5.2 >= 5.2], [ have_pgm_library="yes" ],
+    PKG_CHECK_MODULES([pgm], [openpgm-5.2 >= 5.2], [
+            have_pgm_library="yes"
+            PKGCFG_REQUIRES_PRIVATE="$PKGCFG_REQUIRES_PRIVATE openpgm-5.2" ],
         [PKG_CHECK_MODULES([pgm], [openpgm-5.1 >= 5.1],
-            [ have_pgm_library="yes" ])])
+            [
+                have_pgm_library="yes"
+                PKGCFG_REQUIRES_PRIVATE="$PKGCFG_REQUIRES_PRIVATE openpgm-5.1"
+            ])])
 fi
 
 if test "x$have_pgm_library" = "xyes"; then
@@ -504,6 +515,7 @@ if test "x$with_norm_ext" != "xno"; then
         LIBZMQ_EXTRA_LDFLAGS="-L${norm_path}/lib ${LIBZMQ_EXTRA_LDFLAGS}"
     fi
     LIBS="-L${norm_path}/lib -lnorm $LIBS"
+    PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE libnorm.a"
 else
     AC_MSG_RESULT([no])
 fi
@@ -648,6 +660,9 @@ AC_SUBST(LIBZMQ_EXTRA_LDFLAGS)
 
 AC_SUBST(LIBZMQ_VMCI_CXXFLAGS)
 AC_SUBST(LIBZMQ_VMCI_LDFLAGS)
+
+AC_SUBST(pkg_config_requires_private, $PKGCFG_REQUIRES_PRIVATE)
+AC_SUBST(pkg_config_libs_private, $PKGCFG_LIBS_PRIVATE)
 
 # set pkgconfigdir, allow override
 AC_ARG_WITH([pkgconfigdir],

--- a/src/libzmq.pc.cmake.in
+++ b/src/libzmq.pc.cmake.in
@@ -7,5 +7,6 @@ Name: libzmq
 Description: 0MQ c++ library
 Version: @ZMQ_VERSION_MAJOR@.@ZMQ_VERSION_MINOR@.@ZMQ_VERSION_PATCH@
 Libs: -L${libdir} -lzmq
-Libs.private: -lstdc++
+Libs.private: -lstdc++ @pkg_config_libs_private@
+Requires.private: @pkg_config_requires_private@
 Cflags: -I${includedir} @pkg_config_defines@

--- a/src/libzmq.pc.in
+++ b/src/libzmq.pc.in
@@ -7,5 +7,6 @@ Name: libzmq
 Description: 0MQ c++ library
 Version: @VERSION@
 Libs: -L${libdir} -lzmq
-Libs.private: -lstdc++
+Libs.private: -lstdc++ @pkg_config_libs_private@
+Requires.private: @pkg_config_requires_private@
 Cflags: -I${includedir} @pkg_config_defines@


### PR DESCRIPTION
Solution: add dependencies, if necessary, to the .private Libs and
Requires field of the pkgconfig file at build time.
This way pkg-config --static --libs libzmq will correctly print
dependencies if they were used to build the static libzmq.a library.

Fixes #2132