### PR TITLE
Problem: pkg-config Requires.private is broken

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ if(COMPILER_SUPPORTS_C11)
 endif()
 
 # Will be used to add flags to pkg-config useful when apps want to statically link
-set (pkg_config_requires_private "")
 set (pkg_config_libs_private "")
 
 option (WITH_OPENPGM "Build with support for OpenPGM" OFF)
@@ -49,7 +48,7 @@ elseif (WITH_LIBSODIUM)
         endif ()
         set (ZMQ_USE_LIBSODIUM 1)
         set (ZMQ_HAVE_CURVE 1)
-        list (APPEND pkg_config_requires_private "libsodium")
+        set (pkg_config_libs_private "${pkg_config_libs_private} -lsodium")
     else ()
         message (FATAL_ERROR
             "libsodium is not installed. Install it, then run CMake again")

--- a/configure.ac
+++ b/configure.ac
@@ -141,7 +141,6 @@ libzmq_on_gnu="no"
 CPPFLAGS="-D_REENTRANT -D_THREAD_SAFE -Wno-long-long $CPPFLAGS"
 
 # Will be used to add flags to pkg-config useful when apps want to statically link
-PKGCFG_REQUIRES_PRIVATE=""
 PKGCFG_LIBS_PRIVATE=""
 
 # For host type checks
@@ -455,7 +454,7 @@ elif test "x$with_libsodium" = "xyes"; then
         ;;
     esac
 
-    PKGCFG_REQUIRES_PRIVATE="$PKGCFG_REQUIRES_PRIVATE libsodium"
+    PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $sodium_LIBS"
 else
     AC_MSG_NOTICE([Using tweetnacl for CURVE security])
     AC_DEFINE(ZMQ_HAVE_CURVE, [1], [Using curve encryption])
@@ -477,18 +476,14 @@ AC_ARG_WITH([pgm], [AS_HELP_STRING([--with-pgm],
 
 # conditionally require pgm package
 if test "x$with_pgm_ext" != "xno"; then
-    PKG_CHECK_MODULES([pgm], [openpgm-5.2 >= 5.2], [
-            have_pgm_library="yes"
-            PKGCFG_REQUIRES_PRIVATE="$PKGCFG_REQUIRES_PRIVATE openpgm-5.2" ],
+    PKG_CHECK_MODULES([pgm], [openpgm-5.2 >= 5.2], [ have_pgm_library="yes" ],
         [PKG_CHECK_MODULES([pgm], [openpgm-5.1 >= 5.1],
-            [
-                have_pgm_library="yes"
-                PKGCFG_REQUIRES_PRIVATE="$PKGCFG_REQUIRES_PRIVATE openpgm-5.1"
-            ])])
+            [ have_pgm_library="yes" ])])
 fi
 
 if test "x$have_pgm_library" = "xyes"; then
     AC_DEFINE(ZMQ_HAVE_OPENPGM, [1], [Have OpenPGM extension])
+    PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE $pgm_LIBS"
 fi
 
 AM_CONDITIONAL(HAVE_PGM, test "x$have_pgm_library" = "xyes")
@@ -515,7 +510,7 @@ if test "x$with_norm_ext" != "xno"; then
         LIBZMQ_EXTRA_LDFLAGS="-L${norm_path}/lib ${LIBZMQ_EXTRA_LDFLAGS}"
     fi
     LIBS="-L${norm_path}/lib -lnorm $LIBS"
-    PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE libnorm.a"
+    PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -lnorm"
 else
     AC_MSG_RESULT([no])
 fi
@@ -661,7 +656,6 @@ AC_SUBST(LIBZMQ_EXTRA_LDFLAGS)
 AC_SUBST(LIBZMQ_VMCI_CXXFLAGS)
 AC_SUBST(LIBZMQ_VMCI_LDFLAGS)
 
-AC_SUBST(pkg_config_requires_private, $PKGCFG_REQUIRES_PRIVATE)
 AC_SUBST(pkg_config_libs_private, $PKGCFG_LIBS_PRIVATE)
 
 # set pkgconfigdir, allow override

--- a/src/libzmq.pc.cmake.in
+++ b/src/libzmq.pc.cmake.in
@@ -8,5 +8,4 @@ Description: 0MQ c++ library
 Version: @ZMQ_VERSION_MAJOR@.@ZMQ_VERSION_MINOR@.@ZMQ_VERSION_PATCH@
 Libs: -L${libdir} -lzmq
 Libs.private: -lstdc++ @pkg_config_libs_private@
-Requires.private: @pkg_config_requires_private@
 Cflags: -I${includedir} @pkg_config_defines@

--- a/src/libzmq.pc.in
+++ b/src/libzmq.pc.in
@@ -8,5 +8,4 @@ Description: 0MQ c++ library
 Version: @VERSION@
 Libs: -L${libdir} -lzmq
 Libs.private: -lstdc++ @pkg_config_libs_private@
-Requires.private: @pkg_config_requires_private@
 Cflags: -I${includedir} @pkg_config_defines@


### PR DESCRIPTION
Solution: use only Libs.private to avoid breaking application builds.
Even though Requires.private are supposed to be parsed only if
pkg-config is called with --static, the --cflags parameter is enough
to trigger the parsing, causing build failures for applications that
do not (and should not) depend on libzmq's dependencies.

See upstream (unresolved) ticket: https://bugs.freedesktop.org/show_bug.cgi?id=4738