### PR TITLE
Problem: Brocade has copyright but not in AUTHORS and RELICENSE

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Copyright (c) 2011 VMware, Inc.
 Copyright (c) 2012 Spotify AB
 Copyright (c) 2013 Ericsson AB
 Copyright (c) 2014 AppDynamics Inc.
+Copyright (c) 2015-2016 Brocade Communications Systems Inc.
 
 Individual Contributors
 =======================

--- a/RELICENSE/brocade_communications_systems.md
+++ b/RELICENSE/brocade_communications_systems.md
@@ -1,0 +1,15 @@
+## Brocade Communications Systems Inc.
+
+This is a statement by Brocade Communications Systems Inc. (Brocade)
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "bluca", with
+commit author "Luca Boccassi <luca.boccassi@gmail.com>" or
+"Luca Boccassi <lboccass@brocade.com>", are copyright of Brocade.
+This permission to relicense includes all past, present and future
+contributions of Brocade employees.
+
+Luca Boccassi
+Software Engineer, Brocade Communications Systems Inc.
+2016-05-16


### PR DESCRIPTION
Solution: add my employer among the corporate contributors in AUTHORS, and add RELICENSE permission.

Both this changes have been approved by Brocade Communications Systems Inc. management and legal.