### PR TITLE
avoid passing duplicate entries to zmq_poll

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -130,6 +130,15 @@ int zmq::proxy (
         { backend_, 0, ZMQ_POLLOUT, 0 }
     };
 
+    int control_idx = 2;
+    if (frontend_ == backend_) {
+        // when frontend & backend are the same,
+        // avoid duplicate poll entries
+        qt_poll_items -= 1;
+        items[1] = items[2];
+        control_idx = 1;
+    }
+
     //  Proxy can be in these three states
     enum {
         active,
@@ -154,7 +163,7 @@ int zmq::proxy (
         }
 
         //  Process a control command if any
-        if (control_ && items [2].revents & ZMQ_POLLIN) {
+        if (control_ && items [control_idx].revents & ZMQ_POLLIN) {
             rc = control_->recv (&msg, 0);
             if (unlikely (rc < 0))
                 return -1;


### PR DESCRIPTION
zmq_poller doesn't allow a socket to appear twice, so when zmq_poll is implemented on top of zmq_poller, a socket may not appear twice there, either. This may be fixable in `zmq_poller_poll` to allow duplicate entries, but that would be a bit complicated in terms of array mapping.