### PR TITLE
Resolve issues with zmq_poll and zmq_poller working together

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -780,6 +780,9 @@ inline int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
     if (rc < 0) {
         zmq_poller_destroy (&poller);
         delete [] events;
+        if (zmq_errno() == ETIMEDOUT) {
+            return 0;
+        }
         return rc;
     }
 


### PR DESCRIPTION
Some things didn't quite work.

- zmq_poll returns 0 on timeout, not -1, ETIMEDOUT like zmq_poller
- socket_poller::wait returns only triggered events

Return value of poller::wait is the number of events found. This also propagates to the return value of zmq_poller_wait_all.

zmq_poller_wait was only returning events on the first-registered socket, due to how n_events was handled. n_events now indicates the maximum number of events to wait for, not the number of sockets on which to poll.

The only remaining compatibility issue I see is that zmq_poll allowed sockets to appear multiple times in pollitems, but the current zmq_poll wrapper does not allow this.