### PR TITLE
Fix zmq poller poll return

### DIFF
--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -31,6 +31,7 @@
 #include "macros.hpp"
 
 #include <string.h>
+#include <unistd.h>
 #include <new>
 #include <sstream>
 

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -31,7 +31,11 @@
 #include "macros.hpp"
 
 #include <string.h>
+
+#ifndef ZMQ_HAVE_WINDOWS
 #include <unistd.h>
+#endif
+
 #include <new>
 #include <sstream>
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -842,7 +842,7 @@ inline int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
     }
 
     //  Cleanup
-    rc = zmq_poller_destroy (&poller);
+    zmq_poller_destroy (&poller);
     delete [] events;
     return rc;
 }

--- a/tests/test_radio_dish.cpp
+++ b/tests/test_radio_dish.cpp
@@ -167,7 +167,7 @@ int main (void)
         { dish, 0, ZMQ_POLLIN, 0 }, // read subscriptions
     };
     rc = zmq_poll(items, 2, 2000);
-    assert (rc == 0);
+    assert (rc == 1);
     assert (items[1].revents == ZMQ_POLLIN);
 
     //  Check the correct message arrived


### PR DESCRIPTION
First, thank you for all the great work with libzmq.  This library is great.  When I upgraded to the current master I first found that it didn't build, hence the commit to include unistd.h.  Then I discovered that polling was not working, hence the second commit.