### PR TITLE
performance enhancement

### DIFF
--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -234,6 +234,8 @@ uint64_t zmq::clock_t::rdtsc ()
     asm("\tstck\t%0\n" : "=Q" (tsc) : : "cc");
     return(tsc);
 #else
-    return 0;
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)(ts.tv_sec) * 1000000000 + ts.tv_nsec;
 #endif
 }


### PR DESCRIPTION
use 'clock_gettime' if there is no instruction to get cpu tick. It will take about 10% performance enhancement in AIX 7.1. 
the 'poll' routine in AIX is very slow that it takes about 0.76us of one call. Other platform without instruction getting cpu tick maybe take benefit from it too.