### PR TITLE
Problem: build API incompatible with 4.1

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -95,8 +95,13 @@ AC_DEFUN([LIBZMQ_CHECK_DOC_BUILD], [{
         AS_HELP_STRING([--without-docs],
             [Don't build and install man pages [default=build]]),
         [with_docs=$withval])
+    AC_ARG_WITH([documentation], [AS_HELP_STRING([--without-documentation],
+        [Don't build and install man pages [default=build] DEPRECATED: use --without-docs])])
 
-    if test "x$with_docs" = "xno"; then
+    if test "x$with_documentation" = "xno"; then
+        AC_MSG_WARN([--without-documentation is DEPRECATED and will be removed in the next release, use --without-docs])
+    fi
+    if test "x$with_docs" = "xno" || test "x$with_documentation" = "xno"; then
         libzmq_build_doc="no"
         libzmq_install_man="no"
     else


### PR DESCRIPTION
Solution: keep the new --without-docs option, but also keep the old
--without-documentation with an added deprecation warning.
We can then remove it in the next major release, to leave enough time
for users and maintainers to change it without disruptions.


Let's be nice to maintainers and users with build scripts :-)