### PR TITLE
clock_gettime is now defined in macOS 10.12 SDK

### DIFF
--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -58,7 +58,7 @@
 #include <time.h>
 #include <sys/time.h>
 
-int clock_gettime (int clock_id, timespec *ts)
+int alt_clock_gettime (int clock_id, timespec *ts)
 {
     // The clock_id specified is not supported on this system.
     if (clock_id != CLOCK_REALTIME) {
@@ -152,7 +152,12 @@ uint64_t zmq::clock_t::now_us ()
 
     //  Use POSIX clock_gettime function to get precise monotonic time.
     struct timespec tv;
+
+#if defined ZMQ_HAVE_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // less than macOS 10.12    
+    int rc = alt_clock_gettime (CLOCK_MONOTONIC, &tv);
+#else
     int rc = clock_gettime (CLOCK_MONOTONIC, &tv);
+#endif
     // Fix case where system has clock_gettime but CLOCK_MONOTONIC is not supported.
     // This should be a configuration check, but I looked into it and writing an
     // AC_FUNC_CLOCK_MONOTONIC seems beyond my powers.

--- a/src/clock.hpp
+++ b/src/clock.hpp
@@ -37,7 +37,7 @@
 #include <mach/mach.h>
 #include <time.h>
 #include <sys/time.h>
-int clock_gettime (int clock_id, timespec *ts);
+int alt_clock_gettime (int clock_id, timespec *ts);
 #ifndef CLOCK_REALTIME
 #define CLOCK_REALTIME 0
 #endif

--- a/src/condition_variable.hpp
+++ b/src/condition_variable.hpp
@@ -159,7 +159,12 @@ namespace zmq
 
             if (timeout_ != -1) {
                 struct timespec timeout;
+
+#if defined ZMQ_HAVE_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // less than macOS 10.12
+                alt_clock_gettime(CLOCK_REALTIME, &timeout);
+#else
                 clock_gettime(CLOCK_REALTIME, &timeout);
+#endif
 
                 timeout.tv_sec += timeout_ / 1000;
                 timeout.tv_nsec += (timeout_ % 1000) * 1000000;


### PR DESCRIPTION
Problem: clock_gettime is now defined in macOS 10.12 SDK

Solution: Rename the custom implementation of clock_gettime for macOS to
alt_clock_gettime and wrap all usage in preprocessor macros to only enable the
alternative version when using macOS <= 10.11.

This issue occurs when targeting macOS 10.11 or earlier but using the 10.12
or newer SDK.