### PR TITLE
Problem: pointer union for zmq_msg_t is a hack

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -229,10 +229,21 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
 /*  0MQ message definition.                                                   */
 /******************************************************************************/
 
-/* union here ensures correct alignment on architectures that require it, e.g.
- * SPARC
+/* Some architectures, like sparc64 and some variants of aarch64, enforce pointer
+ * alignment and raise sigbus on violations. Make sure applications allocate
+ * zmq_msg_t on addresses aligned on a pointer-size boundary to avoid this issue.
  */
-typedef union zmq_msg_t {unsigned char _ [64]; void *p; } zmq_msg_t;
+typedef struct zmq_msg_t {
+#if defined (__GNUC__) || defined ( __INTEL_COMPILER) || \
+        (defined (__SUNPRO_C) && __SUNPRO_C >= 0x590) || \
+        (defined (__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
+    unsigned char _ [64] __attribute__ ((aligned (sizeof (void *))));
+#elif defined(_MSC_VER)
+    __declspec (align (sizeof (void *))) unsigned char _ [64];
+#else
+    unsigned char _ [64];
+#endif
+} zmq_msg_t;
 
 typedef void (zmq_free_fn) (void *data, void *hint);
 


### PR DESCRIPTION
Solution: use compiler's alignment attributes instead which is
clearer and less of a hack.
Pointer alignment violations causing crashes on architectures
such as sparc64 and aarch64.
This also avoid triggering ABI checkers as the change is compatible
even though applications that suffer from the bug should rebuild to
take advantage of the fix.


@somdoron - this problem can be easily reproduced on x86_64 by adding:

```__asm__("pushf\norl $0x40000,(%rsp)\npopf");```

Before creating and initialising a message when building without this or the union hack. I verified that with this change the sigbus does not happen.

Most importantly as mentioned in the commit this is ABI compatible and does not trigger ABI checkers - I built the unit tests programs from the zeromq4-1 repository and run them with the shared library with this change from libzmq master, and they all run fine minus the ZMQ_REQ_CORRELATE due to changes in the library.

So we can get away with doing a release without ABI breakages, and we can worry at a later time about the zmq_msg_t size without rush. What do you think?