### PR TITLE
Problem: MS VC++ build broken

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -238,8 +238,10 @@ typedef struct zmq_msg_t {
         (defined (__SUNPRO_C) && __SUNPRO_C >= 0x590) || \
         (defined (__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
     unsigned char _ [64] __attribute__ ((aligned (sizeof (void *))));
-#elif defined(_MSC_VER)
-    __declspec (align (sizeof (void *))) unsigned char _ [64];
+#elif defined (_MSC_VER) && (defined (_M_X64) || defined (_M_ARM64))
+    __declspec (align (8)) unsigned char _ [64];
+#elif defined (_MSC_VER) && (defined (_M_IX86) || defined (_M_ARM_ARMV7VE))
+    __declspec (align (4)) unsigned char _ [64];
 #else
     unsigned char _ [64];
 #endif


### PR DESCRIPTION
Solution: use __alignof instead of sizeof inside align intrinsic as
expressions are not allowed


Third try - can't use an intrinsic with another intrinsic in vc++, because reasons.
So detect arch and hard code pointer size depending on it. Suggestions welcome.