### PR TITLE
Suppress warning on uninitialized variable use by initializing variable.

### DIFF
--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -182,7 +182,7 @@ int zmq::tcp_address_t::resolve_nic_name (const char *nic_, bool ipv6_, bool is_
 {
     //  Get the addresses.
     ifaddrs *ifa = NULL;
-    int rc;
+    int rc = 0;
     const int max_attempts = 10;
     const int backoff_msec = 1;
     for (int i = 0; i < max_attempts; i++) {


### PR DESCRIPTION
The original behavior causes a failure with -Werror=maybe-uninitialized