### PR TITLE
Problems: need to bump NEWS and libtool version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+0MQ version 4.2.0 rc1, released on 2016/11/01
+=============================================
+
+* Many changes, see ChangeLog.
+
+
 0MQ version 4.1.0 rc1, released on 2014/10/14
 =============================================
 

--- a/configure.ac
+++ b/configure.ac
@@ -37,9 +37,10 @@ AC_SUBST(PACKAGE_VERSION)
 # ZeroMQ version 3.1: 3:0:0 (ABI version 3)
 # ZeroMQ version 4.0: 4:0:0 (ABI version 4)
 # ZeroMQ version 4.1: 5:0:0 (ABI version 5)
+# ZeroMQ version 4.2.0: 6:0:1 (ABI version 5)
 #
 # libzmq -version-info current:revision:age
-LTVER="5:0:0"
+LTVER="6:0:1"
 AC_SUBST(LTVER)
 
 # Take a copy of original flags


### PR DESCRIPTION
Solution: see commits

After this is merged, I'll tag 4.2.0~rc1, and then work a bit on the changelog.

Note that following libtool's recommendation, the effective ABI version is still "5", since we only added symbols, nothing was removed, and old programs work out-of-the-box with new shared libs