### PR TITLE
Problem: socket option marked as draft for 4.2

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -343,8 +343,6 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_HANDSHAKE_IVL 66
 #define ZMQ_SOCKS_PROXY 68
 #define ZMQ_XPUB_NODROP 69
-//  All options after this is for version 4.2 and still *draft*
-//  Subject to arbitrary change without notice
 #define ZMQ_BLOCKY 70
 #define ZMQ_XPUB_MANUAL 71
 #define ZMQ_XPUB_WELCOME_MSG 72
@@ -363,6 +361,8 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
 #define ZMQ_USE_FD 89
+//  All options after this is for version 4.3 and still *draft*
+//  Subject to arbitrary change without notice
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1


### PR DESCRIPTION
Solution: move comment further below to declare new socket
options as stable for the 4.2.0 release.


There haven't been any bugs open or request for changes, so I think we can mark these as stable.
I've already used the USE_FD option and will be using in production shortly.