### PR TITLE
 Add WinXP compatibility

### DIFF
--- a/builds/msvc/vs2015_xp/libzmq.vcxproj
+++ b/builds/msvc/vs2015_xp/libzmq.vcxproj
@@ -1,0 +1,255 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{217AD6A0-8CEA-428D-908F-C34B23CECAAF}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>libzmq</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)..\..\..\bin\$(PlatformName)\$(Configuration)\$(PlatformToolset)\$(DefaultLinkage)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)..\..\..\bin\$(PlatformName)\$(Configuration)\$(PlatformToolset)\$(DefaultLinkage)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;LIBZMQ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;LIBZMQ_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\address.cpp" />
+    <ClCompile Include="..\..\..\src\client.cpp" />
+    <ClCompile Include="..\..\..\src\clock.cpp" />
+    <ClCompile Include="..\..\..\src\ctx.cpp" />
+    <ClCompile Include="..\..\..\src\curve_client.cpp" />
+    <ClCompile Include="..\..\..\src\curve_server.cpp" />
+    <ClCompile Include="..\..\..\src\dealer.cpp" />
+    <ClCompile Include="..\..\..\src\decoder_allocators.cpp" />
+    <ClCompile Include="..\..\..\src\devpoll.cpp" />
+    <ClCompile Include="..\..\..\src\dgram.cpp" />
+    <ClCompile Include="..\..\..\src\dish.cpp" />
+    <ClCompile Include="..\..\..\src\dist.cpp" />
+    <ClCompile Include="..\..\..\src\epoll.cpp" />
+    <ClCompile Include="..\..\..\src\err.cpp" />
+    <ClCompile Include="..\..\..\src\fq.cpp" />
+    <ClCompile Include="..\..\..\src\gather.cpp" />
+    <ClCompile Include="..\..\..\src\gssapi_client.cpp" />
+    <ClCompile Include="..\..\..\src\gssapi_mechanism_base.cpp" />
+    <ClCompile Include="..\..\..\src\gssapi_server.cpp" />
+    <ClCompile Include="..\..\..\src\io_object.cpp" />
+    <ClCompile Include="..\..\..\src\io_thread.cpp" />
+    <ClCompile Include="..\..\..\src\ip.cpp" />
+    <ClCompile Include="..\..\..\src\ipc_address.cpp" />
+    <ClCompile Include="..\..\..\src\ipc_connecter.cpp" />
+    <ClCompile Include="..\..\..\src\ipc_listener.cpp" />
+    <ClCompile Include="..\..\..\src\kqueue.cpp" />
+    <ClCompile Include="..\..\..\src\lb.cpp" />
+    <ClCompile Include="..\..\..\src\mailbox.cpp" />
+    <ClCompile Include="..\..\..\src\mailbox_safe.cpp" />
+    <ClCompile Include="..\..\..\src\mechanism.cpp" />
+    <ClCompile Include="..\..\..\src\metadata.cpp" />
+    <ClCompile Include="..\..\..\src\msg.cpp" />
+    <ClCompile Include="..\..\..\src\mtrie.cpp" />
+    <ClCompile Include="..\..\..\src\norm_engine.cpp" />
+    <ClCompile Include="..\..\..\src\null_mechanism.cpp" />
+    <ClCompile Include="..\..\..\src\object.cpp" />
+    <ClCompile Include="..\..\..\src\options.cpp" />
+    <ClCompile Include="..\..\..\src\own.cpp" />
+    <ClCompile Include="..\..\..\src\pair.cpp" />
+    <ClCompile Include="..\..\..\src\pgm_receiver.cpp" />
+    <ClCompile Include="..\..\..\src\pgm_sender.cpp" />
+    <ClCompile Include="..\..\..\src\pgm_socket.cpp" />
+    <ClCompile Include="..\..\..\src\pipe.cpp" />
+    <ClCompile Include="..\..\..\src\plain_client.cpp" />
+    <ClCompile Include="..\..\..\src\plain_server.cpp" />
+    <ClCompile Include="..\..\..\src\poll.cpp" />
+    <ClCompile Include="..\..\..\src\poller_base.cpp" />
+    <ClCompile Include="..\..\..\src\pollset.cpp" />
+    <ClCompile Include="..\..\..\src\precompiled.cpp" />
+    <ClCompile Include="..\..\..\src\proxy.cpp" />
+    <ClCompile Include="..\..\..\src\pub.cpp" />
+    <ClCompile Include="..\..\..\src\pull.cpp" />
+    <ClCompile Include="..\..\..\src\push.cpp" />
+    <ClCompile Include="..\..\..\src\radio.cpp" />
+    <ClCompile Include="..\..\..\src\random.cpp" />
+    <ClCompile Include="..\..\..\src\raw_decoder.cpp" />
+    <ClCompile Include="..\..\..\src\raw_encoder.cpp" />
+    <ClCompile Include="..\..\..\src\reaper.cpp" />
+    <ClCompile Include="..\..\..\src\rep.cpp" />
+    <ClCompile Include="..\..\..\src\req.cpp" />
+    <ClCompile Include="..\..\..\src\router.cpp" />
+    <ClCompile Include="..\..\..\src\scatter.cpp" />
+    <ClCompile Include="..\..\..\src\select.cpp" />
+    <ClCompile Include="..\..\..\src\server.cpp" />
+    <ClCompile Include="..\..\..\src\session_base.cpp" />
+    <ClCompile Include="..\..\..\src\signaler.cpp" />
+    <ClCompile Include="..\..\..\src\socket_base.cpp" />
+    <ClCompile Include="..\..\..\src\socket_poller.cpp" />
+    <ClCompile Include="..\..\..\src\socks.cpp" />
+    <ClCompile Include="..\..\..\src\socks_connecter.cpp" />
+    <ClCompile Include="..\..\..\src\stream.cpp" />
+    <ClCompile Include="..\..\..\src\stream_engine.cpp" />
+    <ClCompile Include="..\..\..\src\sub.cpp" />
+    <ClCompile Include="..\..\..\src\tcp.cpp" />
+    <ClCompile Include="..\..\..\src\tcp_address.cpp" />
+    <ClCompile Include="..\..\..\src\tcp_connecter.cpp" />
+    <ClCompile Include="..\..\..\src\tcp_listener.cpp" />
+    <ClCompile Include="..\..\..\src\thread.cpp" />
+    <ClCompile Include="..\..\..\src\timers.cpp" />
+    <ClCompile Include="..\..\..\src\tipc_address.cpp" />
+    <ClCompile Include="..\..\..\src\tipc_connecter.cpp" />
+    <ClCompile Include="..\..\..\src\tipc_listener.cpp" />
+    <ClCompile Include="..\..\..\src\trie.cpp" />
+    <ClCompile Include="..\..\..\src\udp_address.cpp" />
+    <ClCompile Include="..\..\..\src\udp_engine.cpp" />
+    <ClCompile Include="..\..\..\src\v1_decoder.cpp" />
+    <ClCompile Include="..\..\..\src\v1_encoder.cpp" />
+    <ClCompile Include="..\..\..\src\v2_decoder.cpp" />
+    <ClCompile Include="..\..\..\src\v2_encoder.cpp" />
+    <ClCompile Include="..\..\..\src\vmci.cpp" />
+    <ClCompile Include="..\..\..\src\vmci_address.cpp" />
+    <ClCompile Include="..\..\..\src\vmci_connecter.cpp" />
+    <ClCompile Include="..\..\..\src\vmci_listener.cpp" />
+    <ClCompile Include="..\..\..\src\xpub.cpp" />
+    <ClCompile Include="..\..\..\src\xsub.cpp" />
+    <ClCompile Include="..\..\..\src\zmq.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\condition_variable.hpp" />
+    <ClInclude Include="..\..\..\src\mutex.hpp" />
+    <ClInclude Include="platform.hpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/builds/msvc/vs2015_xp/platform.hpp
+++ b/builds/msvc/vs2015_xp/platform.hpp
@@ -1,0 +1,15 @@
+#ifndef __PLATFORM_HPP_INCLUDED__
+#define __PLATFORM_HPP_INCLUDED__
+
+#define ZMQ_HAVE_WINDOWS
+#define ZMQ_HAVE_WINDOWS_TARGET_XP
+
+#define ZMQ_BUILD_DRAFT_API
+
+#define ZMQ_USE_SELECT
+#define FD_SETSIZE 1024
+
+#pragma comment(lib,"ws2_32.lib")
+#pragma comment(lib,"Iphlpapi.lib")
+
+#endif

--- a/builds/msvc/vs2015_xp/test_zmq/test_multithread.cpp
+++ b/builds/msvc/vs2015_xp/test_zmq/test_multithread.cpp
@@ -1,0 +1,229 @@
+﻿/*
+Server thread listen ZMQ_SERVER socket and transfer incoming message 
+to worker threads by ZMQ_PUSH-ZMQ_PULL
+Worker thread receive message and send back to ZMQ_SERVER socket
+
+Each client thread open CLIENT_CONNECTION ZMQ_CLIENT sockets, 
+send random size message to each socket and check server answer
+*/
+
+#define ZMQ_BUILD_DRAFT_API
+#include "../../../../include/zmq.h"
+
+#pragma comment(lib,"libzmq.lib")
+
+#include <assert.h>
+#include <stdlib.h>
+#include <thread>
+#include <atomic>
+
+#define SERVER_ADDR "tcp://127.0.0.1:12345"
+#define SERVER_WORKER_COUNT 3	// worker threads count
+
+#define CLIENT_COUNT 5			// client threads count
+#define CLIENT_CONNECTION 100	// ZMQ_CLIENT sockets at each client
+#define CLIENT_RECCONECT 1000	// reconnect one socket after messages
+
+#define MESSAGE_MAX_SIZE 1024
+
+//*******************************************************************
+//****** MESSAGE ****************************************************
+//*******************************************************************
+
+void message_fill(zmq_msg_t* msg, int val) {
+	assert(val > 0);
+	int size = sizeof(int) * 2 + val;
+	int rc = zmq_msg_init_size(msg, size); assert(rc == 0);
+	uint8_t* data = (uint8_t*)zmq_msg_data(msg);
+	memcpy(data, &val, sizeof(int));
+	data += sizeof(int);
+	memset(data, val & 0xFF, val);
+	int check_sum = val + (val & 0xFF) * val;
+	data += val;
+	memcpy(data, &check_sum, sizeof(int));
+}
+
+int message_check(zmq_msg_t* msg) {
+	uint8_t* data = (uint8_t*)zmq_msg_data(msg);
+	int size = zmq_msg_size(msg);
+	assert(size > sizeof(int) * 2);
+	// check size
+	int val;
+	memcpy(&val, data, sizeof(int));
+	if(size != sizeof(int) * 2 + val) { 
+		fprintf(stderr, "wrong message: val = %d size = %d\n", val, size);
+		return -1;
+	}
+	// check sum
+	data += sizeof(int);
+	int cs = val;
+	for(int i = 0; i < val; i++) {
+		cs += data[i];
+	}
+	data += val;
+	int check_sum;
+	memcpy(&check_sum, data, sizeof(int));
+	if(check_sum != cs) {
+		fprintf(stderr, "wrong message: cs = %d check_sum = %d\n", cs, check_sum);
+		return -1;
+	}
+	return val;
+}
+
+//*******************************************************************
+//****** SERVER *****************************************************
+//*******************************************************************
+
+void *server_ctx = NULL;
+void *server_sock = NULL;
+
+std::atomic<int> worker_cnt[SERVER_WORKER_COUNT] = {0}; // statistic
+
+// worker thread
+void worker(int num) {
+	printf("worker %d start\n", num);
+	void* queue = zmq_socket(server_ctx, ZMQ_PULL); assert(queue);
+	int rc = zmq_connect(queue, "inproc://queue"); assert(rc == 0);
+
+	while (1) {
+		// receive messages from the queue
+		zmq_msg_t msg;
+		rc = zmq_msg_init(&msg); assert(rc == 0);
+		rc = zmq_msg_recv(&msg, queue, 0); assert(rc > 0);
+		// check message
+		//printf("worker %d recv %d bytes at %X from %X\n", num, zmq_msg_size(&msg), zmq_msg_data(&msg), zmq_msg_routing_id(&msg));
+		// send to client
+		rc = zmq_msg_send(&msg, server_sock, 0); assert(rc != -1);
+		worker_cnt[num]++;
+	}
+	zmq_close(queue);
+}
+
+// server thread
+void server() {
+	server_ctx = zmq_ctx_new(); assert(server_ctx);
+	// create queue
+	void* queue = zmq_socket(server_ctx, ZMQ_PUSH);	assert(queue);
+	int rc = zmq_bind(queue, "inproc://queue"); assert(rc == 0);
+	// start workers
+	std::thread w[SERVER_WORKER_COUNT];
+	for (int i = 0; i < SERVER_WORKER_COUNT; i++) w[i] = std::thread(worker, i);
+	// ZMQ_SERVER for client messages
+	server_sock = zmq_socket(server_ctx, ZMQ_SERVER); assert(server_sock);
+	rc = zmq_bind(server_sock, SERVER_ADDR); assert(rc == 0);
+
+	while (1) {
+		// wait client message
+		zmq_msg_t msg;
+		rc = zmq_msg_init(&msg); assert(rc == 0); 
+		rc = zmq_msg_recv(&msg, server_sock, 0); assert(rc > 0);
+		//printf("recv %d bytes at %X from %X\n", zmq_msg_size(&msg), zmq_msg_data(&msg), zmq_msg_routing_id(&msg));
+		// send message to queue
+		rc = zmq_msg_send(&msg, queue, 0); assert(rc > 0);
+	}
+}
+
+//*******************************************************************
+//****** CLIENT *****************************************************
+//*******************************************************************
+
+std::atomic<int> client_cnt[CLIENT_COUNT] = { 0 }; // statistic
+std::atomic<int> client_ready = 0; 
+
+// client thread
+void client(int num)
+{
+	//printf("client %d start. Open %d connections\n", num, CLIENT_CONNECTION);
+
+	void *ctx = zmq_ctx_new(); assert(ctx);
+
+	void *sock[CLIENT_CONNECTION];
+	int rc;
+	// open ZMQ_CLIENT connections
+	for (int i = 0; i < CLIENT_CONNECTION; i++) {
+		sock[i] = zmq_socket(ctx, ZMQ_CLIENT); assert(sock[i]);
+		rc = zmq_connect(sock[i], SERVER_ADDR); assert(rc == 0);
+		// test connection
+		zmq_msg_t msg;
+		int v = rand() % 256 + 1;
+		message_fill(&msg, v);
+		rc = zmq_msg_send(&msg, sock[i], 0); assert(rc > 0);
+		rc = zmq_msg_init(&msg); assert(rc == 0);
+		rc = zmq_msg_recv(&msg, sock[i], 0); assert(rc > 0);
+		rc = message_check(&msg); assert(rc == v);
+		zmq_msg_close(&msg);
+	}
+	printf("client %d open %d connections\n", num, CLIENT_CONNECTION);
+	client_ready++;
+	while (client_ready < CLIENT_COUNT) Sleep(10); // wait while all clients open sockets
+
+	int recconect = 0;
+	while(1) {
+		int val[CLIENT_CONNECTION];
+		zmq_msg_t msg;
+		// send messages
+		for(int i = 0; i < CLIENT_CONNECTION; i++) {
+			val[i] = rand() % MESSAGE_MAX_SIZE + 1;
+			message_fill(&msg, val[i]);
+			rc = zmq_msg_send(&msg, sock[i], 0); assert(rc > 0);
+		}
+		// recv and check
+		for (int i = 0; i < CLIENT_CONNECTION; i++) {
+			rc = zmq_msg_init(&msg); assert(rc == 0);
+			rc = zmq_msg_recv(&msg, sock[i], 0); assert(rc > 0);
+			rc = message_check(&msg);
+			if(rc != val[i] && rc > 0) {
+				fprintf(stderr, "wrong message: send %d recv %d     \n", val[i], rc);
+			}
+			zmq_msg_close(&msg);
+			client_cnt[num]++;
+		}
+		// reconnect one
+		recconect++;
+		if(recconect == CLIENT_RECCONECT) {
+			int n = rand() % CLIENT_CONNECTION;
+			zmq_close(sock[n]);
+			sock[n] = zmq_socket(ctx, ZMQ_CLIENT); assert(sock[n]);
+			int rc = zmq_connect(sock[n], SERVER_ADDR); assert(rc == 0);
+		}
+	}
+}
+
+//*******************************************************************
+int main (void) {
+	int v1, v2, v3; zmq_version(&v1, &v2, &v3);
+	printf("ZMQ version %d.%d.%d. Compile %s %s\n", v1, v2, v3, __DATE__, __TIME__);
+
+	std::thread ct[CLIENT_COUNT];
+	for (int i = 0; i < CLIENT_COUNT; i++) ct[i] = std::thread(client, i);
+
+	std::thread st(server);
+
+	int w[SERVER_WORKER_COUNT] = { 0 };
+	int c[CLIENT_COUNT] = { 0 };
+	int total = 0;
+
+	while(1) {
+		Sleep(1000);
+		if (client_ready < CLIENT_COUNT) continue;
+		// check workers
+		for(int i = 0; i < SERVER_WORKER_COUNT; i++) {
+			if(w[i] == worker_cnt[i]) {
+				fprintf(stderr, "worker %d not work        \n", i);
+			}
+			w[i] = worker_cnt[i];
+		}
+		// check clients
+		int t = 0;
+		for (int i = 0; i < CLIENT_COUNT; i++) {
+			if (c[i] == client_cnt[i]) {
+				fprintf(stderr, "client %d not work        \n", i);
+			}
+			c[i] = client_cnt[i];
+			t += c[i];
+		}
+		printf("\rTotal %d messages. Speed %d per second  ", t, t - total);
+		total = t;
+	}
+	return 0;
+}

--- a/builds/msvc/vs2015_xp/test_zmq/test_zmq.vcxproj
+++ b/builds/msvc/vs2015_xp/test_zmq/test_zmq.vcxproj
@@ -1,0 +1,155 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{101324AB-CF3E-4D99-8B69-2000CEA487B6}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>test_zmq</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)..\..\..\..\bin\$(PlatformName)\$(Configuration)\$(PlatformToolset)\$(DefaultLinkage)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)..\..\..\..\bin\$(PlatformName)\$(Configuration)\$(PlatformToolset)\$(DefaultLinkage)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\..\bin\$(PlatformName)\$(Configuration)\$(PlatformToolset)\$(DefaultLinkage)\</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(ProjectDir)..\..\..\..\bin\$(PlatformName)\$(Configuration)\$(PlatformToolset)\$(DefaultLinkage)\</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="test_multithread.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/condition_variable.hpp
+++ b/src/condition_variable.hpp
@@ -81,9 +81,15 @@ namespace zmq
 
 #else
 
+#ifdef ZMQ_HAVE_WINDOWS_TARGET_XP
+#include <condition_variable> 
+#include <mutex> 
+#endif
+
 namespace zmq
 {
 
+#ifndef ZMQ_HAVE_WINDOWS_TARGET_XP
     class condition_variable_t
     {
     public:
@@ -126,7 +132,54 @@ namespace zmq
         condition_variable_t (const condition_variable_t&);
         void operator = (const condition_variable_t&);
     };
+#else
+	class condition_variable_t
+	{
+	public:
+		inline condition_variable_t()
+		{
 
+		}
+
+		inline ~condition_variable_t()
+		{
+
+		}
+
+		inline int wait(mutex_t* mutex_, int timeout_)
+		{
+			std::unique_lock<std::mutex> lck(mtx);  // lock mtx
+			mutex_->unlock();                       // unlock mutex_ 
+			int res = 0;
+			if(timeout_ == -1) {
+				cv.wait(lck);                       // unlock mtx and wait cv.notify_all(), lock mtx after cv.notify_all()
+			} else if (cv.wait_for(lck, std::chrono::milliseconds(timeout_)) == std::cv_status::timeout) {
+				// time expired
+				errno = EAGAIN;
+				res = -1;
+			}
+			lck.unlock();                           // unlock mtx
+			mutex_->lock();                         // lock mutex_
+			return res;
+		}
+
+		inline void broadcast()
+		{
+			std::unique_lock<std::mutex> lck(mtx);  // lock mtx
+			cv.notify_all();
+		}
+
+	private:
+
+		std::condition_variable cv;
+		std::mutex mtx;
+
+		//  Disable copy construction and assignment.
+		condition_variable_t(const condition_variable_t&);
+		void operator = (const condition_variable_t&);
+	};
+
+#endif
 }
 
 #endif

--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -245,7 +245,9 @@ int zmq::tcp_address_t::get_interface_name(unsigned long index, char ** dest) co
 	
 	char * if_name_result = NULL;
 
+#ifndef ZMQ_HAVE_WINDOWS_TARGET_XP
 	if_name_result = if_indextoname(index, buffer);
+#endif
 	
 	if (if_name_result == NULL) {
 		free(buffer);


### PR DESCRIPTION
In 4.2.0 used Windows Condition variable. Is supported from Windows Vista and later.

I added emulation with std::condition_variable in class condition_variable_t

This code no effect for Windows Vista and later. It used only if compile with 
#define ZMQ_HAVE_WINDOWS_TARGET_XP

[test_multithread.cpp](https://github.com/Dmitriy-GH/libzmq/blob/master/builds/msvc/vs2015_xp/test_zmq/test_multithread.cpp) is a multithread test ZMQ_CLIENT/ZMQ_SERVER sockets. 5 clients thread with 100 sockets per each permanently send messages to server.
On i7 with 4 core working stable without deadlock and any problem. Already sent 70 000 000 messages and it is working on.

PS Sorry for my English. I used autotranslator.
