### PR TITLE
Problem: curve_keygen not packaged by RPM spec

### DIFF
--- a/packaging/redhat/zeromq.spec
+++ b/packaging/redhat/zeromq.spec
@@ -103,6 +103,20 @@ multiple transport protocols and more.
 
 This package contains ZeroMQ related development libraries and header files.
 
+%package -n libzmq-tools
+Summary:   ZeroMQ tools
+Group:     Productivity/Networking/Web/Servers
+
+%description -n libzmq-tools
+The 0MQ lightweight messaging kernel is a library which extends the
+standard socket interfaces with features traditionally provided by
+specialised messaging middleware products. 0MQ sockets provide an
+abstraction of asynchronous message queues, multiple messaging
+patterns, message filtering (subscriptions), seamless access to
+multiple transport protocols and more.
+
+This package contains tools such as curve_keygen to use with libzmq.
+
 %prep
 %setup -q
 
@@ -176,7 +190,14 @@ autoreconf -fi
 %{_mandir}/man7/zmq_udp.7.gz
 %{_mandir}/man7/zmq_vmci.7.gz
 
+%files -n libzmq-tools
+%defattr(-,root,root,-)
+%{_bindir}/curve_keygen
+
 %changelog
+* Sun Nov 06 2016 Luca Boccassi <luca.boccassi@gmail.com>
+- Add libzmq-tool to package curve_keygen in /usr/bin
+
 * Sun Jul 31 2016 Luca Boccassi <luca.boccassi@gmail.com>
 - Follow RPM standards and rename zeromq to libzmq5
 


### PR DESCRIPTION
Solution: add new libzmq-tools package to ship it


Fixes broken RPM package builds