### PR TITLE
Problem: linker fails looking for dladdr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -650,6 +650,7 @@ PKG_CHECK_MODULES(LIBUNWIND, [libunwind],
         AC_DEFINE(HAVE_LIBUNWIND, 1, [The libunwind library is to be used])
         AC_SUBST([LIBUNWIND_CFLAGS])
         AC_SUBST([LIBUNWIND_LIBS])
+        AC_CHECK_LIB([dl], [dladdr])
     ],
     [
         AC_MSG_WARN([Cannot find libunwind])


### PR DESCRIPTION
Solution: search and add it via AC_CHECK_LIB when building with
libunwind, as the backtrace function uses dladdr. This problem
only appears on some distributions and with some compiler/toolchain
versions.

Fixes https://github.com/zeromq/libzmq/issues/2033