### PR TITLE
Make ZMQ_TOS work with IPv6 sockets

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -172,4 +172,17 @@ void zmq::set_ip_type_of_service (fd_t s_, int iptos)
 #else
     errno_assert (rc == 0);
 #endif
+
+    rc = setsockopt(
+        s_,
+        IPPROTO_IPV6,
+        IPV6_TCLASS,
+        reinterpret_cast<const char*>(&iptos),
+        sizeof(iptos));
+
+#ifdef ZMQ_HAVE_WINDOWS
+    wsa_assert (rc != SOCKET_ERROR);
+#else
+    errno_assert (rc == 0);
+#endif
 }


### PR DESCRIPTION
Summary:
To set `Type Of Service` for IP layer packets ZMQ provides `ZMQ_TOS` socket
option. However this only works for v4 sockets. Considering things are moving to
IPv6 heavily (especially within enterprise networks), ZMQ should support setting
`traffic class` for v6 based on `ZMQ_TOS`.

There is a subtle difference between v4 and v6 in terms of the positioning of
field but TOS has same meaning in both v4 and v6. Linux provides following APIs
for v4/v6 to set TOS field value.
```
// For v4
setsockopt(fd, IPPROTO_IP, IP_TOS, tos, sizeof(tos));

// For v6
setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, tos, sizeof(tos));
```

Test Plan:
Make sure Cmake works fine and all tests passes.
Imported this change to `OpenR` project and tested on our local testbed.
Captured some packets exchanged between PUB/SUB and ROUTER/ROUTER sockets
pairs. Verify that `TCLASS` value is set as per expectation.

Tasks: #2208