### PR TITLE
Document terminating NUL behavior in API more explicitly

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -26,7 +26,9 @@ DESCRIPTION
 The _zmq_setsockopt()_ function shall set the option specified by the
 'option_name' argument to the value pointed to by the 'option_value' argument
 for the 0MQ socket pointed to by the 'socket' argument. The 'option_len'
-argument is the size of the option value in bytes.
+argument is the size of the option value in bytes. For options taking a value of
+type "character string", the provided byte data should either contain no zero
+bytes, or end in a single zero byte (terminating ASCII NUL character).
 
 The following socket options can be set with the _zmq_setsockopt()_ function:
 


### PR DESCRIPTION
This addresses #2169.