### PR TITLE
Problem: size of zmq_msg_t is not known to FFI wrappers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 0MQ version 4.2.1 stable, released on 201x/xx/xx
 =============================================
 
+* New Context options:
+  - ZMQ_MSG_T_SIZE
+
 
 0MQ version 4.2.0 stable, released on 2016/11/04
 =============================================

--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -57,6 +57,13 @@ zero if the "block forever on context termination" gambit was disabled by
 setting ZMQ_BLOCKY to false on all new contexts.
 
 
+ZMQ_MSG_T_SIZE: Get the zmq_msg_t size at runtime
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_MSG_T_SIZE' argument returns the size of the zmq_msg_t structure at
+runtime, as defined in the include/zmq.h public header.
+This is useful for example for FFI bindings that can't simply do a sizeof().
+
+
 RETURN VALUE
 ------------
 The _zmq_ctx_get()_ function returns a value of 0 or greater if successful.

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -206,6 +206,9 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 #define ZMQ_THREAD_PRIORITY 3
 #define ZMQ_THREAD_SCHED_POLICY 4
 #define ZMQ_MAX_MSGSZ 5
+//  All options after this is for version 4.3 and still *draft*
+//  Subject to arbitrary change without notice
+#define ZMQ_MSG_T_SIZE 6
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT  1

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -301,6 +301,9 @@ int zmq::ctx_t::get (int option_)
     else
     if (option_ == ZMQ_MAX_MSGSZ)
         rc = max_msgsz;
+    else
+    if (option_ == ZMQ_MSG_T_SIZE)
+        rc = sizeof (zmq_msg_t);
     else {
         errno = EINVAL;
         rc = -1;

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -48,6 +48,7 @@ int main (void)
 #endif
     assert (zmq_ctx_get (ctx, ZMQ_IO_THREADS) == ZMQ_IO_THREADS_DFLT);
     assert (zmq_ctx_get (ctx, ZMQ_IPV6) == 0);
+    assert (zmq_ctx_get (ctx, ZMQ_MSG_T_SIZE) == sizeof (zmq_msg_t));
     
     rc = zmq_ctx_set (ctx, ZMQ_IPV6, true);
     assert (zmq_ctx_get (ctx, ZMQ_IPV6) == 1);


### PR DESCRIPTION
Solution: add a ZMQ_MSG_T_SIZE context read-only option so that
wrappers can call zmq_ctx_get (ctx, ZMQ_MSG_T_SIZE) to get the
size at runtime.

Fixes https://github.com/zeromq/libzmq/issues/1599