### PR TITLE
Add a single sentence explaining what a context is

### DIFF
--- a/doc/zmq.txt
+++ b/doc/zmq.txt
@@ -30,6 +30,9 @@ provided by the 0MQ library.
 
 Context
 ~~~~~~~
+The 0MQ 'context' keeps the list of sockets and manages the async I/O thread
+and internal queries.
+
 Before using any 0MQ library functions you must create a 0MQ 'context'. When
 you exit your application you must destroy the 'context'. These functions let
 you work with 'contexts':


### PR DESCRIPTION
I was wondering for the longest time what a ZMQ context is. The docs go into that I *need* a context, but they never actually tell me what it is. For example, compare the first sentence for `context` and `socket`:

> Before using any 0MQ library functions you must create a 0MQ 'context'.

vs

> 0MQ sockets present an abstraction of a asynchronous _message queue_, [...]

The latter is very succinct and helps me at least get a rough idea of what's going on.

@bluca on freeode/zeromq helped me understand the context a bit better, so the sentence I added to the doc is pretty much lifted from him.