### PR TITLE
Problem: Windows does not support IPV6_TCLASS

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -173,6 +173,8 @@ void zmq::set_ip_type_of_service (fd_t s_, int iptos)
     errno_assert (rc == 0);
 #endif
 
+    //  Windows does not support IPV6_TCLASS
+#ifndef ZMQ_HAVE_WINDOWS
     rc = setsockopt(
         s_,
         IPPROTO_IPV6,
@@ -180,14 +182,8 @@ void zmq::set_ip_type_of_service (fd_t s_, int iptos)
         reinterpret_cast<const char*>(&iptos),
         sizeof(iptos));
 
-    //  If IPv6 is not enabled ENOPROTOOPT will be returned on Windows and
-    //  Linux, and EINVAL on OSX
-#ifdef ZMQ_HAVE_WINDOWS
-    if (rc == SOCKET_ERROR) {
-        const int last_error = WSAGetLastError();
-        wsa_assert (last_error == WSAENOPROTOOPT);
-    }
-#else
+    //  If IPv6 is not enabled ENOPROTOOPT will be returned on Linux and
+    //  EINVAL on OSX
     if (rc == -1) {
         errno_assert (errno == ENOPROTOOPT ||
                       errno == EINVAL);


### PR DESCRIPTION
Solution: don't use it on Windows.
There is a Windows-specific API for ToS, even IPv4 does not work and
it's just a silent no-op on that platform.

Fixes https://github.com/zeromq/libzmq/issues/2229