### PR TITLE
bug fix: AIX pollset error

### DIFF
--- a/src/pollset.cpp
+++ b/src/pollset.cpp
@@ -99,10 +99,10 @@ void zmq::pollset_t::rm_fd (handle_t handle_)
     pollset_ctl (pollset_fd, &pc, 1);
 
     fd_table [pe->fd] = NULL;
-    
+
     pe->fd = retired_fd;
-    retired.push_back (pe);    
-    
+    retired.push_back (pe);
+
     //  Decrease the load metric of the thread.
     adjust_load (-1);
 }

--- a/src/pollset.cpp
+++ b/src/pollset.cpp
@@ -98,13 +98,13 @@ void zmq::pollset_t::rm_fd (handle_t handle_)
     pc.events = 0;
     pollset_ctl (pollset_fd, &pc, 1);
 
+    fd_table [pe->fd] = NULL;
+    
     pe->fd = retired_fd;
-    retired.push_back (pe);
-
+    retired.push_back (pe);    
+    
     //  Decrease the load metric of the thread.
     adjust_load (-1);
-
-    fd_table [pe->fd] = NULL;
 }
 
 void zmq::pollset_t::set_pollin (handle_t handle_)


### PR DESCRIPTION
buf fix:  AIX only, pollset 'rm_fd' set fd_table to null first then set pe->fd to retired_fd