### PR TITLE
Problem: PR #2236 breaks the build

### DIFF
--- a/src/epoll.cpp
+++ b/src/epoll.cpp
@@ -92,9 +92,7 @@ void zmq::epoll_t::rm_fd (handle_t handle_)
     int rc = epoll_ctl (epoll_fd, EPOLL_CTL_DEL, pe->fd, &pe->ev);
     errno_assert (rc != -1);
     pe->fd = retired_fd;
-    retired_sync.lock ();
     retired.push_back (pe);
-    retired_sync.unlock ();
 
     //  Decrease the load metric of the thread.
     adjust_load (-1);
@@ -182,12 +180,10 @@ void zmq::epoll_t::loop ()
         }
 
         //  Destroy retired event sources.
-        retired_sync.lock ();
         for (retired_t::iterator it = retired.begin (); it != retired.end (); ++it) {
             LIBZMQ_DELETE(*it);
         }
         retired.clear ();
-        retired_sync.unlock ();
     }
 }
 

--- a/src/epoll.hpp
+++ b/src/epoll.hpp
@@ -41,7 +41,6 @@
 #include "fd.hpp"
 #include "thread.hpp"
 #include "poller_base.hpp"
-#include "mutex.h"
 
 namespace zmq
 {
@@ -102,9 +101,6 @@ namespace zmq
 
         //  Handle of the physical thread doing the I/O work.
         thread_t worker;
-
-        // Synchronisation of the retired event source
-        mutex_t retired_sync;
 
         epoll_t (const epoll_t&);
         const epoll_t &operator = (const epoll_t&);


### PR DESCRIPTION
Solution: Revert "avoid crashing in the multi-thread operation for std::vector"

This reverts commit e1368bdac804a49de101725ede1f900aebe82c10.

Fixes #2237