### PR TITLE
avoid crashing in the multi-thread operation for std::vector

### DIFF
--- a/src/epoll.hpp
+++ b/src/epoll.hpp
@@ -41,6 +41,7 @@
 #include "fd.hpp"
 #include "thread.hpp"
 #include "poller_base.hpp"
+#include "mutex.hpp"
 
 namespace zmq
 {
@@ -101,6 +102,9 @@ namespace zmq
 
         //  Handle of the physical thread doing the I/O work.
         thread_t worker;
+
+        //  Synchronisation of retired event sources
+        mutex_t retired_sync;
 
         epoll_t (const epoll_t&);
         const epoll_t &operator = (const epoll_t&);


### PR DESCRIPTION
1. stl container is not thread safety
2. rm_fd() and loop() end to clear the retired event source will in multi-thread operation
3. may be crashed in reaper thread to delete the items in the std::vector as the source is nullptr