### PR TITLE
Problem: 4.2.0 won't compile on AIX 7.1

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -112,6 +112,13 @@ extern "C" {
 #   include <stdint.h>
 #endif
 
+//  32-bit AIX's pollfd struct members are called reqevents and rtnevents so it
+//  defines compatibility macros for them. Need to include that header first to
+//  stop build failures since zmq_pollset_t defines them as events and revents.
+#ifdef ZMQ_HAVE_AIX
+    #include <poll.h>
+#endif
+
 
 /******************************************************************************/
 /*  0MQ errors.                                                               */

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -27,17 +27,23 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+//  On AIX platform, poll.h has to be included first to get consistent
+//  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'
+//  instead of 'events' and 'revents' and defines macros to map from POSIX-y
+//  names to AIX-specific names).
+//  zmq.h must be included *after* poll.h for AIX to build properly.
+//  precompiled.hpp includes include/zmq.h
+#if defined ZMQ_POLL_BASED_ON_POLL && defined ZMQ_HAVE_AIX
+#include <poll.h>
+#endif
+
 #include "precompiled.hpp"
 #include <stddef.h>
 #include "poller.hpp"
 #include "proxy.hpp"
 #include "likely.hpp"
 
-//  On AIX platform, poll.h has to be included first to get consistent
-//  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'
-//  instead of 'events' and 'revents' and defines macros to map from POSIX-y
-//  names to AIX-specific names).
-#if defined ZMQ_POLL_BASED_ON_POLL && !defined ZMQ_HAVE_WINDOWS
+#if defined ZMQ_POLL_BASED_ON_POLL && !defined ZMQ_HAVE_WINDOWS && !defined ZMQ_HAVE_AIX
 #include <poll.h>
 #endif
 
@@ -45,10 +51,6 @@
 // dependency chain
 #include "socket_base.hpp"
 #include "err.hpp"
-
-// TODO: determine if this is an issue, since zmq.h is being loaded from pch.
-// zmq.h must be included *after* poll.h for AIX to build properly
-//#include "../include/zmq.h"
 
 int capture(
         class zmq::socket_base_t *capture_,

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -27,15 +27,21 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "precompiled.hpp"
-#include "poller.hpp"
-
 //  On AIX, poll.h has to be included before zmq.h to get consistent
 //  definition of pollfd structure (AIX uses 'reqevents' and 'retnevents'
 //  instead of 'events' and 'revents' and defines macros to map from POSIX-y
 //  names to AIX-specific names).
+//  zmq.h must be included *after* poll.h for AIX to build properly.
+//  precompiled.hpp includes include/zmq.h
+#if defined ZMQ_POLL_BASED_ON_POLL && defined ZMQ_HAVE_AIX
+#include <poll.h>
+#endif
+
+#include "precompiled.hpp"
+#include "poller.hpp"
+
 #if defined ZMQ_POLL_BASED_ON_POLL
-#if !defined ZMQ_HAVE_WINDOWS
+#if !defined ZMQ_HAVE_WINDOWS && !defined ZMQ_HAVE_AIX
 #include <poll.h>
 #endif
 #elif defined ZMQ_POLL_BASED_ON_SELECT


### PR DESCRIPTION
Solution: restore inclusion of poll.h if using poll before zmq.h as
it was originally, as AIX redefines the POSIX structures and provides
compatibility macros.
Also add alternative aliases for 32 bit AIX's pollitem struct:
  events -> reqevents
  revents -> rtnevents

Partially fixes #2234