### PR TITLE
Fix #include case for <mstcpip.h>

### DIFF
--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -58,10 +58,10 @@
 #include <iphlpapi.h>
 
 #if !defined __MINGW32__
-#include <Mstcpip.h>
+#include <mstcpip.h>
 #endif
 
-//  Workaround missing Mstcpip.h in mingw32 (MinGW64 provides this)
+//  Workaround missing mstcpip.h in mingw32 (MinGW64 provides this)
 //  __MINGW64_VERSION_MAJOR is only defined when using in mingw-w64
 #if defined __MINGW32__ && !defined SIO_KEEPALIVE_VALS && \
     !defined __MINGW64_VERSION_MAJOR


### PR DESCRIPTION
On native Windows, the file system is case-insensitive, so this this
doesn't matter there.

However, when compiling on a case-sensitive filesystem, such as when
cross-compiling from a Unixoid using mingw, we have to use the case
the file is supplied with, which is all lowercase.