### PR TITLE
Problem: check for item.fd causes zloop_poller regression

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -834,7 +834,7 @@ inline int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
         for (int j = j_start; j < found_events; ++j) {
             if (
                 (items_[i].socket && items_[i].socket == events[j].socket) ||
-                (!(items_[i].socket || items_[j].socket) && items_[i].fd == events[j].fd)
+                (!items_[i].socket && items_[i].fd == events[j].fd)
             ) {
                 items_[i].revents = events[j].events & items_[i].events;
                 if (!repeat_items) {


### PR DESCRIPTION
Solution: fix the check for the socket.
This regression happens when using zloop with zmq_pollitem_it with
only file descriptors registered through zloop_poller.

@minrk narrowed a test failure I got in our application at work to commit f302d8a7b6cc74f6e8308e1d61ffb4804961c346 and this change fixes it. As the commit says we are simply registering some file descriptors and using them in a CZMQ zloop, but the events stopped working with that commit.