### PR TITLE
fix bug zmq4.x PUB msg to ZMTP1.0 SUB server

### DIFF
--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -752,10 +752,19 @@ int zmq::stream_engine_t::process_identity_msg (msg_t *msg_)
         errno_assert (rc == 0);
     }
 
-    if (subscription_required)
-        process_msg = &stream_engine_t::write_subscription_msg;
-    else
-        process_msg = &stream_engine_t::push_msg_to_session;
+    if (subscription_required) {
+        msg_t subscription;
+
+        //  Inject the subscription message, so that also
+        //  ZMQ 2.x peers receive published messages.
+        int rc = subscription.init_size (1);
+        errno_assert (rc == 0);
+        *(unsigned char*) subscription.data () = 1;
+        rc = session->push_msg (&subscription);
+        errno_assert (rc == 0);
+    }
+
+    process_msg = &stream_engine_t::push_msg_to_session;
 
     return 0;
 }
@@ -945,23 +954,6 @@ int zmq::stream_engine_t::push_one_then_decode_and_push (msg_t *msg_)
     if (rc == 0)
         process_msg = &stream_engine_t::decode_and_push;
     return rc;
-}
-
-int zmq::stream_engine_t::write_subscription_msg (msg_t *msg_)
-{
-    msg_t subscription;
-
-    //  Inject the subscription message, so that also
-    //  ZMQ 2.x peers receive published messages.
-    int rc = subscription.init_size (1);
-    errno_assert (rc == 0);
-    *(unsigned char*) subscription.data () = 1;
-    rc = session->push_msg (&subscription);
-    if (rc == -1)
-       return -1;
-
-    process_msg = &stream_engine_t::push_msg_to_session;
-    return push_msg_to_session (msg_);
 }
 
 void zmq::stream_engine_t::error (error_reason_t reason)

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -116,8 +116,6 @@ namespace zmq
 
         void mechanism_ready ();
 
-        int write_subscription_msg (msg_t *msg_);
-
         size_t add_property (unsigned char *ptr,
             const char *name, const void *value, size_t value_len);
 


### PR DESCRIPTION
This pr fix issues[https://github.com/zeromq/libzmq/issues/2254](https://github.com/zeromq/libzmq/issues/2254) which zmq4.x pub msg to sub server run with ZMTP 1.0 protocol, such as zmq 2.x

The problem was included in pr[https://github.com/zeromq/libzmq/pull/542](https://github.com/zeromq/libzmq/pull/542)