### PR TITLE
zmq_poll: only compare FD when neither item is a zmq socket

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -834,7 +834,7 @@ inline int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
         for (int j = j_start; j < found_events; ++j) {
             if (
                 (items_[i].socket && items_[i].socket == events[j].socket) ||
-                (!items_[i].socket && items_[i].fd == events[j].fd)
+                (!(items_[i].socket || events[j].socket) && items_[i].fd == events[j].fd)
             ) {
                 items_[i].revents = events[j].events & items_[i].events;
                 if (!repeat_items) {


### PR DESCRIPTION
The bug fixed by #2250 was that `j` is an index into `events`, not `items_`. Removing the comparison altogether in #2250 ought to be safe because unlike `items_`, `events` comes internally from libzmq. Still, I'm more comfortable with only comparing FD if neither side is a zmq socket event.

Still passes the test case in #2255