### PR TITLE
Fixed issue #2227

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -417,6 +417,8 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_EVENT_CLOSE_FAILED      0x0100
 #define ZMQ_EVENT_DISCONNECTED      0x0200
 #define ZMQ_EVENT_MONITOR_STOPPED   0x0400
+#define ZMQ_EVENT_HANDSHAKE_FAILED  0x0800
+#define ZMQ_EVENT_HANDSHAKE_SUCCEED 0x1000
 #define ZMQ_EVENT_ALL               0xFFFF
 
 ZMQ_EXPORT void *zmq_socket (void *, int type);

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -310,13 +310,14 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
                               sizeof hello_box,
                               hello_nonce, cn_client, secret_key);
     if (rc != 0) {
-        //  Temporary support for security debugging
-        puts ("CURVE I: cannot open client HELLO -- wrong server key?");
-        errno = EPROTO;
-        return -1;
+        // Hard error, the client knows a wrong server public key, it shall not try to reconnect using the same.
+        status_code = "100";
+        state = send_error;
+        rc = 0;
     }
+    else
+        state = send_welcome;
 
-    state = send_welcome;
     return rc;
 }
 

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -421,7 +421,8 @@ void zmq::session_base_t::engine_error (
     if (pipe)
         clean_pipes ();
 
-    zmq_assert (reason == stream_engine_t::connection_error
+    zmq_assert (reason == stream_engine_t::encryption_error
+             || reason == stream_engine_t::connection_error
              || reason == stream_engine_t::timeout_error
              || reason == stream_engine_t::protocol_error);
 
@@ -433,6 +434,7 @@ void zmq::session_base_t::engine_error (
             else
                 terminate ();
             break;
+        case stream_engine_t::encryption_error:
         case stream_engine_t::protocol_error:
             terminate ();
             break;

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1678,6 +1678,16 @@ void zmq::socket_base_t::event_disconnected (const std::string &addr_, zmq::fd_t
     event(addr_, fd_, ZMQ_EVENT_DISCONNECTED);
 }
 
+void zmq::socket_base_t::event_handshake_failed(const std::string &addr_, int err_)
+{
+	event(addr_, err_, ZMQ_EVENT_HANDSHAKE_FAILED);
+}
+
+void zmq::socket_base_t::event_handshake_succeed(const std::string &addr_, int err_)
+{
+	event(addr_, err_, ZMQ_EVENT_HANDSHAKE_SUCCEED);
+}
+
 void zmq::socket_base_t::event(const std::string &addr_, intptr_t value_, int type_)
 {
     scoped_lock_t lock(monitor_sync);

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -133,6 +133,8 @@ namespace zmq
         void event_closed (const std::string &addr_, zmq::fd_t fd_);
         void event_close_failed (const std::string &addr_, int err_);
         void event_disconnected (const std::string &addr_, zmq::fd_t fd_);
+        void event_handshake_failed(const std::string &addr_, int err_);
+		void event_handshake_succeed(const std::string &addr_, int err_);
 
     protected:
 

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -65,7 +65,8 @@ namespace zmq
         enum error_reason_t {
             protocol_error,
             connection_error,
-            timeout_error
+            timeout_error,
+            encryption_error
         };
 
         stream_engine_t (fd_t fd_, const options_t &options_,


### PR DESCRIPTION
# Problem
See #2227 
ZMQ doesn't provide status about the encryption handshake. When it fails, the client tries to reconnect indefinitely.

# Solution
Added two new monitoring events:
 - **ZMQ_EVENT_HANDSHAKE_SUCCEED** is raised once the encryption handshake succeed
 - **ZMQ_EVENT_HANDSHAKE_FAILED** is raised when it failed
Both events are raised on server and client side.

Also, when the curve engine find out the client uses a different (server) public key, it sends back a hard error to the client so it doesn't tries to reconnect infinitely.
That error message contains an error code abitrarily set to 100:

```
// src/curve_server.cpp
status_code = "100";
```

This can (or should) be modified, as the error code is not read so far, I had to set a value.

_**Nb:** I compiled and tested my code under **Visual Studio 2015** (non XP), I did **not** tested with any language binding or other zmq projects._