### PR TITLE
Code formatting + reverted hard error handshake fail

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -417,8 +417,6 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_EVENT_CLOSE_FAILED      0x0100
 #define ZMQ_EVENT_DISCONNECTED      0x0200
 #define ZMQ_EVENT_MONITOR_STOPPED   0x0400
-#define ZMQ_EVENT_HANDSHAKE_FAILED  0x0800
-#define ZMQ_EVENT_HANDSHAKE_SUCCEED 0x1000
 #define ZMQ_EVENT_ALL               0xFFFF
 
 ZMQ_EXPORT void *zmq_socket (void *, int type);
@@ -563,7 +561,11 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_SCATTER 17
 #define ZMQ_DGRAM 18
 
-/*  DRAFT Context options                                                           */
+/*  DRAFT 0MQ socket events and monitoring                                    */
+#define ZMQ_EVENT_HANDSHAKE_FAILED  0x0800
+#define ZMQ_EVENT_HANDSHAKE_SUCCEED 0x1000
+
+/*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6
 
 /*  DRAFT Socket methods.                                                     */

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -310,14 +310,13 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
                               sizeof hello_box,
                               hello_nonce, cn_client, secret_key);
     if (rc != 0) {
-        // Hard error, the client knows a wrong server public key, it shall not try to reconnect using the same.
-        status_code = "100";
-        state = send_error;
-        rc = 0;
+        //  Temporary support for security debugging
+        puts("CURVE I: cannot open client HELLO -- wrong server key?");
+        errno = EPROTO;
+        return -1;
     }
-    else
-        state = send_welcome;
-
+    
+    state = send_welcome;
     return rc;
 }
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1680,12 +1680,12 @@ void zmq::socket_base_t::event_disconnected (const std::string &addr_, zmq::fd_t
 
 void zmq::socket_base_t::event_handshake_failed(const std::string &addr_, int err_)
 {
-	event(addr_, err_, ZMQ_EVENT_HANDSHAKE_FAILED);
+    event(addr_, err_, ZMQ_EVENT_HANDSHAKE_FAILED);
 }
 
 void zmq::socket_base_t::event_handshake_succeed(const std::string &addr_, int err_)
 {
-	event(addr_, err_, ZMQ_EVENT_HANDSHAKE_SUCCEED);
+    event(addr_, err_, ZMQ_EVENT_HANDSHAKE_SUCCEED);
 }
 
 void zmq::socket_base_t::event(const std::string &addr_, intptr_t value_, int type_)

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -134,7 +134,7 @@ namespace zmq
         void event_close_failed (const std::string &addr_, int err_);
         void event_disconnected (const std::string &addr_, zmq::fd_t fd_);
         void event_handshake_failed(const std::string &addr_, int err_);
-		void event_handshake_succeed(const std::string &addr_, int err_);
+        void event_handshake_succeed(const std::string &addr_, int err_);
 
     protected:
 

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -790,8 +790,8 @@ int zmq::stream_engine_t::next_handshake_command (msg_t *msg_)
 
         if (rc == 0)
             msg_->set_flags (msg_t::command);
-		if(mechanism->status() == mechanism_t::error)
-			socket->event_handshake_failed(endpoint, 0);
+        if(mechanism->status() == mechanism_t::error)
+            socket->event_handshake_failed(endpoint, 0);
 
         return rc;
     }

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -46,7 +46,11 @@
 #define ZMQ_SCATTER 17
 #define ZMQ_DGRAM 18
 
-/*  DRAFT Context options                                                           */
+/*  DRAFT 0MQ socket events and monitoring                                    */
+#define ZMQ_EVENT_HANDSHAKE_FAILED  0x0800
+#define ZMQ_EVENT_HANDSHAKE_SUCCEED 0x1000
+
+/*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6
 
 /*  DRAFT Socket methods.                                                     */


### PR DESCRIPTION
## Regarding the regression introduced in the PR #2280 :

 - Moved new events in draft section + added to zmq_draft.h
 - Removed the remainning tabs
 - Reverted the _hard_ error (_back_ to soft error) in `curve_server.cpp`

## The feature doesn't work anymore:
 - The ZMQ_EVENT_HANDSHAKE_FAILED is raised only on the server's side.
 - The ZMQ_EVENT_HANDSHAKE_SUCCEED still works on both sides

## About the build fails:
 - I was not able to replay the tests on my computer so far.
