### PR TITLE
Problems: test_monitor failing, DRAFT events leaking when draft APIs are disabled

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@
 
 * New DRAFT (see NEWS for 4.2.0) Context options:
   - ZMQ_MSG_T_SIZE
+  See doc/zmq_ctx_get.txt for more information.
 
 * Fixed #2268 - improved compatibility with mingw32
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 0MQ version 4.2.1 stable, released on 201x/xx/xx
 =============================================
 
+* New DRAFT (see NEWS for 4.2.0) Socket Monitor events:
+  - ZMQ_EVENT_HANDSHAKE_SUCCEED
+  - ZMQ_EVENT_HANDSHAKE_FAILED
+  These events trigger when the ZMTP security mechanism handshake is
+  completed. See doc/zmq_socket_monitor.txt for more information.
+
 * New DRAFT (see NEWS for 4.2.0) Context options:
   - ZMQ_MSG_T_SIZE
 

--- a/doc/zmq_socket_monitor.txt
+++ b/doc/zmq_socket_monitor.txt
@@ -23,7 +23,10 @@ your own 'ZMQ_PAIR' socket, and connect that to the endpoint.
 
 The 'events' argument is a bitmask of the socket events you wish to
 monitor, see 'Supported events' below. To monitor all events, use the
-event value ZMQ_EVENT_ALL.
+event value ZMQ_EVENT_ALL. NOTE: as new events are added, the catch-all
+value will start returning them. An application that relies on a strict
+and fixed sequence of events must not use ZMQ_EVENT_ALL in order to
+guarantee compatibility with future versions.
 
 Each event is sent as two frames. The first frame contains an event
 number (16 bits), and an event value (32 bits) that provides additional

--- a/doc/zmq_socket_monitor.txt
+++ b/doc/zmq_socket_monitor.txt
@@ -99,6 +99,18 @@ ZMQ_EVENT_MONITOR_STOPPED
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Monitoring on this socket ended.
 
+ZMQ_EVENT_HANDSHAKE_FAILED
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ZMTP security mechanism handshake failed.
+The event value is unspecified.
+NOTE: in DRAFT state, not yet available in stable releases.
+
+ZMQ_EVENT_HANDSHAKE_SUCCEED
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ZMTP security mechanism handshake succeeded.
+The event value is unspecified.
+NOTE: in DRAFT state, not yet available in stable releases.
+
 
 RETURN VALUE
 ------------

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -790,8 +790,10 @@ int zmq::stream_engine_t::next_handshake_command (msg_t *msg_)
 
         if (rc == 0)
             msg_->set_flags (msg_t::command);
+#ifdef ZMQ_BUILD_DRAFT_API
         if(mechanism->status() == mechanism_t::error)
             socket->event_handshake_failed(endpoint, 0);
+#endif
 
         return rc;
     }
@@ -871,7 +873,9 @@ void zmq::stream_engine_t::mechanism_ready ()
     if (!properties.empty ())
         metadata = new (std::nothrow) metadata_t (properties);
 
+#ifdef ZMQ_BUILD_DRAFT_API
     socket->event_handshake_succeed(endpoint, 0);
+#endif
 }
 
 int zmq::stream_engine_t::pull_msg_from_session (msg_t *msg_)
@@ -976,8 +980,10 @@ void zmq::stream_engine_t::error (error_reason_t reason)
         terminator.close();
     }
     zmq_assert (session);
+#ifdef ZMQ_BUILD_DRAFT_API
     if(reason == encryption_error)
         socket->event_handshake_failed(endpoint, (int) s);
+#endif
     socket->event_disconnected (endpoint, (int) s);
     session->flush ();
     session->engine_error (reason);

--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -116,6 +116,10 @@ int main (void)
     if (event == ZMQ_EVENT_CONNECT_DELAYED)
         event = get_monitor_event (client_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_CONNECTED);
+#ifdef ZMQ_BUILD_DRAFT_API
+    event = get_monitor_event (client_mon, NULL, NULL);
+    assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEED);
+#endif
     event = get_monitor_event (client_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_MONITOR_STOPPED);
 
@@ -124,6 +128,10 @@ int main (void)
     assert (event == ZMQ_EVENT_LISTENING);
     event = get_monitor_event (server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_ACCEPTED);
+#ifdef ZMQ_BUILD_DRAFT_API
+    event = get_monitor_event (server_mon, NULL, NULL);
+    assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEED);
+#endif
     event = get_monitor_event (server_mon, NULL, NULL);
     //  Sometimes the server sees the client closing before it gets closed.
     if (event != ZMQ_EVENT_DISCONNECTED) {


### PR DESCRIPTION
Solutions: see commits

The basic issue was that the catch-all flag, ZMQ_EVENT_ALL, was enabling the new events. This is kindof expected given the name. But to further clarify, I've added a note to the docs. In my opinion using such a flag implies that new events will be enabled as they are added. It wouldn't make any sense to have a ZMQ_EVENT_ALL flag that doesn't trigger all events (stable ones, that is).