### PR TITLE
Fixed issue #2227 second part

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -421,8 +421,7 @@ void zmq::session_base_t::engine_error (
     if (pipe)
         clean_pipes ();
 
-    zmq_assert (reason == stream_engine_t::encryption_error
-             || reason == stream_engine_t::connection_error
+    zmq_assert (reason == stream_engine_t::connection_error
              || reason == stream_engine_t::timeout_error
              || reason == stream_engine_t::protocol_error);
 
@@ -434,7 +433,6 @@ void zmq::session_base_t::engine_error (
             else
                 terminate ();
             break;
-        case stream_engine_t::encryption_error:
         case stream_engine_t::protocol_error:
             terminate ();
             break;

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -356,10 +356,7 @@ void zmq::stream_engine_t::in_event ()
     //  or the session has rejected the message.
     if (rc == -1) {
         if (errno != EAGAIN) {
-            if(this->process_msg == &stream_engine_t::process_handshake_command)
-                error(encryption_error);
-            else
-                error(protocol_error);
+            error(protocol_error);
             return;
         }
         input_stopped = true;
@@ -981,7 +978,7 @@ void zmq::stream_engine_t::error (error_reason_t reason)
     }
     zmq_assert (session);
 #ifdef ZMQ_BUILD_DRAFT_API
-    if(reason == encryption_error)
+    if(mechanism->status() == mechanism_t::handshaking)
         socket->event_handshake_failed(endpoint, (int) s);
 #endif
     socket->event_disconnected (endpoint, (int) s);

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -978,7 +978,7 @@ void zmq::stream_engine_t::error (error_reason_t reason)
     }
     zmq_assert (session);
 #ifdef ZMQ_BUILD_DRAFT_API
-    if(mechanism->status() == mechanism_t::handshaking)
+    if(mechanism == NULL || mechanism->status() == mechanism_t::handshaking)
         socket->event_handshake_failed(endpoint, (int) s);
 #endif
     socket->event_disconnected (endpoint, (int) s);

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -65,8 +65,7 @@ namespace zmq
         enum error_reason_t {
             protocol_error,
             connection_error,
-            timeout_error,
-            encryption_error
+            timeout_error
         };
 
         stream_engine_t (fd_t fd_, const options_t &options_,

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,8 @@ to add a sleep, please be consistent with all the other tests and use:
 
 # Building tests in Windows
 
+According to the version of your compiler, you should adapt the path `libzmq.lib` in the file `tests/CMakeLists.txt`.
+
 Install CMAKE
 CMD> CMAKE libzmq/tests
 CMD> tests.sln


### PR DESCRIPTION
**Problem:** the feature was signaling the handshake fail only on the server side (see #2281 )

**Solution:**
 - removed the previously added encryption_error => _less changes less bug_
 - handshake fail is now signaled when an error happen while the
   mechanism is still hanshaking

> @bluca  **Be careful of this before merge!**
> In `stream_engine.cpp` I check `if(mechanism->status() == mechanism_t::handshaking)`
> I am not 100% sure that this does not leads to crashes (if mechanism becomes null for some reason) in race conditions especially.

It was the case, see commit e6b057f05cf5a861ffc652805b025482554a5d34