### PR TITLE
Problem: build fails on GNU/Hurd as it does not support IPV6_TCLASS

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -173,8 +173,8 @@ void zmq::set_ip_type_of_service (fd_t s_, int iptos)
     errno_assert (rc == 0);
 #endif
 
-    //  Windows does not support IPV6_TCLASS
-#ifndef ZMQ_HAVE_WINDOWS
+    //  Windows and Hurd do not support IPV6_TCLASS
+#if !defined (ZMQ_HAVE_WINDOWS) && defined (IPV6_TCLASS)
     rc = setsockopt(
         s_,
         IPPROTO_IPV6,


### PR DESCRIPTION
Solution: check if IPV6_TCLASS is defined so that when Hurd adds
support it will just work. Also it will avoid tripping over this on
other similar legacy systems.