### PR TITLE
Problem:capitalized include filenames trip mingw

### DIFF
--- a/tests/test_srcfd.cpp
+++ b/tests/test_srcfd.cpp
@@ -32,8 +32,8 @@
 #define MSG_SIZE 20
 
 #ifdef _WIN32
-#include <Winsock2.h>
-#include <Ws2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #else
 #include <sys/types.h>
 #include <sys/socket.h>


### PR DESCRIPTION
Solution: use lowercase

Fixes https://github.com/zeromq/libzmq/issues/1235