### PR TITLE
Windows cmake build fixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,7 @@ endif ()
 # source files
 
 set (cxx-sources
+        precompiled.cpp
         address.cpp
         client.cpp
         clock.cpp
@@ -510,7 +511,6 @@ set (cxx-sources
         poll.cpp
         poller_base.cpp
         pollset.cpp
-        precompiled.cpp
         proxy.cpp
         pub.cpp
         pull.cpp


### PR DESCRIPTION
Fixes #2253.

@bluca This solves only the build, not the installation on windows. I will make another PR for this problem.
