### PR TITLE
Cmake win install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -844,17 +844,19 @@ endif ()
 #-----------------------------------------------------------------------------
 # installer
 
+include(GNUInstallDirs)
+
 if (MSVC)
   install (TARGETS libzmq libzmq-static
-          ARCHIVE DESTINATION lib
-          LIBRARY DESTINATION lib
-          PUBLIC_HEADER DESTINATION include
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           COMPONENT SDK)
   if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     install (TARGETS libzmq libzmq-static
-            RUNTIME DESTINATION bin
-            ARCHIVE DESTINATION lib
-            PUBLIC_HEADER DESTINATION include
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
             COMPONENT SDK)
     if (NOT CMAKE_PDB_OUTPUT_DIRECTORY)
       install (FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}.pdb DESTINATION lib
@@ -862,17 +864,17 @@ if (MSVC)
     endif ()
   else ()
     install (TARGETS libzmq
-            RUNTIME DESTINATION bin
-            PUBLIC_HEADER DESTINATION include
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
             COMPONENT Runtime)
   endif ()
 else ()
   install (TARGETS libzmq libzmq-static
-          RUNTIME DESTINATION bin
-          ARCHIVE DESTINATION lib
-          LIBRARY DESTINATION lib
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           FRAMEWORK DESTINATION "Library/Frameworks"
-          PUBLIC_HEADER DESTINATION include)
+          PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif ()
 
 # install (FILES ${public_headers}
@@ -898,6 +900,27 @@ if (WITH_DOC)
     install (FILES ${html-docs} DESTINATION doc/zmq COMPONENT RefGuide)
   endif ()
 endif ()
+
+include(CMakePackageConfigHelpers)
+
+string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
+get_property(libzmq_pf TARGET libzmq PROPERTY ${U_CMAKE_BUILD_TYPE}_POSTFIX)
+set(libzmq_file libzmq${libzmq_pf}${CMAKE_LINK_LIBRARY_SUFFIX})
+get_property(libzmq_static_pf TARGET libzmq-static PROPERTY ${U_CMAKE_BUILD_TYPE}_POSTFIX)
+set(libzmq_static_file libzmq-static${libzmq_static_pf}${CMAKE_LINK_LIBRARY_SUFFIX})
+
+# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
+set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
+
+configure_package_config_file(${PROJECT_NAME}Config.cmake.in
+                              "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+                              INSTALL_DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+                                 VERSION ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}
+                                 COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+              DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
 
 option(ENABLE_CPACK "Enables cpack rules" ON)
 if (MSVC AND ENABLE_CPACK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -889,11 +889,7 @@ foreach (readme ${readme-docs})
   configure_file (${CMAKE_CURRENT_SOURCE_DIR}/${readme} ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt)
 
   if (NOT ZMQ_BUILD_FRAMEWORK)
-    if (MSVC)
-      install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION .)
-    else ()
-      install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION share/zmq)
-    endif ()
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION share/zmq)
   endif ()
 endforeach ()
 
@@ -903,8 +899,8 @@ if (WITH_DOC)
   endif ()
 endif ()
 
-
-if (MSVC)
+option(ENABLE_CPACK "Enables cpack rules" ON)
+if (MSVC AND ENABLE_CPACK)
   include (InstallRequiredSystemLibraries)
 
   if (CMAKE_CL_64)

--- a/INSTALL
+++ b/INSTALL
@@ -14,6 +14,28 @@ If you clone the Git repository then you should start by running the
 command `./autogen.sh`. This is not necessary if you get the source
 packages.
 
+CMake installation
+==================
+
+The following options are available for cmake invocation:
+
+- `WITH_PERF_TOOL'
+    Enables the build of performance tools. Default value is ON.
+- `ZMQ_BUILD_TESTS'
+    Builds ZeroMQ tests. Default value is ON.
+- `ENABLE_CPACK'
+    Enables CPack build rules. This option has effect on Windows
+    platform only. Default value is ON. Turn it to OFF if you
+    don't want the runtime libraries to be installed (typically
+    if your installation destination already contains them).
+    
+
+Example: installing ZeroMQ on Windows with no tests, no performance
+tools, and no runtime library copy:
+
+cmake -G "NMake Makefiles" -D WITH_PERF_TOOL=OFF -D ZMQ_BUILD_TESTS=OFF
+-D ENABLE_CPACK=OFF -D CMAKE_BUILD_TYPE=Release
+
 Windows Builds
 ==============
 

--- a/ZeroMQConfig.cmake.in
+++ b/ZeroMQConfig.cmake.in
@@ -1,0 +1,15 @@
+# ZeroMQ cmake module
+# This module sets the following variables in your project::
+#
+#   ZeroMQ_FOUND - true if ZeroMQ found on the system
+#   ZeroMQ_INCLUDE_DIR - the directory containing ZeroMQ headers
+#   ZeroMQ_LIBRARY - 
+#   ZeroMQ_STATIC_LIBRARY
+
+@PACKAGE_INIT@
+
+set(PN ZeroMQ)
+set_and_check(${PN}_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(${PN}_LIBRARY "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@/@libzmq_file@")
+set_and_check(${PN}_STATIC_LIBRARY "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@/@libzmq_static_file@")
+check_required_components(${PN})


### PR DESCRIPTION
This PR fixes CMake installation:

- it adds ZeroMQConfig.cmake generation rules so you don't need any FindZeroMQ.cmake external file anymor to have find_package(ZeroMQ) working.

- it provides the `ENABLE_CPACK' option that allows to turn on/off CPack rules. Default value is ON so it doesn't break old behavior. This option is useful if you want to prevent system runtime libraries to be copied (if your installation destination already contains them for instance).

- The INSTALL file has been updated to include CMake installation instructions.