### PR TITLE
Problem: set hwm after connect lead to infinite hwm

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -83,8 +83,8 @@ zmq::pipe_t::pipe_t (object_t *parent_, upipe_t *inpipe_, upipe_t *outpipe_,
     out_active (true),
     hwm (outhwm_),
     lwm (compute_lwm (inhwm_)),
-    inhwmboost(0),
-    outhwmboost(0),
+    inhwmboost(1),
+    outhwmboost(1),
     msgs_read (0),
     msgs_written (0),
     peers_msgs_read (0),
@@ -520,6 +520,11 @@ void zmq::pipe_t::set_hwms (int inhwm_, int outhwm_)
 
     lwm = compute_lwm(in);
     hwm = out;
+}
+
+void zmq::pipe_t::set_peer_hwms (int inhwm_, int outhwm_)
+{
+    peer->set_hwms(inhwm_, outhwm_);
 }
 
 void zmq::pipe_t::set_hwms_boost(int inhwmboost_, int outhwmboost_)

--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -133,6 +133,9 @@ namespace zmq
         //  Set the high water marks.
         void set_hwms (int inhwm_, int outhwm_);
 
+        //  Set the high water marks for peer.
+        void set_peer_hwms (int inhwm_, int outhwm_);
+
         //  Set the boost to high water marks, used by inproc sockets so total hwm are sum of connect and bind sockets watermarks
         void set_hwms_boost(int inhwmboost_, int outhwmboost_);
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1414,6 +1414,7 @@ void zmq::socket_base_t::update_pipe_options(int option_)
         for (pipes_t::size_type i = 0; i != pipes.size(); ++i)
         {
             pipes[i]->set_hwms(options.rcvhwm, options.sndhwm);
+            pipes[i]->set_peer_hwms(options.sndhwm, options.rcvhwm);
         }
     }
 


### PR DESCRIPTION
This pr is wrote to fix bug descibe here [Problem: infinite hwm of version 4.2 lead to catch no msg](https://github.com/zeromq/libzmq/issues/2228)

The pr can be divide into two part:
**1. fix: set hwm after connect lead the hwm of pipe wrong**
**2. fix: set hwm after lead to infinite hwm**
For example:
we set sndhwm to 20, rcvhwm to 20 after connect
```
[before]
socket_base ( hwm 1000, lwm 500 )
session_base ( hwm 1000, lwm 500 )

[after]
socket_base ( hwm 0, lwm 0 )
session_base ( hwm 1000, lwm 500 )
```

The behavior is not expected, so we need also to set peer hwm

after part 1, the result is descibe as follow
```
[before]
socket_base ( hwm 1000, lwm 500 )
session_base ( hwm 1000, lwm 500 )

[after]
socket_base ( hwm 0, lwm 0 )
session_base ( hwm 0, lwm 0 )
```

now our hwm is calc right, but infinite hwm is also not expected.
so, we include this change
```
-    inhwmboost(0),
-    outhwmboost(0),
+    inhwmboost(1),
+    outhwmboost(1),
```

Then 
```
[before]
socket_base ( hwm 1000, lwm 500 )
session_base ( hwm 1000, lwm 500 )

[after]
socket_base ( hwm 20, lwm 10 )
session_base ( hwm 20, lwm 10 )
```

Now the result is what we expected