### PR TITLE
Make OS Xframwork build optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option (WITH_OPENPGM "Build with support for OpenPGM" OFF)
 option (WITH_VMCI "Build with support for VMware VMCI socket" OFF)
 
 if (APPLE)
-    option (ZMQ_BUILD_FRAMEWORK "Build as OS X framework" ON)
+    option (ZMQ_BUILD_FRAMEWORK "Build as OS X framework" OFF)
 endif ()
 
 # Select curve encryption library, defaults to tweetnacl


### PR DESCRIPTION
Problem: on OS X, the cmake build produces different artefacts than the regular Unix build.

Solution: the reason is that the default built target on OS is that of "framework"

 - This fixes #1801 
 - This will simplify the build script for zmq in the conda package manager which special cases OS X to add `-DZMQ_BUILD_FRAMEWORK=OFF`
   (cf https://github.com/conda-forge/zeromq-feedstock/blob/master/recipe/build.sh#L6