### PR TITLE
Problem: v4-in-v6 mapped addresses cause parsing failure

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -842,7 +842,7 @@ int zmq::socket_base_t::connect (const char *addr_)
         //  Following code is quick and dirty check to catch obvious errors,
         //  without trying to be fully accurate.
         const char *check = address.c_str ();
-        if (isalnum (*check) || isxdigit (*check) || *check == '[') {
+        if (isalnum (*check) || isxdigit (*check) || *check == '[' || *check == ':') {
             check++;
             while (isalnum  (*check)
                 || isxdigit (*check)


### PR DESCRIPTION
Solution: in the address validator accept an endpoint that starts
with :, eg: ::ffff:192.168.0.1:12345 as it's a valid mapped
address.