### PR TITLE
Include FindSodium.cmake in dist tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -791,6 +791,7 @@ XFAIL_TESTS += test_ipc_wildcard \
 endif
 
 EXTRA_DIST = \
+	FindSodium.cmake \
 	CMakeLists.txt \
 	autogen.sh	\
 	version.sh	\


### PR DESCRIPTION
**Problem:** FindSodium.cmake is missing in release tarballs.
**Solution:** As suggested by @bluca , list the file in MakeFile.am.

Closes #1952 