### PR TITLE
Problem: distcheck tests fail sometimes

### DIFF
--- a/tests/test_client_server.cpp
+++ b/tests/test_client_server.cpp
@@ -63,8 +63,10 @@ int main (void)
     rc = zmq_msg_recv (&msg, server, 0);
     assert (rc == 1);
 
+#ifdef ZMQ_BUILD_DRAFT_API
     uint32_t routing_id = zmq_msg_routing_id (&msg);
     assert (routing_id != 0);
+#endif
 
     rc = zmq_msg_close (&msg);
     assert (rc == 0);
@@ -75,8 +77,10 @@ int main (void)
     data = (char *)zmq_msg_data (&msg);
     data[0] = 2;
 
+#ifdef ZMQ_BUILD_DRAFT_API
     rc = zmq_msg_set_routing_id (&msg, routing_id);
     assert (rc == 0);
+#endif
 
     rc = zmq_msg_send (&msg, server, ZMQ_SNDMORE);
     assert (rc == -1);
@@ -87,8 +91,10 @@ int main (void)
     rc = zmq_msg_recv (&msg, client, 0);
     assert (rc == 1);
 
+#ifdef ZMQ_BUILD_DRAFT_API
     routing_id = zmq_msg_routing_id (&msg);
     assert (routing_id == 0);
+#endif
 
     rc = zmq_msg_close (&msg);
     assert (rc == 0);

--- a/tests/test_use_fd_ipc.cpp
+++ b/tests/test_use_fd_ipc.cpp
@@ -160,8 +160,10 @@ void test_client_server ()
     rc = zmq_msg_recv (&msg, sb, 0);
     assert (rc == 1);
 
+#ifdef ZMQ_BUILD_DRAFT_API
     uint32_t routing_id = zmq_msg_routing_id (&msg);
     assert (routing_id != 0);
+#endif
 
     rc = zmq_msg_close (&msg);
     assert (rc == 0);
@@ -172,8 +174,10 @@ void test_client_server ()
     data = (char *)zmq_msg_data (&msg);
     data[0] = 2;
 
+#ifdef ZMQ_BUILD_DRAFT_API
     rc = zmq_msg_set_routing_id (&msg, routing_id);
     assert (rc == 0);
+#endif
 
     rc = zmq_msg_send (&msg, sb, ZMQ_SNDMORE);
     assert (rc == -1);
@@ -184,8 +188,10 @@ void test_client_server ()
     rc = zmq_msg_recv (&msg, sc, 0);
     assert (rc == 1);
 
+#ifdef ZMQ_BUILD_DRAFT_API
     routing_id = zmq_msg_routing_id (&msg);
     assert (routing_id == 0);
+#endif
 
     rc = zmq_msg_close (&msg);
     assert (rc == 0);

--- a/tests/test_use_fd_tcp.cpp
+++ b/tests/test_use_fd_tcp.cpp
@@ -166,8 +166,10 @@ void test_client_server ()
     rc = zmq_msg_recv (&msg, sb, 0);
     assert (rc == 1);
 
+#ifdef ZMQ_BUILD_DRAFT_API
     uint32_t routing_id = zmq_msg_routing_id (&msg);
     assert (routing_id != 0);
+#endif
 
     rc = zmq_msg_close (&msg);
     assert (rc == 0);
@@ -178,8 +180,10 @@ void test_client_server ()
     data = (char *)zmq_msg_data (&msg);
     data[0] = 2;
 
+#ifdef ZMQ_BUILD_DRAFT_API
     rc = zmq_msg_set_routing_id (&msg, routing_id);
     assert (rc == 0);
+#endif
 
     rc = zmq_msg_send (&msg, sb, ZMQ_SNDMORE);
     assert (rc == -1);
@@ -190,8 +194,10 @@ void test_client_server ()
     rc = zmq_msg_recv (&msg, sc, 0);
     assert (rc == 1);
 
+#ifdef ZMQ_BUILD_DRAFT_API
     routing_id = zmq_msg_routing_id (&msg);
     assert (routing_id == 0);
+#endif
 
     rc = zmq_msg_close (&msg);
     assert (rc == 0);


### PR DESCRIPTION
Solution: try to ifdef-away tests for DRAFT functionality (routing_id stuff)

NOTE: my local distchecks still fail, so the issue must be elsewhere... but this fix still seems reasonable (I don't think we do tests ONLY in draft-api mode?)