### PR TITLE
cmake WITH_LIBSODIUM option is broken

### DIFF
--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -35,7 +35,7 @@
 
 #cmakedefine ZMQ_HAVE_CURVE
 #cmakedefine ZMQ_USE_TWEETNACL
-#cmakedefine ZMQ_USE_LIBSOIUM
+#cmakedefine ZMQ_USE_LIBSODIUM
 
 #ifdef _AIX
   #define ZMQ_HAVE_AIX

--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -35,7 +35,7 @@
 
 #cmakedefine ZMQ_HAVE_CURVE
 #cmakedefine ZMQ_USE_TWEETNACL
-#cmakedefine HAVE_LIBSODIUM
+#cmakedefine ZMQ_USE_LIBSOIUM
 
 #ifdef _AIX
   #define ZMQ_HAVE_AIX

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -133,7 +133,7 @@ zmq::ctx_t::~ctx_t ()
 
     //  If we've done any Curve encryption, we may have a file handle
     //  to /dev/urandom open that needs to be cleaned up.
-#if defined (ZMQ_USE_TWEETNACL)
+#ifdef ZMQ_HAVE_CURVE
     randombytes_close ();
 #endif
 

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -133,7 +133,7 @@ zmq::ctx_t::~ctx_t ()
 
     //  If we've done any Curve encryption, we may have a file handle
     //  to /dev/urandom open that needs to be cleaned up.
-#ifdef ZMQ_HAVE_CURVE
+#if defined (ZMQ_USE_TWEETNACL)
     randombytes_close ();
 #endif
 


### PR DESCRIPTION
- Fixed the variable name in platform.hpp.in
