### PR TITLE
Problem: unnecessary change to router_mandatory_hwm test

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1120,13 +1120,7 @@ int zmq::socket_base_t::send (msg_t *msg_, int flags_)
     if (rc == 0) {
         return 0;
     }
-
-    // In case of ZMQ_ROUTER_MANDATORY option set and peer disconnected
-    if (likely(errno == EHOSTUNREACH)) {
-        return -1;
-    }
-
-    if (unlikely(errno != EAGAIN)) {
+    if (unlikely (errno != EAGAIN)) {
         return -1;
     }
 

--- a/tests/test_router_mandatory_hwm.cpp
+++ b/tests/test_router_mandatory_hwm.cpp
@@ -84,15 +84,11 @@ int main (void)
     const int BUF_SIZE = 65536;
     char buf[BUF_SIZE];
     memset(buf, 0, BUF_SIZE);
-
     // Send first batch of messages
     for(i = 0; i < 100000; ++i) {
-        if (TRACE_ENABLED) 
-            fprintf(stderr, "Sending message %d ...\n", i);
-
+        if (TRACE_ENABLED) fprintf(stderr, "Sending message %d ...\n", i);
         rc = zmq_send (router, "X", 1, ZMQ_DONTWAIT | ZMQ_SNDMORE);
-        if (rc == -1 && zmq_errno() == EHOSTUNREACH)
-            break;
+        if (rc == -1 && zmq_errno() == EAGAIN) break;
         assert (rc == 1);
         rc = zmq_send (router, buf, BUF_SIZE, ZMQ_DONTWAIT);
         assert (rc == BUF_SIZE);
@@ -100,17 +96,12 @@ int main (void)
     // This should fail after one message but kernel buffering could
     // skew results
     assert (i < 10);
-
     msleep (1000);
-
     // Send second batch of messages
     for(; i < 100000; ++i) {
-        if (TRACE_ENABLED) 
-            fprintf(stderr, "Sending message %d (part 2) ...\n", i);
-
+        if (TRACE_ENABLED) fprintf(stderr, "Sending message %d (part 2) ...\n", i);
         rc = zmq_send (router, "X", 1, ZMQ_DONTWAIT | ZMQ_SNDMORE);
-        if (rc == -1 && zmq_errno() == EHOSTUNREACH)
-            break;
+        if (rc == -1 && zmq_errno() == EAGAIN) break;
         assert (rc == 1);
         rc = zmq_send (router, buf, BUF_SIZE, ZMQ_DONTWAIT);
         assert (rc == BUF_SIZE);
@@ -119,8 +110,7 @@ int main (void)
     // skew results
     assert (i < 20);
 
-    if (TRACE_ENABLED) 
-        fprintf(stderr, "Done sending messages.\n");
+    if (TRACE_ENABLED) fprintf(stderr, "Done sending messages.\n");
 
     rc = zmq_close (router);
     assert (rc == 0);


### PR DESCRIPTION
Solution:

Revert "Problem with ZMQ_ROUTER_MANDATORY option when peer lost"

This partially reverts commit 06740b5d8c1fbf13205c9b6c63ba7e7ef4350a04.

The change in the mentioned commit was fixed to be backward
compatible so test changes are no longer necessary.
Partially revert the commit, leaving only the bug fix and taking out
the test change and the superfluous change in socket_base.