### PR TITLE
Problem: router pipe can block forever

### DIFF
--- a/src/router.cpp
+++ b/src/router.cpp
@@ -213,26 +213,19 @@ int zmq::router_t::xsend (msg_t *msg_)
             if (it != outpipes.end ()) {
                 current_out = it->second.pipe;
 
-                // Check whether pipe is full or not
-                if (!current_out->check_hwm()) {
-                    it->second.active = false;
-                    current_out = NULL;
-
-                    if (mandatory) {
-                        more_out = false;
-                        errno = EAGAIN;
-                        return -1;
-                    }
-                }
                 // Check whether pipe is closed or not
-                else 
                 if (!current_out->check_write()) {
+                    // Check whether pipe is full or not
+                    bool pipe_full = !current_out->check_hwm ();
                     it->second.active = false;
                     current_out = NULL;
 
                     if (mandatory) {
                         more_out = false;
-                        errno = EHOSTUNREACH;
+                        if (pipe_full)
+                            errno = EAGAIN;
+                        else
+                            errno = EHOSTUNREACH;
                         return -1;
                     }
                 }


### PR DESCRIPTION
Solution: invert check_write and check_hwm calls in router xsend
function so that check_write can mark the pipe as inactive if
necessary.

@somdoron is this what you had in mind? Tried adding a test case for this but couldn't quite make it fail without the fix