### PR TITLE
Fix issue #2303: Assertion failed in zmq::signaler_t::send

### DIFF
--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -187,9 +187,13 @@ void zmq::signaler_t::send ()
     errno_assert (sz == sizeof (inc));
 #elif defined ZMQ_HAVE_WINDOWS
     unsigned char dummy = 0;
-    int nbytes = ::send (w, (char *) &dummy, sizeof (dummy), 0);
-    wsa_assert (nbytes != SOCKET_ERROR);
-    zmq_assert (nbytes == sizeof (dummy));
+    while (true) {
+        int nbytes = ::send (w, (char*) &dummy, sizeof (dummy), 0);
+        if (unlikely (nbytes == SOCKET_ERROR))
+            continue;
+        zmq_assert (nbytes == sizeof (dummy));
+        break;
+    }
 #else
     unsigned char dummy = 0;
     while (true) {


### PR DESCRIPTION
**Problem:**
`Assertion failed: nbytes == sizeof (dummy)` in `signaler.cpp` in method `zmq::signaler_t::send` on Windows. `send` may return `-1` sometimes.
**Solution:**
Change to the way it does below on non-Windows platforms, retry when `send` returns `-1`.
