### PR TITLE
Problem: zmq::signaler_t::send may loop forever

### DIFF
--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -189,6 +189,7 @@ void zmq::signaler_t::send ()
     unsigned char dummy = 0;
     while (true) {
         int nbytes = ::send (w, (char*) &dummy, sizeof (dummy), 0);
+        wsa_assert (nbytes != SOCKET_ERROR);
         if (unlikely (nbytes == SOCKET_ERROR))
             continue;
         zmq_assert (nbytes == sizeof (dummy));


### PR DESCRIPTION
Solution: restore the wsa_assert statement which was previously removed.