### PR TITLE
problem: zmq_poll is slow because FD is being created on every call

### DIFF
--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -87,7 +87,7 @@ namespace zmq
         uint32_t tag;
 
         //  Signaler used for thread safe sockets polling
-        signaler_t signaler;
+        signaler_t* signaler;
 
         typedef struct item_t {
             socket_base_t *socket;


### PR DESCRIPTION
solution: making the creation of FD only when thread safe sockets are in use
within the zmq_poller which improve the zmq_poll performance.