### PR TITLE
Problem: refactor gone wrong, redundant thread name

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -412,7 +412,7 @@ void zmq::ctx_t::start_thread (thread_t &thread_, thread_fn *tfn_, void *arg_) c
 {
     thread_.start(tfn_, arg_);
     thread_.setSchedulingParameters(thread_priority, thread_sched_policy);
-    thread_.setThreadName ("ZMQ b/g thread");
+    thread_.setThreadName ("ZMQ background");
 }
 
 void zmq::ctx_t::send_command (uint32_t tid_, const command_t &command_)

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -170,16 +170,16 @@ void zmq::thread_t::setThreadName(const char *name_)
     if (!name_)
         return;
 
-#if defined(HAVE_PTHREAD_SETNAME_1)
+#if defined(ZMQ_HAVE_PTHREAD_SETNAME_1)
     int rc = pthread_setname_np(name_);
     posix_assert (rc);
-#elif defined(HAVE_PTHREAD_SETNAME_2)
+#elif defined(ZMQ_HAVE_PTHREAD_SETNAME_2)
     int rc = pthread_setname_np(descriptor, name_);
     posix_assert (rc);
-#elif defined(HAVE_PTHREAD_SETNAME_3)
+#elif defined(ZMQ_HAVE_PTHREAD_SETNAME_3)
     int rc = pthread_setname_np(descriptor, name_, NULL);
     posix_assert (rc);
-#elif defined(HAVE_PTHREAD_SET_NAME)
+#elif defined(ZMQ_HAVE_PTHREAD_SET_NAME)
     pthread_set_name_np(descriptor, name_);
 #endif
 }


### PR DESCRIPTION
Solution: fix silly copypasta, rename threads to "ZMQ background"