### PR TITLE
libsodium leaves errno set to ENOENT from searching for random bits

### DIFF
--- a/tests/test_sodium.cpp
+++ b/tests/test_sodium.cpp
@@ -28,6 +28,7 @@
 */
 
 #include "testutil.hpp"
+#include <stdio.h>
 
 // There is no way to test for correctness because of the embedded RNG.
 void test__zmq_curve_keypair__always__success (void)
@@ -40,7 +41,8 @@ void test__zmq_curve_keypair__always__success (void)
 
 #if defined (ZMQ_HAVE_CURVE)
     assert (rc == 0);
-    assert (zmq_errno () == 0);
+    // libsodium leaves errno set to ENOENT from searching for random bits
+    // assert (zmq_errno () == 0);
 #else
     assert (rc == -1);
     assert (zmq_errno () == ENOTSUP);


### PR DESCRIPTION
Problem: test_sodium fails with libsodium because errno can be left ENOENT on success

Solution: don't assert errno is 0, assering a success return value is enough
