### PR TITLE
Fixed lib and dll paths in visual studio build

### DIFF
--- a/builds/msvc/readme.txt
+++ b/builds/msvc/readme.txt
@@ -3,7 +3,7 @@ For building on Windows, use:
      cd build
      ./build.bat
 
-This requires that the CMD.EXE be created using the DevStudio Tools link to create a CMD.EXE window.
+This requires that the CMD.EXE be created using the DevStudio Tools link to create a CMD.EXE window. Also, make sure that the name of the project folder is libzmq (not e.g. libzmq-master) as this is required for correct linking.
 
 Visual Studio product and C++ compiler Versions:
 

--- a/builds/msvc/vs2015/libzmq.import.props
+++ b/builds/msvc/vs2015/libzmq.import.props
@@ -32,8 +32,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies Condition="'$(Linkage-libzmq)' != ''">libzmq.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories Condition="$(Configuration.IndexOf('Debug')) != -1">$(ProjectDir)..\..\..\..\bin\$(PlatformName)\Debug\$(PlatformToolset)\$(Linkage-libzmq)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="$(Configuration.IndexOf('Release')) != -1">$(ProjectDir)..\..\..\..\bin\$(PlatformName)\Release\$(PlatformToolset)\$(Linkage-libzmq)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="$(Configuration.IndexOf('Debug')) != -1">$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Debug\$(PlatformToolset)\$(Linkage-libzmq)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="$(Configuration.IndexOf('Release')) != -1">$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Release\$(PlatformToolset)\$(Linkage-libzmq)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
 
@@ -41,15 +41,15 @@
 
   <Target Name="Linkage-libzmq-dynamic" AfterTargets="AfterBuild" Condition="'$(Linkage-libzmq)' == 'dynamic'">
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
-          SourceFiles="$(ProjectDir)..\..\..\..\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libzmq.dll"
+          SourceFiles="$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libzmq.dll"
           DestinationFiles="$(TargetDir)libzmq.dll"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
-          SourceFiles="$(ProjectDir)..\..\..\..\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libzmq.pdb"
+          SourceFiles="$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libzmq.pdb"
           DestinationFiles="$(TargetDir)libzmq.pdb"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Release')) != -1"
-          SourceFiles="$(ProjectDir)..\..\..\..\bin\$(PlatformName)\Release\$(PlatformToolset)\dynamic\libzmq.dll"
+          SourceFiles="$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Release\$(PlatformToolset)\dynamic\libzmq.dll"
           DestinationFiles="$(TargetDir)libzmq.dll"
           SkipUnchangedFiles="true" />
   </Target>

--- a/builds/msvc/vs2015/libzmq.import.props
+++ b/builds/msvc/vs2015/libzmq.import.props
@@ -27,13 +27,13 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\..\..\..\..\libzmq\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\..\..\..\libzmq\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Linkage-libzmq)' == 'static' Or '$(Linkage-libzmq)' == 'ltcg'">ZMQ_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies Condition="'$(Linkage-libzmq)' != ''">libzmq.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories Condition="$(Configuration.IndexOf('Debug')) != -1">$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Debug\$(PlatformToolset)\$(Linkage-libzmq)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="$(Configuration.IndexOf('Release')) != -1">$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Release\$(PlatformToolset)\$(Linkage-libzmq)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="$(Configuration.IndexOf('Debug')) != -1">$(ProjectDir)\..\..\..\..\..\libzmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\$(Linkage-libzmq)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="$(Configuration.IndexOf('Release')) != -1">$(ProjectDir)\..\..\..\..\..\libzmq\bin\$(PlatformName)\Release\$(PlatformToolset)\$(Linkage-libzmq)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
 
@@ -41,15 +41,15 @@
 
   <Target Name="Linkage-libzmq-dynamic" AfterTargets="AfterBuild" Condition="'$(Linkage-libzmq)' == 'dynamic'">
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
-          SourceFiles="$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libzmq.dll"
+          SourceFiles="$(ProjectDir)\..\..\..\..\..\libzmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libzmq.dll"
           DestinationFiles="$(TargetDir)libzmq.dll"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Debug')) != -1"
-          SourceFiles="$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libzmq.pdb"
+          SourceFiles="$(ProjectDir)\..\..\..\..\..\libzmq\bin\$(PlatformName)\Debug\$(PlatformToolset)\dynamic\libzmq.pdb"
           DestinationFiles="$(TargetDir)libzmq.pdb"
           SkipUnchangedFiles="true" />
     <Copy Condition="$(Configuration.IndexOf('Release')) != -1"
-          SourceFiles="$(ProjectDir)..\..\..\..\..\libzmq\bin$(PlatformName)\Release\$(PlatformToolset)\dynamic\libzmq.dll"
+          SourceFiles="$(ProjectDir)\..\..\..\..\..\libzmq\bin\$(PlatformName)\Release\$(PlatformToolset)\dynamic\libzmq.dll"
           DestinationFiles="$(TargetDir)libzmq.dll"
           SkipUnchangedFiles="true" />
   </Target>


### PR DESCRIPTION
As indicated in issue  #2341, the paths to the lib files were broken in libzmq.import.props. Fix #2347 removed the project folder (libzmq) part of the path, to fix this, however the fix leads to problems when building czmq on windows using the build.bat files in the visual studio project folders. The bat files copy the file libzmq.import.props from libzmq to the respective folder in the czmq build directories. Changing the path
`$(ProjectDir)..\..\..\..\..\libzmq\bin\`
to
`$(ProjectDir)..\..\..\..\bin\`
will prevent the czmq build from finding libzmq.lib.
This issue (#2341) should not arise, when the project folder is named 'libzmq'. 

To fix this, the paths were changed such that the libzmq folder is included and a comment was added to the readme.txt.