### PR TITLE
Relicense permission by Paul Colomiets

### DIFF
--- a/RELICENSE/tailhook.md
+++ b/RELICENSE/tailhook.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Paul Colomiets
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "tailhook", with
+commit author "Paul Colomiets <paul@colomiets.name>" or "Paul Colomiets
+<pc@gafol.net>", are copyright of Paul Colomiets.  This document hereby grants
+the libzmq project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Paul Colomiets
+2017/03/19


### PR DESCRIPTION
As asked in the email, I'm granting permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL.

I think it's going to be hard (hopefully not so), but it's a good move. Thanks!