### PR TITLE
Relisenceing & modifying build so msys is allowed

### DIFF
--- a/RELICENSE/chugga_fan.md
+++ b/RELICENSE/chugga_fan.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by  "chugga\_fan"
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "chugga\_fan", with
+commit author "chugga\_fan chuggafans@gmail.com", are copyright of "chugga\_fan" .
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+"chugga\_fan"
+2017/03/19

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -7,7 +7,7 @@ AC_DEFUN([LIBZMQ_CONFIG_LIBTOOL],  [{
 
     # Libtool configuration for different targets
     case "${host_os}" in
-        *mingw*|*cygwin*)
+        *mingw*|*cygwin*|*msys*)
             # Disable static build by default
             AC_DISABLE_STATIC
         ;;

--- a/builds/msvc/build/buildall.bat
+++ b/builds/msvc/build/buildall.bat
@@ -2,7 +2,7 @@
 :: Usage: buildall.bat
 
 :: Build all configurations for all solutions.
-call buildbase.bat ..\vs2017\libzmq.sln 17
+call buildbase.bat ..\vs2017\libzmq.sln 15
 ECHO.
 CALL buildbase.bat ..\vs2015\libzmq.sln 14
 ECHO.

--- a/builds/msvc/build/buildbase.bat
+++ b/builds/msvc/build/buildbase.bat
@@ -12,7 +12,7 @@ if NOT "%target%" == "" set target=/t:%target%&set ACTION=Cleaning
 
 SET log=build_%version%.log
 SET tools=Microsoft Visual Studio %version%.0\VC\vcvarsall.bat
-if "%version%" == "17" SET tools=Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
+if "%version%" == "15" SET tools=Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
 SET environment="%programfiles(x86)%\%tools%"
 IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools

--- a/builds/msvc/readme.txt
+++ b/builds/msvc/readme.txt
@@ -12,10 +12,11 @@ Visual C++ 2010 => Visual C++ 10
 Visual C++ 2012 => Visual C++ 11
 Visual C++ 2013 => Visual C++ 12
 Visual C++ 2015 => Visual C++ 14
+Visual C++ 2017 => Visual C++ 15
 
-Note that solution file icons reflect the compiler version ([9], [10], [11], [12], [14]), not the product version.
+Note that solution file icons reflect the compiler version ([9], [10], [11], [12], [14], [15]), not the product version.
 
-The vs2015/vs2013/vs2012/vs2010 solution and project files differ only in versioning.
+The vs2017/vs2015/vs2013/vs2012/vs2010 solution and project files differ only in versioning.
 
 More info here:
 

--- a/configure.ac
+++ b/configure.ac
@@ -257,7 +257,7 @@ case "${host_os}" in
         LIBZMQ_CHECK_LANG_FLAG_PREPEND([-Ae])
         AC_CHECK_FUNCS(gethrtime)
         ;;
-    *mingw*)
+    *mingw*|*msys*)
         AC_DEFINE(ZMQ_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(ZMQ_HAVE_MINGW, 1, [Have MinGW])
         AC_CHECK_HEADERS(windows.h)
@@ -273,7 +273,6 @@ case "${host_os}" in
         if test "x$enable_static" = "xyes"; then
             CPPFLAGS="-DZMQ_STATIC $CPPFLAGS"
         fi
-        
 	# Set FD_SETSIZE to 16384
 	CPPFLAGS=" -DFD_SETSIZE=16384 $CPPFLAGS"
         ;;


### PR DESCRIPTION
MSYS is now allowed if you use configure.ac, also I changed buildall/buildbase to use correct version names for VC++, also I did the re-licensing stuff, only issue with MSYS building is on my machine the headers are off and so they don't immediately compile, but I am unsure if this is an issue with only MSYS2 and will test this more and see if there is a proper solution