### PR TITLE
problem: ZMQ_POLLIN & OUT marked depracted but still in use

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -439,11 +439,6 @@ ZMQ_EXPORT int zmq_socket_monitor (void *s, const char *addr, int events);
 /*  Deprecated I/O multiplexing. Prefer using zmq_poller API                  */
 /******************************************************************************/
 
-#define ZMQ_POLLIN 1
-#define ZMQ_POLLOUT 2
-#define ZMQ_POLLERR 4
-#define ZMQ_POLLPRI 8
-
 typedef struct zmq_pollitem_t
 {
     void *socket;
@@ -581,6 +576,11 @@ ZMQ_EXPORT const char *zmq_msg_group(zmq_msg_t *msg);
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
 /******************************************************************************/
+
+#define ZMQ_POLLIN 1
+#define ZMQ_POLLOUT 2
+#define ZMQ_POLLERR 4
+#define ZMQ_POLLPRI 8
 
 #define ZMQ_HAVE_POLLER
 


### PR DESCRIPTION
solution: move them to the zmq_poller block
