### PR TITLE
Problem: implicit cast from size_t to int implies data loss.

### DIFF
--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -75,7 +75,7 @@ namespace zmq
 
         int wait (event_t *event, int n_events, long timeout);
 
-        inline int size (void) { return items.size (); };
+        inline int size (void) { return static_cast <int> (items.size ()); };
 
         //  Return false if object is not a socket.
         bool check_tag ();


### PR DESCRIPTION
Solution: use static_cast<> operator to make explicit