### PR TITLE
Problem: __STDC_LIMIT_MACROS before PCH causes VC++ warning.

### DIFF
--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -32,6 +32,8 @@
 
 #include "platform.hpp"
 
+#define __STDC_LIMIT_MACROS 
+
 // This must be included before any windows headers are compiled.
 #if defined ZMQ_HAVE_WINDOWS
 #include "windows.hpp"

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -27,11 +27,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define __STDC_LIMIT_MACROS 
-
 #include "precompiled.hpp"
-#include "macros.hpp"
 
+#include "macros.hpp"
 #include "clock.hpp"
 #include "err.hpp"
 #include "thread.hpp"


### PR DESCRIPTION
Solution: move it after the PCH include. See [discussion](https://github.com/zeromq/libzmq/issues/2452).