### PR TITLE
Added relicense permit

### DIFF
--- a/RELICENSE/ulikoehler.md
+++ b/RELICENSE/ulikoehler.md
@@ -9,7 +9,7 @@ BDFL (Benevolent Dictator for Life).
 All commits made by the Github handle "ulikoehler", with
 commit author "Uli Köhler", are copyright of Uli Köhler.
 
-This document hereby grants the libzmq project team to relicense libzmq, 
+This document hereby grants the libzmq project team to relicense libzmq and / or CZMQ, 
 including all past, present and future contributions of the author listed above.
 
 Uli Köhler

--- a/RELICENSE/ulikoehler.md
+++ b/RELICENSE/ulikoehler.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Uli Köhler.
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+All commits made by the Github handle "ulikoehler", with
+commit author "Uli Köhler", are copyright of Uli Köhler.
+
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Uli Köhler
+2017/03/25


### PR DESCRIPTION
I have modified only tw small portion of the template: First, *All* commits by my account are of my own (personal ) copyright. I just want to make it clear that it's not just *a portion* of all commits.

Second, I've included CZMQ in the permission as well as libzmq, as most of my contributions are for CZMQ.

I hope that's OK. If not, I can modify it to your specification.