### PR TITLE
Problem: insufficient use of const complicates calling.

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -266,11 +266,11 @@ ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_move (zmq_msg_t *dest, zmq_msg_t *src);
 ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest, zmq_msg_t *src);
 ZMQ_EXPORT void *zmq_msg_data (zmq_msg_t *msg);
-ZMQ_EXPORT size_t zmq_msg_size (zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_more (zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_get (zmq_msg_t *msg, int property);
+ZMQ_EXPORT size_t zmq_msg_size (const zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_more (const zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_get (const zmq_msg_t *msg, int property);
 ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int property, int optval);
-ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
+ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg, const char *property);
 
 /******************************************************************************/
 /*  0MQ socket definition.                                                    */

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -46,7 +46,7 @@
 typedef char zmq_msg_size_check
     [2 * ((sizeof (zmq::msg_t) == sizeof (zmq_msg_t)) != 0) - 1];
 
-bool zmq::msg_t::check ()
+bool zmq::msg_t::check () const
 {
      return u.base.type >= type_min && u.base.type <= type_max;
 }
@@ -355,7 +355,7 @@ void *zmq::msg_t::data ()
     }
 }
 
-size_t zmq::msg_t::size ()
+size_t zmq::msg_t::size () const
 {
     //  Check the validity of the message.
     zmq_assert (check ());
@@ -375,7 +375,7 @@ size_t zmq::msg_t::size ()
     }
 }
 
-unsigned char zmq::msg_t::flags ()
+unsigned char zmq::msg_t::flags () const
 {
     return u.base.flags;
 }

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -82,7 +82,7 @@ namespace zmq
             shared = 128
         };
 
-        bool check ();
+        bool check () const;
         int init();
 
         int init (void* data, size_t size_,
@@ -101,8 +101,8 @@ namespace zmq
         int move (msg_t &src_);
         int copy (msg_t &src_);
         void *data ();
-        size_t size ();
-        unsigned char flags ();
+        size_t size () const;
+        unsigned char flags () const;
         void set_flags (unsigned char flags_);
         void reset_flags (unsigned char flags_);
         metadata_t *metadata () const;

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -674,17 +674,17 @@ void *zmq_msg_data (zmq_msg_t *msg_)
     return ((zmq::msg_t*) msg_)->data ();
 }
 
-size_t zmq_msg_size (zmq_msg_t *msg_)
+size_t zmq_msg_size (const zmq_msg_t *msg_)
 {
     return ((zmq::msg_t*) msg_)->size ();
 }
 
-int zmq_msg_more (zmq_msg_t *msg_)
+int zmq_msg_more (const zmq_msg_t *msg_)
 {
     return zmq_msg_get (msg_, ZMQ_MORE);
 }
 
-int zmq_msg_get (zmq_msg_t *msg_, int property_)
+int zmq_msg_get (const zmq_msg_t *msg_, int property_)
 {
     const char* fd_string;
 
@@ -735,7 +735,7 @@ const char *zmq_msg_group (zmq_msg_t *msg_)
 
 //  Get message metadata string
 
-const char *zmq_msg_gets (zmq_msg_t *msg_, const char *property_)
+const char *zmq_msg_gets (const zmq_msg_t *msg_, const char *property_)
 {
     zmq::metadata_t *metadata = ((zmq::msg_t *) msg_)->metadata ();
     const char *value = NULL;


### PR DESCRIPTION
Solution: make methods that don't mutate members const.

There are probably more, these were just the obvious ones.