### PR TITLE
Improve oom handling

### DIFF
--- a/RELICENSE/t-b.md
+++ b/RELICENSE/t-b.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Thomas Braun
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "t-b", with
+commit author "thomas.braun@virtuell-zuhause.de" and "thomas.braun@byte-physics.de", are copyright of Thomas Braun.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Thomas Braun
+2017/03/27

--- a/src/gssapi_mechanism_base.cpp
+++ b/src/gssapi_mechanism_base.cpp
@@ -80,6 +80,8 @@ int zmq::gssapi_mechanism_base_t::encode_message (msg_t *msg_)
         flags |= 0x02;
 
     uint8_t *plaintext_buffer = static_cast <uint8_t *>(malloc(msg_->size ()+1));
+    alloc_assert(plaintext_buffer);
+
     plaintext_buffer[0] = flags;
     memcpy (plaintext_buffer+1, msg_->data(), msg_->size());
 

--- a/src/gssapi_mechanism_base.cpp
+++ b/src/gssapi_mechanism_base.cpp
@@ -149,8 +149,9 @@ int zmq::gssapi_mechanism_base_t::decode_message (msg_t *msg_)
     // TODO: instead of malloc/memcpy, can we just do: wrapped.value = ptr;
     const size_t alloc_length = wrapped.length? wrapped.length: 1;
     wrapped.value = static_cast <char *> (malloc (alloc_length));
+    alloc_assert (wrapped.value);
+
     if (wrapped.length) {
-        alloc_assert (wrapped.value);
         memcpy(wrapped.value, ptr, wrapped.length);
         ptr += wrapped.length;
         bytes_left -= wrapped.length;
@@ -247,9 +248,11 @@ int zmq::gssapi_mechanism_base_t::process_initiate (msg_t *msg_, void **token_va
         errno = EPROTO;
         return -1;
     }
+
     *token_value_ = static_cast <char *> (malloc (token_length_ ? token_length_ : 1));
+    alloc_assert (*token_value_);
+
     if (token_length_) {
-        alloc_assert (*token_value_);
         memcpy(*token_value_, ptr, token_length_);
         ptr += token_length_;
         bytes_left -= token_length_;

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -415,7 +415,8 @@ void zmq::norm_engine_t::recv_data(NormObjectHandle object)
         if (NULL == rxState)
         {
             // This is a new stream, so create rxState with zmq decoder, etc
-            rxState = new NormRxStreamState(object, options.maxmsgsize);
+            rxState = new (std::nothrow) NormRxStreamState(object, options.maxmsgsize);
+
             if (!rxState->Init())
             {
                 errno_assert(false);

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -416,6 +416,7 @@ void zmq::norm_engine_t::recv_data(NormObjectHandle object)
         {
             // This is a new stream, so create rxState with zmq decoder, etc
             rxState = new (std::nothrow) NormRxStreamState(object, options.maxmsgsize);
+            errno_assert(rxState);
 
             if (!rxState->Init())
             {

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -84,6 +84,8 @@ int zmq::req_t::xsend (msg_t *msg_)
 
             //  Copy request id before sending (see issue #1695 for details).
             uint32_t *request_id_copy = (uint32_t *) malloc (sizeof (uint32_t));
+            zmq_assert (request_id_copy);
+
             *request_id_copy = request_id;
 
             msg_t id;

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -533,6 +533,8 @@ int zmq::signaler_t::make_fdpair (fd_t *r_, fd_t *w_)
     if (*r_ != INVALID_SOCKET) {
         size_t dummy_size = 1024 * 1024;        //  1M to overload default receive buffer
         unsigned char *dummy = (unsigned char *) malloc (dummy_size);
+        wsa_assert (dummy);
+
         int still_to_send = (int) dummy_size;
         int still_to_recv = (int) dummy_size;
         while (still_to_send || still_to_recv) {

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -204,9 +204,10 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_, uint32_t tid_, int sid_, bool
     options.linger = parent_->get (ZMQ_BLOCKY)? -1: 0;
 
     if (thread_safe)
-        mailbox = new mailbox_safe_t(&sync);
+        mailbox = new (std::nothrow) mailbox_safe_t(&sync);
     else {
-        mailbox_t *m = new mailbox_t();
+        mailbox_t *m = new (std::nothrow) mailbox_t();
+
         if (m->get_fd () != retired_fd)
             mailbox = m;
         else {
@@ -1298,7 +1299,7 @@ void zmq::socket_base_t::start_reaping (poller_t *poller_)
     else {
         scoped_optional_lock_t sync_lock(thread_safe ? &sync : NULL);
 
-        reaper_signaler =  new signaler_t();
+        reaper_signaler = new (std::nothrow) signaler_t();
 
         //  Add signaler to the safe mailbox
         fd = reaper_signaler->get_fd();

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -204,9 +204,13 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_, uint32_t tid_, int sid_, bool
     options.linger = parent_->get (ZMQ_BLOCKY)? -1: 0;
 
     if (thread_safe)
+    {
         mailbox = new (std::nothrow) mailbox_safe_t(&sync);
+        zmq_assert (mailbox);
+    }
     else {
         mailbox_t *m = new (std::nothrow) mailbox_t();
+        zmq_assert (m);
 
         if (m->get_fd () != retired_fd)
             mailbox = m;
@@ -1300,6 +1304,7 @@ void zmq::socket_base_t::start_reaping (poller_t *poller_)
         scoped_optional_lock_t sync_lock(thread_safe ? &sync : NULL);
 
         reaper_signaler = new (std::nothrow) signaler_t();
+        zmq_assert (reaper_signaler);
 
         //  Add signaler to the safe mailbox
         fd = reaper_signaler->get_fd();

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -212,6 +212,7 @@ void zmq::stream_engine_t::plug (io_thread_t *io_thread_,
             //  Compile metadata.
             zmq_assert (metadata == NULL);
             metadata = new (std::nothrow) metadata_t (properties);
+            alloc_assert (metadata);
         }
 
         if (options.raw_notify) {
@@ -861,7 +862,10 @@ void zmq::stream_engine_t::mechanism_ready ()
 
     zmq_assert (metadata == NULL);
     if (!properties.empty ())
+    {
         metadata = new (std::nothrow) metadata_t (properties);
+        alloc_assert (metadata);
+    }
 
 #ifdef ZMQ_BUILD_DRAFT_API
     socket->event_handshake_succeed(endpoint, 0);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -757,7 +757,7 @@ inline int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
     // implement zmq_poll on top of zmq_poller
     int rc;
     zmq_poller_event_t *events;
-    events = new zmq_poller_event_t[nitems_];
+    events = new (std::nothrow) zmq_poller_event_t[nitems_];
     alloc_assert(events);
     void *poller = zmq_poller_new ();
     alloc_assert(poller);

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -77,6 +77,7 @@ unsigned long zmq_stopwatch_stop (void *watch_)
 void *zmq_threadstart(zmq_thread_fn* func, void* arg)
 {
     zmq::thread_t* thread = new (std::nothrow) zmq::thread_t;
+    alloc_assert(thread);
     thread->start(func, arg);
     return thread;
 }

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -36,6 +36,7 @@
 #include "atomic_counter.hpp"
 #include "atomic_ptr.hpp"
 #include <assert.h>
+#include <new>
 #include <stdint.h>
 
 #if !defined ZMQ_HAVE_WINDOWS
@@ -75,7 +76,7 @@ unsigned long zmq_stopwatch_stop (void *watch_)
 
 void *zmq_threadstart(zmq_thread_fn* func, void* arg)
 {
-    zmq::thread_t* thread = new zmq::thread_t;
+    zmq::thread_t* thread = new (std::nothrow) zmq::thread_t;
     thread->start(func, arg);
     return thread;
 }
@@ -265,7 +266,7 @@ int zmq_curve_public (char *z85_public_key, const char *z85_secret_key)
 
 void *zmq_atomic_counter_new (void)
 {
-    zmq::atomic_counter_t *counter = new zmq::atomic_counter_t;
+    zmq::atomic_counter_t *counter = new (std::nothrow) zmq::atomic_counter_t;
     alloc_assert (counter);
     return counter;
 }


### PR DESCRIPTION
I had some issues with my application built on top of libzmq in cases of on an out of memory condition. And therefore I also took a look into libzmq itself.

I've fixed a couple of places which used the throwing new version and also added a couple of forgotten asserts. Compiles and all tests pass on debian jessie x64 and x86/x64 Windows 7 with Visual Studio 2015. 
