### PR TITLE
[WIP DO NOT MERGE] Added handshake error details in monitoring event value (#2002)

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -562,8 +562,10 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_DGRAM 18
 
 /*  DRAFT 0MQ socket events and monitoring                                    */
-#define ZMQ_EVENT_HANDSHAKE_FAILED  0x0800
-#define ZMQ_EVENT_HANDSHAKE_SUCCEED 0x1000
+#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL   0x0800
+#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL    0x1000
+#define ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION  0x2000
+#define ZMQ_EVENT_HANDSHAKE_SUCCEED            0x4000
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -102,7 +102,7 @@ int zmq::curve_server_t::process_handshake_command (msg_t *msg_)
             break;
         default:
             //  Temporary support for security debugging
-            puts ("CURVE I: invalid handshake command");
+            puts ("CURVE I: invalid handshake command"); // error_status_t::protocol
             errno = EPROTO;
             rc = -1;
             break;
@@ -174,7 +174,7 @@ int zmq::curve_server_t::decode (msg_t *msg_)
 
     if (msg_->size () < 33) {
         //  Temporary support for security debugging
-        puts ("CURVE I: invalid CURVE client, sent malformed command");
+        puts ("CURVE I: invalid CURVE client, sent malformed command"); // error_status_t::protocol
         errno = EPROTO;
         return -1;
     }
@@ -182,7 +182,7 @@ int zmq::curve_server_t::decode (msg_t *msg_)
     const uint8_t *message = static_cast <uint8_t *> (msg_->data ());
     if (memcmp (message, "\x07MESSAGE", 8)) {
         //  Temporary support for security debugging
-        puts ("CURVE I: invalid CURVE client, did not send MESSAGE");
+        puts ("CURVE I: invalid CURVE client, did not send MESSAGE"); // error_status_t::protocol
         errno = EPROTO;
         return -1;
     }
@@ -230,7 +230,7 @@ int zmq::curve_server_t::decode (msg_t *msg_)
     }
     else {
         //  Temporary support for security debugging
-        puts ("CURVE I: connection key used for MESSAGE is wrong");
+        puts ("CURVE I: connection key used for MESSAGE is wrong"); // error_status_t::encryption
         errno = EPROTO;
     }
     free (message_plaintext);
@@ -264,11 +264,17 @@ zmq::mechanism_t::status_t zmq::curve_server_t::status () const
         return mechanism_t::handshaking;
 }
 
+zmq::mechanism_t::error_detail_t zmq::curve_server_t::error_detail() const
+{
+    // TODO implementation
+    return no_detail;
+}
+
 int zmq::curve_server_t::process_hello (msg_t *msg_)
 {
     if (msg_->size () != 200) {
         //  Temporary support for security debugging
-        puts ("CURVE I: client HELLO is not correct size");
+        puts ("CURVE I: client HELLO is not correct size"); // error_status_t::protocol
         errno = EPROTO;
         return -1;
     }
@@ -276,7 +282,7 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
     const uint8_t * const hello = static_cast <uint8_t *> (msg_->data ());
     if (memcmp (hello, "\x05HELLO", 6)) {
         //  Temporary support for security debugging
-        puts ("CURVE I: client HELLO has invalid command name");
+        puts ("CURVE I: client HELLO has invalid command name"); // error_status_t::protocol
         errno = EPROTO;
         return -1;
     }
@@ -286,7 +292,7 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
 
     if (major != 1 || minor != 0) {
         //  Temporary support for security debugging
-        puts ("CURVE I: client HELLO has unknown version number");
+        puts ("CURVE I: client HELLO has unknown version number"); // error_status_t::protocol
         errno = EPROTO;
         return -1;
     }
@@ -311,7 +317,7 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
                               hello_nonce, cn_client, secret_key);
     if (rc != 0) {
         //  Temporary support for security debugging
-        puts ("CURVE I: cannot open client HELLO -- wrong server key?");
+        puts ("CURVE I: cannot open client HELLO -- wrong server key?"); // error_status_t::encryption
         errno = EPROTO;
         return -1;
     }
@@ -385,7 +391,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
 {
     if (msg_->size () < 257) {
         //  Temporary support for security debugging
-        puts ("CURVE I: client INITIATE is not correct size");
+        puts ("CURVE I: client INITIATE is not correct size"); // error_status_t::protocol
         errno = EPROTO;
         return -1;
     }
@@ -393,7 +399,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     const uint8_t *initiate = static_cast <uint8_t *> (msg_->data ());
     if (memcmp (initiate, "\x08INITIATE", 9)) {
         //  Temporary support for security debugging
-        puts ("CURVE I: client INITIATE has invalid command name");
+        puts ("CURVE I: client INITIATE has invalid command name"); // error_status_t::protocol
         errno = EPROTO;
         return -1;
     }
@@ -414,7 +420,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
                                     cookie_nonce, cookie_key);
     if (rc != 0) {
         //  Temporary support for security debugging
-        puts ("CURVE I: cannot open client INITIATE cookie");
+        puts ("CURVE I: cannot open client INITIATE cookie"); // error_status_t::encryption
         errno = EPROTO;
         return -1;
     }
@@ -423,7 +429,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     if (memcmp (cookie_plaintext + crypto_secretbox_ZEROBYTES, cn_client, 32)
     ||  memcmp (cookie_plaintext + crypto_secretbox_ZEROBYTES + 32, cn_secret, 32)) {
         //  Temporary support for security debugging
-        puts ("CURVE I: client INITIATE cookie is not valid");
+        puts ("CURVE I: client INITIATE cookie is not valid"); // error_status_t::encryption
         errno = EPROTO;
         return -1;
     }
@@ -447,7 +453,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
                           clen, initiate_nonce, cn_client, cn_secret);
     if (rc != 0) {
         //  Temporary support for security debugging
-        puts ("CURVE I: cannot open client INITIATE");
+        puts ("CURVE I: cannot open client INITIATE"); // error_status_t::encryption
         errno = EPROTO;
         return -1;
     }
@@ -472,7 +478,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
                           vouch_nonce, client_key, cn_secret);
     if (rc != 0) {
         //  Temporary support for security debugging
-        puts ("CURVE I: cannot open client INITIATE vouch");
+        puts ("CURVE I: cannot open client INITIATE vouch"); // error_status_t::encryption
         errno = EPROTO;
         return -1;
     }
@@ -480,7 +486,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     //  What we decrypted must be the client's short-term public key
     if (memcmp (vouch_plaintext + crypto_box_ZEROBYTES, cn_client, 32)) {
         //  Temporary support for security debugging
-        puts ("CURVE I: invalid handshake from client (public key)");
+        puts ("CURVE I: invalid handshake from client (public key)"); // error_status_t::encryption
         errno = EPROTO;
         return -1;
     }
@@ -664,7 +670,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
             return close_and_return (msg, -1);
         if ((msg [i].flags () & msg_t::more) == (i < 6? 0: msg_t::more)) {
             //  Temporary support for security debugging
-            puts ("CURVE I: ZAP handler sent incomplete reply message");
+            puts ("CURVE I: ZAP handler sent incomplete reply message"); // error_status_t::protocol
             errno = EPROTO;
             return close_and_return (msg, -1);
         }
@@ -673,7 +679,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     //  Address delimiter frame
     if (msg [0].size () > 0) {
         //  Temporary support for security debugging
-        puts ("CURVE I: ZAP handler sent malformed reply message");
+        puts ("CURVE I: ZAP handler sent malformed reply message"); // error_status_t::protocol
         errno = EPROTO;
         return close_and_return (msg, -1);
     }
@@ -681,7 +687,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     //  Version frame
     if (msg [1].size () != 3 || memcmp (msg [1].data (), "1.0", 3)) {
         //  Temporary support for security debugging
-        puts ("CURVE I: ZAP handler sent bad version number");
+        puts ("CURVE I: ZAP handler sent bad version number"); // error_status_t::protocol
         errno = EPROTO;
         return close_and_return (msg, -1);
     }
@@ -689,7 +695,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     //  Request id frame
     if (msg [2].size () != 1 || memcmp (msg [2].data (), "1", 1)) {
         //  Temporary support for security debugging
-        puts ("CURVE I: ZAP handler sent bad request ID");
+        puts ("CURVE I: ZAP handler sent bad request ID"); // error_status_t::protocol
         errno = EPROTO;
         return close_and_return (msg, -1);
     }
@@ -697,7 +703,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     //  Status code frame
     if (msg [3].size () != 3) {
         //  Temporary support for security debugging
-        puts ("CURVE I: ZAP handler rejected client authentication");
+        puts ("CURVE I: ZAP handler rejected client authentication"); // error_status_t::protocol
         errno = EACCES;
         return close_and_return (msg, -1);
     }

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -45,6 +45,7 @@ zmq::curve_server_t::curve_server_t (session_base_t *session_,
     session (session_),
     peer_address (peer_address_),
     state (expect_hello),
+    current_error_detail(no_detail),
     cn_nonce (1),
     cn_peer_nonce(1)
 {

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -274,7 +274,7 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
     if (msg_->size () != 200) {
         //  Temporary support for security debugging
         puts ("CURVE I: client HELLO is not correct size"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EPROTO;
         return -1;
     }
@@ -283,7 +283,7 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
     if (memcmp (hello, "\x05HELLO", 6)) {
         //  Temporary support for security debugging
         puts ("CURVE I: client HELLO has invalid command name"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EPROTO;
         return -1;
     }
@@ -294,7 +294,7 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
     if (major != 1 || minor != 0) {
         //  Temporary support for security debugging
         puts ("CURVE I: client HELLO has unknown version number"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EPROTO;
         return -1;
     }
@@ -320,7 +320,7 @@ int zmq::curve_server_t::process_hello (msg_t *msg_)
     if (rc != 0) {
         //  Temporary support for security debugging
         puts ("CURVE I: cannot open client HELLO -- wrong server key?"); // error_status_t::encryption
-        current_error_detail = error_detail_t::encryption;
+        current_error_detail = encryption;
         errno = EPROTO;
         return -1;
     }
@@ -395,7 +395,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     if (msg_->size () < 257) {
         //  Temporary support for security debugging
         puts ("CURVE I: client INITIATE is not correct size"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EPROTO;
         return -1;
     }
@@ -404,7 +404,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     if (memcmp (initiate, "\x08INITIATE", 9)) {
         //  Temporary support for security debugging
         puts ("CURVE I: client INITIATE has invalid command name"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EPROTO;
         return -1;
     }
@@ -426,7 +426,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     if (rc != 0) {
         //  Temporary support for security debugging
         puts ("CURVE I: cannot open client INITIATE cookie"); // error_status_t::encryption
-        current_error_detail = error_detail_t::encryption;
+        current_error_detail = encryption;
         errno = EPROTO;
         return -1;
     }
@@ -436,7 +436,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     ||  memcmp (cookie_plaintext + crypto_secretbox_ZEROBYTES + 32, cn_secret, 32)) {
         //  Temporary support for security debugging
         puts ("CURVE I: client INITIATE cookie is not valid"); // error_status_t::encryption
-        current_error_detail = error_detail_t::encryption;
+        current_error_detail = encryption;
         errno = EPROTO;
         return -1;
     }
@@ -461,7 +461,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     if (rc != 0) {
         //  Temporary support for security debugging
         puts ("CURVE I: cannot open client INITIATE"); // error_status_t::encryption
-        current_error_detail = error_detail_t::encryption;
+        current_error_detail = encryption;
         errno = EPROTO;
         return -1;
     }
@@ -487,7 +487,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     if (rc != 0) {
         //  Temporary support for security debugging
         puts ("CURVE I: cannot open client INITIATE vouch"); // error_status_t::encryption
-        current_error_detail = error_detail_t::encryption;
+        current_error_detail = encryption;
         errno = EPROTO;
         return -1;
     }
@@ -496,7 +496,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     if (memcmp (vouch_plaintext + crypto_box_ZEROBYTES, cn_client, 32)) {
         //  Temporary support for security debugging
         puts ("CURVE I: invalid handshake from client (public key)"); // error_status_t::encryption
-        current_error_detail = error_detail_t::encryption;
+        current_error_detail = encryption;
         errno = EPROTO;
         return -1;
     }
@@ -681,7 +681,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
         if ((msg [i].flags () & msg_t::more) == (i < 6? 0: msg_t::more)) {
             //  Temporary support for security debugging
             puts ("CURVE I: ZAP handler sent incomplete reply message"); // error_status_t::protocol
-            current_error_detail = error_detail_t::protocol;
+            current_error_detail = protocol;
             errno = EPROTO;
             return close_and_return (msg, -1);
         }
@@ -691,7 +691,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     if (msg [0].size () > 0) {
         //  Temporary support for security debugging
         puts ("CURVE I: ZAP handler sent malformed reply message"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EPROTO;
         return close_and_return (msg, -1);
     }
@@ -700,7 +700,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     if (msg [1].size () != 3 || memcmp (msg [1].data (), "1.0", 3)) {
         //  Temporary support for security debugging
         puts ("CURVE I: ZAP handler sent bad version number"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EPROTO;
         return close_and_return (msg, -1);
     }
@@ -709,7 +709,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     if (msg [2].size () != 1 || memcmp (msg [2].data (), "1", 1)) {
         //  Temporary support for security debugging
         puts ("CURVE I: ZAP handler sent bad request ID"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EPROTO;
         return close_and_return (msg, -1);
     }
@@ -718,7 +718,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     if (msg [3].size () != 3) {
         //  Temporary support for security debugging
         puts ("CURVE I: ZAP handler rejected client authentication"); // error_status_t::protocol
-        current_error_detail = error_detail_t::protocol;
+        current_error_detail = protocol;
         errno = EACCES;
         return close_and_return (msg, -1);
     }

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -99,6 +99,9 @@ namespace zmq
         //  Status code as received from ZAP handler
         std::string status_code;
 
+        //  Details about the current error state
+        error_detail_t current_error_detail;
+
         uint64_t cn_nonce;
         uint64_t cn_peer_nonce;
 

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -73,7 +73,8 @@ namespace zmq
         virtual int encode (msg_t *msg_);
         virtual int decode (msg_t *msg_);
         virtual int zap_msg_available ();
-        virtual status_t status () const;
+        virtual status_t status() const;
+        virtual error_detail_t error_detail() const;
 
     private:
 

--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -53,6 +53,13 @@ namespace zmq
             error
         };
 
+        //  Provides more details when in status_t::error
+        enum error_detail_t {
+            no_detail,
+            protocol,
+            encryption
+        };
+
         mechanism_t (const options_t &options_);
 
         virtual ~mechanism_t ();
@@ -71,7 +78,11 @@ namespace zmq
         virtual int zap_msg_available () { return 0; }
 
         //  Returns the status of this mechanism.
-        virtual status_t status () const = 0;
+        virtual status_t status() const = 0;
+
+        //  Returns details about of the current error of the mechanism.
+        //  Returned value does not makes sense if the current status is not error.
+        virtual error_detail_t error_detail() const { return no_detail; }
 
         void set_peer_identity (const void *id_ptr, size_t id_size);
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1685,9 +1685,19 @@ void zmq::socket_base_t::event_disconnected (const std::string &addr_, zmq::fd_t
     event(addr_, fd_, ZMQ_EVENT_DISCONNECTED);
 }
 
-void zmq::socket_base_t::event_handshake_failed(const std::string &addr_, int err_)
+void zmq::socket_base_t::event_handshake_failed_no_detail(const std::string &addr_, int err_)
 {
-    event(addr_, err_, ZMQ_EVENT_HANDSHAKE_FAILED);
+    event(addr_, err_, ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL);
+}
+
+void zmq::socket_base_t::event_handshake_failed_protocol(const std::string &addr_, int err_)
+{
+    event(addr_, err_, ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL);
+}
+
+void zmq::socket_base_t::event_handshake_failed_encryption(const std::string &addr_, int err_)
+{
+    event(addr_, err_, ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
 }
 
 void zmq::socket_base_t::event_handshake_succeed(const std::string &addr_, int err_)

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -133,7 +133,9 @@ namespace zmq
         void event_closed (const std::string &addr_, zmq::fd_t fd_);
         void event_close_failed (const std::string &addr_, int err_);
         void event_disconnected (const std::string &addr_, zmq::fd_t fd_);
-        void event_handshake_failed(const std::string &addr_, int err_);
+        void event_handshake_failed_no_detail(const std::string &addr_, int err_);
+        void event_handshake_failed_protocol(const std::string &addr_, int err_);
+        void event_handshake_failed_encryption(const std::string &addr_, int err_);
         void event_handshake_succeed(const std::string &addr_, int err_);
 
     protected:

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -786,6 +786,10 @@ int zmq::stream_engine_t::next_handshake_command (msg_t *msg_)
         {
             if(mechanism->error_detail() == mechanism_t::protocol)
                 socket->event_handshake_failed_protocol(endpoint, 0);
+            else if(mechanism->error_detail() == mechanism_t::encryption)
+                socket->event_handshake_failed_encryption(endpoint, 0);
+            else
+                socket->event_handshake_failed_no_detail(endpoint, 0);
         }
 #endif
 

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -978,8 +978,12 @@ void zmq::stream_engine_t::error (error_reason_t reason)
     }
     zmq_assert (session);
 #ifdef ZMQ_BUILD_DRAFT_API
-    if(mechanism == NULL)
-        socket->event_handshake_failed_no_detail(endpoint, (int) s);
+    if(mechanism == NULL) {
+        if(reason == protocol_error)
+            socket->event_handshake_failed_protocol(endpoint, (int) s);
+        else
+            socket->event_handshake_failed_no_detail(endpoint, (int) s);
+    }
     else if(mechanism->status() == mechanism_t::handshaking) {
         if(mechanism->error_detail() == mechanism_t::protocol)
             socket->event_handshake_failed_protocol(endpoint, (int) s);

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -783,7 +783,10 @@ int zmq::stream_engine_t::next_handshake_command (msg_t *msg_)
             msg_->set_flags (msg_t::command);
 #ifdef ZMQ_BUILD_DRAFT_API
         if(mechanism->status() == mechanism_t::error)
-            socket->event_handshake_failed(endpoint, (int) mechanism->error_detail());
+        {
+            if(mechanism->error_detail() == mechanism_t::protocol)
+                socket->event_handshake_failed_protocol(endpoint, 0);
+        }
 #endif
 
         return rc;
@@ -976,9 +979,15 @@ void zmq::stream_engine_t::error (error_reason_t reason)
     zmq_assert (session);
 #ifdef ZMQ_BUILD_DRAFT_API
     if(mechanism == NULL)
-        socket->event_handshake_failed(endpoint, (int) s);
-    else if(mechanism->status() == mechanism_t::handshaking)
-        socket->event_handshake_failed(endpoint, (int) mechanism->error_detail());
+        socket->event_handshake_failed_no_detail(endpoint, (int) s);
+    else if(mechanism->status() == mechanism_t::handshaking) {
+        if(mechanism->error_detail() == mechanism_t::protocol)
+            socket->event_handshake_failed_protocol(endpoint, (int) s);
+        else if(mechanism->error_detail() == mechanism_t::encryption)
+            socket->event_handshake_failed_encryption(endpoint, (int) s);
+        else
+            socket->event_handshake_failed_no_detail(endpoint, (int) s);
+    }
 #endif
     socket->event_disconnected (endpoint, (int) s);
     session->flush ();

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -783,7 +783,7 @@ int zmq::stream_engine_t::next_handshake_command (msg_t *msg_)
             msg_->set_flags (msg_t::command);
 #ifdef ZMQ_BUILD_DRAFT_API
         if(mechanism->status() == mechanism_t::error)
-            socket->event_handshake_failed(endpoint, 0);
+            socket->event_handshake_failed(endpoint, (int) mechanism->error_detail());
 #endif
 
         return rc;
@@ -975,8 +975,10 @@ void zmq::stream_engine_t::error (error_reason_t reason)
     }
     zmq_assert (session);
 #ifdef ZMQ_BUILD_DRAFT_API
-    if(mechanism == NULL || mechanism->status() == mechanism_t::handshaking)
+    if(mechanism == NULL)
         socket->event_handshake_failed(endpoint, (int) s);
+    else if(mechanism->status() == mechanism_t::handshaking)
+        socket->event_handshake_failed(endpoint, (int) mechanism->error_detail());
 #endif
     socket->event_disconnected (endpoint, (int) s);
     session->flush ();

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -47,8 +47,10 @@
 #define ZMQ_DGRAM 18
 
 /*  DRAFT 0MQ socket events and monitoring                                    */
-#define ZMQ_EVENT_HANDSHAKE_FAILED  0x0800
-#define ZMQ_EVENT_HANDSHAKE_SUCCEED 0x1000
+#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL   0x0800
+#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL    0x1000
+#define ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION  0x2000
+#define ZMQ_EVENT_HANDSHAKE_SUCCEED            0x4000
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -208,10 +208,8 @@ int main (void)
     assert (rc == 0);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    int event_value = -1;
-    int event = get_monitor_event (server_mon, &event_value, NULL);
+    int event = get_monitor_event (server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEED);
-    assert (event_value == 0);
 #endif
 
     //  Check CURVE security with a garbage server key
@@ -231,10 +229,8 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event_value = -1;
-    event = get_monitor_event (server_mon, &event_value, NULL);
+    event = get_monitor_event (server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
-    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with a garbage client public key
@@ -253,10 +249,8 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event_value = -1;
-    event = get_monitor_event (server_mon, &event_value, NULL);
+    event = get_monitor_event (server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
-    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with a garbage client secret key
@@ -275,10 +269,8 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event_value = -1;
-    event = get_monitor_event (server_mon, &event_value, NULL);
+    event = get_monitor_event (server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
-    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with bogus client credentials
@@ -301,10 +293,8 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event_value = -1;
-    event = get_monitor_event(server_mon, &event_value, NULL);
+    event = get_monitor_event(server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
-    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with NULL client credentials
@@ -317,10 +307,8 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event_value = -1;
-    event = get_monitor_event(server_mon, &event_value, NULL);
+    event = get_monitor_event(server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
-    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with PLAIN client credentials

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -308,7 +308,7 @@ int main (void)
 
 #ifdef ZMQ_BUILD_DRAFT_API
     event = get_monitor_event(server_mon, NULL, NULL);
-    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
+    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL);
 #endif
 
     //  Check CURVE security with PLAIN client credentials

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -179,7 +179,8 @@ int main (void)
 #ifdef ZMQ_BUILD_DRAFT_API
     //  Monitor handshake events on the server
     rc = zmq_socket_monitor (server, "inproc://monitor-server",
-            ZMQ_EVENT_HANDSHAKE_SUCCEED | ZMQ_EVENT_HANDSHAKE_FAILED);
+            ZMQ_EVENT_HANDSHAKE_SUCCEED | ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL |
+            ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL | ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
     assert (rc == 0);
 
     //  Create socket for collecting monitor events
@@ -232,7 +233,7 @@ int main (void)
 #ifdef ZMQ_BUILD_DRAFT_API
     event_value = -1;
     event = get_monitor_event (server_mon, &event_value, NULL);
-    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
     assert (event_value == 2);
 #endif
 
@@ -254,7 +255,7 @@ int main (void)
 #ifdef ZMQ_BUILD_DRAFT_API
     event_value = -1;
     event = get_monitor_event (server_mon, &event_value, NULL);
-    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
     assert (event_value == 2);
 #endif
 
@@ -276,7 +277,7 @@ int main (void)
 #ifdef ZMQ_BUILD_DRAFT_API
     event_value = -1;
     event = get_monitor_event (server_mon, &event_value, NULL);
-    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
     assert (event_value == 2);
 #endif
 
@@ -302,7 +303,7 @@ int main (void)
 #ifdef ZMQ_BUILD_DRAFT_API
     event_value = -1;
     event = get_monitor_event(server_mon, &event_value, NULL);
-    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
     assert (event_value == 2);
 #endif
 
@@ -318,7 +319,7 @@ int main (void)
 #ifdef ZMQ_BUILD_DRAFT_API
     event_value = -1;
     event = get_monitor_event(server_mon, &event_value, NULL);
-    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
     assert (event_value == 2);
 #endif
 

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -207,8 +207,10 @@ int main (void)
     assert (rc == 0);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    int event = get_monitor_event (server_mon, NULL, NULL);
+    int event_value = -1;
+    int event = get_monitor_event (server_mon, &event_value, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEED);
+    assert (event_value == 0);
 #endif
 
     //  Check CURVE security with a garbage server key
@@ -228,8 +230,10 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event = get_monitor_event (server_mon, NULL, NULL);
+    event_value = -1;
+    event = get_monitor_event (server_mon, &event_value, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with a garbage client public key
@@ -248,8 +252,10 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event = get_monitor_event (server_mon, NULL, NULL);
+    event_value = -1;
+    event = get_monitor_event (server_mon, &event_value, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with a garbage client secret key
@@ -268,8 +274,10 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event = get_monitor_event (server_mon, NULL, NULL);
+    event_value = -1;
+    event = get_monitor_event (server_mon, &event_value, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with bogus client credentials
@@ -292,8 +300,10 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event = get_monitor_event (server_mon, NULL, NULL);
+    event_value = -1;
+    event = get_monitor_event(server_mon, &event_value, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with NULL client credentials
@@ -306,8 +316,10 @@ int main (void)
     close_zero_linger (client);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    event = get_monitor_event (server_mon, NULL, NULL);
+    event_value = -1;
+    event = get_monitor_event(server_mon, &event_value, NULL);
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED);
+    assert (event_value == 2);
 #endif
 
     //  Check CURVE security with PLAIN client credentials


### PR DESCRIPTION
This PR aims to fix the issue #2002 by removing the prints in the standart output _(not committed yet)_.
The error details are provided as the value of the event `ZMQ_EVENT_HANDSHAKE_FAILED`.

**Work in progress**
* Need feedback and advices about the event's details. currently the value is and a raw integer with no macro defined in the public API.
* Need to check the CI is not broken
* Need to adapt the test cases