### PR TITLE
Problem: lack of out-of-bound memory checks in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ matrix:
         - xmlto
   - env: BUILD_TYPE=default CURVE=libsodium
     os: osx
+  - env: BUILD_TYPE=default CURVE=tweetnacl DRAFT=enabled ADDRESS_SANITIZER=enabled
+    os: linux
 
 sudo: required
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -15,6 +15,11 @@ if [ $BUILD_TYPE == "default" ]; then
     CONFIG_OPTS+=("PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig")
     CONFIG_OPTS+=("--prefix=${BUILD_PREFIX}")
 
+    if [ -n "$ADDRESS_SANITIZER" ] && [ "$ADDRESS_SANITIZER" == "enabled" ]; then
+        CONFIG_OPTS+=("CFLAGS=-fsanitize=address")
+        CONFIG_OPTS+=("CXXFLAGS=-fsanitize=address")
+    fi
+
     if [ -z $CURVE ]; then
         CONFIG_OPTS+=("--disable-curve")
     elif [ $CURVE == "libsodium" ]; then


### PR DESCRIPTION
Solution: add a CI build run with GCC's Address Sanitizer enabled.
This compiler flag will make the unit test programs abort if it
detects errors such as out-of-bound memory access or use-after-free.