### PR TITLE
Relicense: Wouter Overmeire (lodagro)

### DIFF
--- a/RELICENSE/lodagro.md
+++ b/RELICENSE/lodagro.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen
+# by the current ZeroMQ BDFL
+
+This is a statement by Wouter Overmeire that grants permission to relicense its
+copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License
+v2 (MPLv2) or any other Open Source Initiative approved license chosen by the
+current ZeroMQ BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "lodagro", with commit
+author "lodagro <lodagro@gmail.com>", are copyright of Wouter Overmeire.  This
+document hereby grants the libzmq project team to relicense libzmq, including
+all past, present and future contributions of the author listed above.
+
+Wouter Overmeire
+2017/04/01


### PR DESCRIPTION
#2376 

Only made one little contribution: a doc typo fix.
Added is my license grant, up to you to merge or not (might not be necessary).

```
> glb --author=lodagro
dfdd84f Relicense: Wouter Overmeire (lodagro)
(6 minutes ago by Wouter Overmeire) (HEAD, origin/master, origin/HEAD, master)

a5f4d82 fix doc typo
(3 years, 3 months ago by Wouter Overmeire) (origin/patch-1)
```