### PR TITLE
CMake: Add cross compiling support and export targets to package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required (VERSION 2.8.12)
 project (ZeroMQ)
 
-list (INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}")
+list (INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}")
 
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=gnu++11" COMPILER_SUPPORTS_CXX11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,6 +777,15 @@ else ()
       PREFIX "")
 endif ()
 
+foreach (target libzmq libzmq-static)
+  target_include_directories (${target}
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+      $<INSTALL_INTERFACE:include>
+  )
+endforeach()
+
 target_link_libraries (libzmq ${CMAKE_THREAD_LIBS_INIT})
 
 if (SODIUM_FOUND)
@@ -856,6 +865,7 @@ include(GNUInstallDirs)
 
 if (MSVC)
   install (TARGETS libzmq libzmq-static
+          EXPORT ${PROJECT_NAME}-targets
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -878,6 +888,7 @@ if (MSVC)
   endif ()
 else ()
   install (TARGETS libzmq libzmq-static
+          EXPORT ${PROJECT_NAME}-targets
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -911,26 +922,22 @@ endif ()
 
 include(CMakePackageConfigHelpers)
 
-if (MSVC)
-  string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
-  get_property(libzmq_pf TARGET libzmq PROPERTY ${U_CMAKE_BUILD_TYPE}_POSTFIX)
-  set(libzmq_file libzmq${libzmq_pf}${CMAKE_LINK_LIBRARY_SUFFIX})
-  get_property(libzmq_static_pf TARGET libzmq-static PROPERTY ${U_CMAKE_BUILD_TYPE}_POSTFIX)
-  set(libzmq_static_file libzmq${libzmq_static_pf}${CMAKE_LINK_LIBRARY_SUFFIX})
-else()
-  set(libzmq_file libzmq${CMAKE_SHARED_LIBRARY_SUFFIX})
-  set(libzmq_static_file libzmq${CMAKE_STATIC_LIBRARY_SUFFIX})
-endif()
-
 # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
 set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
 
+if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+  export(EXPORT ${PROJECT_NAME}-targets
+         FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
+endif()
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
                               INSTALL_DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
                                  VERSION ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}
                                  COMPATIBILITY AnyNewerVersion)
+install(EXPORT ${PROJECT_NAME}-targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
               DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,9 @@ set (ZMQ_CMAKE_MODULES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/Modules)
 list (APPEND CMAKE_MODULE_PATH ${ZMQ_CMAKE_MODULES_DIR})
 
 include (TestZMQVersion)
-include (ZMQSourceRunChecks)
+if (NOT CMAKE_CROSSCOMPILING)
+  include (ZMQSourceRunChecks)
+endif ()
 include (CheckIncludeFiles)
 include (CheckLibraryExists)
 include (CheckCCompilerFlag)
@@ -187,7 +189,7 @@ if( ${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore" AND ${CMAKE_SYSTEM_VERSION} STR
 endif()
 check_include_files (sys/uio.h ZMQ_HAVE_UIO)
 check_include_files (sys/eventfd.h ZMQ_HAVE_EVENTFD)
-if (ZMQ_HAVE_EVENTFD)
+if (ZMQ_HAVE_EVENTFD AND NOT CMAKE_CROSSCOMPILING)
   zmq_check_efd_cloexec ()
 endif ()
 
@@ -320,15 +322,16 @@ endif ()
 
 
 #-----------------------------------------------------------------------------
-zmq_check_sock_cloexec ()
-zmq_check_so_keepalive ()
-zmq_check_tcp_keepcnt ()
-zmq_check_tcp_keepidle ()
-zmq_check_tcp_keepintvl ()
-zmq_check_tcp_keepalive ()
-zmq_check_tcp_tipc ()
-zmq_check_pthread_setname ()
-
+if (NOT CMAKE_CROSSCOMPILING)
+  zmq_check_sock_cloexec ()
+  zmq_check_so_keepalive ()
+  zmq_check_tcp_keepcnt ()
+  zmq_check_tcp_keepidle ()
+  zmq_check_tcp_keepintvl ()
+  zmq_check_tcp_keepalive ()
+  zmq_check_tcp_tipc ()
+  zmq_check_pthread_setname ()
+endif ()
 
 if (    CMAKE_SYSTEM_NAME MATCHES "Linux"
     OR CMAKE_SYSTEM_NAME MATCHES "GNU/kFreeBSD"

--- a/ZeroMQConfig.cmake.in
+++ b/ZeroMQConfig.cmake.in
@@ -1,4 +1,12 @@
 # ZeroMQ cmake module
+#
+# The following import targets are created
+#
+# ::
+#
+#   libzmq-static
+#   libzmq
+#
 # This module sets the following variables in your project::
 #
 #   ZeroMQ_FOUND - true if ZeroMQ found on the system
@@ -8,8 +16,10 @@
 
 @PACKAGE_INIT@
 
-set(PN ZeroMQ)
-set_and_check(${PN}_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
-set_and_check(${PN}_LIBRARY "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@/@libzmq_file@")
-set_and_check(${PN}_STATIC_LIBRARY "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@/@libzmq_static_file@")
-check_required_components(${PN})
+if(NOT TARGET libzmq AND NOT TARGET libzmq-static)
+  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+endif()
+
+get_target_property(@PROJECT_NAME@_INCLUDE_DIR libzmq INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(@PROJECT_NAME@_LIBRARY libzmq LOCATION)
+get_target_property(@PROJECT_NAME@_STATIC_LIBRARY libzmq-static LOCATION)


### PR DESCRIPTION
Add cross compiling support to CMake by disable runtime checks during cross compile.

Export the targets to the CMake package config and thereby to user projects. This allows other projects to include this project as a sub directory.
