### PR TITLE
Problem: typos in RELICENSE/ptroja.md

### DIFF
--- a/RELICENSE/ptroja.md
+++ b/RELICENSE/ptroja.md
@@ -5,8 +5,8 @@ copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License
 v2 (MPLv2) or any other Open Source Initiative approved license chosen by the
 current ZeroMQ BDFL (Benevolent Dictator for Life).
 
-A portion of the commits made by the Github handle "{{github username}}", with
-commit author "{{github commit author}}", are copyright of {{ name }} .
+A portion of the commits made by the Github handle "ptroja", with
+commit author "Piotr Trojanek <piotr.trojanek@gmail.com>", are copyright of Piotr Trojanek.
 This document hereby grants the libzmq project team to relicense libzmq,
 including all past, present and future contributions of the author listed above.
 


### PR DESCRIPTION
Solution: fill in the missing fields