### PR TITLE
cmake: Remove build/msvc include path to remove file name clash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,6 @@ if (MINGW)
   endif ()
 endif ()
 
-include_directories (include ${CMAKE_CURRENT_BINARY_DIR})
 set (public_headers include/zmq.h
                     include/zmq_utils.h)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,7 +133,6 @@ ENDIF (ENABLE_DRAFTS)
 if(WIN32)
     add_definitions(-DZMQ_CUSTOM_PLATFORM_HPP)
     add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
-    include_directories(../builds/msvc)
     # Same name on 64bit systems
     link_libraries(Ws2_32.lib)
 endif()


### PR DESCRIPTION
Remove the `build/msvc` include path from the test project to fix a problem with the order of the include paths. Additionally remove the unnecessary `include_directories` from the master project.
