### PR TITLE
cmake: Use LOCATION property only for imported targets

### DIFF
--- a/ZeroMQConfig.cmake.in
+++ b/ZeroMQConfig.cmake.in
@@ -18,8 +18,8 @@
 
 if(NOT TARGET libzmq AND NOT TARGET libzmq-static)
   include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-endif()
 
-get_target_property(@PROJECT_NAME@_INCLUDE_DIR libzmq INTERFACE_INCLUDE_DIRECTORIES)
-get_target_property(@PROJECT_NAME@_LIBRARY libzmq LOCATION)
-get_target_property(@PROJECT_NAME@_STATIC_LIBRARY libzmq-static LOCATION)
+  get_target_property(@PROJECT_NAME@_INCLUDE_DIR libzmq INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(@PROJECT_NAME@_LIBRARY libzmq LOCATION)
+  get_target_property(@PROJECT_NAME@_STATIC_LIBRARY libzmq-static LOCATION)
+endif()


### PR DESCRIPTION
Newer CMake versions allow use of the LOCATION target property only for
imported targets (CMP0026). Because the old package variables are only
needed for backward compatibility after configuration they could be
deactivated for super projects which build ZeroMQ together with other
projects.