### PR TITLE
Problem: Windows build broken by #if ZMQ_USE_POLL

### DIFF
--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -83,7 +83,7 @@ struct tcp_keepalive {
 #include <process.h>
 #endif
 
-#if ZMQ_USE_POLL
+#if defined ZMQ_USE_POLL
 static inline int poll(struct pollfd *pfd, unsigned long nfds, int timeout) { return WSAPoll(pfd, nfds, timeout); }
 #endif
 


### PR DESCRIPTION
Solution: use #if defined ZMQ_USE_POLL
