### PR TITLE
fix misc. bugs in GSSAPI support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -427,7 +427,8 @@ AC_ARG_WITH([libgssapi_krb5], [AS_HELP_STRING([--with-libgssapi_krb5],
 # conditionally require libgssapi_krb5
 if test "x$require_libgssapi_krb5_ext" != "xno"; then
     AC_CHECK_HEADERS(gssapi/gssapi_generic.h)
-    AC_SEARCH_LIBS([gss_init_sec_context], [gssapi_krb5 gssapi],,
+    AC_SEARCH_LIBS([gss_init_sec_context], [gssapi_krb5 gssapi],
+        AC_DEFINE(HAVE_LIBGSSAPI_KRB5, [1], [Enabled GSSAPI security]),
         AC_MSG_ERROR(libgssapi_krb5 is needed for GSSAPI security))
 fi
 

--- a/doc/zmq_gssapi.txt
+++ b/doc/zmq_gssapi.txt
@@ -22,16 +22,17 @@ CLIENT AND SERVER ROLES
 -----------------------
 A socket using GSSAPI can be either client or server, but not both.
 
-To become either a GSSAPI client or server, the application sets the
-ZMQ_GSSAPI_PRINCIPAL option to provide the socket with the name of the principal
-for whom GSSAPI credentials should be acquired.
+To become a GSSAPI server, the application sets the ZMQ_GSSAPI_SERVER
+option on the socket.
 
-To become a GSSAPI server, the application additionally sets the
-ZMQ_GSSAPI_SERVER option on the socket.
+To become a GSSAPI client, the application sets the ZMQ_GSSAPI_SERVICE_PRINCIPAL
+option to the name of the principal on the server to which it intends to
+connect.
 
-To become a GSSAPI client, the application additionally sets the
-ZMQ_GSSAPI_SERVICE_PRINCIPAL option to the name of the principal of the server
-to which it intends to connect.
+On client or server, the application may additionally set the
+ZMQ_GSSAPI_PRINCIPAL option to provide the socket with the name of the
+principal for whom GSSAPI credentials should be acquired.  If this option
+is not set, default credentials are used.
 
 
 OPTIONAL ENCRYPTION

--- a/src/gssapi_client.cpp
+++ b/src/gssapi_client.cpp
@@ -173,7 +173,7 @@ int zmq::gssapi_client_t::initialize_context ()
     // First time through, import service_name into target_name
     if (target_name == GSS_C_NO_NAME) {
         send_tok.value = service_name;
-        send_tok.length = strlen(service_name);
+        send_tok.length = strlen(service_name) + 1;
         OM_uint32 maj = gss_import_name(&min_stat, &send_tok,
                                         GSS_C_NT_HOSTBASED_SERVICE,
                                         &target_name);

--- a/src/gssapi_client.cpp
+++ b/src/gssapi_client.cpp
@@ -166,6 +166,10 @@ zmq::mechanism_t::status_t zmq::gssapi_client_t::status () const
 
 int zmq::gssapi_client_t::initialize_context ()
 {
+    // principal was specified but credentials could not be acquired
+    if (principal_name != NULL && cred == NULL)
+        return -1;
+
     // First time through, import service_name into target_name
     if (target_name == GSS_C_NO_NAME) {
         send_tok.value = service_name;

--- a/src/gssapi_mechanism_base.cpp
+++ b/src/gssapi_mechanism_base.cpp
@@ -338,7 +338,7 @@ int zmq::gssapi_mechanism_base_t::acquire_credentials (char * service_name_, gss
         return -1;
 
     maj_stat = gss_acquire_cred (&min_stat, server_name, 0,
-                                 GSS_C_NO_OID_SET, GSS_C_ACCEPT,
+                                 GSS_C_NO_OID_SET, GSS_C_BOTH,
                                  cred_, NULL, NULL);
 
     if (maj_stat != GSS_S_COMPLETE)


### PR DESCRIPTION
As discussed in #2531, the ZMQ_GSSAPI_PRINCIPAL socket option cannot be used on the client side due to an incorrect flag in the call to `gss_acquire_cred()` which makes a successfully acquired cred unusable in `gss_init_sec_context()`.  This probably went unnoticed because client creds are acquired with the GSS_C_NT_HOSTBASED_SERVICE flag which would fail for a user principal.  Failure to acquire a credential is not treated as a fatal error - the code proceeds to call `gss_init_sec_context()` with a NULL cred, which indicates that the default credentials should be used.   This PR fixes the incorrect flag, and changes the logic to abort authentication if credentials cannot be acquired for the desired principal.

The code is written so that not setting ZMQ_GSSAPI_PRINCIPAL on either client or server causes default credentials to be used, and in fact this may be desirable.  On the client side, not specifying it is the only way to use a user principal, and on the server side, according to https://web.mit.edu/kerberos/krb5-1.13/doc/appdev/gssapi.html
> The simplest choice is to pass GSS_C_NO_CREDENTIAL as the acceptor credential. In this case, clients may authenticate to any service principal in the default keytab (typically DEFKTNAME, or the value of the KRB5_KTNAME environment variable). This is the recommended approach if the server application has no specific requirements to the contrary.

The zmq_gssapi(7) manual page is updated to indicate that ZMQ_GSSAPI_PRINCIPAL is optional.

Finally, configure.ac is updated to fix an missing AC_DEFINE that was preventing the GSSAPI support from being compiled when `--with-libgssapi_krb5` is configured.

I've tested GSSAPI with these fixes in two scenarios:

1) My user principal authenticating to a service principal (keytab), with ZMQ_GSSAPI_PRINCIPAL not set on client, and both with and without ZMQ_GSSAPI_PRINCIPAL option set on server.

2) Service principal (keytab) to service principal (keytab), with and without ZMQ_GSSAPI_PRINCIPAL option set on client and server.  (client and server can use same or different principals).