### PR TITLE
add GSSAPI NAMETYPE socket options

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -21,7 +21,8 @@ MAN3 = zmq_bind.3 zmq_unbind.3 zmq_connect.3 zmq_disconnect.3 zmq_close.3 \
     zmq_atomic_counter_value.3 zmq_atomic_counter_destroy.3
 
 MAN7 = zmq.7 zmq_tcp.7 zmq_pgm.7 zmq_inproc.7 zmq_ipc.7 \
-    zmq_null.7 zmq_plain.7 zmq_curve.7 zmq_tipc.7 zmq_vmci.7 zmq_udp.7
+    zmq_null.7 zmq_plain.7 zmq_curve.7 zmq_tipc.7 zmq_vmci.7 zmq_udp.7 \
+    zmq_gssapi.7
 
 MAN_DOC =
 

--- a/doc/zmq_gssapi.txt
+++ b/doc/zmq_gssapi.txt
@@ -44,6 +44,26 @@ ZMQ_GSSAPI_PLAINTEXT option.  Both the client and server must set this option
 to the same value.
 
 
+PRINCIPAL NAMES
+---------------
+Principal names specified with the ZMQ_GSSAPI_SERVICE_PRINCIPAL or
+ZMQ_GSSAPI_PRINCIPAL options are interpreted as "host based" name types
+by default.  The ZMQ_GSSAPI_PRINCIPAL_NAMETYPE and
+ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE options may be used to change the
+name type to one of:
+
+*ZMQ_GSSAPI_NT_HOSTBASED*::
+The name should be of the form "service" or "service@hostname",
+which will parse into a principal of "service/hostname"
+in the local realm.  This is the default name type.
+*ZMQ_GSSAPI_NT_USER_NAME*::
+The name should be a local username, which will parse into a single-component
+principal in the local realm.
+*ZMQ_GSSAPI_NT_KRB5_PRINCIPAL*::
+The name is a principal name string.  This name type only works with
+the krb5 GSSAPI mechanism.
+
+
 SEE ALSO
 --------
 linkzmq:zmq_setsockopt[3]

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -368,6 +368,13 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg, const char *property)
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
 #define ZMQ_USE_FD 89
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
+
+/*  GSSAPI principal name types                                               */
+#define ZMQ_GSSAPI_NT_HOSTBASED 0
+#define ZMQ_GSSAPI_NT_USER_NAME 1
+#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1

--- a/src/gssapi_client.hpp
+++ b/src/gssapi_client.hpp
@@ -68,6 +68,8 @@ namespace zmq
         //  Human-readable principal name of the service we are connecting to
         char * service_name;
 
+	gss_OID service_name_type;
+
         //  Current FSM state
         state_t state;
 

--- a/src/gssapi_mechanism_base.hpp
+++ b/src/gssapi_mechanism_base.hpp
@@ -79,10 +79,14 @@ namespace zmq
         //  the  established security context.
         int decode_message (msg_t *msg_);
 
+	//  Convert ZMQ_GSSAPI_NT values to GSSAPI name_type
+	static const gss_OID convert_nametype (int zmq_name_type_);
+
         //  Acquire security context credentials from the
         //  underlying mechanism.
         static int acquire_credentials (char * principal_name_,
-                                        gss_cred_id_t * cred_);
+                                        gss_cred_id_t * cred_,
+					int zmq_name_type_);
 
     protected:
         //  Opaque GSSAPI token for outgoing data

--- a/src/gssapi_server.cpp
+++ b/src/gssapi_server.cpp
@@ -59,7 +59,8 @@ zmq::gssapi_server_t::gssapi_server_t (session_base_t *session_,
         assert(principal_name);
         memcpy(principal_name, options_.gss_principal.c_str(), principal_size+1 );
 
-        if (acquire_credentials (principal_name, &cred) != 0)
+        if (acquire_credentials (principal_name, &cred,
+                                 options_.gss_principal_nt) != 0)
             maj_stat = GSS_S_FAILURE;
     }
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -69,6 +69,8 @@ zmq::options_t::options_t () :
     tcp_keepalive_intvl (-1),
     mechanism (ZMQ_NULL),
     as_server (0),
+    gss_principal_nt (ZMQ_GSSAPI_NT_HOSTBASED),
+    gss_service_principal_nt (ZMQ_GSSAPI_NT_HOSTBASED),
     gss_plaintext (false),
     socket_id (0),
     conflate (false),
@@ -506,6 +508,22 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
         case ZMQ_GSSAPI_PLAINTEXT:
             if (is_int && (value == 0 || value == 1)) {
                 gss_plaintext = (value != 0);
+                return 0;
+            }
+            break;
+        case ZMQ_GSSAPI_PRINCIPAL_NAMETYPE:
+            if (is_int && (value == ZMQ_GSSAPI_NT_HOSTBASED
+                        || value == ZMQ_GSSAPI_NT_USER_NAME
+                        || value == ZMQ_GSSAPI_NT_KRB5_PRINCIPAL)) {
+                gss_principal_nt = value;
+                return 0;
+            }
+            break;
+        case ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE:
+            if (is_int && (value == ZMQ_GSSAPI_NT_HOSTBASED
+                        || value == ZMQ_GSSAPI_NT_USER_NAME
+                        || value == ZMQ_GSSAPI_NT_KRB5_PRINCIPAL)) {
+                gss_service_principal_nt = value;
                 return 0;
             }
             break;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -199,6 +199,10 @@ namespace zmq
         std::string gss_principal;
         std::string gss_service_principal;
 
+	//  Name types GSSAPI principals
+	int gss_principal_nt;
+	int gss_service_principal_nt;
+
         //  If true, gss encryption will be disabled
         bool gss_plaintext;
 


### PR DESCRIPTION
Add two new socket options as discussed in #2542 that allow the GSSAPI name type to be changed from "host type" to "user name" or "krb5 principal".

There is a description of the various name types from the MIT kerberos perspective at https://web.mit.edu/kerberos/krb5-1.12/doc/appdev/gssapi.html

The upshot is it allows zeromq to be a bit more flexible with respect to the type of principals used for GSSAPI authentication.