### PR TITLE
move GSSAPI NAMETYPE options to DRAFT, etc.

### DIFF
--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -232,6 +232,41 @@ Option value unit:: N/A
 Default value:: null string
 Applicable socket types:: all, when using TCP or IPC transports
 
+ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE: Retrieve nametype for service principal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Returns the 'ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE' option, if any, previously
+set on the socket.  A value of 'ZMQ_GSSAPI_NT_HOSTBASED' (0) means the name
+specified with 'ZMQ_GSSAPI_SERVICE_PRINCIPAL' is interpreted as a host based
+name.  A value of 'ZMQ_GSSAPI_NT_USER_NAME' (1) means it is interpreted as
+a local user name.  A value of 'ZMQ_GSSAPI_NT_KRB5_PRINCIPAL' (2) means it
+is interpreted as an unparsed principal name string (valid only with the
+krb5 GSSAPI mechanism).
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1, 2
+Default value:: 0 (ZMQ_GSSAPI_NT_HOSTBASED)
+Applicable socket types:: all, when using TCP or IPC transports
+
+ZMQ_GSSAPI_PRINCIPAL_NAMETYPE: Retrieve nametype for service principal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Returns the 'ZMQ_GSSAPI_PRINCIPAL_NAMETYPE' option, if any, previously
+set on the socket.  A value of 'ZMQ_GSSAPI_NT_HOSTBASED' (0) means the name
+specified with 'ZMQ_GSSAPI_PRINCIPAL' is interpreted as a host based
+name.  A value of 'ZMQ_GSSAPI_NT_USER_NAME' (1) means it is interpreted as
+a local user name.  A value of 'ZMQ_GSSAPI_NT_KRB5_PRINCIPAL' (2) means it
+is interpreted as an unparsed principal name string (valid only with the
+krb5 GSSAPI mechanism).
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1, 2
+Default value:: 0 (ZMQ_GSSAPI_NT_HOSTBASED)
+Applicable socket types:: all, when using TCP or IPC transports
 
 ZMQ_HANDSHAKE_IVL: Retrieve maximum handshake interval
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -249,6 +249,39 @@ Option value unit:: N/A
 Default value:: not set
 Applicable socket types:: all, when using TCP transport
 
+ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE: Set name type of service principal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the name type of the GSSAPI service principal.  A value of
+'ZMQ_GSSAPI_NT_HOSTBASED' (0) means the name specified with
+'ZMQ_GSSAPI_SERVICE_PRINCIPAL' is interpreted as a host based name.  A value
+of 'ZMQ_GSSAPI_NT_USER_NAME' (1) means it is interpreted as a local user name.
+A value of 'ZMQ_GSSAPI_NT_KRB5_PRINCIPAL' (2) means it is interpreted as an
+unparsed principal name string (valid only with the krb5 GSSAPI mechanism).
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1, 2
+Default value:: 0 (ZMQ_GSSAPI_NT_HOSTBASED)
+Applicable socket types:: all, when using TCP or IPC transport
+
+ZMQ_GSSAPI_PRINCIPAL_NAMETYPE: Set name type of principal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the name type of the GSSAPI principal.  A value of
+'ZMQ_GSSAPI_NT_HOSTBASED' (0) means the name specified with
+'ZMQ_GSSAPI_PRINCIPAL' is interpreted as a host based name.  A value of
+'ZMQ_GSSAPI_NT_USER_NAME' (1) means it is interpreted as a local user name.
+A value of 'ZMQ_GSSAPI_NT_KRB5_PRINCIPAL' (2) means it is interpreted as an
+unparsed principal name string (valid only with the krb5 GSSAPI mechanism).
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1, 2
+Default value:: 0 (ZMQ_GSSAPI_NT_HOSTBASED)
+Applicable socket types:: all, when using TCP or IPC transport
 
 ZMQ_HANDSHAKE_IVL: Set maximum handshake interval
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -368,13 +368,6 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg, const char *property)
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
 #define ZMQ_USE_FD 89
-#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
-#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
-
-/*  GSSAPI principal name types                                               */
-#define ZMQ_GSSAPI_NT_HOSTBASED 0
-#define ZMQ_GSSAPI_NT_USER_NAME 1
-#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
@@ -637,6 +630,18 @@ ZMQ_EXPORT int   zmq_timers_set_interval (void *timers, int timer_id, size_t int
 ZMQ_EXPORT int   zmq_timers_reset (void *timers, int timer_id);
 ZMQ_EXPORT long  zmq_timers_timeout (void *timers);
 ZMQ_EXPORT int   zmq_timers_execute (void *timers);
+
+/******************************************************************************/
+/*  GSSAPI socket options to set name type                                    */
+/******************************************************************************/
+
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 1090
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 1091
+
+/*  GSSAPI principal name types                                               */
+#define ZMQ_GSSAPI_NT_HOSTBASED 0
+#define ZMQ_GSSAPI_NT_USER_NAME 1
+#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/src/gssapi_client.cpp
+++ b/src/gssapi_client.cpp
@@ -51,8 +51,12 @@ zmq::gssapi_client_t::gssapi_client_t (const options_t &options_) :
     service_name = static_cast <char *>(malloc(service_size+1));
     assert(service_name);
     memcpy(service_name, options_.gss_service_principal.c_str(), service_size+1 );
-    service_name_type = convert_nametype (options_.gss_service_principal_nt);
 
+#ifdef ZMQ_BUILD_DRAFT_API
+    service_name_type = convert_nametype (options_.gss_service_principal_nt);
+#else
+    service_name_type = GSS_C_NT_HOSTBASED_SERVICE;
+#endif
     maj_stat = GSS_S_COMPLETE;
     if(!options_.gss_principal.empty())
     {
@@ -61,8 +65,12 @@ zmq::gssapi_client_t::gssapi_client_t (const options_t &options_) :
         assert(principal_name);
         memcpy(principal_name, options_.gss_principal.c_str(), principal_size+1 );
 
-        if (acquire_credentials (principal_name, &cred,
-                                 options_.gss_principal_nt) != 0)
+#ifdef ZMQ_BUILD_DRAFT_API
+        gss_OID name_type = convert_nametype (options_.gss_principal_nt);
+#else
+        gss_OID name_type = GSS_C_NT_HOSTBASED_SERVICE;
+#endif
+        if (acquire_credentials (principal_name, &cred, name_type) != 0)
             maj_stat = GSS_S_FAILURE;
     }
 

--- a/src/gssapi_mechanism_base.cpp
+++ b/src/gssapi_mechanism_base.cpp
@@ -320,9 +320,9 @@ int zmq::gssapi_mechanism_base_t::process_ready (msg_t *msg_)
     bytes_left -= 6;
     return parse_metadata (ptr, bytes_left);
 }
-
 const gss_OID zmq::gssapi_mechanism_base_t::convert_nametype (int zmq_nametype)
 {
+#ifdef ZMQ_BUILD_DRAFT_API
     switch (zmq_nametype) {
         case ZMQ_GSSAPI_NT_HOSTBASED:
             return GSS_C_NT_HOSTBASED_SERVICE;
@@ -335,22 +335,22 @@ const gss_OID zmq::gssapi_mechanism_base_t::convert_nametype (int zmq_nametype)
             return GSS_C_NT_USER_NAME;
 #endif
     }
+#endif
     return NULL;
 }
 
-int zmq::gssapi_mechanism_base_t::acquire_credentials (char * service_name_, gss_cred_id_t * cred_, int zmq_name_type_)
+int zmq::gssapi_mechanism_base_t::acquire_credentials (char * service_name_, gss_cred_id_t * cred_, gss_OID name_type_)
 {
     OM_uint32 maj_stat;
     OM_uint32 min_stat;
     gss_name_t server_name;
-    gss_OID name_type = convert_nametype (zmq_name_type_);
 
     gss_buffer_desc name_buf;
     name_buf.value = service_name_;
     name_buf.length = strlen ((char *) name_buf.value) + 1;
 
     maj_stat = gss_import_name (&min_stat, &name_buf,
-                                name_type, &server_name);
+                                name_type_, &server_name);
 
     if (maj_stat != GSS_S_COMPLETE)
         return -1;

--- a/src/gssapi_mechanism_base.hpp
+++ b/src/gssapi_mechanism_base.hpp
@@ -86,7 +86,7 @@ namespace zmq
         //  underlying mechanism.
         static int acquire_credentials (char * principal_name_,
                                         gss_cred_id_t * cred_,
-					int zmq_name_type_);
+					gss_OID name_type_);
 
     protected:
         //  Opaque GSSAPI token for outgoing data

--- a/src/gssapi_server.cpp
+++ b/src/gssapi_server.cpp
@@ -58,9 +58,12 @@ zmq::gssapi_server_t::gssapi_server_t (session_base_t *session_,
         principal_name = static_cast <char *>(malloc(principal_size+1));
         assert(principal_name);
         memcpy(principal_name, options_.gss_principal.c_str(), principal_size+1 );
-
-        if (acquire_credentials (principal_name, &cred,
-                                 options_.gss_principal_nt) != 0)
+#ifdef ZMQ_BUILD_DRAFT_API
+        gss_OID name_type = convert_nametype (options_.gss_principal_nt);
+#else
+        gss_OID name_type = GSS_C_NT_HOSTBASED_SERVICE;
+#endif
+        if (acquire_credentials (principal_name, &cred, name_type) != 0)
             maj_stat = GSS_S_FAILURE;
     }
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -69,8 +69,10 @@ zmq::options_t::options_t () :
     tcp_keepalive_intvl (-1),
     mechanism (ZMQ_NULL),
     as_server (0),
+#ifdef ZMQ_BUILD_DRAFT_API
     gss_principal_nt (ZMQ_GSSAPI_NT_HOSTBASED),
     gss_service_principal_nt (ZMQ_GSSAPI_NT_HOSTBASED),
+#endif
     gss_plaintext (false),
     socket_id (0),
     conflate (false),
@@ -511,6 +513,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
+#ifdef ZMQ_BUILD_DRAFT_API
         case ZMQ_GSSAPI_PRINCIPAL_NAMETYPE:
             if (is_int && (value == ZMQ_GSSAPI_NT_HOSTBASED
                         || value == ZMQ_GSSAPI_NT_USER_NAME
@@ -527,6 +530,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
+#endif
 #endif
 
         case ZMQ_HANDSHAKE_IVL:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -965,6 +965,20 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
                 return 0;
             }
             break;
+#ifdef ZMQ_BUILD_DRAFT_API
+        case ZMQ_GSSAPI_PRINCIPAL_NAMETYPE:
+            if (is_int) {
+                *value = gss_principal_nt;
+                return 0;
+            }
+            break;
+        case ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE:
+            if (is_int) {
+                *value = gss_service_principal_nt;
+                return 0;
+            }
+            break;
+#endif
 #endif
 
         case ZMQ_HANDSHAKE_IVL:

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -198,11 +198,11 @@ namespace zmq
         //  Principals for GSSAPI mechanism
         std::string gss_principal;
         std::string gss_service_principal;
-
+#ifdef ZMQ_BUILD_DRAFT_API
 	//  Name types GSSAPI principals
 	int gss_principal_nt;
 	int gss_service_principal_nt;
-
+#endif
         //  If true, gss encryption will be disabled
         bool gss_plaintext;
 

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -116,6 +116,18 @@ int   zmq_timers_reset (void *timers, int timer_id);
 long  zmq_timers_timeout (void *timers);
 int   zmq_timers_execute (void *timers);
 
+/******************************************************************************/
+/*  GSSAPI socket options to set name type                                    */
+/******************************************************************************/
+
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 1090
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 1091
+
+/*  GSSAPI principal name types                                               */
+#define ZMQ_GSSAPI_NT_HOSTBASED 0
+#define ZMQ_GSSAPI_NT_USER_NAME 1
+#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
+
 #endif // ZMQ_BUILD_DRAFT_API
 
 #endif //ifndef __ZMQ_DRAFT_H_INCLUDED__


### PR DESCRIPTION
Per feedback in PR #2545, this PR
* moves new GSSAPI options to DRAFT section of header
* adds the options to `zmq_getsockopt()`
* documents the options in `zmq_getsockopt(3)`, `zmq_setsockopt(3)` man pages