### PR TITLE
Clean up after move of GSSAPI NAMETYPE options to DRAFT

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -635,8 +635,8 @@ ZMQ_EXPORT int   zmq_timers_execute (void *timers);
 /*  GSSAPI socket options to set name type                                    */
 /******************************************************************************/
 
-#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 1090
-#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 1091
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
 
 /*  GSSAPI principal name types                                               */
 #define ZMQ_GSSAPI_NT_HOSTBASED 0

--- a/src/gssapi_client.cpp
+++ b/src/gssapi_client.cpp
@@ -52,11 +52,7 @@ zmq::gssapi_client_t::gssapi_client_t (const options_t &options_) :
     assert(service_name);
     memcpy(service_name, options_.gss_service_principal.c_str(), service_size+1 );
 
-#ifdef ZMQ_BUILD_DRAFT_API
     service_name_type = convert_nametype (options_.gss_service_principal_nt);
-#else
-    service_name_type = GSS_C_NT_HOSTBASED_SERVICE;
-#endif
     maj_stat = GSS_S_COMPLETE;
     if(!options_.gss_principal.empty())
     {
@@ -65,11 +61,7 @@ zmq::gssapi_client_t::gssapi_client_t (const options_t &options_) :
         assert(principal_name);
         memcpy(principal_name, options_.gss_principal.c_str(), principal_size+1 );
 
-#ifdef ZMQ_BUILD_DRAFT_API
         gss_OID name_type = convert_nametype (options_.gss_principal_nt);
-#else
-        gss_OID name_type = GSS_C_NT_HOSTBASED_SERVICE;
-#endif
         if (acquire_credentials (principal_name, &cred, name_type) != 0)
             maj_stat = GSS_S_FAILURE;
     }

--- a/src/gssapi_mechanism_base.cpp
+++ b/src/gssapi_mechanism_base.cpp
@@ -322,7 +322,6 @@ int zmq::gssapi_mechanism_base_t::process_ready (msg_t *msg_)
 }
 const gss_OID zmq::gssapi_mechanism_base_t::convert_nametype (int zmq_nametype)
 {
-#ifdef ZMQ_BUILD_DRAFT_API
     switch (zmq_nametype) {
         case ZMQ_GSSAPI_NT_HOSTBASED:
             return GSS_C_NT_HOSTBASED_SERVICE;
@@ -335,7 +334,6 @@ const gss_OID zmq::gssapi_mechanism_base_t::convert_nametype (int zmq_nametype)
             return GSS_C_NT_USER_NAME;
 #endif
     }
-#endif
     return NULL;
 }
 

--- a/src/gssapi_server.cpp
+++ b/src/gssapi_server.cpp
@@ -58,11 +58,7 @@ zmq::gssapi_server_t::gssapi_server_t (session_base_t *session_,
         principal_name = static_cast <char *>(malloc(principal_size+1));
         assert(principal_name);
         memcpy(principal_name, options_.gss_principal.c_str(), principal_size+1 );
-#ifdef ZMQ_BUILD_DRAFT_API
         gss_OID name_type = convert_nametype (options_.gss_principal_nt);
-#else
-        gss_OID name_type = GSS_C_NT_HOSTBASED_SERVICE;
-#endif
         if (acquire_credentials (principal_name, &cred, name_type) != 0)
             maj_stat = GSS_S_FAILURE;
     }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -69,10 +69,8 @@ zmq::options_t::options_t () :
     tcp_keepalive_intvl (-1),
     mechanism (ZMQ_NULL),
     as_server (0),
-#ifdef ZMQ_BUILD_DRAFT_API
     gss_principal_nt (ZMQ_GSSAPI_NT_HOSTBASED),
     gss_service_principal_nt (ZMQ_GSSAPI_NT_HOSTBASED),
-#endif
     gss_plaintext (false),
     socket_id (0),
     conflate (false),
@@ -513,7 +511,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
-#ifdef ZMQ_BUILD_DRAFT_API
+
         case ZMQ_GSSAPI_PRINCIPAL_NAMETYPE:
             if (is_int && (value == ZMQ_GSSAPI_NT_HOSTBASED
                         || value == ZMQ_GSSAPI_NT_USER_NAME
@@ -522,6 +520,7 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
+
         case ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE:
             if (is_int && (value == ZMQ_GSSAPI_NT_HOSTBASED
                         || value == ZMQ_GSSAPI_NT_USER_NAME
@@ -530,7 +529,6 @@ int zmq::options_t::setsockopt (int option_, const void *optval_,
                 return 0;
             }
             break;
-#endif
 #endif
 
         case ZMQ_HANDSHAKE_IVL:
@@ -965,7 +963,7 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
                 return 0;
             }
             break;
-#ifdef ZMQ_BUILD_DRAFT_API
+
         case ZMQ_GSSAPI_PRINCIPAL_NAMETYPE:
             if (is_int) {
                 *value = gss_principal_nt;
@@ -978,7 +976,6 @@ int zmq::options_t::getsockopt (int option_, void *optval_, size_t *optvallen_) 
                 return 0;
             }
             break;
-#endif
 #endif
 
         case ZMQ_HANDSHAKE_IVL:

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -198,11 +198,11 @@ namespace zmq
         //  Principals for GSSAPI mechanism
         std::string gss_principal;
         std::string gss_service_principal;
-#ifdef ZMQ_BUILD_DRAFT_API
+
 	//  Name types GSSAPI principals
 	int gss_principal_nt;
 	int gss_service_principal_nt;
-#endif
+
         //  If true, gss encryption will be disabled
         bool gss_plaintext;
 

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -120,8 +120,8 @@ int   zmq_timers_execute (void *timers);
 /*  GSSAPI socket options to set name type                                    */
 /******************************************************************************/
 
-#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 1090
-#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 1091
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
 
 /*  GSSAPI principal name types                                               */
 #define ZMQ_GSSAPI_NT_HOSTBASED 0


### PR DESCRIPTION
As discussed in PR #2548, DRAFT socket options should use their final option numbers, and ifdefs on ZMQ_BUILD_DRAFT_API are unnecessary in the code due to zmq_draft.h.