### PR TITLE
Problem: new zmq_poller used by zmq_poll without DRAFTs

### DIFF
--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -67,8 +67,6 @@ const char *zmq_msg_group(zmq_msg_t *msg);
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
 /******************************************************************************/
 
-#define ZMQ_HAVE_POLLER
-
 typedef struct zmq_poller_event_t
 {
     void *socket;
@@ -102,8 +100,6 @@ int zmq_poller_remove_fd (void *poller, int fd);
 /******************************************************************************/
 /*  Scheduling timers                                                         */
 /******************************************************************************/
-
-#define ZMQ_HAVE_TIMERS
 
 typedef void (zmq_timer_fn)(int timer_id, void *arg);
 


### PR DESCRIPTION
Solution: do not define ZMQ_HAVE_POLLER in src/zmq_drafts.h otherwise
src/zmq.cpp will implement zmq_poll using the new poller classes.
Same for ZMQ_HAVE_TIMERS, even though it has no internal effect, but
to be safe against future development.

Fixes #2540

This sneaked in a few releases without me realising it.
I noticed now because I'm facing some major memory utilisation issues when moving an application from 4.1 to 4.2, and I noticed using the old implementation of zmq_poll seems to help keep it down. I will do my best to trace it as soon as I can and open a new issue/PR as needed. But in the meanwhile we shouldn't have it on by default unless the user wants the DRAFT stuff enabled.