### PR TITLE
Problem: RPM build fails due to ignored zmq_gssapi.7

### DIFF
--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -2,7 +2,9 @@
   <service name="tar_scm">
     <param name="url">https://github.com/zeromq/libzmq</param>
     <param name="scm">git</param>
-    <!--<param name="versionformat">@PARENT_TAG@+git%cd</param>-->
+    <param name="versionformat">@PARENT_TAG@+git%cd</param>
+    <param name="versionrewrite-pattern">v(.*)</param>
+    <param name="versionrewrite-replacement">\1</param>
     <param name="exclude">.git</param>
     <param name="changesgenerate">enable</param>
     <param name="filename">zeromq</param>

--- a/packaging/redhat/zeromq.spec
+++ b/packaging/redhat/zeromq.spec
@@ -177,16 +177,8 @@ autoreconf -fi
 %{_libdir}/libzmq.so
 
 %{_mandir}/man3/zmq*
-%{_mandir}/man7/zmq_curve.7.gz
-%{_mandir}/man7/zmq_inproc.7.gz
-%{_mandir}/man7/zmq_ipc.7.gz
-%{_mandir}/man7/zmq_null.7.gz
-%{_mandir}/man7/zmq_pgm.7.gz
-%{_mandir}/man7/zmq_plain.7.gz
-%{_mandir}/man7/zmq_tcp.7.gz
-%{_mandir}/man7/zmq_tipc.7.gz
-%{_mandir}/man7/zmq_udp.7.gz
-%{_mandir}/man7/zmq_vmci.7.gz
+# skip man7/zmq.7.gz
+%{_mandir}/man7/zmq_*
 
 %files -n libzmq-tools
 %defattr(-,root,root,-)


### PR DESCRIPTION
Solution: use wildcard to pick up manpages in the spec file