### PR TITLE
Problem: no way to deploy releases to OBS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,20 @@ os:
 dist: trusty
 
 env:
-- BUILD_TYPE=default CURVE=tweetnacl DRAFT=enabled
-- BUILD_TYPE=android CURVE=tweetnacl
-- BUILD_TYPE=cmake CURVE=tweetnacl
-- BUILD_TYPE=default
+  matrix:
+    - BUILD_TYPE=default CURVE=tweetnacl DRAFT=enabled
+    - BUILD_TYPE=android CURVE=tweetnacl
+    - BUILD_TYPE=cmake CURVE=tweetnacl
+    - BUILD_TYPE=default
+  # tokens to deploy releases on OBS and create/delete temporary branch on Github.
+  # 1) Create a token on https://github.com/settings/tokens/new with "public_repo"
+  #    capability and encrypt it with travis encrypt --org -r zeromq/libzmq GH_TOKEN="<token>"
+  # 2) Create 2 OBS tokens with osc token --create network:messaging:zeromq:release-<stable|draft> libzmq
+  #    encrypt them with travis encrypt --org -r zeromq/libzmq OBS_<STABLE|DRAFT>_TOKEN="<token>"
+  global:
+    - secure: aaIs9Y44FYp9VFCqa6LLD4illBH4aUfbS0zzzbAQ5xJvD6NfBsMiKEIhf/kRNCHAtP+1VfQVOejTD6/i08ALsVr3cZD9oB/t7874tz2/jeZUIhRNo+1KwyaVqNg0yUSV6ASIoq4aOfuGnjBlezNQ8LQ2bjQB2m4Enl5wxoYcYdA=
+    - secure: YFrcedBIKe0NR1WC6qQi9phZgtnzOiBIXm40TirvCtstV4eVnSouKgtQfLLArZ4o2tjflq4grQQNo1rJatvyi5YPOXsMcndsni18S+4Ffu8qbECdtPrK52vBweuf7q9oV9Ydax0Fm4bEqEMOZ2/mRBy3nK+mgsE3upeMwyWR0Zw=
+    - secure: lbZSzmqN39QdJwewKOZgq/1ijPKuyx9MFrGzMqXj2+eOSlaZS/tNavHMdKJOev+qJGK9wxmwzxOxS10AiH+AvN7WBacXX4ZtudjScz2HKJRDWTKyzMbzyScq51afniItzrsm+Vo8NHkenNFkux0sSbh0aHlpkLwrGQu+WZWcDN4=
 
 matrix:
   include:

--- a/ci_deploy.sh
+++ b/ci_deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+# do NOT set -x or it will log the secret tokens!
 set -e
 
 if [[ $BUILD_TYPE == "default" && $CURVE == "libsodium" && -z $DRAFT ]]; then
@@ -15,6 +15,20 @@ if [[ $BUILD_TYPE == "default" && $CURVE == "libsodium" && -z $DRAFT ]]; then
     md5sum *.zip *.tar.gz > MD5SUMS
     sha1sum *.zip *.tar.gz > SHA1SUMS
     cd -
+
+    # Trigger source run on new tag on OBS.
+    # We have to create a temporary branch from the tag and delete it, as it is
+    # not possible to edit files on OBS with secure tokens, and it is not
+    # possible to dynamically fetch the latest git tag either.
+    if [ -n "${GH_TOKEN}" -a -n "${OBS_STABLE_TOKEN}" -a -n "${OBS_DRAFT_TOKEN}" ]; then
+        TAG_SHA=$(curl -s -H "Authorization: token ${GH_TOKEN}" -X GET https://api.github.com/repos/zeromq/libzmq/git/refs/tags/${TRAVIS_TAG} | grep -o -P '(?<=sha":\s).*(?=,)')
+        curl -H "Authorization: token ${GH_TOKEN}" -X POST --data "{\"ref\":\"refs/heads/tmp_obs_release_branch\",\"sha\":${TAG_SHA}}" https://api.github.com/repos/zeromq/libzmq/git/refs
+        curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+        curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+        # give some time for the git clone to happen before deleting the temp branch
+        sleep 60
+        curl -H "Authorization: token ${GH_TOKEN}" -X DELETE https://api.github.com/repos/zeromq/libzmq/git/refs/heads/tmp_obs_release_branch
+    fi
 else
     export LIBZMQ_DEPLOYMENT=""
 fi


### PR DESCRIPTION
Solution: add new tokens to .travis.yml and change ci_deploy.sh
script to use Github APIs to create a temporary branch at the tag,
and the OBS APIs to trigger a source service run in the stable and
draft release projects:
network:messaging:zeromq:release-stable
network:messaging:zeromq:release-draft

The branch hack is unfortunately necessary as it is not possible to
modify OBS sources with the token APIs, and it is also not possible
to automatically fetch the latest tag in the service files.
The temporary branch is immediately deleted.