### PR TITLE
Problem: not using official api FD_ZERO to init fd_set

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1048,9 +1048,12 @@ int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
     //  file descriptors.
     zmq_assert (nitems_ <= FD_SETSIZE);
 
-    fd_set pollset_in  = { 0 };
-    fd_set pollset_out = { 0 };
-    fd_set pollset_err = { 0 };
+    fd_set pollset_in;
+    FD_ZERO (&pollset_in);
+    fd_set pollset_out;
+    FD_ZERO (&pollset_out);
+    fd_set pollset_err;
+    FD_ZERO (&pollset_err);
 
     zmq::fd_t maxfd = 0;
 


### PR DESCRIPTION
Solution: fix it

In particular, on Windows, using FD_ZERO is much more efficient than
zeroing out the whole structure.

This reverts the change made in https://github.com/zeromq/libzmq/commit/b3d5fa63a0643afdf7de44dc1739725766ae459e