### PR TITLE
Problem: abort at socket creation on Android with jzmq

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -412,7 +412,9 @@ void zmq::ctx_t::start_thread (thread_t &thread_, thread_fn *tfn_, void *arg_) c
 {
     thread_.start(tfn_, arg_);
     thread_.setSchedulingParameters(thread_priority, thread_sched_policy);
+#ifndef ZMQ_HAVE_ANDROID
     thread_.setThreadName ("ZMQ background");
+#endif
 }
 
 void zmq::ctx_t::send_command (uint32_t tid_, const command_t &command_)


### PR DESCRIPTION
Solution: don't set thread name on Android

Setting a thread name on Android may fail with "permission denied" error and abort the process due to failed assertion. Tested on Android 5 and 6 (two phones). Strangely enough, it only happens on signed APKs and is fine in debug. Using JeroMQ is not an option as we need TCP keepalive settings and authentication which JeroMQ doesn't support.