### PR TITLE
Use OBJECT_DEPENDS and OBJECT_OUTPUTS for precompiled.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,15 +703,19 @@ endif ()
 if (MSVC)
     # default for all sources is to use precompiled headers
     foreach(source ${sources})
-        set_source_files_properties(${source}
-            PROPERTIES
-            COMPILE_FLAGS "/Yuprecompiled.hpp"
-            )
+        if (NOT ${source} STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/src/precompiled.cpp")
+            set_source_files_properties(${source}
+                PROPERTIES
+                COMPILE_FLAGS "/Yuprecompiled.hpp"
+                OBJECT_DEPENDS precompiled.hpp
+                )
+        endif()
     endforeach()
     # create precompiled header
     set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/precompiled.cpp
         PROPERTIES
         COMPILE_FLAGS "/Ycprecompiled.hpp"
+        OBJECT_OUTPUTS precompiled.hpp
         )
     # C and C++ can not use the same precompiled header
     set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/tweetnacl.c


### PR DESCRIPTION
This fix, allows to have a correct dependency tree for precompiled header.
The issue is triggered when using ninja build system, which doesn't take the source files in the given order (fixed for make in #2294).
This allow to use ninja for building libzmq on windows (on linux it works as it is)