### PR TITLE
Problem: use-after-free in test_poller

### DIFF
--- a/tests/test_poller.cpp
+++ b/tests/test_poller.cpp
@@ -150,6 +150,10 @@ int main (void)
     assert (event.socket == server);
     assert (event.user_data == NULL);
     assert (event.events == ZMQ_POLLOUT);
+
+    //  Stop polling server
+    rc = zmq_poller_remove (poller, server);
+    assert (rc == 0);
 #endif
 
     //  Destory sockets, poller and ctx    


### PR DESCRIPTION
Solution: remove server socket from poller before closing it
Fixes #2581