### PR TITLE
Suppress linker warning 4221 for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -741,6 +741,9 @@ if (BUILD_STATIC)
 endif()
 
 if (MSVC)
+  # Suppress linker warnings caused by #ifdef omission
+  # of file content.
+  set( CMAKE_STATIC_LINKER_FLAGS /ignore:4221 )
   if (BUILD_SHARED)
     add_library (libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in)
     target_link_libraries (libzmq ${OPTIONAL_LIBRARIES})


### PR DESCRIPTION
Problem:

Some #define switches cause the body of entire files to be omitted. This
causes a linker warning on Visual Studio 2017, for example

    warning LNK4221: This object file does not define any previously
    undefined public symbols, so it will not be used by any link
    operation that consumes this library

Solution:

Add a linker flag to suppress this warning on MSVC builds.
