### PR TITLE
fix bug: coredump if set linger and immediate together

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -506,6 +506,11 @@ void zmq::session_base_t::reconnect ()
         pipe->terminate (false);
         terminating_pipes.insert (pipe);
         pipe = NULL;
+
+        if (has_linger_timer) {
+            cancel_timer (linger_timer_id);
+            has_linger_timer = false;
+        }
     }
 
     reset ();


### PR DESCRIPTION
In function session_base_t::reconnect, if we set immediate to 1 and set linger, we will get into first block of reconnect function, and set pipe to NULL, but we forget to cancel timer of linger. Once timer tiggered, we will get coredump. 

Solution: In function session_base_t::reconnect cancel timer in the end of set pipe to NULL


ref [https://github.com/zeromq/libzmq/issues/2590](https://github.com/zeromq/libzmq/issues/2590)