### PR TITLE
fix bug: #2592 dish client does not resend subscriptions to radio server after radio server restart

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -521,7 +521,7 @@ void zmq::session_base_t::reconnect ()
 
     //  For subscriber sockets we hiccup the inbound pipe, which will cause
     //  the socket object to resend all the subscriptions.
-    if (pipe && (options.type == ZMQ_SUB || options.type == ZMQ_XSUB))
+    if (pipe && (options.type == ZMQ_SUB || options.type == ZMQ_XSUB || options.type == ZMQ_DISH))
         pipe->hiccup ();
 }
 


### PR DESCRIPTION
problem: for zmq radio/dish pattern, if the radio process restarts, the dish will not resend subscriptions to radio. And the result is that the dish will never receive any more messages.

solution: in session_base_t::reconnect (), take ZMQ_DISH into consideration when invoking hiccup method.