### PR TITLE
Problem: XPUB_MANUAL subscriptions not removed on peer term

### DIFF
--- a/tests/test_xpub_manual.cpp
+++ b/tests/test_xpub_manual.cpp
@@ -37,12 +37,10 @@ int test_basic()
     //  Create a publisher
     void *pub = zmq_socket (ctx, ZMQ_XPUB);
     assert (pub);
-    int rc = zmq_bind (pub, "inproc://soname");
-    assert (rc == 0);
-
-    //  set pub socket options
     int manual = 1;
-    rc = zmq_setsockopt(pub, ZMQ_XPUB_MANUAL, &manual, 4);
+    int rc = zmq_setsockopt(pub, ZMQ_XPUB_MANUAL, &manual, 4);
+    assert (rc == 0);
+    rc = zmq_bind (pub, "inproc://soname");
     assert (rc == 0);
 
     //  Create a subscriber


### PR DESCRIPTION
Solution: remove the pipe from the real trie when a peer disconnects.
Also add a unit test that exercises the behaviour by reconnecting
a different socket and sending a message that matches.
Fixes #2601 and introduced by #2042

Also fix another unit test.