### PR TITLE
Problem: CURVE server (connect) fails when client rebinds

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -323,7 +323,8 @@ void zmq::session_base_t::process_plug ()
 //  security flaw.
 int zmq::session_base_t::zap_connect ()
 {
-    zmq_assert (zap_pipe == NULL);
+    if (zap_pipe != NULL)
+        return 0;
 
     endpoint_t peer = find_endpoint ("inproc://zeromq.zap.01");
     if (peer.socket == NULL) {


### PR DESCRIPTION
Solution: if a CURVE server is using zmq_connect, the same session
will be used for any client "reconnect" (actual binds). This is
acceptable, so do not assert if zap_pipe already exists during the
handshake, but simply reuse it.
Fixes #2608