### PR TITLE
configure.ac: allow user to disable libunwind discovery via --disable-libunwind

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -721,16 +721,28 @@ else
     AC_SUBST(pkg_config_defines, "")
 fi
 
-PKG_CHECK_MODULES(LIBUNWIND, [libunwind],
-    [
-        AC_DEFINE(HAVE_LIBUNWIND, 1, [The libunwind library is to be used])
-        AC_SUBST([LIBUNWIND_CFLAGS])
-        AC_SUBST([LIBUNWIND_LIBS])
-        AC_CHECK_LIB([dl], [dladdr])
-    ],
-    [
-        AC_MSG_WARN([Cannot find libunwind])
-    ])
+AC_ARG_ENABLE([libunwind],
+    [AS_HELP_STRING([--enable-libunwind],
+        [enable libunwind [default=auto]])],
+    [enable_libunwind=$enableval],
+    [enable_libunwind="auto"])
+
+if test "x$enable_libunwind" != "xno"; then
+    PKG_CHECK_MODULES(LIBUNWIND, [libunwind],
+        [
+            AC_DEFINE(HAVE_LIBUNWIND, 1, [The libunwind library is to be used])
+            AC_SUBST([LIBUNWIND_CFLAGS])
+            AC_SUBST([LIBUNWIND_LIBS])
+            AC_CHECK_LIB([dl], [dladdr])
+        ],
+        [
+            if test "x$enable_libunwind" = "xyes"; then
+                AC_MSG_ERROR([Cannot find libunwind])
+            else
+                AC_MSG_WARN([Cannot find libunwind])
+            fi
+        ])
+fi
 
 # Subst LIBZMQ_EXTRA_CFLAGS & CXXFLAGS & LDFLAGS
 AC_SUBST(LIBZMQ_EXTRA_CFLAGS)


### PR DESCRIPTION
on ia64 architecture libunwind comes with gcc. Unfortunately
libunwind is not directly usable as-is and fails at link time:

```
    ia64-unknown-linux-gnu-g++ -o perf/.libs/local_lat perf/local_lat.o src/.libs/libzmq.so -lsodium -lrt -lpthread -ldl
    src/.libs/libzmq.so: undefined reference to `_ULia64_step'
```

The change adds --{enable,disable}-libunwind flag to control
automatic dependency. The default is unchanged: use if available.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>