### PR TITLE
Don't try to set IPV6_V6ONLY on OpenBSD

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -108,7 +108,7 @@ void zmq::enable_ipv4_mapping (fd_t s_)
 {
   (void) s_;
 
-#ifdef IPV6_V6ONLY
+#if defined IPV6_V6ONLY && !defined ZMQ_HAVE_OPENBSD
 #ifdef ZMQ_HAVE_WINDOWS
     DWORD flag = 0;
 #else


### PR DESCRIPTION
Problem: IPV6_V6ONLY is read-only on OpenBSD
Solution: skip setsockopt call resulting in EINVAL