### PR TITLE
Fix error code when ZAP handler sends an invalid status code

### DIFF
--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -703,7 +703,7 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
     if (msg [3].size () != 3) {
         //  Temporary support for security debugging
         puts ("CURVE I: ZAP handler rejected client authentication");
-        errno = EACCES;
+        errno = EPROTO;
         return close_and_return (msg, -1);
     }
 


### PR DESCRIPTION
Problem: Misleading error code in case ZAP handler sends an invalid status code (#2643)

Solution: Use EPROTO instead of EACCES error code in that case
