### PR TITLE
Problem: Message property names are duplicated

### DIFF
--- a/doc/zmq_msg_gets.txt
+++ b/doc/zmq_msg_gets.txt
@@ -27,7 +27,6 @@ function:
 
     Socket-Type
     Identity
-    Resource
 
 Additionally, when available for the underlying transport, the *Peer-Address*
 property will return the IP address of the remote endpoint as returned by

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -584,6 +584,12 @@ ZMQ_EXPORT uint32_t zmq_msg_routing_id(zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_set_group(zmq_msg_t *msg, const char *group);
 ZMQ_EXPORT const char *zmq_msg_group(zmq_msg_t *msg);
 
+/*  DRAFT Msg property names.                                                 */
+#define ZMQ_MSG_PROPERTY_IDENTITY      "Identity"
+#define ZMQ_MSG_PROPERTY_SOCKET_TYPE   "Socket-Type"
+#define ZMQ_MSG_PROPERTY_USER_ID       "User-Id"
+#define ZMQ_MSG_PROPERTY_PEER_ADDRESS  "Peer-Address"
+
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
 /******************************************************************************/

--- a/src/curve_client.cpp
+++ b/src/curve_client.cpp
@@ -356,13 +356,15 @@ int zmq::curve_client_t::produce_initiate (msg_t *msg_)
 
     //  Add socket type property
     const char *socket_type = socket_type_string (options.type);
-    ptr += add_property (ptr, "Socket-Type", socket_type, strlen (socket_type));
+    ptr += add_property (ptr, ZMQ_MSG_PROPERTY_SOCKET_TYPE, socket_type,
+                         strlen (socket_type));
 
     //  Add identity property
     if (options.type == ZMQ_REQ
     ||  options.type == ZMQ_DEALER
     ||  options.type == ZMQ_ROUTER)
-        ptr += add_property (ptr, "Identity", options.identity, options.identity_size);
+        ptr += add_property (ptr, ZMQ_MSG_PROPERTY_IDENTITY, options.identity,
+                             options.identity_size);
 
     const size_t mlen = ptr - initiate_plaintext;
 

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -534,13 +534,15 @@ int zmq::curve_server_t::produce_ready (msg_t *msg_)
 
     //  Add socket type property
     const char *socket_type = socket_type_string (options.type);
-    ptr += add_property (ptr, "Socket-Type", socket_type, strlen (socket_type));
+    ptr += add_property (ptr, ZMQ_MSG_PROPERTY_SOCKET_TYPE, socket_type,
+                         strlen (socket_type));
 
     //  Add identity property
     if (options.type == ZMQ_REQ
     ||  options.type == ZMQ_DEALER
     ||  options.type == ZMQ_ROUTER)
-        ptr += add_property (ptr, "Identity", options.identity, options.identity_size);
+        ptr += add_property (ptr, ZMQ_MSG_PROPERTY_IDENTITY, options.identity,
+                             options.identity_size);
 
     const size_t mlen = ptr - ready_plaintext;
 

--- a/src/gssapi_mechanism_base.cpp
+++ b/src/gssapi_mechanism_base.cpp
@@ -281,13 +281,15 @@ int zmq::gssapi_mechanism_base_t::produce_ready (msg_t *msg_)
 
     //  Add socket type property
     const char *socket_type = socket_type_string (options.type);
-    ptr += add_property (ptr, "Socket-Type", socket_type, strlen (socket_type));
+    ptr += add_property (ptr, ZMQ_MSG_PROPERTY_SOCKET_TYPE, socket_type,
+                         strlen (socket_type));
 
     //  Add identity property
     if (options.type == ZMQ_REQ
     ||  options.type == ZMQ_DEALER
     ||  options.type == ZMQ_ROUTER)
-        ptr += add_property (ptr, "Identity", options.identity, options.identity_size);
+        ptr += add_property (ptr, ZMQ_MSG_PROPERTY_IDENTITY, options.identity,
+                             options.identity_size);
 
     const size_t command_size = ptr - command_buffer;
     const int rc = msg_->init_size (command_size);

--- a/src/mechanism.cpp
+++ b/src/mechanism.cpp
@@ -61,9 +61,8 @@ void zmq::mechanism_t::peer_identity (msg_t *msg_)
 void zmq::mechanism_t::set_user_id (const void *data_, size_t size_)
 {
     user_id = blob_t (static_cast <const unsigned char*> (data_), size_);
-    zap_properties.insert (
-        metadata_t::dict_t::value_type (
-            "User-Id", std::string ((char *) data_, size_)));
+    zap_properties.insert (metadata_t::dict_t::value_type (
+      ZMQ_MSG_PROPERTY_USER_ID, std::string ((char *) data_, size_)));
 }
 
 zmq::blob_t zmq::mechanism_t::get_user_id () const
@@ -127,10 +126,10 @@ int zmq::mechanism_t::parse_metadata (const unsigned char *ptr_,
         ptr_ += value_length;
         bytes_left -= value_length;
 
-        if (name == "Identity" && options.recv_identity)
+        if (name == ZMQ_MSG_PROPERTY_IDENTITY && options.recv_identity)
             set_peer_identity (value, value_length);
         else
-        if (name == "Socket-Type") {
+        if (name == ZMQ_MSG_PROPERTY_SOCKET_TYPE) {
             const std::string socket_type ((char *) value, value_length);
             if (!check_socket_type (socket_type)) {
                 errno = EINVAL;

--- a/src/null_mechanism.cpp
+++ b/src/null_mechanism.cpp
@@ -109,13 +109,15 @@ int zmq::null_mechanism_t::next_handshake_command (msg_t *msg_)
 
     //  Add socket type property
     const char *socket_type = socket_type_string (options.type);
-    ptr += add_property (ptr, "Socket-Type", socket_type, strlen (socket_type));
+    ptr += add_property (ptr, ZMQ_MSG_PROPERTY_SOCKET_TYPE, socket_type,
+                         strlen (socket_type));
 
     //  Add identity property
     if (options.type == ZMQ_REQ
     ||  options.type == ZMQ_DEALER
     ||  options.type == ZMQ_ROUTER)
-        ptr += add_property (ptr, "Identity", options.identity, options.identity_size);
+        ptr += add_property (ptr, ZMQ_MSG_PROPERTY_IDENTITY, options.identity,
+                             options.identity_size);
 
     const size_t command_size = ptr - command_buffer;
     const int rc = msg_->init_size (command_size);

--- a/src/plain_client.cpp
+++ b/src/plain_client.cpp
@@ -170,14 +170,15 @@ int zmq::plain_client_t::produce_initiate (msg_t *msg_) const
 
     //  Add socket type property
     const char *socket_type = socket_type_string (options.type);
-    ptr += add_property (ptr, "Socket-Type", socket_type, strlen (socket_type));
+    ptr += add_property (ptr, ZMQ_MSG_PROPERTY_SOCKET_TYPE, socket_type,
+                         strlen (socket_type));
 
     //  Add identity property
     if (options.type == ZMQ_REQ
     ||  options.type == ZMQ_DEALER
     ||  options.type == ZMQ_ROUTER)
-        ptr += add_property (
-            ptr, "Identity", options.identity, options.identity_size);
+        ptr += add_property (ptr, ZMQ_MSG_PROPERTY_IDENTITY, options.identity,
+                             options.identity_size);
 
     const size_t command_size = ptr - command_buffer;
     const int rc = msg_->init_size (command_size);

--- a/src/plain_server.cpp
+++ b/src/plain_server.cpp
@@ -250,14 +250,15 @@ int zmq::plain_server_t::produce_ready (msg_t *msg_) const
 
     //  Add socket type property
     const char *socket_type = socket_type_string (options.type);
-    ptr += add_property (ptr, "Socket-Type", socket_type, strlen (socket_type));
+    ptr += add_property (ptr, ZMQ_MSG_PROPERTY_SOCKET_TYPE, socket_type,
+                         strlen (socket_type));
 
     //  Add identity property
     if (options.type == ZMQ_REQ
     ||  options.type == ZMQ_DEALER
     ||  options.type == ZMQ_ROUTER)
-        ptr += add_property (
-            ptr, "Identity", options.identity, options.identity_size);
+        ptr += add_property (ptr, ZMQ_MSG_PROPERTY_IDENTITY, options.identity,
+                             options.identity_size);
 
     const size_t command_size = ptr - command_buffer;
     const int rc = msg_->init_size (command_size);

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -1023,7 +1023,8 @@ void zmq::stream_engine_t::set_handshake_timer ()
 
 bool zmq::stream_engine_t::init_properties (properties_t & properties) {
     if (peer_address.empty()) return false;
-    properties.insert (std::make_pair("Peer-Address", peer_address));
+    properties.insert (
+      std::make_pair (ZMQ_MSG_PROPERTY_PEER_ADDRESS, peer_address));
 
     //  Private property to support deprecated SRCFD
     std::ostringstream stream;

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -69,6 +69,12 @@ uint32_t zmq_msg_routing_id(zmq_msg_t *msg);
 int zmq_msg_set_group(zmq_msg_t *msg, const char *group);
 const char *zmq_msg_group(zmq_msg_t *msg);
 
+/*  DRAFT Msg property names.                                                 */
+#define ZMQ_MSG_PROPERTY_IDENTITY      "Identity"
+#define ZMQ_MSG_PROPERTY_SOCKET_TYPE   "Socket-Type"
+#define ZMQ_MSG_PROPERTY_USER_ID       "User-Id"
+#define ZMQ_MSG_PROPERTY_PEER_ADDRESS  "Peer-Address"
+
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
 /******************************************************************************/


### PR DESCRIPTION
Solution: Introduce defines in the (DRAFT) API, this also makes them accessible to libzmq users
