### PR TITLE
Problems: timeout in curve test, redundant windows and android CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ dist: trusty
 env:
   matrix:
     - BUILD_TYPE=default CURVE=tweetnacl DRAFT=enabled
-    - BUILD_TYPE=android CURVE=tweetnacl
     - BUILD_TYPE=cmake CURVE=tweetnacl
     - BUILD_TYPE=default
   # tokens to deploy releases on OBS and create/delete temporary branch on Github.
@@ -74,6 +73,9 @@ matrix:
         packages:
         - g++-6
         - gcc-6
+  - env: BUILD_TYPE=android CURVE=tweetnacl
+    os: linux
+    dist: trusty
 
 sudo: required
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,6 @@ environment:
       ENABLE_CURVE: OFF
     - platform: Win32
       configuration: Release
-      WITH_LIBSODIUM: ON
-      ENABLE_CURVE: OFF
-    - platform: Win32
-      configuration: Release
       WITH_LIBSODIUM: OFF
       ENABLE_CURVE: ON
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -170,7 +170,7 @@ foreach(test ${tests})
 endforeach()
 
 #override timeout for these tests
-set_tests_properties(test_security_curve PROPERTIES TIMEOUT 20)
+set_tests_properties(test_security_curve PROPERTIES TIMEOUT 60)
 
 #Check whether all tests in the current folder are present
 file(READ "${CMAKE_CURRENT_LIST_FILE}" CURRENT_LIST_FILE_CONTENT)


### PR DESCRIPTION
Solutions: bump timeout for test_security_curve to 60 seconds, remove CI jobs