### PR TITLE
Problem: zmq::curve_server_t::produce_error sends sizeof std::string instead of status code length

### DIFF
--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -572,13 +572,14 @@ int zmq::curve_server_t::produce_ready (msg_t *msg_)
 
 int zmq::curve_server_t::produce_error (msg_t *msg_) const
 {
+    const size_t expected_status_code_length = 3;
     zmq_assert (status_code.length () == 3);
-    const int rc = msg_->init_size (6 + 1 + status_code.length ());
+    const int rc = msg_->init_size (6 + 1 + expected_status_code_length);
     zmq_assert (rc == 0);
     char *msg_data = static_cast <char *> (msg_->data ());
     memcpy (msg_data, "\5ERROR", 6);
-    msg_data [6] = sizeof status_code;
-    memcpy (msg_data + 7, status_code.c_str (), status_code.length ());
+    msg_data [6] = expected_status_code_length;
+    memcpy (msg_data + 7, status_code.c_str (), expected_status_code_length);
     return 0;
 }
 


### PR DESCRIPTION
Solution: send status code length (always 3) instead
