### PR TITLE
Problems: use-before-initialise error in print_backtrace, test_security_curve sometimes fails due to unexpected ECONNRESET

### DIFF
--- a/src/err.cpp
+++ b/src/err.cpp
@@ -415,16 +415,16 @@ void zmq::print_backtrace (void)
         if (unw_get_proc_info (&cursor, &p_info))
             break;
 
+        rc = unw_get_proc_name (&cursor, func_name, 256, &offset);
+        if (rc == -UNW_ENOINFO)
+            strcpy(func_name, "?");
+
         addr = (void *)(p_info.start_ip + offset);
 
         if (dladdr (addr, &dl_info) && dl_info.dli_fname)
             file_name = dl_info.dli_fname;
         else
             file_name = "?";
-
-        rc = unw_get_proc_name (&cursor, func_name, 256, &offset);
-        if (rc == -UNW_ENOINFO)
-            strcpy(func_name, "?");
 
         demangled_name = abi::__cxa_demangle (func_name, NULL, NULL, &rc);
 

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -276,8 +276,8 @@ void expect_new_client_curve_bounce_fail (void *ctx,
 //  expects that one or more occurrences of the expected event are received 
 //  via the specified socket monitor
 //  returns the number of occurrences of the expected event
-//  interrupts, if a ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL/EPIPE occurs; 
-//  in this case, 0 is returned
+//  interrupts, if a ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL/EPIPE/ECONNRESET
+//  occurs; in this case, 0 is returned
 //  this should be investigated further, see 
 //  https://github.com/zeromq/libzmq/issues/2644
 int expect_monitor_event_multiple (void *server_mon,
@@ -295,8 +295,11 @@ int expect_monitor_event_multiple (void *server_mon,
       != -1) {
         timeout = 250;
 
-        // ignore errors with EPIPE, which happen sporadically, see above
-        if (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL && err == EPIPE) {
+        // ignore errors with EPIPE/ECONNRESET, which happen sporadically
+        // ECONNRESET can happen on very slow machines, when the engine writes
+        // to the peer and then tries to read the socket before the peer reads
+        if (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL &&
+                (err == EPIPE || err == ECONNRESET)) {
             fprintf (stderr, "Ignored event: %x (err = %i)\n", event, err);
             client_closed_connection = 1;
             break;


### PR DESCRIPTION
Solutions: fix the order of API calls, ignore ECONNRESET