### PR TITLE
Problems: test_security_curve occasionally hangs or fails due to ECONNABORTED

### DIFF
--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -311,8 +311,8 @@ void expect_new_client_curve_bounce_fail (void *ctx,
 //  expects that one or more occurrences of the expected event are received 
 //  via the specified socket monitor
 //  returns the number of occurrences of the expected event
-//  interrupts, if a ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL/EPIPE/ECONNRESET
-//  occurs; in this case, 0 is returned
+//  interrupts, if a ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL with EPIPE, ECONNRESET
+//  or ECONNABORTED occurs; in this case, 0 is returned
 //  this should be investigated further, see 
 //  https://github.com/zeromq/libzmq/issues/2644
 int expect_monitor_event_multiple (void *server_mon,
@@ -330,11 +330,12 @@ int expect_monitor_event_multiple (void *server_mon,
       != -1) {
         timeout = 250;
 
-        // ignore errors with EPIPE/ECONNRESET, which happen sporadically
+        // ignore errors with EPIPE/ECONNRESET/ECONNABORTED, which can happen
         // ECONNRESET can happen on very slow machines, when the engine writes
         // to the peer and then tries to read the socket before the peer reads
+        // ECONNABORTED happens when a client aborts a connection via RST/timeout
         if (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL &&
-                (err == EPIPE || err == ECONNRESET)) {
+                (err == EPIPE || err == ECONNRESET || err == ECONNABORTED)) {
             fprintf (stderr, "Ignored event: %x (err = %i)\n", event, err);
             client_closed_connection = 1;
             break;


### PR DESCRIPTION
Solution: add missing flags parameter

Fixes https://github.com/zeromq/libzmq/issues/2658