### PR TITLE
Problem: getrandom usage breaks build

### DIFF
--- a/src/tweetnacl.c
+++ b/src/tweetnacl.c
@@ -933,7 +933,7 @@ void randombytes (unsigned char *x,unsigned long long xlen)
             i = 1048576;
 
 #ifdef ZMQ_HAVE_GETRANDOM
-        i = getrandom (x, i);
+        i = getrandom (x, i, 0);
 #else
         i = read(fd,x,i);
 #endif


### PR DESCRIPTION
Solution: add missing flags parameter

Note: cherry-pick of a fix from PR #2659 by @bluca to be merged quickly while other commit(s) from that PR are in discussion ;)