### PR TITLE
Problem: occasional test failures due to messages not (yet) received in test assertion

### DIFF
--- a/tests/test_hwm.cpp
+++ b/tests/test_hwm.cpp
@@ -53,9 +53,12 @@ int test_defaults ()
 
     // Send until we block
     int send_count = 0;
-    while (send_count < MAX_SENDS && zmq_send (connect_socket, NULL, 0, ZMQ_DONTWAIT) == 0)
+    while (send_count < MAX_SENDS
+           && zmq_send (connect_socket, NULL, 0, ZMQ_DONTWAIT) == 0)
         ++send_count;
 
+    msleep (SETTLE_TIME);
+    
     // Now receive all sent messages
     int recv_count = 0;
     while (zmq_recv (bind_socket, NULL, 0, ZMQ_DONTWAIT) == 0)

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -58,10 +58,11 @@ int test_defaults (int send_hwm, int msgCnt)
     while (send_count < msgCnt && zmq_send (pub_socket, NULL, 0, ZMQ_DONTWAIT) == 0)
         ++send_count;
 
+    msleep (SETTLE_TIME);
+
     // Now receive all sent messages
     int recv_count = 0;
-    while (0 == zmq_recv (sub_socket, NULL, 0, ZMQ_DONTWAIT))
-    {
+    while (0 == zmq_recv (sub_socket, NULL, 0, ZMQ_DONTWAIT)) {
         ++recv_count;
     }
 


### PR DESCRIPTION
Solution: add sleep
