### PR TITLE
Problem: some test cases may still fail because of EPIPE/ECONNABORT/ECONNRESET

### DIFF
--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -335,8 +335,7 @@ int expect_monitor_event_multiple (void *server_mon,
         // to the peer and then tries to read the socket before the peer reads
         // ECONNABORTED happens when a client aborts a connection via RST/timeout
         if (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL &&
-                (err == EPIPE || err == ECONNRESET || err == ECONNABORTED)) {
-            fprintf (stderr, "Ignored event: %x (err = %i)\n", event, err);
+                (err == EPIPE || err == ECONNRESET || err == ECONNABORTED)) {            fprintf (stderr, "Ignored event: %x (err = %i)\n", event, err);
             client_closed_connection = 1;
             break;
         }
@@ -618,7 +617,7 @@ void test_curve_security_zap_unsuccessful (void *ctx,
     int events_received = 0;
 #ifdef ZMQ_BUILD_DRAFT_API
     events_received =
-      expect_monitor_event_multiple (server_mon, expected_event, expected_err);
+    expect_monitor_event_multiple (server_mon, expected_event, expected_err);
 #endif
 
     // there may be more than one ZAP request due to repeated attempts by the client

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -54,7 +54,7 @@ void *zap_requests_handled;
 //  in case of error.
 
 static int
-get_monitor_event (void *monitor, int *value, char **address, int recv_flag)
+get_monitor_event_internal (void *monitor, int *value, char **address, int recv_flag)
 {
     //  First frame in message contains event number and value
     zmq_msg_t msg;
@@ -91,8 +91,25 @@ int get_monitor_event_with_timeout (void *monitor,
                                     char **address,
                                     int timeout)
 {
-    zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
-    int res = get_monitor_event (monitor, value, address, 0);
+    int res;
+    if (timeout == -1) {
+        // process infinite timeout in small steps to allow the user
+        // to see some information on the console
+
+        int timeout_step = 250;
+        int wait_time = 0;
+        zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout_step,
+                        sizeof (timeout_step));
+        while ((res = get_monitor_event_internal (monitor, value, address, 0))
+               == -1) {
+            wait_time += timeout_step;
+            fprintf (stderr, "Still waiting for monitor event after %i ms\n",
+                     wait_time);
+        }
+    } else {
+        zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
+        res = get_monitor_event_internal (monitor, value, address, 0);
+    }
     int timeout_infinite = -1;
     zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout_infinite,
                     sizeof (timeout_infinite));
@@ -112,22 +129,6 @@ int get_monitor_event_with_timeout (void *monitor,
             fprintf (stderr, "Unexpected event: %x (err = %i)\n", event, err); \
         }                                                                      \
         assert (event_count == 0);                                             \
-    }
-
-#define assert_monitor_event(monitor, expected_events)                         \
-    {                                                                          \
-        int err;                                                               \
-        int event = get_monitor_event (monitor, &err, NULL, 0);                \
-        assert (event != -1);                                                  \
-        if ((event & (expected_events)) == 0) {                                \
-            fprintf (stderr, "Unexpected event: %x (err = %i)\n", event, err); \
-            while (                                                            \
-              (event = get_monitor_event (monitor, NULL, NULL, (timeout)))     \
-              != -1) {                                                         \
-                fprintf (stderr, "Further event: %x\n", event);                \
-            }                                                                  \
-            assert (false);                                                    \
-        }                                                                      \
     }
 
 #endif
@@ -335,7 +336,11 @@ int expect_monitor_event_multiple (void *server_mon,
         // to the peer and then tries to read the socket before the peer reads
         // ECONNABORTED happens when a client aborts a connection via RST/timeout
         if (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL &&
-                (err == EPIPE || err == ECONNRESET || err == ECONNABORTED)) {            fprintf (stderr, "Ignored event: %x (err = %i)\n", event, err);
+                (err == EPIPE || err == ECONNRESET || err == ECONNABORTED)) {
+            fprintf (
+              stderr,
+              "Ignored event (skipping any further events): %x (err = %i)\n",
+              event, err);
             client_closed_connection = 1;
             break;
         }
@@ -489,7 +494,7 @@ void test_curve_security_with_valid_credentials (
     assert (rc == 0);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    int event = get_monitor_event (server_mon, NULL, NULL, 0);
+    int event = get_monitor_event_with_timeout (server_mon, NULL, NULL, -1);
     assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
 
     assert_no_more_monitor_events_with_timeout (server_mon, timeout);
@@ -508,7 +513,7 @@ void test_curve_security_with_bogus_client_credentials (
                                          bogus_secret, my_endpoint, server);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    int event = get_monitor_event (server_mon, NULL, NULL, 0);
+    int event = get_monitor_event_with_timeout (server_mon, NULL, NULL, -1);
     // TODO add another event type ZMQ_EVENT_HANDSHAKE_FAILED_AUTH for this case?
     assert (
       event
@@ -531,7 +536,7 @@ void expect_zmtp_failure (void *client, char *my_endpoint, void *server, void *s
 
 #ifdef ZMQ_BUILD_DRAFT_API
     int err;
-    int event = get_monitor_event (server_mon, &err, NULL, 0);
+    int event = get_monitor_event_with_timeout (server_mon, &err, NULL, -1);
 
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_ZMTP
             || (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL && err == EPIPE));
@@ -681,6 +686,7 @@ int main (void)
     void *server_mon;
     char my_endpoint [MAX_SOCKET_STRING];
 
+    fprintf (stderr, "test_curve_security_with_valid_credentials\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint);
     test_curve_security_with_valid_credentials (ctx, my_endpoint, server,
@@ -720,6 +726,7 @@ int main (void)
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
             handler);
 
+    fprintf (stderr, "test_curve_security_with_bogus_client_credentials\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint);
     test_curve_security_with_bogus_client_credentials (ctx, my_endpoint, server,
@@ -727,6 +734,7 @@ int main (void)
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
             handler);
 
+    fprintf (stderr, "test_curve_security_with_null_client_credentials\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint);
     test_curve_security_with_null_client_credentials (ctx, my_endpoint, server,
@@ -734,6 +742,7 @@ int main (void)
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
             handler);
 
+    fprintf (stderr, "test_curve_security_with_plain_client_credentials\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint);
     test_curve_security_with_plain_client_credentials (ctx, my_endpoint, server,
@@ -741,6 +750,7 @@ int main (void)
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
             handler);
 
+    fprintf (stderr, "test_curve_security_unauthenticated_message\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint);
     test_curve_security_unauthenticated_message (my_endpoint, server, timeout);
@@ -750,6 +760,7 @@ int main (void)
     //  Invalid ZAP protocol tests
 
     //  wrong version
+    fprintf (stderr, "test_curve_security_zap_protocol_error wrong_version\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint,
                                    &zap_handler_wrong_version);
@@ -759,6 +770,7 @@ int main (void)
             handler);
 
     //  wrong request id
+    fprintf (stderr, "test_curve_security_zap_protocol_error wrong_request_id\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint,
                                    &zap_handler_wrong_request_id);
@@ -768,6 +780,7 @@ int main (void)
             handler);
 
     //  status invalid (not a 3-digit number)
+    fprintf (stderr, "test_curve_security_zap_protocol_error wrong_status_invalid\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint,
                                    &zap_handler_wrong_status_invalid);
@@ -777,6 +790,7 @@ int main (void)
             handler);
 
     //  too many parts
+    fprintf (stderr, "test_curve_security_zap_protocol_error too_many_parts\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint,
                                    &zap_handler_too_many_parts);


### PR DESCRIPTION
Solution: uniformly handle these error conditions in all test cases
