### PR TITLE
Problem: ZAP status codes != 200 do not result in an appropriate monitor event

### DIFF
--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -739,14 +739,15 @@ int zmq::curve_server_t::receive_and_process_zap_reply ()
 
 void zmq::curve_server_t::handle_zap_status_code ()
 {
-    if (status_code == "200") {
+    //  we can assume here that status_code is a valid ZAP status code, 
+    //  i.e. 200, 300, 400 or 500
+    if (status_code [0] == '2') {
         state = send_ready;
     } else {
         state = send_error;
-        // TODO how do we get the endpoint address here?
 
         int err = 0;
-        switch (status_code[0]) {
+        switch (status_code [0]) {
             case '3':
                 err = EAGAIN;
                 break;
@@ -757,7 +758,11 @@ void zmq::curve_server_t::handle_zap_status_code ()
                 err = EFAULT;
                 break;
         }
-        session->get_socket ()->event_handshake_failed_no_detail ("", err);
+        //  TODO use event_handshake_failed_zap here? but this is not a ZAP 
+        //  protocol error
+        
+        session->get_socket ()->event_handshake_failed_no_detail (
+          session->get_endpoint (), err);
     }
 }
 

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -131,6 +131,7 @@ namespace zmq
 
         int send_zap_request (const uint8_t *key);
         int receive_and_process_zap_reply ();
+        void handle_zap_status_code ();
     };
 
 }

--- a/src/i_engine.hpp
+++ b/src/i_engine.hpp
@@ -58,6 +58,9 @@ namespace zmq
         virtual void restart_output () = 0;
 
         virtual void zap_msg_available () = 0;
+
+        virtual const char * get_endpoint() const = 0;
+
     };
 
 }

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -113,6 +113,11 @@ zmq::session_base_t::session_base_t (class io_thread_t *io_thread_,
 {
 }
 
+const char *zmq::session_base_t::get_endpoint () const
+{
+    return engine->get_endpoint ();
+}
+
 zmq::session_base_t::~session_base_t ()
 {
     zmq_assert (!pipe);

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -97,6 +97,7 @@ namespace zmq
         int write_zap_msg (msg_t *msg_);
 
         socket_base_t *get_socket ();
+        const char *get_endpoint () const;
 
     protected:
 

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -785,23 +785,6 @@ int zmq::stream_engine_t::next_handshake_command (msg_t *msg_)
         if (rc == 0)
             msg_->set_flags (msg_t::command);
 
-#if 0
-        // FIXME emitting the event here leads to extra EAGAIN errors
-#ifdef ZMQ_BUILD_DRAFT_API
-        if (mechanism->status () == mechanism_t::error) {
-            int err = errno;
-            if (mechanism->error_detail () == mechanism_t::zmtp)
-                socket->event_handshake_failed_zmtp (endpoint, err);
-            else if (mechanism->error_detail () == mechanism_t::zap)
-                socket->event_handshake_failed_zap (endpoint, err);
-            else if (mechanism->error_detail () == mechanism_t::encryption)
-                socket->event_handshake_failed_encryption (endpoint, err);
-            else
-                socket->event_handshake_failed_no_detail (endpoint, err);
-        }
-#endif
-#endif
-
         return rc;
     }
 }
@@ -838,6 +821,11 @@ void zmq::stream_engine_t::zap_msg_available ()
         restart_input ();
     if (output_stopped)
         restart_output ();
+}
+
+const char *zmq::stream_engine_t::get_endpoint () const
+{
+    return endpoint.c_str ();
 }
 
 void zmq::stream_engine_t::mechanism_ready ()

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -784,6 +784,9 @@ int zmq::stream_engine_t::next_handshake_command (msg_t *msg_)
 
         if (rc == 0)
             msg_->set_flags (msg_t::command);
+
+#if 0
+        // FIXME emitting the event here leads to extra EAGAIN errors
 #ifdef ZMQ_BUILD_DRAFT_API
         if (mechanism->status () == mechanism_t::error) {
             int err = errno;
@@ -796,6 +799,7 @@ int zmq::stream_engine_t::next_handshake_command (msg_t *msg_)
             else
                 socket->event_handshake_failed_no_detail (endpoint, err);
         }
+#endif
 #endif
 
         return rc;

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -79,6 +79,7 @@ namespace zmq
         void restart_input ();
         void restart_output ();
         void zap_msg_available ();
+        const char *get_endpoint () const;
 
         //  i_poll_events interface implementation.
         void in_event ();

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -289,6 +289,11 @@ void zmq::udp_engine_t::out_event()
        reset_pollout (handle);
 }
 
+const char *zmq::udp_engine_t::get_endpoint () const
+{
+    return "";
+}
+
 void zmq::udp_engine_t::restart_output()
 {
     //  If we don't support send we just drop all messages

--- a/src/udp_engine.hpp
+++ b/src/udp_engine.hpp
@@ -44,7 +44,9 @@ namespace zmq
             void in_event ();
             void out_event ();
 
-        private:
+            const char * get_endpoint() const;
+
+    private:
 
             int resolve_raw_address (char *addr_, size_t length_);
             void sockaddr_to_msg (zmq::msg_t *msg, sockaddr_in* addr);

--- a/src/udp_engine.hpp
+++ b/src/udp_engine.hpp
@@ -44,10 +44,9 @@ namespace zmq
             void in_event ();
             void out_event ();
 
-            const char * get_endpoint() const;
+            const char *get_endpoint () const;
 
-    private:
-
+        private:
             int resolve_raw_address (char *addr_, size_t length_);
             void sockaddr_to_msg (zmq::msg_t *msg, sockaddr_in* addr);
 

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -531,7 +531,7 @@ void test_curve_security_with_bogus_client_credentials (
 
 #ifdef ZMQ_BUILD_DRAFT_API
     int err;
-    int event = get_monitor_event (server_mon, &err, NULL, 0);
+    int event = get_monitor_event_with_timeout (server_mon, &err, NULL, 0);
     // TODO add another event type ZMQ_EVENT_HANDSHAKE_FAILED_AUTH for this case?
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
             && err == EACCES); // ZAP handle the error,  not curve_server
@@ -703,6 +703,7 @@ int main (void)
     void *server_mon;
     char my_endpoint [MAX_SOCKET_STRING];
 
+#if 0
     fprintf (stderr, "test_curve_security_with_valid_credentials\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint);
@@ -806,6 +807,7 @@ int main (void)
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
             handler);
 
+#endif
     //  too many parts
     fprintf (stderr, "test_curve_security_zap_protocol_error too_many_parts\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
@@ -818,7 +820,11 @@ int main (void)
 
     //  ZAP non-standard cases
 
+    //  TODO make these observable on the client side as well (they are 
+    //  transmitted as an ERROR message)
+
     //  status 300 temporary failure
+    fprintf (stderr, "test_curve_security_zap_unsuccessful status 300\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint,
                                    &zap_handler_wrong_status_temporary_failure);
@@ -832,7 +838,9 @@ int main (void)
     );
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
             handler);
+
     //  status 500 internal error
+    fprintf (stderr, "test_curve_security_zap_unsuccessful status 500\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint,
                                    &zap_handler_wrong_status_internal_error);

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -639,7 +639,7 @@ void test_curve_security_zap_unsuccessful (void *ctx,
     int events_received = 0;
 #ifdef ZMQ_BUILD_DRAFT_API
     events_received =
-    expect_monitor_event_multiple (server_mon, expected_event, expected_err);
+      expect_monitor_event_multiple (server_mon, expected_event, expected_err);
 #endif
 
     // there may be more than one ZAP request due to repeated attempts by the client
@@ -832,22 +832,6 @@ int main (void)
     );
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
             handler);
-
-    //  status 500 internal error    
-    setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
-                                   &server_mon, my_endpoint,
-                                   &zap_handler_wrong_status_internal_error);
-    test_curve_security_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-                                          ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
-                                          EFAULT
-#else
-                                          0, 0
-#endif
-    );
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
-            handler);
-
     //  status 500 internal error
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint,

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -107,7 +107,7 @@ int get_monitor_event_with_timeout (void *monitor,
                      wait_time);
         }
     } else {
-        zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
+    zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
         res = get_monitor_event_internal (monitor, value, address, 0);
     }
     int timeout_infinite = -1;
@@ -530,11 +530,11 @@ void test_curve_security_with_bogus_client_credentials (
                                          bogus_secret, my_endpoint, server);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    int event = get_monitor_event_with_timeout (server_mon, NULL, NULL, -1);
+    int err;
+    int event = get_monitor_event_with_timeout (server_mon, &err, NULL, 0);
     // TODO add another event type ZMQ_EVENT_HANDSHAKE_FAILED_AUTH for this case?
-    assert (
-      event
-      == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL); // ZAP handle the error,  not curve_server
+    assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
+            && err == EACCES); // ZAP handle the error,  not curve_server
 
     assert_no_more_monitor_events_with_timeout (server_mon, timeout);
 #endif
@@ -639,7 +639,7 @@ void test_curve_security_zap_unsuccessful (void *ctx,
     int events_received = 0;
 #ifdef ZMQ_BUILD_DRAFT_API
     events_received =
-    expect_monitor_event_multiple (server_mon, expected_event, expected_err);
+      expect_monitor_event_multiple (server_mon, expected_event, expected_err);
 #endif
 
     // there may be more than one ZAP request due to repeated attempts by the client

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -107,7 +107,7 @@ int get_monitor_event_with_timeout (void *monitor,
                      wait_time);
         }
     } else {
-    zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
+        zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
         res = get_monitor_event_internal (monitor, value, address, 0);
     }
     int timeout_infinite = -1;
@@ -703,7 +703,6 @@ int main (void)
     void *server_mon;
     char my_endpoint [MAX_SOCKET_STRING];
 
-#if 0
     fprintf (stderr, "test_curve_security_with_valid_credentials\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint);
@@ -807,7 +806,6 @@ int main (void)
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
             handler);
 
-#endif
     //  too many parts
     fprintf (stderr, "test_curve_security_zap_protocol_error too_many_parts\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -211,6 +211,7 @@ static void zap_handler_generic (void *ctx, zap_protocol_t zap_protocol)
                                : sequence);
 
         if (streq (client_key_text, valid_client_public)) {
+            const char *status_code;
             switch (zap_protocol) {
                 case zap_status_internal_error:
                     status_code = "500";

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -530,8 +530,21 @@ void test_curve_security_with_bogus_client_credentials (
                                          bogus_secret, my_endpoint, server);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    int err;
-    int event = get_monitor_event_with_timeout (server_mon, &err, NULL, 0);
+    test_curve_security_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
+#ifdef ZMQ_BUILD_DRAFT_API
+                                          ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
+                                          EFAULT
+#else
+                                          0, 0
+#endif
+    );
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+            handler);
+
+    //  status 500 internal error
+    setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
+                                   &server_mon, my_endpoint,
+                                   &zap_handler_wrong_status_internal_error);
     // TODO add another event type ZMQ_EVENT_HANDSHAKE_FAILED_AUTH for this case?
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
             && err == EACCES); // ZAP handle the error,  not curve_server

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -211,7 +211,7 @@ static void zap_handler_generic (void *ctx, zap_protocol_t zap_protocol)
                                : sequence);
 
         if (streq (client_key_text, valid_client_public)) {
-            char *status_code;
+            const char *status_code;
             switch (zap_protocol) {
                 case zap_status_internal_error:
                     status_code = "500";

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -276,8 +276,7 @@ static void zap_handler_wrong_status_invalid (void *ctx)
     zap_handler_generic (ctx, zap_status_invalid);
 }
 
-static void zap_handler_wrong_status_temporary_failure (void *ctx)
-{
+static void zap_handler_wrong_status_temporary_failure (void *ctx){
     zap_handler_generic (ctx, zap_status_temporary_failure);
 }
 
@@ -652,7 +651,7 @@ void test_curve_security_zap_unsuccessful (void *ctx,
     int events_received = 0;
 #ifdef ZMQ_BUILD_DRAFT_API
     events_received =
-      expect_monitor_event_multiple (server_mon, expected_event, expected_err);
+    expect_monitor_event_multiple (server_mon, expected_event, expected_err);
 #endif
 
     // there may be more than one ZAP request due to repeated attempts by the client

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -529,21 +529,20 @@ void test_curve_security_with_bogus_client_credentials (
                                          bogus_secret, my_endpoint, server);
 
 #ifdef ZMQ_BUILD_DRAFT_API
-    test_curve_security_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-                                          ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
-                                          EFAULT
-#else
-                                          0, 0
-#endif
-    );
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
-            handler);
+    int err;
+    int event = get_monitor_event (server_mon, &err, NULL, 0);
 
-    //  status 500 internal error
-    setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
-                                   &server_mon, my_endpoint,
-                                   &zap_handler_wrong_status_internal_error);
+
+
+
+
+
+
+
+
+
+
+
     // TODO add another event type ZMQ_EVENT_HANDSHAKE_FAILED_AUTH for this case?
     assert (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
             && err == EACCES); // ZAP handle the error,  not curve_server

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -211,7 +211,6 @@ static void zap_handler_generic (void *ctx, zap_protocol_t zap_protocol)
                                : sequence);
 
         if (streq (client_key_text, valid_client_public)) {
-            const char *status_code;
             switch (zap_protocol) {
                 case zap_status_internal_error:
                     status_code = "500";
@@ -277,6 +276,11 @@ static void zap_handler_wrong_status_invalid (void *ctx)
 }
 
 static void zap_handler_wrong_status_temporary_failure (void *ctx)
+{
+    zap_handler_generic (ctx, zap_status_temporary_failure);
+}
+
+static void zap_handler_wrong_status_internal_error (void *ctx)
 {
     zap_handler_generic (ctx, zap_status_temporary_failure);
 }
@@ -639,7 +643,7 @@ void test_curve_security_zap_unsuccessful (void *ctx,
     int events_received = 0;
 #ifdef ZMQ_BUILD_DRAFT_API
     events_received =
-      expect_monitor_event_multiple (server_mon, expected_event, expected_err);
+    expect_monitor_event_multiple (server_mon, expected_event, expected_err);
 #endif
 
     // there may be more than one ZAP request due to repeated attempts by the client
@@ -826,6 +830,19 @@ int main (void)
 #ifdef ZMQ_BUILD_DRAFT_API
                                           ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
                                           EAGAIN
+#else
+                                          0, 0
+#endif
+    );
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon);
+
+    //  status 500 internal error    setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
+                                   &server_mon, my_endpoint,
+                                   &zap_handler_wrong_status_internal_error);
+    test_curve_security_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
+#ifdef ZMQ_BUILD_DRAFT_API
+                                          ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
+                                          EFAULT
 #else
                                           0, 0
 #endif

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -283,11 +283,6 @@ static void zap_handler_wrong_status_temporary_failure (void *ctx)
 
 static void zap_handler_wrong_status_internal_error (void *ctx)
 {
-    zap_handler_generic (ctx, zap_status_temporary_failure);
-}
-
-static void zap_handler_wrong_status_internal_error (void *ctx)
-{
     zap_handler_generic (ctx, zap_status_internal_error);
 }
 
@@ -835,9 +830,11 @@ int main (void)
                                           0, 0
 #endif
     );
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon);
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+            handler);
 
-    //  status 500 internal error    setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
+    //  status 500 internal error    
+    setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
                                    &server_mon, my_endpoint,
                                    &zap_handler_wrong_status_internal_error);
     test_curve_security_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
@@ -848,7 +845,8 @@ int main (void)
                                           0, 0
 #endif
     );
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon);
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+            handler);
 
     //  status 500 internal error
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,


### PR DESCRIPTION
Solution: move emitting of monitor events to the point where zap reply is processed and use appropriate errnos

Also fix some more EPIPE/ECONNRESET/ECONNAGAIN failures
