### PR TITLE
Problem: PGM/NORM builds broken due to i_engine API change

### DIFF
--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -728,5 +728,9 @@ zmq::norm_engine_t::NormRxStreamState* zmq::norm_engine_t::NormRxStreamState::Li
     return nextItem;
 }  // end zmq::norm_engine_t::NormRxStreamState::List::Iterator::GetNextItem()
 
+const char *zmq::norm_engine_t::get_endpoint () const
+{
+    return "";
+}
 
 #endif // ZMQ_HAVE_NORM

--- a/src/norm_engine.hpp
+++ b/src/norm_engine.hpp
@@ -46,6 +46,8 @@ namespace zmq
 
             virtual void zap_msg_available () {};
 
+            virtual const char *get_endpoint () const;
+
             // i_poll_events interface implementation.
             // (we only need in_event() for NormEvent notification)
             // (i.e., don't have any output events or timers (yet))

--- a/src/pgm_receiver.cpp
+++ b/src/pgm_receiver.cpp
@@ -152,6 +152,11 @@ void zmq::pgm_receiver_t::restart_input ()
     in_event ();
 }
 
+const char *zmq::pgm_receiver_t::get_endpoint () const
+{
+    return "";
+}
+
 void zmq::pgm_receiver_t::in_event ()
 {
     // Read data from the underlying pgm_socket.

--- a/src/pgm_receiver.hpp
+++ b/src/pgm_receiver.hpp
@@ -64,6 +64,7 @@ namespace zmq
         void restart_input ();
         void restart_output ();
         void zap_msg_available () {}
+        const char *get_endpoint () const;
 
         //  i_poll_events interface implementation.
         void in_event ();

--- a/src/pgm_sender.cpp
+++ b/src/pgm_sender.cpp
@@ -136,6 +136,11 @@ void zmq::pgm_sender_t::restart_input ()
     zmq_assert (false);
 }
 
+const char *zmq::pgm_sender_t::get_endpoint () const
+{
+    return "";
+}
+
 zmq::pgm_sender_t::~pgm_sender_t ()
 {
     int rc = msg.close ();

--- a/src/pgm_sender.hpp
+++ b/src/pgm_sender.hpp
@@ -63,6 +63,7 @@ namespace zmq
         void restart_input ();
         void restart_output ();
         void zap_msg_available () {}
+        const char *get_endpoint () const;
 
         //  i_poll_events interface implementation.
         void in_event ();


### PR DESCRIPTION
Solution: implement get_endpoint in the NORM and PGM engines too

Fixes https://github.com/zeromq/libzmq/issues/2666