### PR TITLE
Problem: CMake build does not allow static linking libsodium

### DIFF
--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -40,6 +40,7 @@
 #cmakedefine ZMQ_HAVE_CURVE
 #cmakedefine ZMQ_USE_TWEETNACL
 #cmakedefine ZMQ_USE_LIBSODIUM
+#cmakedefine SODIUM_STATIC
 
 #ifdef _AIX
   #define ZMQ_HAVE_AIX


### PR DESCRIPTION
Solution: Pass along SODIUM_STATIC define if set in CMake config
