### PR TITLE
add missing uint32_t typedef on msvc

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -102,6 +102,9 @@ extern "C" {
 #   ifndef int32_t
         typedef __int32 int32_t;
 #   endif
+#   ifndef uint32_t
+        typedef unsigned __int32 uint32_t;
+#   endif
 #   ifndef uint16_t
         typedef unsigned __int16 uint16_t;
 #   endif


### PR DESCRIPTION
uint32_t is used in the draft APIs and undefined on MSC 1500, preventing compilation.