### PR TITLE
Problem: ZAP client code duplicated across mechanisms with behaviour deviations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,7 +565,8 @@ set (cxx-sources
         udp_engine.cpp
         udp_address.cpp
         scatter.cpp
-        gather.cpp)
+        gather.cpp
+		zap_client.cpp)
 
 set (rc-sources version.rc)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -523,7 +523,10 @@ tests_test_security_null_LDADD = src/libzmq.la
 tests_test_security_plain_SOURCES = tests/test_security_plain.cpp
 tests_test_security_plain_LDADD = src/libzmq.la
 
-tests_test_security_zap_SOURCES = tests/test_security_zap.cpp
+tests_test_security_zap_SOURCES = \
+	tests/test_security_zap.cpp \
+	tests/testutil_security.hpp \
+	tests/testutil.hpp
 tests_test_security_zap_LDADD = src/libzmq.la
 
 tests_test_spec_req_SOURCES = tests/test_spec_req.cpp
@@ -629,6 +632,7 @@ test_apps += \
 
 tests_test_security_curve_SOURCES = \
 	tests/test_security_curve.cpp \
+	tests/testutil_security.hpp \
 	tests/testutil.hpp \
 	src/curve_client_tools.hpp \
 	src/clock.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -376,6 +376,7 @@ test_apps = \
 	tests/test_ctx_destroy \
 	tests/test_security_null \
 	tests/test_security_plain \
+	tests/test_security_zap \
 	tests/test_iov \
 	tests/test_spec_req \
 	tests/test_spec_rep \
@@ -521,6 +522,9 @@ tests_test_security_null_LDADD = src/libzmq.la
 
 tests_test_security_plain_SOURCES = tests/test_security_plain.cpp
 tests_test_security_plain_LDADD = src/libzmq.la
+
+tests_test_security_zap_SOURCES = tests/test_security_zap.cpp
+tests_test_security_zap_LDADD = src/libzmq.la
 
 tests_test_spec_req_SOURCES = tests/test_spec_req.cpp
 tests_test_spec_req_LDADD = src/libzmq.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -242,6 +242,8 @@ src_libzmq_la_SOURCES = \
 	src/decoder_allocators.hpp \
 	src/socket_poller.cpp \
 	src/socket_poller.hpp \
+	src/zap_client.cpp \
+	src/zap_client.hpp \
 	src/zmq_draft.h
 
 if USE_TWEETNACL

--- a/builds/gyp/project-tests.gypi
+++ b/builds/gyp/project-tests.gypi
@@ -375,6 +375,17 @@
       ],
     },
     {
+      'target_name': 'test_security_zap',
+      'type': 'executable',
+      'sources': [
+        '../../tests/test_security_zap.cpp',
+        '../../tests/testutil.hpp'
+      ],
+      'dependencies': [
+        'libzmq'
+      ],
+    },
+    {
       'target_name': 'test_iov',
       'type': 'executable',
       'sources': [

--- a/builds/gyp/project-tests.xml
+++ b/builds/gyp/project-tests.xml
@@ -33,6 +33,7 @@
     <test name = "test_security_null" />
     <test name = "test_security_plain" />
     <test name = "test_security_curve" />
+    <test name = "test_security_zap" />
     <test name = "test_iov" />
     <test name = "test_spec_req" />
     <test name = "test_spec_rep" />

--- a/builds/gyp/project.gyp
+++ b/builds/gyp/project.gyp
@@ -272,6 +272,8 @@
         '../../src/ypipe_base.hpp',
         '../../src/ypipe_conflate.hpp',
         '../../src/yqueue.hpp',
+        '../../src/zap_client.cpp',
+        '../../src/zap_client.hpp',
         '../../src/zmq.cpp',
         '../../src/zmq_utils.cpp'
       ],

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -492,15 +492,9 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
         if (rc != 0)
             return -1;
         rc = receive_and_process_zap_reply ();
-        if (rc == 0)
-            handle_zap_status_code ();
-        else
-        if (errno == EAGAIN)
-            state = waiting_for_zap_reply;
-        else
+        if (rc == -1)
             return -1;
-    }
-    else
+    } else
         state = sending_ready;
 
     return parse_metadata (initiate_plaintext + crypto_box_ZEROBYTES + 128,
@@ -571,14 +565,6 @@ int zmq::curve_server_t::send_zap_request (const uint8_t *key)
 {
     return zap_client_t::send_zap_request ("CURVE", 5, key,
                                            crypto_box_PUBLICKEYBYTES);
-}
-
-int zmq::curve_server_t::receive_and_process_zap_reply ()
-{
-    int rc = zap_client_t::receive_and_process_zap_reply ();
-    if (rc == -1 && errno == EPROTO)
-        current_error_detail = zap;
-    return rc;
 }
 
 #endif

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -42,8 +42,7 @@ zmq::curve_server_t::curve_server_t (session_base_t *session_,
                                      const std::string &peer_address_,
                                      const options_t &options_) :
     mechanism_t (options_),
-    zap_client_t (session_, peer_address_, options_),
-    state (waiting_for_hello),
+    zap_client_common_handshake_t (session_, peer_address_, options_),
     current_error_detail (no_detail),
     cn_nonce (1),
     cn_peer_nonce (1)
@@ -258,17 +257,6 @@ int zmq::curve_server_t::zap_msg_available ()
     if (rc == 0)
         handle_zap_status_code ();
     return rc;
-}
-
-zmq::mechanism_t::status_t zmq::curve_server_t::status () const
-{
-    if (state == ready)
-        return mechanism_t::ready;
-    else
-    if (state == error_sent)
-        return mechanism_t::error;
-    else
-        return mechanism_t::handshaking;
 }
 
 zmq::mechanism_t::error_detail_t zmq::curve_server_t::error_detail() const

--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -488,9 +488,7 @@ int zmq::curve_server_t::process_initiate (msg_t *msg_)
     //  not work properly the program will abort.
     rc = session->zap_connect ();
     if (rc == 0) {
-        rc = send_zap_request (client_key);
-        if (rc != 0)
-            return -1;
+        send_zap_request (client_key);
         rc = receive_and_process_zap_reply ();
         if (rc == -1)
             return -1;
@@ -561,10 +559,9 @@ int zmq::curve_server_t::produce_error (msg_t *msg_) const
     return 0;
 }
 
-int zmq::curve_server_t::send_zap_request (const uint8_t *key)
+void zmq::curve_server_t::send_zap_request (const uint8_t *key)
 {
-    return zap_client_t::send_zap_request ("CURVE", 5, key,
-                                           crypto_box_PUBLICKEYBYTES);
+    zap_client_t::send_zap_request ("CURVE", 5, key, crypto_box_PUBLICKEYBYTES);
 }
 
 #endif

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -104,7 +104,6 @@ namespace zmq
         int produce_error (msg_t *msg_) const;
 
         int send_zap_request (const uint8_t *key);
-        int receive_and_process_zap_reply ();
     };
 
 }

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -59,7 +59,7 @@ namespace zmq
     class msg_t;
     class session_base_t;
 
-    class curve_server_t : public zap_client_t
+    class curve_server_t : public zap_client_common_handshake_t
     {
     public:
 
@@ -74,13 +74,9 @@ namespace zmq
         virtual int encode (msg_t *msg_);
         virtual int decode (msg_t *msg_);
         virtual int zap_msg_available ();
-        virtual status_t status () const;
         virtual error_detail_t error_detail () const;
 
     private:
-
-        //  Current FSM state
-        state_t state;
 
         //  Details about the current error state
         error_detail_t current_error_detail;

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -59,7 +59,7 @@ namespace zmq
     class msg_t;
     class session_base_t;
 
-    class curve_server_t : public mechanism_t
+    class curve_server_t : public zap_client_t
     {
     public:
 
@@ -90,17 +90,8 @@ namespace zmq
             connected
         };
 
-        session_base_t * const session;
-
-        const std::string peer_address;
-
-        zap_client_t zap_client;
-
         //  Current FSM state
         state_t state;
-
-        //  Status code as received from ZAP handler
-        std::string status_code;
 
         //  Details about the current error state
         error_detail_t current_error_detail;

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -51,6 +51,7 @@
 
 #include "mechanism.hpp"
 #include "options.hpp"
+#include "zap_client.hpp"
 
 namespace zmq
 {
@@ -92,6 +93,8 @@ namespace zmq
         session_base_t * const session;
 
         const std::string peer_address;
+
+        zap_client_t zap_client;
 
         //  Current FSM state
         state_t state;

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -103,7 +103,7 @@ namespace zmq
         int produce_ready (msg_t *msg_);
         int produce_error (msg_t *msg_) const;
 
-        int send_zap_request (const uint8_t *key);
+        void send_zap_request (const uint8_t *key);
     };
 
 }

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -79,17 +79,6 @@ namespace zmq
 
     private:
 
-        enum state_t {
-            expect_hello,
-            send_welcome,
-            expect_initiate,
-            expect_zap_reply,
-            send_ready,
-            send_error,
-            error_sent,
-            connected
-        };
-
         //  Current FSM state
         state_t state;
 

--- a/src/curve_server.hpp
+++ b/src/curve_server.hpp
@@ -73,13 +73,8 @@ namespace zmq
         virtual int process_handshake_command (msg_t *msg_);
         virtual int encode (msg_t *msg_);
         virtual int decode (msg_t *msg_);
-        virtual int zap_msg_available ();
-        virtual error_detail_t error_detail () const;
 
     private:
-
-        //  Details about the current error state
-        error_detail_t current_error_detail;
 
         uint64_t cn_nonce;
         uint64_t cn_peer_nonce;
@@ -110,7 +105,6 @@ namespace zmq
 
         int send_zap_request (const uint8_t *key);
         int receive_and_process_zap_reply ();
-        void handle_zap_status_code ();
     };
 
 }

--- a/src/gssapi_mechanism_base.hpp
+++ b/src/gssapi_mechanism_base.hpp
@@ -50,7 +50,7 @@ namespace zmq
     /// process context-level GSSAPI tokens (via INITIATE commands)
     /// and per-message GSSAPI tokens (via MESSAGE commands).
     class gssapi_mechanism_base_t:
-        public mechanism_t
+        public virtual mechanism_t
     {
     public:
         gssapi_mechanism_base_t (const options_t &options_);

--- a/src/gssapi_server.cpp
+++ b/src/gssapi_server.cpp
@@ -130,7 +130,7 @@ int zmq::gssapi_server_t::process_handshake_command (msg_t *msg_)
                 return -1;
             rc = receive_and_process_zap_reply ();
             if (rc != 0) {
-                if (errno != EAGAIN)
+                if (rc == -1)
                     return -1;
                 expecting_zap_reply = true;
             }
@@ -192,7 +192,7 @@ int zmq::gssapi_server_t::zap_msg_available ()
     const int rc = receive_and_process_zap_reply ();
     if (rc == 0)
         state = send_ready;
-    return rc;
+    return rc == -1 ? -1 : 0;
 }
 
 zmq::mechanism_t::status_t zmq::gssapi_server_t::status () const

--- a/src/gssapi_server.cpp
+++ b/src/gssapi_server.cpp
@@ -125,9 +125,7 @@ int zmq::gssapi_server_t::process_handshake_command (msg_t *msg_)
         bool expecting_zap_reply = false;
         int rc = session->zap_connect ();
         if (rc == 0) {
-            rc = send_zap_request ();
-            if (rc != 0)
-                return -1;
+            send_zap_request ();
             rc = receive_and_process_zap_reply ();
             if (rc != 0) {
                 if (rc == -1)
@@ -151,16 +149,14 @@ int zmq::gssapi_server_t::process_handshake_command (msg_t *msg_)
     return 0;
 }
 
-int zmq::gssapi_server_t::send_zap_request ()
+void zmq::gssapi_server_t::send_zap_request ()
 {
     gss_buffer_desc principal;
     gss_display_name (&min_stat, target_name, &principal, NULL);
-    int rc = zap_client_t::send_zap_request ("GSSAPI", 6, principal.value,
-                                             principal.length);
+    zap_client_t::send_zap_request ("GSSAPI", 6, principal.value,
+                                    principal.length);
 
     gss_release_buffer (&min_stat, &principal);
-
-    return rc;
 }
 
 int zmq::gssapi_server_t::encode (msg_t *msg_)

--- a/src/gssapi_server.cpp
+++ b/src/gssapi_server.cpp
@@ -45,10 +45,9 @@
 zmq::gssapi_server_t::gssapi_server_t (session_base_t *session_,
                                        const std::string &peer_address_,
                                        const options_t &options_) :
+    mechanism_t (options_),
     gssapi_mechanism_base_t (options_),
-    session (session_),
-    peer_address (peer_address_),
-    zap_client (session, peer_address, options),
+    zap_client_t (session_, peer_address_, options_),
     state (recv_next_token),
     security_context_established (false)
 {
@@ -156,78 +155,13 @@ int zmq::gssapi_server_t::send_zap_request ()
 {
     gss_buffer_desc principal;
     gss_display_name (&min_stat, target_name, &principal, NULL);
-    int rc = zap_client.send_zap_request ("GSSAPI", 6, principal.value,
-                                          principal.length);
+    int rc = zap_client_t::send_zap_request ("GSSAPI", 6, principal.value,
+                                             principal.length);
 
     gss_release_buffer (&min_stat, &principal);
 
     return rc;
 }
-
-int zmq::gssapi_server_t::receive_and_process_zap_reply ()
-{
-    int rc = 0;
-    msg_t msg [7];  //  ZAP reply consists of 7 frames
-
-    //  Initialize all reply frames
-    for (int i = 0; i < 7; i++) {
-        rc = msg [i].init ();
-        errno_assert (rc == 0);
-    }
-
-    for (int i = 0; i < 7; i++) {
-        rc = session->read_zap_msg (&msg [i]);
-        if (rc == -1)
-            return close_and_return (msg, -1);
-        if ((msg [i].flags () & msg_t::more) == (i < 6? 0: msg_t::more)) {
-            errno = EPROTO;
-            return close_and_return (msg, -1);
-        }
-    }
-
-    //  Address delimiter frame
-    if (msg [0].size () > 0) {
-        errno = EPROTO;
-        return close_and_return (msg, -1);
-    }
-
-    //  Version frame
-    if (msg [1].size () != 3 || memcmp (msg [1].data (), "1.0", 3)) {
-        errno = EPROTO;
-        return close_and_return (msg, -1);
-    }
-
-    //  Request id frame
-    if (msg [2].size () != 1 || memcmp (msg [2].data (), "1", 1)) {
-        errno = EPROTO;
-        return close_and_return (msg, -1);
-    }
-
-    //  Status code frame
-    if (msg [3].size () != 3 || memcmp (msg [3].data (), "200", 3)) {
-        errno = EACCES;
-        return close_and_return (msg, -1);
-    }
-
-    //  Save user id
-    set_user_id (msg [5].data (), msg [5].size ());
-
-    //  Process metadata frame
-    rc = parse_metadata (static_cast <const unsigned char*> (msg [6].data ()),
-                         msg [6].size (), true);
-
-    if (rc != 0)
-        return close_and_return (msg, -1);
-
-    //  Close all reply frames
-    for (int i = 0; i < 7; i++) {
-        const int rc2 = msg [i].close ();
-        errno_assert (rc2 == 0);
-    }
-
-    return 0;
-}
-
 
 int zmq::gssapi_server_t::encode (msg_t *msg_)
 {

--- a/src/gssapi_server.hpp
+++ b/src/gssapi_server.hpp
@@ -33,6 +33,7 @@
 #ifdef HAVE_LIBGSSAPI_KRB5
 
 #include "gssapi_mechanism_base.hpp"
+#include "zap_client.hpp"
 
 namespace zmq
 {
@@ -72,6 +73,8 @@ namespace zmq
         session_base_t * const session;
 
         const std::string peer_address;
+
+        zap_client_t zap_client;
 
         //  Current FSM state
         state_t state;

--- a/src/gssapi_server.hpp
+++ b/src/gssapi_server.hpp
@@ -88,7 +88,7 @@ namespace zmq
         void accept_context ();
         int produce_next_token (msg_t *msg_);
         int process_next_token (msg_t *msg_);
-        int send_zap_request ();
+        void send_zap_request ();
     };
 
 }

--- a/src/gssapi_server.hpp
+++ b/src/gssapi_server.hpp
@@ -41,8 +41,8 @@ namespace zmq
     class msg_t;
     class session_base_t;
 
-    class gssapi_server_t :
-        public gssapi_mechanism_base_t
+    class gssapi_server_t 
+      : public gssapi_mechanism_base_t, public zap_client_t
     {
     public:
 
@@ -89,7 +89,6 @@ namespace zmq
         int produce_next_token (msg_t *msg_);
         int process_next_token (msg_t *msg_);
         int send_zap_request ();
-        int receive_and_process_zap_reply();
     };
 
 }

--- a/src/null_mechanism.cpp
+++ b/src/null_mechanism.cpp
@@ -194,7 +194,7 @@ zmq::mechanism_t::status_t zmq::null_mechanism_t::status () const
 
 int zmq::null_mechanism_t::send_zap_request ()
 {
-    return zap_client.send_zap_request ("NULL", 4, NULL, 0);
+    return zap_client.send_zap_request ("NULL", 4, NULL, NULL, 0);
 }
 
 int zmq::null_mechanism_t::receive_and_process_zap_reply ()

--- a/src/null_mechanism.cpp
+++ b/src/null_mechanism.cpp
@@ -43,9 +43,7 @@ zmq::null_mechanism_t::null_mechanism_t (session_base_t *session_,
                                          const std::string &peer_address_,
                                          const options_t &options_) :
     mechanism_t (options_),
-    session (session_),
-    peer_address (peer_address_),
-    zap_client (session, peer_address, options),
+    zap_client_t (session_, peer_address_, options_),
     ready_command_sent (false),
     error_command_sent (false),
     ready_command_received (false),
@@ -86,15 +84,14 @@ int zmq::null_mechanism_t::next_handshake_command (msg_t *msg_)
         zap_reply_received = true;
     }
 
-    if (zap_reply_received
-    &&  strncmp (status_code, "200", sizeof status_code) != 0) {
-        const int rc = msg_->init_size (6 + 1 + sizeof status_code);
+    if (zap_reply_received && status_code != "200") {
+        const size_t status_code_len = 3;
+        const int rc = msg_->init_size (6 + 1 + status_code_len);
         zmq_assert (rc == 0);
-        unsigned char *msg_data =
-            static_cast <unsigned char *> (msg_->data ());
+        unsigned char *msg_data = static_cast<unsigned char *> (msg_->data ());
         memcpy (msg_data, "\5ERROR", 6);
-        msg_data [6] = sizeof status_code;
-        memcpy (msg_data + 7, status_code, sizeof status_code);
+        msg_data [6] = status_code_len;
+        memcpy (msg_data + 7, status_code.c_str (), status_code_len);
         error_command_sent = true;
         return 0;
     }
@@ -194,82 +191,6 @@ zmq::mechanism_t::status_t zmq::null_mechanism_t::status () const
 
 int zmq::null_mechanism_t::send_zap_request ()
 {
-    return zap_client.send_zap_request ("NULL", 4, NULL, NULL, 0);
+    return zap_client_t::send_zap_request ("NULL", 4, NULL, NULL, 0);
 }
 
-int zmq::null_mechanism_t::receive_and_process_zap_reply ()
-{
-    int rc = 0;
-    msg_t msg [7];  //  ZAP reply consists of 7 frames
-
-    //  Initialize all reply frames
-    for (int i = 0; i < 7; i++) {
-        rc = msg [i].init ();
-        errno_assert (rc == 0);
-    }
-
-    for (int i = 0; i < 7; i++) {
-        rc = session->read_zap_msg (&msg [i]);
-        if (rc == -1)
-            return close_and_return (msg, -1);
-        if ((msg [i].flags () & msg_t::more) == (i < 6? 0: msg_t::more)) {
-            //  Temporary support for security debugging
-            puts ("NULL I: ZAP handler sent incomplete reply message");
-            errno = EPROTO;
-            return close_and_return (msg, -1);
-        }
-    }
-
-    //  Address delimiter frame
-    if (msg [0].size () > 0) {
-        //  Temporary support for security debugging
-        puts ("NULL I: ZAP handler sent malformed reply message");
-        errno = EPROTO;
-        return close_and_return (msg, -1);
-    }
-
-    //  Version frame
-    if (msg [1].size () != 3 || memcmp (msg [1].data (), "1.0", 3)) {
-        //  Temporary support for security debugging
-        puts ("NULL I: ZAP handler sent bad version number");
-        errno = EPROTO;
-        return close_and_return (msg, -1);
-    }
-
-    //  Request id frame
-    if (msg [2].size () != 1 || memcmp (msg [2].data (), "1", 1)) {
-        //  Temporary support for security debugging
-        puts ("NULL I: ZAP handler sent bad request ID");
-        errno = EPROTO;
-        return close_and_return (msg, -1);
-    }
-
-    //  Status code frame
-    if (msg [3].size () != 3) {
-        //  Temporary support for security debugging
-        puts ("NULL I: ZAP handler sent bad status code");
-        errno = EPROTO;
-        return close_and_return (msg, -1);
-    }
-
-    //  Save status code
-    memcpy (status_code, msg [3].data (), sizeof status_code);
-
-    //  Save user id
-    set_user_id (msg [5].data (), msg [5].size ());
-
-    //  Process metadata frame
-    rc = parse_metadata (static_cast <const unsigned char*> (msg [6].data ()),
-                         msg [6].size (), true);
-
-    if (rc != 0)
-        return close_and_return (msg, -1);
-
-    //  Close all reply frames
-    for (int i = 0; i < 7; i++) {
-        const int rc2 = msg [i].close ();
-        errno_assert (rc2 == 0);
-    }
-
-    return 0;
-}

--- a/src/null_mechanism.cpp
+++ b/src/null_mechanism.cpp
@@ -74,11 +74,9 @@ int zmq::null_mechanism_t::next_handshake_command (msg_t *msg_)
             errno = EAGAIN;
             return -1;
         }
-        int rc = send_zap_request ();
-        if (rc != 0)
-            return -1;
+        send_zap_request ();
         zap_request_sent = true;
-        rc = receive_and_process_zap_reply ();
+        int rc = receive_and_process_zap_reply ();
         if (rc == -1 || rc == 1)
             return -1;
         zap_reply_received = true;
@@ -189,8 +187,8 @@ zmq::mechanism_t::status_t zmq::null_mechanism_t::status () const
         return handshaking;
 }
 
-int zmq::null_mechanism_t::send_zap_request ()
+void zmq::null_mechanism_t::send_zap_request ()
 {
-    return zap_client_t::send_zap_request ("NULL", 4, NULL, NULL, 0);
+    zap_client_t::send_zap_request ("NULL", 4, NULL, NULL, 0);
 }
 

--- a/src/null_mechanism.cpp
+++ b/src/null_mechanism.cpp
@@ -181,7 +181,7 @@ zmq::mechanism_t::status_t zmq::null_mechanism_t::status () const
         ready_command_received || error_command_received;
 
     if (ready_command_sent && ready_command_received)
-        return ready;
+        return mechanism_t::ready;
     else
     if (command_sent && command_received)
         return error;

--- a/src/null_mechanism.cpp
+++ b/src/null_mechanism.cpp
@@ -79,7 +79,7 @@ int zmq::null_mechanism_t::next_handshake_command (msg_t *msg_)
             return -1;
         zap_request_sent = true;
         rc = receive_and_process_zap_reply ();
-        if (rc != 0)
+        if (rc == -1 || rc == 1)
             return -1;
         zap_reply_received = true;
     }
@@ -170,7 +170,7 @@ int zmq::null_mechanism_t::zap_msg_available ()
     const int rc = receive_and_process_zap_reply ();
     if (rc == 0)
         zap_reply_received = true;
-    return rc;
+    return rc == -1 ? -1 : 0;
 }
 
 zmq::mechanism_t::status_t zmq::null_mechanism_t::status () const

--- a/src/null_mechanism.hpp
+++ b/src/null_mechanism.hpp
@@ -70,7 +70,7 @@ namespace zmq
         int process_error_command (
             const unsigned char *cmd_data, size_t data_size);
 
-        int send_zap_request ();
+        void send_zap_request ();
     };
 
 }

--- a/src/null_mechanism.hpp
+++ b/src/null_mechanism.hpp
@@ -32,6 +32,7 @@
 
 #include "mechanism.hpp"
 #include "options.hpp"
+#include "zap_client.hpp"
 
 namespace zmq
 {
@@ -61,6 +62,8 @@ namespace zmq
         char status_code [3];
 
         const std::string peer_address;
+
+        zap_client_t zap_client;
 
         bool ready_command_sent;
         bool error_command_sent;

--- a/src/null_mechanism.hpp
+++ b/src/null_mechanism.hpp
@@ -40,7 +40,7 @@ namespace zmq
     class msg_t;
     class session_base_t;
 
-    class null_mechanism_t : public mechanism_t
+    class null_mechanism_t : public zap_client_t
     {
     public:
 
@@ -57,14 +57,6 @@ namespace zmq
 
     private:
 
-        session_base_t * const session;
-
-        char status_code [3];
-
-        const std::string peer_address;
-
-        zap_client_t zap_client;
-
         bool ready_command_sent;
         bool error_command_sent;
         bool ready_command_received;
@@ -79,7 +71,6 @@ namespace zmq
             const unsigned char *cmd_data, size_t data_size);
 
         int send_zap_request ();
-        int receive_and_process_zap_reply ();
     };
 
 }

--- a/src/plain_server.cpp
+++ b/src/plain_server.cpp
@@ -68,7 +68,7 @@ int zmq::plain_server_t::next_handshake_command (msg_t *msg_)
         case sending_error:
             rc = produce_error (msg_);
             if (rc == 0)
-                state = error_command_sent;
+                state = error_sent;
             break;
         default:
             errno = EAGAIN;
@@ -109,7 +109,7 @@ zmq::mechanism_t::status_t zmq::plain_server_t::status () const
     if (state == ready)
         return mechanism_t::ready;
     else
-    if (state == error_command_sent)
+    if (state == error_sent)
         return mechanism_t::error;
     else
         return mechanism_t::handshaking;

--- a/src/plain_server.cpp
+++ b/src/plain_server.cpp
@@ -172,16 +172,7 @@ int zmq::plain_server_t::process_hello (msg_t *msg_)
     rc = send_zap_request (username, password);
     if (rc != 0)
         return -1;
-    rc = receive_and_process_zap_reply ();
-    if (rc == 0)
-        handle_zap_status_code ();
-    else
-    if (errno == EAGAIN)
-        state = waiting_for_zap_reply;
-    else
-        return -1;
-
-    return 0;
+    return receive_and_process_zap_reply () == -1 ? -1 : 0;
 }
 
 int zmq::plain_server_t::produce_welcome (msg_t *msg_) const

--- a/src/plain_server.cpp
+++ b/src/plain_server.cpp
@@ -169,9 +169,7 @@ int zmq::plain_server_t::process_hello (msg_t *msg_)
     int rc = session->zap_connect ();
     if (rc != 0)
         return -1;
-    rc = send_zap_request (username, password);
-    if (rc != 0)
-        return -1;
+    send_zap_request (username, password);
     return receive_and_process_zap_reply () == -1 ? -1 : 0;
 }
 
@@ -219,13 +217,13 @@ int zmq::plain_server_t::produce_error (msg_t *msg_) const
     return 0;
 }
 
-int zmq::plain_server_t::send_zap_request (const std::string &username,
-                                           const std::string &password)
+void zmq::plain_server_t::send_zap_request (const std::string &username,
+                                            const std::string &password)
 {
     const uint8_t *credentials[] = {
       reinterpret_cast<const uint8_t *> (username.c_str ()),
       reinterpret_cast<const uint8_t *> (password.c_str ())};
     size_t credentials_sizes[] = {username.size (), password.size ()};
-    return zap_client_t::send_zap_request ("PLAIN", 5, credentials,
-                                           credentials_sizes, 2);
+    zap_client_t::send_zap_request ("PLAIN", 5, credentials, credentials_sizes,
+                                    2);
 }

--- a/src/plain_server.cpp
+++ b/src/plain_server.cpp
@@ -41,8 +41,7 @@ zmq::plain_server_t::plain_server_t (session_base_t *session_,
                                      const std::string &peer_address_,
                                      const options_t &options_) :
     mechanism_t (options_),
-    zap_client_t (session_, peer_address_, options_),
-    state (waiting_for_hello)
+    zap_client_common_handshake_t (session_, peer_address_, options_)
 {
 }
 
@@ -102,17 +101,6 @@ int zmq::plain_server_t::process_handshake_command (msg_t *msg_)
         errno_assert (rc == 0);
     }
     return rc;
-}
-
-zmq::mechanism_t::status_t zmq::plain_server_t::status () const
-{
-    if (state == ready)
-        return mechanism_t::ready;
-    else
-    if (state == error_sent)
-        return mechanism_t::error;
-    else
-        return mechanism_t::handshaking;
 }
 
 int zmq::plain_server_t::zap_msg_available ()

--- a/src/plain_server.hpp
+++ b/src/plain_server.hpp
@@ -52,11 +52,8 @@ namespace zmq
         // mechanism implementation
         virtual int next_handshake_command (msg_t *msg_);
         virtual int process_handshake_command (msg_t *msg_);
-        virtual int zap_msg_available ();
 
     private:
-
-        state_t state;
 
         int produce_welcome (msg_t *msg_) const;
         int produce_ready (msg_t *msg_) const;

--- a/src/plain_server.hpp
+++ b/src/plain_server.hpp
@@ -62,8 +62,8 @@ namespace zmq
         int process_hello (msg_t *msg_);
         int process_initiate (msg_t *msg_);
 
-        int send_zap_request(const std::string &username,
-                             const std::string &password);
+        void send_zap_request (const std::string &username,
+                               const std::string &password);
     };
 
 }

--- a/src/plain_server.hpp
+++ b/src/plain_server.hpp
@@ -57,17 +57,6 @@ namespace zmq
 
     private:
 
-        enum state_t {
-            waiting_for_hello,
-            sending_welcome,
-            waiting_for_initiate,
-            sending_ready,
-            waiting_for_zap_reply,
-            sending_error,
-            error_command_sent,
-            ready
-        };
-
         state_t state;
 
         int produce_welcome (msg_t *msg_) const;

--- a/src/plain_server.hpp
+++ b/src/plain_server.hpp
@@ -40,7 +40,7 @@ namespace zmq
     class msg_t;
     class session_base_t;
 
-    class plain_server_t : public zap_client_t
+    class plain_server_t : public zap_client_common_handshake_t
     {
     public:
 
@@ -53,7 +53,6 @@ namespace zmq
         virtual int next_handshake_command (msg_t *msg_);
         virtual int process_handshake_command (msg_t *msg_);
         virtual int zap_msg_available ();
-        virtual status_t status () const;
 
     private:
 

--- a/src/plain_server.hpp
+++ b/src/plain_server.hpp
@@ -32,6 +32,7 @@
 
 #include "mechanism.hpp"
 #include "options.hpp"
+#include "zap_client.hpp"
 
 namespace zmq
 {
@@ -70,6 +71,8 @@ namespace zmq
         session_base_t * const session;
 
         const std::string peer_address;
+
+        zap_client_t zap_client;
 
         //  Status code as received from ZAP handler
         std::string status_code;

--- a/src/plain_server.hpp
+++ b/src/plain_server.hpp
@@ -40,7 +40,7 @@ namespace zmq
     class msg_t;
     class session_base_t;
 
-    class plain_server_t : public mechanism_t
+    class plain_server_t : public zap_client_t
     {
     public:
 
@@ -68,15 +68,6 @@ namespace zmq
             ready
         };
 
-        session_base_t * const session;
-
-        const std::string peer_address;
-
-        zap_client_t zap_client;
-
-        //  Status code as received from ZAP handler
-        std::string status_code;
-
         state_t state;
 
         int produce_welcome (msg_t *msg_) const;
@@ -88,7 +79,6 @@ namespace zmq
 
         int send_zap_request(const std::string &username,
                              const std::string &password);
-        int receive_and_process_zap_reply ();
     };
 
 }

--- a/src/zap_client.cpp
+++ b/src/zap_client.cpp
@@ -220,4 +220,23 @@ int zap_client_t::receive_and_process_zap_reply ()
 
     return 0;
 }
+
+zap_client_common_handshake_t::zap_client_common_handshake_t (
+  session_base_t *const session_,
+  const std::string &peer_address_,
+  const options_t &options_) :
+    zap_client_t (session_, peer_address_, options_),
+    state (waiting_for_hello)
+{
+}
+
+zmq::mechanism_t::status_t zap_client_common_handshake_t::status () const
+{
+    if (state == ready)
+        return mechanism_t::ready;
+    else if (state == error_sent)
+        return mechanism_t::error;
+    else
+        return mechanism_t::handshaking;
+}
 }

--- a/src/zap_client.cpp
+++ b/src/zap_client.cpp
@@ -31,15 +31,16 @@
 
 #include "zap_client.hpp"
 #include "msg.hpp"
+#include "session_base.hpp"
 
 namespace zmq
 {
 zap_client_t::zap_client_t (session_base_t *const session_,
                             const std::string &peer_address_,
                             const options_t &options_) :
+    mechanism_t (options_),
     session (session_),
-    peer_address (peer_address_),
-    options (options_)
+    peer_address (peer_address_)
 {
 }
 
@@ -140,6 +141,81 @@ int zap_client_t::send_zap_request (const char *mechanism,
         rc = session->write_zap_msg (&msg);
         if (rc != 0)
             return close_and_return (&msg, -1);
+    }
+
+    return 0;
+}
+
+int zap_client_t::receive_and_process_zap_reply ()
+{
+    int rc = 0;
+    msg_t msg[7]; //  ZAP reply consists of 7 frames
+
+    //  Initialize all reply frames
+    for (int i = 0; i < 7; i++) {
+        rc = msg[i].init ();
+        errno_assert (rc == 0);
+    }
+
+    for (int i = 0; i < 7; i++) {
+        rc = session->read_zap_msg (&msg[i]);
+        if (rc == -1)
+            return close_and_return (msg, -1);
+        if ((msg[i].flags () & msg_t::more) == (i < 6 ? 0 : msg_t::more)) {
+            // CURVE I : ZAP handler sent incomplete reply message
+            errno = EPROTO;
+            return close_and_return (msg, -1);
+        }
+    }
+
+    //  Address delimiter frame
+    if (msg[0].size () > 0) {
+        // CURVE I: ZAP handler sent malformed reply message
+        errno = EPROTO;
+        return close_and_return (msg, -1);
+    }
+
+    //  Version frame
+    if (msg[1].size () != 3 || memcmp (msg[1].data (), "1.0", 3)) {
+        // CURVE I: ZAP handler sent bad version number
+        errno = EPROTO;
+        return close_and_return (msg, -1);
+    }
+
+    //  Request id frame
+    if (msg[2].size () != 1 || memcmp (msg[2].data (), "1", 1)) {
+        // CURVE I: ZAP handler sent bad request ID
+        errno = EPROTO;
+        return close_and_return (msg, -1);
+    }
+
+    //  Status code frame, only 200, 300, 400 and 500 are valid status codes
+    char *status_code_data = static_cast<char *> (msg[3].data ());
+    if (msg[3].size () != 3 || status_code_data[0] < '2'
+        || status_code_data[0] > '5' || status_code_data[1] != '0'
+        || status_code_data[2] != '0') {
+        // CURVE I: ZAP handler sent invalid status code
+        errno = EPROTO;
+        return close_and_return (msg, -1);
+    }
+
+    //  Save status code
+    status_code.assign (static_cast<char *> (msg[3].data ()), 3);
+
+    //  Save user id
+    set_user_id (msg[5].data (), msg[5].size ());
+
+    //  Process metadata frame
+    rc = parse_metadata (static_cast<const unsigned char *> (msg[6].data ()),
+                         msg[6].size (), true);
+
+    if (rc != 0)
+        return close_and_return (msg, -1);
+
+    //  Close all reply frames
+    for (int i = 0; i < 7; i++) {
+        const int rc2 = msg[i].close ();
+        errno_assert (rc2 == 0);
     }
 
     return 0;

--- a/src/zap_client.cpp
+++ b/src/zap_client.cpp
@@ -1,0 +1,123 @@
+/*
+    Copyright (c) 2007-2016 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "precompiled.hpp"
+
+#include "zap_client.hpp"
+#include "msg.hpp"
+
+namespace zmq
+{
+int zap_client_t::send_zap_request (const char *mechanism,
+                                    size_t mechanism_length,
+                                    const uint8_t *credentials,
+                                    size_t credentials_size)
+{
+    // TODO  I don't think the rc can be -1 anywhere below.
+    // It might only be -1 if the HWM was exceeded, but on the ZAP socket,
+    // the HWM is disabled. They should be changed to zmq_assert (rc == 0);
+    // The method's return type can be changed to void then.
+
+    int rc;
+    msg_t msg;
+
+    //  Address delimiter frame
+    rc = msg.init ();
+    errno_assert (rc == 0);
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    if (rc != 0)
+        return close_and_return (&msg, -1);
+
+    //  Version frame
+    rc = msg.init_size (3);
+    errno_assert (rc == 0);
+    memcpy (msg.data (), "1.0", 3);
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    if (rc != 0)
+        return close_and_return (&msg, -1);
+
+    //  Request ID frame
+    rc = msg.init_size (1);
+    errno_assert (rc == 0);
+    memcpy (msg.data (), "1", 1);
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    if (rc != 0)
+        return close_and_return (&msg, -1);
+
+    //  Domain frame
+    rc = msg.init_size (options.zap_domain.length ());
+    errno_assert (rc == 0);
+    memcpy (msg.data (), options.zap_domain.c_str (),
+            options.zap_domain.length ());
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    if (rc != 0)
+        return close_and_return (&msg, -1);
+
+    //  Address frame
+    rc = msg.init_size (peer_address.length ());
+    errno_assert (rc == 0);
+    memcpy (msg.data (), peer_address.c_str (), peer_address.length ());
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    if (rc != 0)
+        return close_and_return (&msg, -1);
+
+    //  Identity frame
+    rc = msg.init_size (options.identity_size);
+    errno_assert (rc == 0);
+    memcpy (msg.data (), options.identity, options.identity_size);
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    if (rc != 0)
+        return close_and_return (&msg, -1);
+
+    //  Mechanism frame
+    rc = msg.init_size (mechanism_length);
+    errno_assert (rc == 0);
+    memcpy (msg.data (), mechanism, mechanism_length);
+    msg.set_flags (msg_t::more);
+    rc = session->write_zap_msg (&msg);
+    if (rc != 0)
+        return close_and_return (&msg, -1);
+
+    //  Credentials frame
+    rc = msg.init_size (credentials_size);
+    errno_assert (rc == 0);
+    memcpy (msg.data (), credentials, credentials_size);
+    rc = session->write_zap_msg (&msg);
+    if (rc != 0)
+        return close_and_return (&msg, -1);
+
+    return 0;
+}
+}

--- a/src/zap_client.cpp
+++ b/src/zap_client.cpp
@@ -111,12 +111,15 @@ int zap_client_t::send_zap_request (const char *mechanism,
         return close_and_return (&msg, -1);
 
     //  Credentials frame
-    rc = msg.init_size (credentials_size);
-    errno_assert (rc == 0);
-    memcpy (msg.data (), credentials, credentials_size);
-    rc = session->write_zap_msg (&msg);
-    if (rc != 0)
-        return close_and_return (&msg, -1);
+    //  Skip if credential is NULL
+    if (credentials) {
+        rc = msg.init_size (credentials_size);
+        errno_assert (rc == 0);
+        memcpy (msg.data (), credentials, credentials_size);
+        rc = session->write_zap_msg (&msg);
+        if (rc != 0)
+            return close_and_return (&msg, -1);
+    }
 
     return 0;
 }

--- a/src/zap_client.cpp
+++ b/src/zap_client.cpp
@@ -105,7 +105,8 @@ int zap_client_t::send_zap_request (const char *mechanism,
     rc = msg.init_size (mechanism_length);
     errno_assert (rc == 0);
     memcpy (msg.data (), mechanism, mechanism_length);
-    msg.set_flags (msg_t::more);
+    if (credentials)
+        msg.set_flags (msg_t::more);
     rc = session->write_zap_msg (&msg);
     if (rc != 0)
         return close_and_return (&msg, -1);

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -39,17 +39,18 @@ class zap_client_t
   public:
     zap_client_t (session_base_t *const session_,
                   const std::string &peer_address_,
-                  const options_t &options_) :
-        session (session_),
-        peer_address (peer_address_),
-        options (options_)
-    {
-    }
+                  const options_t &options_);
 
     int send_zap_request (const char *mechanism,
                           size_t mechanism_length,
                           const uint8_t *credentials,
                           size_t credentials_size);
+
+    int send_zap_request (const char *mechanism,
+                          size_t mechanism_length,
+                          const uint8_t **credentials,
+                          size_t *credentials_sizes,
+                          size_t credentials_count);
 
   private:
     session_base_t *const session;

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -63,6 +63,17 @@ class zap_client_t : public virtual mechanism_t
 
     //  Status code as received from ZAP handler
     std::string status_code;
+};
+
+class zap_client_common_handshake_t : public zap_client_t
+{
+  protected:
+    zap_client_common_handshake_t (session_base_t *const session_,
+                                   const std::string &peer_address_,
+                                   const options_t &options_);
+
+    // methods from mechanism_t
+    status_t status () const;
 
     enum state_t
     {
@@ -75,6 +86,9 @@ class zap_client_t : public virtual mechanism_t
         error_sent,
         ready
     };
+
+    //  Current FSM state
+    state_t state;
 };
 }
 

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -43,16 +43,16 @@ class zap_client_t : public virtual mechanism_t
                   const std::string &peer_address_,
                   const options_t &options_);
 
-    int send_zap_request (const char *mechanism,
-                          size_t mechanism_length,
-                          const uint8_t *credentials,
-                          size_t credentials_size);
+    void send_zap_request (const char *mechanism,
+                           size_t mechanism_length,
+                           const uint8_t *credentials,
+                           size_t credentials_size);
 
-    int send_zap_request (const char *mechanism,
-                          size_t mechanism_length,
-                          const uint8_t **credentials,
-                          size_t *credentials_sizes,
-                          size_t credentials_count);
+    void send_zap_request (const char *mechanism,
+                           size_t mechanism_length,
+                           const uint8_t **credentials,
+                           size_t *credentials_sizes,
+                           size_t credentials_count);
 
     virtual int receive_and_process_zap_reply ();
     virtual void handle_zap_status_code ();

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -30,11 +30,13 @@
 #ifndef __ZMQ_ZAP_CLIENT_HPP_INCLUDED__
 #define __ZMQ_ZAP_CLIENT_HPP_INCLUDED__
 
-#include "session_base.hpp"
+#include "mechanism.hpp"
 
 namespace zmq
 {
-class zap_client_t
+class session_base_t;
+
+class zap_client_t : public virtual mechanism_t
 {
   public:
     zap_client_t (session_base_t *const session_,
@@ -52,10 +54,15 @@ class zap_client_t
                           size_t *credentials_sizes,
                           size_t credentials_count);
 
-  private:
+
+    int receive_and_process_zap_reply ();
+
+  protected:
     session_base_t *const session;
-    const std::string &peer_address;
-    const options_t &options;
+    const std::string peer_address;
+
+    //  Status code as received from ZAP handler
+    std::string status_code;
 };
 }
 

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -63,6 +63,18 @@ class zap_client_t : public virtual mechanism_t
 
     //  Status code as received from ZAP handler
     std::string status_code;
+
+    enum state_t
+    {
+        waiting_for_hello,
+        sending_welcome,
+        waiting_for_initiate,
+        waiting_for_zap_reply,
+        sending_ready,
+        sending_error,
+        error_sent,
+        ready
+    };
 };
 }
 

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -55,7 +55,10 @@ class zap_client_t : public virtual mechanism_t
                           size_t credentials_count);
 
     virtual int receive_and_process_zap_reply ();
-    virtual void handle_zap_status_code () {}
+    virtual void handle_zap_status_code ();
+
+    //  methods from mechanism_t
+    error_detail_t error_detail () const;
 
   protected:
     session_base_t *const session;
@@ -63,6 +66,10 @@ class zap_client_t : public virtual mechanism_t
 
     //  Status code as received from ZAP handler
     std::string status_code;
+
+    //  Details about the current error state
+    //  TODO remove this
+    error_detail_t current_error_detail;
 };
 
 class zap_client_common_handshake_t : public zap_client_t
@@ -88,7 +95,6 @@ class zap_client_common_handshake_t : public zap_client_t
     //  methods from mechanism_t
     status_t status () const;
     int zap_msg_available ();
-    error_detail_t error_detail () const;
 
     //  zap_client_t methods
     int receive_and_process_zap_reply ();
@@ -96,10 +102,6 @@ class zap_client_common_handshake_t : public zap_client_t
 
     //  Current FSM state
     state_t state;
-
-    //  Details about the current error state
-    //  TODO remove this
-    error_detail_t current_error_detail;
 
   private:
     const state_t zap_reply_ok_state;

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -68,13 +68,6 @@ class zap_client_t : public virtual mechanism_t
 class zap_client_common_handshake_t : public zap_client_t
 {
   protected:
-    zap_client_common_handshake_t (session_base_t *const session_,
-                                   const std::string &peer_address_,
-                                   const options_t &options_);
-
-    // methods from mechanism_t
-    status_t status () const;
-
     enum state_t
     {
         waiting_for_hello,
@@ -87,8 +80,28 @@ class zap_client_common_handshake_t : public zap_client_t
         ready
     };
 
+    zap_client_common_handshake_t (session_base_t *const session_,
+                                   const std::string &peer_address_,
+                                   const options_t &options_,
+                                   state_t zap_reply_ok_state);
+
+    // methods from mechanism_t
+    status_t status () const;
+    int zap_msg_available ();
+    error_detail_t error_detail () const;
+
+    // own methods
+    void handle_zap_status_code ();
+
     //  Current FSM state
     state_t state;
+
+    //  Details about the current error state
+    //  TODO remove this
+    error_detail_t current_error_detail;
+
+  private:
+    const state_t zap_reply_ok_state;
 };
 }
 

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -1,0 +1,61 @@
+/*
+    Copyright (c) 2007-2016 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __ZMQ_ZAP_CLIENT_HPP_INCLUDED__
+#define __ZMQ_ZAP_CLIENT_HPP_INCLUDED__
+
+#include "session_base.hpp"
+
+namespace zmq
+{
+class zap_client_t
+{
+  public:
+    zap_client_t (session_base_t *const session_,
+                  const std::string &peer_address_,
+                  const options_t &options_) :
+        session (session_),
+        peer_address (peer_address_),
+        options (options_)
+    {
+    }
+
+    int send_zap_request (const char *mechanism,
+                          size_t mechanism_length,
+                          const uint8_t *credentials,
+                          size_t credentials_size);
+
+  private:
+    session_base_t *const session;
+    const std::string &peer_address;
+    const options_t &options;
+};
+}
+
+#endif

--- a/src/zap_client.hpp
+++ b/src/zap_client.hpp
@@ -54,8 +54,8 @@ class zap_client_t : public virtual mechanism_t
                           size_t *credentials_sizes,
                           size_t credentials_count);
 
-
-    int receive_and_process_zap_reply ();
+    virtual int receive_and_process_zap_reply ();
+    virtual void handle_zap_status_code () {}
 
   protected:
     session_base_t *const session;
@@ -85,12 +85,13 @@ class zap_client_common_handshake_t : public zap_client_t
                                    const options_t &options_,
                                    state_t zap_reply_ok_state);
 
-    // methods from mechanism_t
+    //  methods from mechanism_t
     status_t status () const;
     int zap_msg_available ();
     error_detail_t error_detail () const;
 
-    // own methods
+    //  zap_client_t methods
+    int receive_and_process_zap_reply ();
     void handle_zap_status_code ();
 
     //  Current FSM state

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(tests
         test_ctx_destroy
         test_security_null
         test_security_plain
+        test_security_zap
         test_iov
         test_spec_req
         test_spec_rep
@@ -184,9 +185,15 @@ if(ZMQ_HAVE_CURVE)
 	"../src/err.cpp" 
 	"../src/random.cpp" 
 	"../src/clock.cpp"
+	"testutil_security.hpp"
 	)
   target_compile_definitions(test_security_curve PRIVATE "-DZMQ_USE_TWEETNACL")
 endif()
+
+target_sources(test_security_zap PRIVATE 
+  "testutil_security.hpp"
+)
+set_tests_properties(test_security_zap PROPERTIES TIMEOUT 60)
 
 #Check whether all tests in the current folder are present
 file(READ "${CMAKE_CURRENT_LIST_FILE}" CURRENT_LIST_FILE_CONTENT)

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -28,6 +28,7 @@
 */
 
 #include "testutil.hpp"
+#include "testutil_security.hpp"
 #if defined (ZMQ_HAVE_WINDOWS)
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
@@ -52,82 +53,7 @@ const char large_identity[] = "0123456789012345678901234567890123456789"
                               "0123456789012345678901234567890123456789"
                               "012345678901234";
 
-//  We'll generate random test keys at startup
-static char valid_client_public [41];
-static char valid_client_secret [41];
-static char valid_server_public [41];
-static char valid_server_secret [41];
-
-void *zap_requests_handled;
-
 #ifdef ZMQ_BUILD_DRAFT_API
-//  Read one event off the monitor socket; return value and address
-//  by reference, if not null, and event number by value. Returns -1
-//  in case of error.
-
-static int
-get_monitor_event_internal (void *monitor, int *value, char **address, int recv_flag)
-{
-    //  First frame in message contains event number and value
-    zmq_msg_t msg;
-    zmq_msg_init (&msg);
-    if (zmq_msg_recv (&msg, monitor, recv_flag) == -1) {
-        assert (errno == EAGAIN);
-        return -1; //  timed out or no message available
-    }
-    assert (zmq_msg_more (&msg));
-
-    uint8_t *data = (uint8_t *) zmq_msg_data (&msg);
-    uint16_t event = *(uint16_t *) (data);
-    if (value)
-        *value = *(uint32_t *) (data + 2);
-
-    //  Second frame in message contains event address
-    zmq_msg_init (&msg);
-    int res = zmq_msg_recv (&msg, monitor, recv_flag) == -1;
-    assert (res != -1);
-    assert (!zmq_msg_more (&msg));
-
-    if (address) {
-        uint8_t *data = (uint8_t *) zmq_msg_data (&msg);
-        size_t size = zmq_msg_size (&msg);
-        *address = (char *) malloc (size + 1);
-        memcpy (*address, data, size);
-        *address [size] = 0;
-    }
-    return event;
-}
-
-int get_monitor_event_with_timeout (void *monitor,
-                                    int *value,
-                                    char **address,
-                                    int timeout)
-{
-    int res;
-    if (timeout == -1) {
-        // process infinite timeout in small steps to allow the user
-        // to see some information on the console
-
-        int timeout_step = 250;
-        int wait_time = 0;
-        zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout_step,
-                        sizeof (timeout_step));
-        while ((res = get_monitor_event_internal (monitor, value, address, 0))
-               == -1) {
-            wait_time += timeout_step;
-            fprintf (stderr, "Still waiting for monitor event after %i ms\n",
-                     wait_time);
-        }
-    } else {
-        zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
-        res = get_monitor_event_internal (monitor, value, address, 0);
-    }
-    int timeout_infinite = -1;
-    zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout_infinite,
-                    sizeof (timeout_infinite));
-    return res;
-}
-
 // assert_* are macros rather than functions, to allow assertion failures be
 // attributed to the causing source code line
 #define assert_no_more_monitor_events_with_timeout(monitor, timeout)           \
@@ -145,232 +71,9 @@ int get_monitor_event_with_timeout (void *monitor,
 
 #endif
 
-//  --------------------------------------------------------------------------
-//  This methods receives and validates ZAP requests (allowing or denying
-//  each client connection).
-
-enum zap_protocol_t
-{
-  zap_ok,
-  // ZAP-compliant non-standard cases
-  zap_status_temporary_failure,
-  zap_status_internal_error,
-  // ZAP protocol errors
-  zap_wrong_version,
-  zap_wrong_request_id,
-  zap_status_invalid,
-  zap_too_many_parts
-};
-
-static void zap_handler_generic (void *ctx,
-                                 zap_protocol_t zap_protocol,
-                                 const char *expected_identity = "IDENT")
-{
-    void *control = zmq_socket (ctx, ZMQ_REQ);
-    assert (control);
-    int rc = zmq_connect (control, "inproc://handler-control");
-    assert (rc == 0);
-
-    void *handler = zmq_socket (ctx, ZMQ_REP);
-    assert (handler);
-    rc = zmq_bind (handler, "inproc://zeromq.zap.01");
-    assert (rc == 0);
-
-    //  Signal main thread that we are ready
-    rc = s_send (control, "GO");
-    assert (rc == 2);
-
-    zmq_pollitem_t items [] = {
-        { control, 0, ZMQ_POLLIN, 0 },
-        { handler, 0, ZMQ_POLLIN, 0 },
-    };
-
-    //  Process ZAP requests forever
-    while (zmq_poll (items, 2, -1) >= 0) {
-        if (items [0].revents & ZMQ_POLLIN) {
-            char *buf = s_recv (control);
-            assert (buf);
-            assert (streq (buf, "STOP"));
-            free (buf);
-            break; //  Terminating - main thread signal
-        }
-        if (!(items [1].revents & ZMQ_POLLIN))
-            continue;
-
-        char *version = s_recv (handler);
-        if (!version)
-            break; //  Terminating - peer's socket closed
-
-        char *sequence = s_recv (handler);
-        char *domain = s_recv (handler);
-        char *address = s_recv (handler);
-        char *identity = s_recv (handler);
-        char *mechanism = s_recv (handler);
-        uint8_t client_key [32];
-        int size = zmq_recv (handler, client_key, 32, 0);
-        assert (size == 32);
-
-        char client_key_text [41];
-        zmq_z85_encode (client_key_text, client_key, 32);
-
-        assert (streq (version, "1.0"));
-        assert (streq (mechanism, "CURVE"));
-        assert (streq (identity, expected_identity));
-
-        s_sendmore (handler, zap_protocol == zap_wrong_version
-                               ? "invalid_version"
-                               : version);
-        s_sendmore (handler, zap_protocol == zap_wrong_request_id
-                               ? "invalid_request_id"
-                               : sequence);
-
-        if (streq (client_key_text, valid_client_public)) {
-            const char *status_code;
-            switch (zap_protocol) {
-                case zap_status_internal_error:
-                    status_code = "500";
-                    break;
-                case zap_status_temporary_failure:
-                    status_code = "300";
-                    break;
-                case zap_status_invalid:
-                    status_code = "invalid_status";
-                    break;
-                default:
-                    status_code = "200";
-            }
-            s_sendmore (handler, status_code);
-            s_sendmore (handler, "OK");
-            s_sendmore (handler, "anonymous");
-            if (zap_protocol == zap_too_many_parts) {
-                s_sendmore (handler, "");
-            }
-            s_send (handler, "");
-        } else {
-            s_sendmore (handler, "400");
-            s_sendmore (handler, "Invalid client public key");
-            s_sendmore (handler, "");
-            s_send (handler, "");
-        }
-        free (version);
-        free (sequence);
-        free (domain);
-        free (address);
-        free (identity);
-        free (mechanism);
-
-        zmq_atomic_counter_inc (zap_requests_handled);
-    }
-    rc = zmq_unbind (handler, "inproc://zeromq.zap.01");
-    assert (rc == 0);
-    close_zero_linger (handler);
-
-    rc = s_send (control, "STOPPED");
-    assert (rc == 7);
-    close_zero_linger (control);
-}
-
-static void zap_handler (void *ctx)
-{
-    zap_handler_generic (ctx, zap_ok);
-}
-
 static void zap_handler_large_identity (void *ctx)
 {
     zap_handler_generic (ctx, zap_ok, large_identity);
-}
-
-static void zap_handler_wrong_version (void *ctx)
-{
-    zap_handler_generic (ctx, zap_wrong_version);
-}
-
-static void zap_handler_wrong_request_id (void *ctx)
-{
-    zap_handler_generic (ctx, zap_wrong_request_id);
-}
-
-static void zap_handler_wrong_status_invalid (void *ctx)
-{
-    zap_handler_generic (ctx, zap_status_invalid);
-}
-
-static void zap_handler_wrong_status_temporary_failure (void *ctx)
-{
-    zap_handler_generic (ctx, zap_status_temporary_failure);
-}
-
-static void zap_handler_wrong_status_internal_error (void *ctx)
-{
-    zap_handler_generic (ctx, zap_status_internal_error);
-}
-
-static void zap_handler_too_many_parts (void *ctx)
-{
-    zap_handler_generic (ctx, zap_too_many_parts);
-}
-
-typedef void(socket_config_fn) (void *, void *);
-
-void socket_config_curve_server(void *server, void*) 
-{
-    int as_server = 1;
-    int rc = zmq_setsockopt (server, ZMQ_CURVE_SERVER, &as_server, sizeof (int));
-    assert (rc == 0);
-
-    rc = zmq_setsockopt (server, ZMQ_CURVE_SECRETKEY, valid_server_secret, 41);
-    assert (rc == 0);
-}
-
-struct curve_client_data_t
-{
-    const char *server_public;
-    const char *client_public;
-    const char *client_secret;
-};
-
-void socket_config_curve_client (void *client, void *data)
-{
-    curve_client_data_t *curve_client_data =
-      static_cast<curve_client_data_t *> (data);
-
-    int rc = zmq_setsockopt (client, ZMQ_CURVE_SERVERKEY,
-                             curve_client_data->server_public, 41);
-    assert (rc == 0);
-    rc = zmq_setsockopt (client, ZMQ_CURVE_PUBLICKEY,
-                         curve_client_data->client_public, 41);
-    assert (rc == 0);
-    rc = zmq_setsockopt (client, ZMQ_CURVE_SECRETKEY,
-                         curve_client_data->client_secret, 41);
-    assert (rc == 0);
-}
-
-void *create_and_connect_client (void *ctx,
-                                 char *my_endpoint,
-                                 socket_config_fn socket_config_,
-                                 void *socket_config_data_)
-{
-    void *client = zmq_socket (ctx, ZMQ_DEALER);
-    assert (client);
-
-    socket_config_ (client, socket_config_data_);
-
-    int rc = zmq_connect (client, my_endpoint);
-    assert (rc == 0);
-
-    return client;
-}
-
-void expect_new_client_bounce_fail (void *ctx,
-                                    char *my_endpoint,
-                                    void *server,
-                                    socket_config_fn socket_config_,
-                                    void *socket_config_data_)
-{
-    void *client = create_and_connect_client (ctx, my_endpoint, socket_config_,
-                                              socket_config_data_);
-    expect_bounce_fail (server, client);
-    close_zero_linger (client);
 }
 
 void expect_new_client_curve_bounce_fail (void *ctx,
@@ -385,56 +88,6 @@ void expect_new_client_curve_bounce_fail (void *ctx,
     expect_new_client_bounce_fail (
       ctx, my_endpoint, server, socket_config_curve_client, &curve_client_data);
 }
-
-#ifdef ZMQ_BUILD_DRAFT_API
-//  expects that one or more occurrences of the expected event are received 
-//  via the specified socket monitor
-//  returns the number of occurrences of the expected event
-//  interrupts, if a ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL with EPIPE, ECONNRESET
-//  or ECONNABORTED occurs; in this case, 0 is returned
-//  this should be investigated further, see 
-//  https://github.com/zeromq/libzmq/issues/2644
-int expect_monitor_event_multiple (void *server_mon,
-                                   int expected_event,
-                                   int expected_err = -1)
-{
-    int count_of_expected_events = 0;
-    int client_closed_connection = 0;
-    //  infinite timeout at the start
-    int timeout = -1;
-
-    int event;
-    int err;
-    while (
-      (event = get_monitor_event_with_timeout (server_mon, &err, NULL, timeout))
-      != -1) {
-        timeout = 250;
-
-        // ignore errors with EPIPE/ECONNRESET/ECONNABORTED, which can happen
-        // ECONNRESET can happen on very slow machines, when the engine writes
-        // to the peer and then tries to read the socket before the peer reads
-        // ECONNABORTED happens when a client aborts a connection via RST/timeout
-        if (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL &&
-                (err == EPIPE || err == ECONNRESET || err == ECONNABORTED)) {
-            fprintf (
-              stderr,
-              "Ignored event (skipping any further events): %x (err = %i)\n",
-              event, err);
-            client_closed_connection = 1;
-            break;
-        }
-        if (event != expected_event
-            || (-1 != expected_err && err != expected_err)) {
-            fprintf (stderr, "Unexpected event: %x (err = %i)\n", event, err);
-            assert (false);
-        }
-        ++count_of_expected_events;
-    }
-    assert (count_of_expected_events > 0 || client_closed_connection);
-
-    return count_of_expected_events;
-}
-#endif
 
 void test_garbage_key(void *ctx,
                        void *server,
@@ -462,104 +115,6 @@ void test_garbage_key(void *ctx,
              "count of ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION events: %i\n",
              handshake_failed_encryption_event_count);
 #endif
-}
-
-void setup_context_and_server_side (
-  void **ctx,
-  void **handler,
-  void **zap_thread,
-  void **server,
-  void **server_mon,
-  char *my_endpoint,
-  zmq_thread_fn zap_handler_ = &zap_handler,
-  socket_config_fn socket_config_ = &socket_config_curve_server,
-  void *socket_config_data_ = NULL,
-  const char *identity = "IDENT")
-{
-    *ctx = zmq_ctx_new ();
-    assert (*ctx);
-
-    //  Spawn ZAP handler
-    zap_requests_handled = zmq_atomic_counter_new ();
-    assert (zap_requests_handled != NULL);
-
-    *handler = zmq_socket (*ctx, ZMQ_REP);
-    assert (*handler);
-    int rc = zmq_bind (*handler, "inproc://handler-control");
-    assert (rc == 0);
-
-    *zap_thread = zmq_threadstart (zap_handler_, *ctx);
-
-    char *buf = s_recv (*handler);
-    assert (buf);
-    assert (streq (buf, "GO"));
-    free (buf);
-
-    //  Server socket will accept connections
-    *server = zmq_socket (*ctx, ZMQ_DEALER);
-    assert (*server);
-
-    socket_config_ (*server, socket_config_data_);
-
-    rc = zmq_setsockopt (*server, ZMQ_IDENTITY, identity, strlen(identity));
-    assert (rc == 0);
-
-    rc = zmq_bind (*server, "tcp://127.0.0.1:*");
-    assert (rc == 0);
-
-    size_t len = MAX_SOCKET_STRING;
-    rc = zmq_getsockopt (*server, ZMQ_LAST_ENDPOINT, my_endpoint, &len);
-    assert (rc == 0);
-
-#ifdef ZMQ_BUILD_DRAFT_API
-    char monitor_endpoint [] = "inproc://monitor-server";
-
-    //  Monitor handshake events on the server
-    rc = zmq_socket_monitor (
-      *server, monitor_endpoint,
-      ZMQ_EVENT_HANDSHAKE_SUCCEEDED | ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
-        | ZMQ_EVENT_HANDSHAKE_FAILED_ZAP | ZMQ_EVENT_HANDSHAKE_FAILED_ZMTP
-        | ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
-    assert (rc == 0);
-
-    //  Create socket for collecting monitor events
-    *server_mon = zmq_socket (*ctx, ZMQ_PAIR);
-    assert (*server_mon);
-
-    //  Connect it to the inproc endpoints so they'll get events
-    rc = zmq_connect (*server_mon, monitor_endpoint);
-    assert (rc == 0);
-#endif
-}
-
-void shutdown_context_and_server_side (void *ctx,
-                                       void *zap_thread,
-                                       void *server,
-                                       void *server_mon,
-                                       void *handler)
-{
-    int rc = s_send (handler, "STOP");
-    assert (rc == 4);
-    char *buf = s_recv (handler);
-    assert (buf);
-    assert (streq (buf, "STOPPED"));
-    free (buf);
-    rc = zmq_unbind (handler, "inproc://handler-control");
-    assert (rc == 0);
-    close_zero_linger (handler);
-
-#ifdef ZMQ_BUILD_DRAFT_API
-    close_zero_linger (server_mon);
-#endif
-    close_zero_linger (server);
-
-    //  Wait until ZAP handler terminates
-    zmq_threadclose (zap_thread);
-
-    rc = zmq_ctx_term (ctx);
-    assert (rc == 0);
-
-    zmq_atomic_counter_destroy (&zap_requests_handled);
 }
 
 void test_curve_security_with_valid_credentials (
@@ -1006,45 +561,6 @@ void test_curve_security_invalid_initiate_command_encrypted_content (
     close (s);
 }
 
-void test_zap_unsuccessful (void *ctx,
-                            char *my_endpoint,
-                            void *server,
-                            void *server_mon,
-                            int expected_event,
-                            int expected_err,
-                            socket_config_fn socket_config_,
-                            void *socket_config_data_)
-{
-    expect_new_client_bounce_fail (ctx, my_endpoint, server, socket_config_,
-                                   socket_config_data_);
-
-    int events_received = 0;
-#ifdef ZMQ_BUILD_DRAFT_API
-    events_received =
-      expect_monitor_event_multiple (server_mon, expected_event, expected_err);
-#endif
-
-    // there may be more than one ZAP request due to repeated attempts by the client
-    assert (events_received == 0
-            || 1 <= zmq_atomic_counter_value (zap_requests_handled));
-}
-
-void test_zap_protocol_error (void *ctx,
-                              char *my_endpoint,
-                              void *server,
-                              void *server_mon,
-                              socket_config_fn socket_config_,
-                              void *socket_config_data_)
-{
-    test_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-                           ZMQ_EVENT_HANDSHAKE_FAILED_ZAP, EPROTO,
-#else
-                           0, 0,
-#endif
-                           socket_config_, socket_config_data_);
-}
-
 void test_curve_security_invalid_keysize (void *ctx)
 {
     //  Check return codes for invalid buffer sizes
@@ -1063,101 +579,6 @@ void test_curve_security_invalid_keysize (void *ctx)
     assert (rc == 0);
 }
 
-void test_zap_errors (socket_config_fn server_socket_config_,
-                      void *server_socket_config_data_,
-                      socket_config_fn client_socket_config_,
-                      void *client_socket_config_data_)
-{
-    void *ctx;
-    void *handler;
-    void *zap_thread;
-    void *server;
-    void *server_mon;
-    char my_endpoint[MAX_SOCKET_STRING];
-
-    //  Invalid ZAP protocol tests
-
-    //  wrong version
-    fprintf (stderr, "test_zap_protocol_error wrong_version\n");
-    setup_context_and_server_side (
-      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
-      &zap_handler_wrong_version, server_socket_config_,
-      server_socket_config_data_);
-    test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
-                             client_socket_config_, client_socket_config_data_);
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
-                                      handler);
-
-    //  wrong request id
-    fprintf (stderr, "test_zap_protocol_error wrong_request_id\n");
-    setup_context_and_server_side (
-      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
-      &zap_handler_wrong_request_id, server_socket_config_,
-      server_socket_config_data_);
-    test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
-                             client_socket_config_, client_socket_config_data_);
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
-                                      handler);
-
-    //  status invalid (not a 3-digit number)
-    fprintf (stderr, "test_zap_protocol_error wrong_status_invalid\n");
-    setup_context_and_server_side (
-      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
-      &zap_handler_wrong_status_invalid, server_socket_config_,
-      server_socket_config_data_);
-    test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
-                             client_socket_config_, client_socket_config_data_);
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
-                                      handler);
-
-    //  too many parts
-    fprintf (stderr, "test_zap_protocol_error too_many_parts\n");
-    setup_context_and_server_side (
-      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
-      &zap_handler_too_many_parts, server_socket_config_,
-      server_socket_config_data_);
-    test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
-                             client_socket_config_, client_socket_config_data_);
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
-                                      handler);
-
-    //  ZAP non-standard cases
-
-    //  TODO make these observable on the client side as well (they are
-    //  transmitted as an ERROR message)
-
-    //  status 300 temporary failure
-    fprintf (stderr, "test_zap_unsuccessful status 300\n");
-    setup_context_and_server_side (
-      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
-      &zap_handler_wrong_status_temporary_failure, server_socket_config_,
-      server_socket_config_data_);
-    test_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-                           ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, EAGAIN,
-#else
-                           0, 0,
-#endif
-                           client_socket_config_, client_socket_config_data_);
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
-                                      handler);
-
-    //  status 500 internal error
-    fprintf (stderr, "test_zap_unsuccessful status 500\n");
-    setup_context_and_server_side (
-      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
-      &zap_handler_wrong_status_internal_error, server_socket_config_);
-    test_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-                           ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, EFAULT,
-#else
-                           0, 0,
-#endif
-                           client_socket_config_, client_socket_config_data_);
-    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
-                                      handler);
-}
-
 int main (void)
 {
     if (!zmq_has ("curve")) {
@@ -1167,11 +588,7 @@ int main (void)
 
     zmq::random_open ();
 
-    //  Generate new keypairs for these tests
-    int rc = zmq_curve_keypair (valid_client_public, valid_client_secret);
-    assert (rc == 0);
-    rc = zmq_curve_keypair (valid_server_public, valid_server_secret);
-    assert (rc == 0);
+    setup_testutil_security_curve ();
 
     int timeout = 250;
 
@@ -1255,11 +672,6 @@ int main (void)
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler);
 
-    curve_client_data_t curve_client_data = {
-      valid_server_public, valid_client_public, valid_client_secret};
-    test_zap_errors (&socket_config_curve_server, NULL,
-                     &socket_config_curve_client, &curve_client_data);
-
     //  tests with misbehaving CURVE client
     fprintf (stderr, "test_curve_security_invalid_hello_wrong_length\n");
     setup_context_and_server_side (&ctx, &handler, &zap_thread, &server,
@@ -1320,7 +732,7 @@ int main (void)
     fprintf (stderr, "test_curve_security_with_valid_credentials (large identity)\n");
     setup_context_and_server_side (
       &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
-      &zap_handler_large_identity, &socket_config_curve_server, NULL,
+      &zap_handler_large_identity, &socket_config_curve_server, &valid_server_secret,
       large_identity);
     test_curve_security_with_valid_credentials (ctx, my_endpoint, server,
                                                 server_mon, timeout);
@@ -1329,7 +741,7 @@ int main (void)
 
     ctx = zmq_ctx_new ();
     test_curve_security_invalid_keysize (ctx);
-    rc = zmq_ctx_term (ctx);
+    int rc = zmq_ctx_term (ctx);
     assert (rc == 0);
 
     zmq::random_close ();

--- a/tests/test_security_zap.cpp
+++ b/tests/test_security_zap.cpp
@@ -197,7 +197,12 @@ int main (void)
 {
     setup_test_environment ();
 
+    fprintf (stderr, "NULL mechanism\n");
+    test_zap_errors (&socket_config_null_server, NULL,
+                     &socket_config_null_client, NULL);
+
     if (zmq_has ("curve")) {
+        fprintf (stderr, "CURVE mechanism\n");
         setup_testutil_security_curve ();
 
         curve_client_data_t curve_client_data = {

--- a/tests/test_security_zap.cpp
+++ b/tests/test_security_zap.cpp
@@ -1,0 +1,208 @@
+/*
+    Copyright (c) 2007-2017 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil_security.hpp"
+
+static void zap_handler_wrong_version (void *ctx)
+{
+    zap_handler_generic (ctx, zap_wrong_version);
+}
+
+static void zap_handler_wrong_request_id (void *ctx)
+{
+    zap_handler_generic (ctx, zap_wrong_request_id);
+}
+
+static void zap_handler_wrong_status_invalid (void *ctx)
+{
+    zap_handler_generic (ctx, zap_status_invalid);
+}
+
+static void zap_handler_wrong_status_temporary_failure (void *ctx)
+{
+    zap_handler_generic (ctx, zap_status_temporary_failure);
+}
+
+static void zap_handler_wrong_status_internal_error (void *ctx)
+{
+    zap_handler_generic (ctx, zap_status_internal_error);
+}
+
+static void zap_handler_too_many_parts (void *ctx)
+{
+    zap_handler_generic (ctx, zap_too_many_parts);
+}
+
+void test_zap_unsuccessful (void *ctx,
+                            char *my_endpoint,
+                            void *server,
+                            void *server_mon,
+                            int expected_event,
+                            int expected_err,
+                            socket_config_fn socket_config_,
+                            void *socket_config_data_)
+{
+    expect_new_client_bounce_fail (ctx, my_endpoint, server, socket_config_,
+                                   socket_config_data_);
+
+    int events_received = 0;
+#ifdef ZMQ_BUILD_DRAFT_API
+    events_received =
+      expect_monitor_event_multiple (server_mon, expected_event, expected_err);
+#endif
+
+    // there may be more than one ZAP request due to repeated attempts by the client
+    assert (events_received == 0
+            || 1 <= zmq_atomic_counter_value (zap_requests_handled));
+}
+
+void test_zap_protocol_error (void *ctx,
+                              char *my_endpoint,
+                              void *server,
+                              void *server_mon,
+                              socket_config_fn socket_config_,
+                              void *socket_config_data_)
+{
+    test_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
+#ifdef ZMQ_BUILD_DRAFT_API
+                           ZMQ_EVENT_HANDSHAKE_FAILED_ZAP, EPROTO,
+#else
+                           0, 0,
+#endif
+                           socket_config_, socket_config_data_);
+}
+
+void test_zap_errors (socket_config_fn server_socket_config_,
+                      void *server_socket_config_data_,
+                      socket_config_fn client_socket_config_,
+                      void *client_socket_config_data_)
+{
+    void *ctx;
+    void *handler;
+    void *zap_thread;
+    void *server;
+    void *server_mon;
+    char my_endpoint[MAX_SOCKET_STRING];
+
+    //  Invalid ZAP protocol tests
+
+    //  wrong version
+    fprintf (stderr, "test_zap_protocol_error wrong_version\n");
+    setup_context_and_server_side (
+      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
+      &zap_handler_wrong_version, server_socket_config_,
+      server_socket_config_data_);
+    test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
+                             client_socket_config_, client_socket_config_data_);
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+                                      handler);
+
+    //  wrong request id
+    fprintf (stderr, "test_zap_protocol_error wrong_request_id\n");
+    setup_context_and_server_side (
+      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
+      &zap_handler_wrong_request_id, server_socket_config_,
+      server_socket_config_data_);
+    test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
+                             client_socket_config_, client_socket_config_data_);
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+                                      handler);
+
+    //  status invalid (not a 3-digit number)
+    fprintf (stderr, "test_zap_protocol_error wrong_status_invalid\n");
+    setup_context_and_server_side (
+      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
+      &zap_handler_wrong_status_invalid, server_socket_config_,
+      server_socket_config_data_);
+    test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
+                             client_socket_config_, client_socket_config_data_);
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+                                      handler);
+
+    //  too many parts
+    fprintf (stderr, "test_zap_protocol_error too_many_parts\n");
+    setup_context_and_server_side (
+      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
+      &zap_handler_too_many_parts, server_socket_config_,
+      server_socket_config_data_);
+    test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
+                             client_socket_config_, client_socket_config_data_);
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+                                      handler);
+
+    //  ZAP non-standard cases
+
+    //  TODO make these observable on the client side as well (they are
+    //  transmitted as an ERROR message)
+
+    //  status 300 temporary failure
+    fprintf (stderr, "test_zap_unsuccessful status 300\n");
+    setup_context_and_server_side (
+      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
+      &zap_handler_wrong_status_temporary_failure, server_socket_config_,
+      server_socket_config_data_);
+    test_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
+#ifdef ZMQ_BUILD_DRAFT_API
+                           ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, EAGAIN,
+#else
+                           0, 0,
+#endif
+                           client_socket_config_, client_socket_config_data_);
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+                                      handler);
+
+    //  status 500 internal error
+    fprintf (stderr, "test_zap_unsuccessful status 500\n");
+    setup_context_and_server_side (
+      &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
+      &zap_handler_wrong_status_internal_error, server_socket_config_);
+    test_zap_unsuccessful (ctx, my_endpoint, server, server_mon,
+#ifdef ZMQ_BUILD_DRAFT_API
+                           ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, EFAULT,
+#else
+                           0, 0,
+#endif
+                           client_socket_config_, client_socket_config_data_);
+    shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
+                                      handler);
+}
+
+int main (void)
+{
+    setup_test_environment ();
+
+    if (zmq_has ("curve")) {
+        setup_testutil_security_curve ();
+
+        curve_client_data_t curve_client_data = {
+          valid_server_public, valid_client_public, valid_client_secret};
+        test_zap_errors (&socket_config_curve_server, valid_server_secret,
+                         &socket_config_curve_client, &curve_client_data);
+    }
+}

--- a/tests/test_security_zap.cpp
+++ b/tests/test_security_zap.cpp
@@ -201,6 +201,10 @@ int main (void)
     test_zap_errors (&socket_config_null_server, NULL,
                      &socket_config_null_client, NULL);
 
+    fprintf (stderr, "PLAIN mechanism\n");
+    test_zap_errors (&socket_config_plain_server, NULL,
+                     &socket_config_plain_client, NULL);
+
     if (zmq_has ("curve")) {
         fprintf (stderr, "CURVE mechanism\n");
         setup_testutil_security_curve ();

--- a/tests/testutil_security.hpp
+++ b/tests/testutil_security.hpp
@@ -1,0 +1,465 @@
+/*
+    Copyright (c) 2007-2017 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __TESTUTIL_SECURITY_HPP_INCLUDED__
+#define __TESTUTIL_SECURITY_HPP_INCLUDED__
+
+#include "testutil.hpp"
+
+//  security test utils
+
+typedef void(socket_config_fn) (void *, void *);
+
+//  CURVE specific functions
+
+//  We'll generate random test keys at startup
+char valid_client_public[41];
+char valid_client_secret[41];
+char valid_server_public[41];
+char valid_server_secret[41];
+
+void setup_testutil_security_curve ()
+{
+    //  Generate new keypairs for these tests
+    int rc = zmq_curve_keypair (valid_client_public, valid_client_secret);
+    assert (rc == 0);
+    rc = zmq_curve_keypair (valid_server_public, valid_server_secret);
+    assert (rc == 0);
+}
+
+void socket_config_curve_server (void *server, void *server_secret)
+{
+    int as_server = 1;
+    int rc = zmq_setsockopt (server, ZMQ_CURVE_SERVER, &as_server, sizeof (int));
+    assert (rc == 0);
+
+    rc = zmq_setsockopt (server, ZMQ_CURVE_SECRETKEY, server_secret, 41);
+    assert (rc == 0);
+}
+
+struct curve_client_data_t
+{
+    const char *server_public;
+    const char *client_public;
+    const char *client_secret;
+};
+
+void socket_config_curve_client (void *client, void *data)
+{
+    curve_client_data_t *curve_client_data =
+      static_cast<curve_client_data_t *> (data);
+
+    int rc = zmq_setsockopt (client, ZMQ_CURVE_SERVERKEY,
+                             curve_client_data->server_public, 41);
+    assert (rc == 0);
+    rc = zmq_setsockopt (client, ZMQ_CURVE_PUBLICKEY,
+                         curve_client_data->client_public, 41);
+    assert (rc == 0);
+    rc = zmq_setsockopt (client, ZMQ_CURVE_SECRETKEY,
+                         curve_client_data->client_secret, 41);
+    assert (rc == 0);
+}
+
+//  --------------------------------------------------------------------------
+//  This methods receives and validates ZAP requests (allowing or denying
+//  each client connection).
+
+enum zap_protocol_t
+{
+  zap_ok,
+  // ZAP-compliant non-standard cases
+  zap_status_temporary_failure,
+  zap_status_internal_error,
+  // ZAP protocol errors
+  zap_wrong_version,
+  zap_wrong_request_id,
+  zap_status_invalid,
+  zap_too_many_parts
+};
+
+void *zap_requests_handled;
+
+void zap_handler_generic (void *ctx,
+                          zap_protocol_t zap_protocol,
+                          const char *expected_identity = "IDENT")
+{
+    void *control = zmq_socket (ctx, ZMQ_REQ);
+    assert (control);
+    int rc = zmq_connect (control, "inproc://handler-control");
+    assert (rc == 0);
+
+    void *handler = zmq_socket (ctx, ZMQ_REP);
+    assert (handler);
+    rc = zmq_bind (handler, "inproc://zeromq.zap.01");
+    assert (rc == 0);
+
+    //  Signal main thread that we are ready
+    rc = s_send (control, "GO");
+    assert (rc == 2);
+
+    zmq_pollitem_t items[] = {
+      {control, 0, ZMQ_POLLIN, 0}, {handler, 0, ZMQ_POLLIN, 0},
+    };
+
+    //  Process ZAP requests forever
+    while (zmq_poll (items, 2, -1) >= 0) {
+        if (items[0].revents & ZMQ_POLLIN) {
+            char *buf = s_recv (control);
+            assert (buf);
+            assert (streq (buf, "STOP"));
+            free (buf);
+            break; //  Terminating - main thread signal
+        }
+        if (!(items[1].revents & ZMQ_POLLIN))
+            continue;
+
+        char *version = s_recv (handler);
+        if (!version)
+            break; //  Terminating - peer's socket closed
+
+        char *sequence = s_recv (handler);
+        char *domain = s_recv (handler);
+        char *address = s_recv (handler);
+        char *identity = s_recv (handler);
+        char *mechanism = s_recv (handler);
+        uint8_t client_key[32];
+        int size = zmq_recv (handler, client_key, 32, 0);
+        assert (size == 32);
+
+        char client_key_text[41];
+        zmq_z85_encode (client_key_text, client_key, 32);
+
+        assert (streq (version, "1.0"));
+        assert (streq (mechanism, "CURVE"));
+        assert (streq (identity, expected_identity));
+
+        s_sendmore (handler, zap_protocol == zap_wrong_version
+                               ? "invalid_version"
+                               : version);
+        s_sendmore (handler, zap_protocol == zap_wrong_request_id
+                               ? "invalid_request_id"
+                               : sequence);
+
+        if (streq (client_key_text, valid_client_public)) {
+            const char *status_code;
+            switch (zap_protocol) {
+                case zap_status_internal_error:
+                    status_code = "500";
+                    break;
+                case zap_status_temporary_failure:
+                    status_code = "300";
+                    break;
+                case zap_status_invalid:
+                    status_code = "invalid_status";
+                    break;
+                default:
+                    status_code = "200";
+            }
+            s_sendmore (handler, status_code);
+            s_sendmore (handler, "OK");
+            s_sendmore (handler, "anonymous");
+            if (zap_protocol == zap_too_many_parts) {
+                s_sendmore (handler, "");
+            }
+            s_send (handler, "");
+        } else {
+            s_sendmore (handler, "400");
+            s_sendmore (handler, "Invalid client public key");
+            s_sendmore (handler, "");
+            s_send (handler, "");
+        }
+        free (version);
+        free (sequence);
+        free (domain);
+        free (address);
+        free (identity);
+        free (mechanism);
+
+        zmq_atomic_counter_inc (zap_requests_handled);
+    }
+    rc = zmq_unbind (handler, "inproc://zeromq.zap.01");
+    assert (rc == 0);
+    close_zero_linger (handler);
+
+    rc = s_send (control, "STOPPED");
+    assert (rc == 7);
+    close_zero_linger (control);
+}
+
+void zap_handler (void *ctx)
+{
+    zap_handler_generic (ctx, zap_ok);
+}
+
+void setup_context_and_server_side (
+  void **ctx,
+  void **handler,
+  void **zap_thread,
+  void **server,
+  void **server_mon,
+  char *my_endpoint,
+  zmq_thread_fn zap_handler_ = &zap_handler,
+  socket_config_fn socket_config_ = &socket_config_curve_server,
+  void *socket_config_data_ = valid_server_secret,
+  const char *identity = "IDENT")
+{
+    *ctx = zmq_ctx_new ();
+    assert (*ctx);
+
+    //  Spawn ZAP handler
+    zap_requests_handled = zmq_atomic_counter_new ();
+    assert (zap_requests_handled != NULL);
+
+    *handler = zmq_socket (*ctx, ZMQ_REP);
+    assert (*handler);
+    int rc = zmq_bind (*handler, "inproc://handler-control");
+    assert (rc == 0);
+
+    *zap_thread = zmq_threadstart (zap_handler_, *ctx);
+
+    char *buf = s_recv (*handler);
+    assert (buf);
+    assert (streq (buf, "GO"));
+    free (buf);
+
+    //  Server socket will accept connections
+    *server = zmq_socket (*ctx, ZMQ_DEALER);
+    assert (*server);
+
+    socket_config_ (*server, socket_config_data_);
+
+    rc = zmq_setsockopt (*server, ZMQ_IDENTITY, identity, strlen(identity));
+    assert (rc == 0);
+
+    rc = zmq_bind (*server, "tcp://127.0.0.1:*");
+    assert (rc == 0);
+
+    size_t len = MAX_SOCKET_STRING;
+    rc = zmq_getsockopt (*server, ZMQ_LAST_ENDPOINT, my_endpoint, &len);
+    assert (rc == 0);
+
+#ifdef ZMQ_BUILD_DRAFT_API
+    char monitor_endpoint [] = "inproc://monitor-server";
+
+    //  Monitor handshake events on the server
+    rc = zmq_socket_monitor (
+      *server, monitor_endpoint,
+      ZMQ_EVENT_HANDSHAKE_SUCCEEDED | ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
+        | ZMQ_EVENT_HANDSHAKE_FAILED_ZAP | ZMQ_EVENT_HANDSHAKE_FAILED_ZMTP
+        | ZMQ_EVENT_HANDSHAKE_FAILED_ENCRYPTION);
+    assert (rc == 0);
+
+    //  Create socket for collecting monitor events
+    *server_mon = zmq_socket (*ctx, ZMQ_PAIR);
+    assert (*server_mon);
+
+    //  Connect it to the inproc endpoints so they'll get events
+    rc = zmq_connect (*server_mon, monitor_endpoint);
+    assert (rc == 0);
+#endif
+}
+
+void shutdown_context_and_server_side (void *ctx,
+                                       void *zap_thread,
+                                       void *server,
+                                       void *server_mon,
+                                       void *handler)
+{
+    int rc = s_send (handler, "STOP");
+    assert (rc == 4);
+    char *buf = s_recv (handler);
+    assert (buf);
+    assert (streq (buf, "STOPPED"));
+    free (buf);
+    rc = zmq_unbind (handler, "inproc://handler-control");
+    assert (rc == 0);
+    close_zero_linger (handler);
+
+#ifdef ZMQ_BUILD_DRAFT_API
+    close_zero_linger (server_mon);
+#endif
+    close_zero_linger (server);
+
+    //  Wait until ZAP handler terminates
+    zmq_threadclose (zap_thread);
+
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+
+    zmq_atomic_counter_destroy (&zap_requests_handled);
+}
+
+void *create_and_connect_client (void *ctx,
+                                 char *my_endpoint,
+                                 socket_config_fn socket_config_,
+                                 void *socket_config_data_)
+{
+    void *client = zmq_socket (ctx, ZMQ_DEALER);
+    assert (client);
+
+    socket_config_ (client, socket_config_data_);
+
+    int rc = zmq_connect (client, my_endpoint);
+    assert (rc == 0);
+
+    return client;
+}
+
+void expect_new_client_bounce_fail (void *ctx,
+                                    char *my_endpoint,
+                                    void *server,
+                                    socket_config_fn socket_config_,
+                                    void *socket_config_data_)
+{
+    void *client = create_and_connect_client (ctx, my_endpoint, socket_config_,
+                                              socket_config_data_);
+    expect_bounce_fail (server, client);
+    close_zero_linger (client);
+}
+
+//  Monitor event utilities
+
+//  Read one event off the monitor socket; return value and address
+//  by reference, if not null, and event number by value. Returns -1
+//  in case of error.
+
+static int
+get_monitor_event_internal (void *monitor, int *value, char **address, int recv_flag)
+{
+    //  First frame in message contains event number and value
+    zmq_msg_t msg;
+    zmq_msg_init (&msg);
+    if (zmq_msg_recv (&msg, monitor, recv_flag) == -1) {
+        assert (errno == EAGAIN);
+        return -1; //  timed out or no message available
+    }
+    assert (zmq_msg_more (&msg));
+
+    uint8_t *data = (uint8_t *) zmq_msg_data (&msg);
+    uint16_t event = *(uint16_t *) (data);
+    if (value)
+        *value = *(uint32_t *) (data + 2);
+
+    //  Second frame in message contains event address
+    zmq_msg_init (&msg);
+    int res = zmq_msg_recv (&msg, monitor, recv_flag) == -1;
+    assert (res != -1);
+    assert (!zmq_msg_more (&msg));
+
+    if (address) {
+        uint8_t *data = (uint8_t *) zmq_msg_data (&msg);
+        size_t size = zmq_msg_size (&msg);
+        *address = (char *) malloc (size + 1);
+        memcpy (*address, data, size);
+        *address [size] = 0;
+    }
+    return event;
+}
+
+int get_monitor_event_with_timeout (void *monitor,
+                                    int *value,
+                                    char **address,
+                                    int timeout)
+{
+    int res;
+    if (timeout == -1) {
+        // process infinite timeout in small steps to allow the user
+        // to see some information on the console
+
+        int timeout_step = 250;
+        int wait_time = 0;
+        zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout_step,
+                        sizeof (timeout_step));
+        while ((res = get_monitor_event_internal (monitor, value, address, 0))
+               == -1) {
+            wait_time += timeout_step;
+            fprintf (stderr, "Still waiting for monitor event after %i ms\n",
+                     wait_time);
+        }
+    } else {
+        zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
+        res = get_monitor_event_internal (monitor, value, address, 0);
+    }
+    int timeout_infinite = -1;
+    zmq_setsockopt (monitor, ZMQ_RCVTIMEO, &timeout_infinite,
+                    sizeof (timeout_infinite));
+    return res;
+}
+
+#ifdef ZMQ_BUILD_DRAFT_API
+//  expects that one or more occurrences of the expected event are received 
+//  via the specified socket monitor
+//  returns the number of occurrences of the expected event
+//  interrupts, if a ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL with EPIPE, ECONNRESET
+//  or ECONNABORTED occurs; in this case, 0 is returned
+//  this should be investigated further, see 
+//  https://github.com/zeromq/libzmq/issues/2644
+int expect_monitor_event_multiple (void *server_mon,
+                                   int expected_event,
+                                   int expected_err = -1)
+{
+    int count_of_expected_events = 0;
+    int client_closed_connection = 0;
+    //  infinite timeout at the start
+    int timeout = -1;
+
+    int event;
+    int err;
+    while (
+      (event = get_monitor_event_with_timeout (server_mon, &err, NULL, timeout))
+      != -1) {
+        timeout = 250;
+
+        // ignore errors with EPIPE/ECONNRESET/ECONNABORTED, which can happen
+        // ECONNRESET can happen on very slow machines, when the engine writes
+        // to the peer and then tries to read the socket before the peer reads
+        // ECONNABORTED happens when a client aborts a connection via RST/timeout
+        if (event == ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL &&
+                (err == EPIPE || err == ECONNRESET || err == ECONNABORTED)) {
+            fprintf (
+              stderr,
+              "Ignored event (skipping any further events): %x (err = %i)\n",
+              event, err);
+            client_closed_connection = 1;
+            break;
+        }
+        if (event != expected_event
+            || (-1 != expected_err && err != expected_err)) {
+            fprintf (stderr, "Unexpected event: %x (err = %i)\n", event, err);
+            assert (false);
+        }
+        ++count_of_expected_events;
+    }
+    assert (count_of_expected_events > 0 || client_closed_connection);
+
+    return count_of_expected_events;
+}
+#endif
+
+#endif


### PR DESCRIPTION
Solution: Extracted the ZAP handling code into classes used by all mechanisms, and added tests for ZAP errors for NULL and PLAIN mechanisms