### PR TITLE
specify that groups shall be UTF8

### DIFF
--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -160,6 +160,7 @@ and each message sent by Radio sockets belong to a group.
 
 Groups are null terminated strings limited to 16 chars length (including null).
 The intention is to increase the length to 40 chars (including null).
+The encoding of groups shall be UTF8.
 
 Groups are matched using exact matching (vs prefix matching of PubSub).
 


### PR DESCRIPTION
group being defined as a null-terminated `char *` is logically a text type, which needs an encoding.

Declare in the API that groups shall be UTF8-encoded, matching the `zmq_msg_gets` API, which is the other user-facing null-terminated `char *` API, and has the same encoding specification.

This allows bindings in languages that distinguish bytes from text strings to provide text-type APIs to groups, which they cannot do if arbitrary (non-null) bytes are allowed.