### PR TITLE
Problem: coverage CI job does not print test errors

### DIFF
--- a/builds/coverage/ci_build.sh
+++ b/builds/coverage/ci_build.sh
@@ -29,4 +29,4 @@ fi
 pip install --user cpp-coveralls
 
 # Build, check, and install from local source
-( cd ../..; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j5 check && coveralls --exclude tests --build-root . --gcov-options '\-lp') || exit 1
+( cd ../..; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make VERBOSE=1 -j5 check && coveralls --exclude tests --build-root . --gcov-options '\-lp') || exit 1


### PR DESCRIPTION
Solution: run make check with VERBOSE=1