### PR TITLE
Problem: test_monitor fails sometimes due to a wrong event received but unclear which one

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(tests
         test_base85
         test_bind_after_connect_tcp
         test_sodium
+        test_monitor
 )
 if(ZMQ_HAVE_CURVE)
   list(APPEND tests 
@@ -75,7 +76,6 @@ if(ZMQ_HAVE_CURVE)
 endif()
 if(NOT WIN32)
   list(APPEND tests
-          test_monitor
           test_ipc_wildcard
           test_pair_ipc
           test_reqrep_ipc

--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -28,41 +28,7 @@
 */
 
 #include "testutil.hpp"
-
-//  Read one event off the monitor socket; return value and address
-//  by reference, if not null, and event number by value. Returns -1
-//  in case of error.
-
-static int
-get_monitor_event (void *monitor, int *value, char **address)
-{
-    //  First frame in message contains event number and value
-    zmq_msg_t msg; 
-    zmq_msg_init (&msg);
-    if (zmq_msg_recv (&msg, monitor, 0) == -1)
-        return -1;              //  Interruped, presumably
-    assert (zmq_msg_more (&msg));
-    
-    uint8_t *data = (uint8_t *) zmq_msg_data (&msg);
-    uint16_t event = *(uint16_t *) (data);
-    if (value)
-        *value = *(uint32_t *) (data + 2);
-
-    //  Second frame in message contains event address
-    zmq_msg_init (&msg);
-    if (zmq_msg_recv (&msg, monitor, 0) == -1)
-        return -1;              //  Interruped, presumably
-    assert (!zmq_msg_more (&msg));
-    
-    if (address) {
-        uint8_t *data = (uint8_t *) zmq_msg_data (&msg);
-        size_t size = zmq_msg_size (&msg);
-        *address = (char *) malloc (size + 1);
-        memcpy (*address, data, size);
-        *address [size] = 0;
-    }
-    return event;
-}
+#include "testutil_security.hpp"
 
 int main (void)
 {
@@ -121,20 +87,15 @@ int main (void)
         event = get_monitor_event (client_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_CONNECTED);
 #ifdef ZMQ_BUILD_DRAFT_API
-    event = get_monitor_event (client_mon, NULL, NULL);
-    assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
+    expect_monitor_event (client_mon, ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
 #endif
-    event = get_monitor_event (client_mon, NULL, NULL);
-    assert (event == ZMQ_EVENT_MONITOR_STOPPED);
+    expect_monitor_event (client_mon, ZMQ_EVENT_MONITOR_STOPPED);
 
     //  This is the flow of server events
-    event = get_monitor_event (server_mon, NULL, NULL);
-    assert (event == ZMQ_EVENT_LISTENING);
-    event = get_monitor_event (server_mon, NULL, NULL);
-    assert (event == ZMQ_EVENT_ACCEPTED);
+    expect_monitor_event (server_mon, ZMQ_EVENT_LISTENING);
+    expect_monitor_event (server_mon, ZMQ_EVENT_ACCEPTED);
 #ifdef ZMQ_BUILD_DRAFT_API
-    event = get_monitor_event (server_mon, NULL, NULL);
-    assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
+    expect_monitor_event (server_mon, ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
 #endif
     event = get_monitor_event (server_mon, NULL, NULL);
     //  Sometimes the server sees the client closing before it gets closed.

--- a/tests/testutil_security.hpp
+++ b/tests/testutil_security.hpp
@@ -499,6 +499,22 @@ int get_monitor_event_with_timeout (void *monitor,
     return res;
 }
 
+int get_monitor_event (void *monitor, int *value, char **address)
+{
+    return get_monitor_event_with_timeout (monitor, value, address, -1);
+}
+
+void expect_monitor_event (void *monitor, int expected_event)
+{
+    int event = get_monitor_event (monitor, NULL, NULL);
+    if (event != expected_event)
+    {
+        fprintf (stderr, "Expected monitor event %x but received %x\n",
+                 expected_event, event);
+        assert (event == expected_event);
+    }
+}
+
 #ifdef ZMQ_BUILD_DRAFT_API
 
 void print_unexpected_event (int event,


### PR DESCRIPTION
Solution: add diagnostic output

This also re-enables test_monitor on Windows builds.