### PR TITLE
Problem: ZMQ_HAVE_O_CLOEXEC always disabled

### DIFF
--- a/builds/cmake/Modules/ZMQSourceRunChecks.cmake
+++ b/builds/cmake/Modules/ZMQSourceRunChecks.cmake
@@ -41,7 +41,7 @@ macro(zmq_check_o_cloexec)
 
 int main(int argc, char *argv [])
 {
-    int s = open ("/dev/null", O_CLOEXEC | O_RDONLY);
+    int s = open (\"/dev/null\", O_CLOEXEC | O_RDONLY);
     return (s == -1);
 }
 "


### PR DESCRIPTION
Solution: Escape quotes in cmake test.