### PR TITLE
Excessive check options.mechanism == ZMQ_NULL

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -374,7 +374,7 @@ bool zmq::session_base_t::zap_enabled ()
 {
     return (
          options.mechanism != ZMQ_NULL ||
-        (options.mechanism == ZMQ_NULL && options.zap_domain.length() > 0)
+         !options.zap_domain.empty()
     );
 }
 


### PR DESCRIPTION
V728 An excessive check 'options.mechanism == 0' can be simplified.
 The '||' operator is surrounded by opposite expressions. session_base.cpp 377
