### PR TITLE
Add "STATISTICS" command to zmq_proxy_steerable() 

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -154,9 +154,9 @@ int forward (
 
     // A multipart message counts as 1 packet:
     from_stats->msg_in++;
-    from_stats->bytes_in+=complete_msg_size;
+    from_stats->bytes_in += complete_msg_size;
     to_stats->msg_out++;
-    to_stats->bytes_out+=complete_msg_size;
+    to_stats->bytes_out += complete_msg_size;
 
     return 0;
 }
@@ -169,11 +169,11 @@ int reply_stats(
     // first part: frontend stats
 
     zmq::msg_t stats_msg1, stats_msg2;
-    int rc = stats_msg1.init_size( sizeof(zmq_socket_stats_t) );
+    int rc = stats_msg1.init_size (sizeof(zmq_socket_stats_t));
     if (unlikely (rc < 0))
         return close_and_return (&stats_msg1, -1);
 
-    memcpy( stats_msg1.data(), (const void*) frontend_stats, sizeof(zmq_socket_stats_t) );
+    memcpy (stats_msg1.data(), (const void*) frontend_stats, sizeof(zmq_socket_stats_t));
 
     rc = control_->send (&stats_msg1, ZMQ_SNDMORE);
     if (unlikely (rc < 0))
@@ -181,10 +181,10 @@ int reply_stats(
 
     // second part: backend stats
 
-    rc = stats_msg2.init_size( sizeof(zmq_socket_stats_t) );
+    rc = stats_msg2.init_size (sizeof(zmq_socket_stats_t));
     if (unlikely (rc < 0))
         return close_and_return (&stats_msg2, -1);
-    memcpy( stats_msg2.data(), (const void*) backend_stats,  sizeof(zmq_socket_stats_t) );
+    memcpy (stats_msg2.data(), (const void*) backend_stats, sizeof(zmq_socket_stats_t));
 
     rc = control_->send (&stats_msg2, 0);
     if (unlikely (rc < 0))
@@ -570,7 +570,7 @@ int zmq::proxy (
                         {
                             rc = reply_stats(control_, &frontend_stats, &backend_stats);
                             if (unlikely (rc < 0))
-                                return -1;
+                                return close_and_return (&msg, -1);
                         }
                         else {
                             //  This is an API error, we assert

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -179,9 +179,6 @@ int reply_stats(
     if (unlikely (rc < 0))
         return close_and_return (&stats_msg1, -1);
 
-    stats_msg1.close();
-
-
     // second part: backend stats
 
     rc = stats_msg2.init_size( sizeof(zmq_socket_stats_t) );
@@ -193,7 +190,6 @@ int reply_stats(
     if (unlikely (rc < 0))
         return close_and_return (&stats_msg2, -1);
 
-    stats_msg2.close();
     return 0;
 }
 

--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -48,7 +48,7 @@
 #define ID_SIZE_MAX 32
 #define QT_WORKERS    5
 #define QT_CLIENTS    3
-#define is_verbose 1
+#define is_verbose 0
 
 struct thread_data {
     void *ctx;
@@ -210,8 +210,6 @@ server_task (void *ctx)
     // Control socket receives terminate command from main over inproc
     void *control = zmq_socket (ctx, ZMQ_REP);
     assert (control);
-    /*rc = zmq_setsockopt (control, ZMQ_SUBSCRIBE, "", 0);
-    assert (rc == 0);*/
     rc = zmq_setsockopt (control, ZMQ_LINGER, &linger, sizeof (linger));
     assert (rc == 0);
     rc = zmq_connect (control, "inproc://control_proxy");

--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -48,12 +48,30 @@
 #define ID_SIZE_MAX 32
 #define QT_WORKERS    5
 #define QT_CLIENTS    3
-#define is_verbose 0
+#define is_verbose 1
 
 struct thread_data {
     void *ctx;
     int id;
 };
+
+typedef struct
+{
+    uint64_t pkts_in;
+    uint64_t bytes_in;
+    uint64_t pkts_out;
+    uint64_t bytes_out;
+} zmq_socket_stats_t;
+
+typedef struct
+{
+    zmq_socket_stats_t frontend;
+    zmq_socket_stats_t backend;
+} zmq_proxy_stats_t;
+
+void *g_clients_pkts_out = NULL;
+void *g_workers_pkts_out = NULL;
+
 
 static void
 client_task (void *db)
@@ -100,6 +118,7 @@ client_task (void *db)
     zmq_pollitem_t items [] = { { client, 0, ZMQ_POLLIN, 0 }, { control, 0, ZMQ_POLLIN, 0 } };
     int request_nbr = 0;
     bool run = true;
+    bool keep_sending = true;
     while (run) {
         // Tick once per 200 ms, pulling in arriving messages
         int centitick;
@@ -119,16 +138,32 @@ client_task (void *db)
             }
             if (items [1].revents & ZMQ_POLLIN) {
                 rc = zmq_recv (control, content, CONTENT_SIZE_MAX, 0);
-                if (is_verbose) printf("client receive - identity = %s    command = %s\n", identity, content);
-                if (memcmp (content, "TERMINATE", 9) == 0) {
-                    run = false;
-                    break;
+
+                if (rc > 0)
+                {
+                    content[rc] = 0;        // NULL-terminate the command string
+                    if (is_verbose) printf("client receive - identity = %s    command = %s\n", identity, content);
+                    if (memcmp (content, "TERMINATE", 9) == 0) {
+                        run = false;
+                        break;
+                    }
+                    if (memcmp (content, "STOP", 4) == 0) {
+                        keep_sending = false;
+                        break;
+                    }
                 }
             }
         }
-        sprintf(content, "request #%03d", ++request_nbr); // CONTENT_SIZE
-        rc = zmq_send (client, content, CONTENT_SIZE, 0);
-        assert (rc == CONTENT_SIZE);
+
+        if (keep_sending)
+        {
+            sprintf(content, "request #%03d", ++request_nbr); // CONTENT_SIZE
+            if (is_verbose) printf("client send - identity = %s    request #%03d\n", identity, request_nbr);
+            zmq_atomic_counter_inc(g_clients_pkts_out);
+
+            rc = zmq_send (client, content, CONTENT_SIZE, 0);
+            assert (rc == CONTENT_SIZE);
+        }
     }
 
     rc = zmq_close (client);
@@ -173,13 +208,13 @@ server_task (void *ctx)
     assert (rc == 0);
 
     // Control socket receives terminate command from main over inproc
-    void *control = zmq_socket (ctx, ZMQ_SUB);
+    void *control = zmq_socket (ctx, ZMQ_REP);
     assert (control);
-    rc = zmq_setsockopt (control, ZMQ_SUBSCRIBE, "", 0);
-    assert (rc == 0);
+    /*rc = zmq_setsockopt (control, ZMQ_SUBSCRIBE, "", 0);
+    assert (rc == 0);*/
     rc = zmq_setsockopt (control, ZMQ_LINGER, &linger, sizeof (linger));
     assert (rc == 0);
-    rc = zmq_connect (control, "inproc://control");
+    rc = zmq_connect (control, "inproc://control_proxy");
     assert (rc == 0);
 
     // Launch pool of worker threads, precise number is not critical
@@ -255,13 +290,17 @@ server_worker (void *ctx)
     char identity [ID_SIZE_MAX];      // the size received is the size sent
 
     bool run = true;
+    bool keep_sending = true;
     while (run) {
         rc = zmq_recv (control, content, CONTENT_SIZE_MAX, ZMQ_DONTWAIT); // usually, rc == -1 (no message)
         if (rc > 0) {
+            content[rc] = 0;        // NULL-terminate the command string
             if (is_verbose)
                 printf("server_worker receives command = %s\n", content);
             if (memcmp (content, "TERMINATE", 9) == 0)
                 run = false;
+            if (memcmp (content, "STOP", 4) == 0)
+                keep_sending = false;
         }
         // The DEALER socket gives us the reply envelope and message
         // if we don't poll, we have to use ZMQ_DONTWAIT, if we poll, we can block-receive with 0
@@ -273,15 +312,22 @@ server_worker (void *ctx)
                 printf ("server receive - identity = %s    content = %s\n", identity, content);
 
             // Send 0..4 replies back
-            int reply, replies = rand() % 5;
-            for (reply = 0; reply < replies; reply++) {
-                // Sleep for some fraction of a second
-                msleep (rand () % 10 + 1);
-                //  Send message from server to client
-                rc = zmq_send (worker, identity, ID_SIZE, ZMQ_SNDMORE);
-                assert (rc == ID_SIZE);
-                rc = zmq_send (worker, content, CONTENT_SIZE, 0);
-                assert (rc == CONTENT_SIZE);
+            if (keep_sending)
+            {
+                int reply, replies = rand() % 5;
+                for (reply = 0; reply < replies; reply++) {
+                    // Sleep for some fraction of a second
+                    msleep (rand () % 10 + 1);
+
+                    //  Send message from server to client
+                    if (is_verbose) printf("server send - identity = %s    reply\n", identity);
+                    zmq_atomic_counter_inc(g_workers_pkts_out);
+
+                    rc = zmq_send (worker, identity, ID_SIZE, ZMQ_SNDMORE);
+                    assert (rc == ID_SIZE);
+                    rc = zmq_send (worker, content, CONTENT_SIZE, 0);
+                    assert (rc == CONTENT_SIZE);
+                }
             }
         }
     }
@@ -300,6 +346,11 @@ int main (void)
 
     void *ctx = zmq_ctx_new ();
     assert (ctx);
+
+    g_clients_pkts_out = zmq_atomic_counter_new ();
+    g_workers_pkts_out = zmq_atomic_counter_new ();
+
+
     // Control socket receives terminate command from main over inproc
     void *control = zmq_socket (ctx, ZMQ_PUB);
     assert (control);
@@ -307,6 +358,14 @@ int main (void)
     int rc = zmq_setsockopt (control, ZMQ_LINGER, &linger, sizeof (linger));
     assert (rc == 0);
     rc = zmq_bind (control, "inproc://control");
+    assert (rc == 0);
+
+    // Control socket receives terminate command from main over inproc
+    void *control_proxy = zmq_socket (ctx, ZMQ_REQ);
+    assert (control_proxy);
+    rc = zmq_setsockopt (control_proxy, ZMQ_LINGER, &linger, sizeof (linger));
+    assert (rc == 0);
+    rc = zmq_bind (control_proxy, "inproc://control_proxy");
     assert (rc == 0);
 
     void *threads [QT_CLIENTS + 1];
@@ -319,10 +378,63 @@ int main (void)
     threads[QT_CLIENTS] = zmq_threadstart  (&server_task, ctx);
     msleep (500); // Run for 500 ms then quit
 
+
+    if (is_verbose)
+        printf ("stopping all clients and server workers\n");
+    rc = zmq_send (control, "STOP", 4, 0);
+    assert (rc == 4);
+
+    msleep(500); // Wait for all clients and workers to STOP
+
+
+    if (is_verbose)
+        printf ("retrieving stats from the proxy\n");
+
+    rc = zmq_send (control_proxy, "STATISTICS", 10, 0);
+    assert (rc == 10);
+
+    zmq_msg_t stats_msg;
+    rc = zmq_msg_init (&stats_msg);
+    assert (rc == 0);
+
+    rc = zmq_recvmsg (control_proxy, &stats_msg, 0);
+    assert (rc == sizeof(zmq_proxy_stats_t));
+
+    zmq_proxy_stats_t* stats = (zmq_proxy_stats_t*)zmq_msg_data(&stats_msg);
+    if (is_verbose)
+    {
+        printf ("frontend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
+                stats->frontend.pkts_in, stats->frontend.bytes_in,
+                stats->frontend.pkts_out, stats->frontend.bytes_out);
+        printf ("backend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
+                stats->backend.pkts_in, stats->backend.bytes_in,
+                stats->backend.pkts_out, stats->backend.bytes_out);
+
+        printf ("clients sent out %d requests\n", zmq_atomic_counter_value(g_clients_pkts_out));
+        printf ("workers sent out %d replies\n", zmq_atomic_counter_value(g_workers_pkts_out));
+    }
+    assert( stats->frontend.pkts_in == (unsigned)zmq_atomic_counter_value(g_clients_pkts_out) );
+    assert( stats->frontend.pkts_out == (unsigned)zmq_atomic_counter_value(g_workers_pkts_out) );
+    assert( stats->backend.pkts_in == (unsigned)zmq_atomic_counter_value(g_workers_pkts_out) );
+    assert( stats->backend.pkts_out == (unsigned)zmq_atomic_counter_value(g_clients_pkts_out) );
+
+    rc = zmq_msg_close (&stats_msg);
+    assert (rc == 0);
+
+    if (is_verbose)
+        printf ("shutting down all clients and server workers\n");
     rc = zmq_send (control, "TERMINATE", 9, 0);
     assert (rc == 9);
 
+    if (is_verbose)
+        printf ("shutting down the proxy now\n");
+    rc = zmq_send (control_proxy, "TERMINATE", 9, 0);
+    assert (rc == 9);
+
+
     rc = zmq_close (control);
+    assert (rc == 0);
+    rc = zmq_close (control_proxy);
     assert (rc == 0);
 
     for (int i = 0; i < QT_CLIENTS + 1; i++)


### PR DESCRIPTION
# Pull Request Notice

```
Problem:
Currently there is no visibility on how many packets / bytes a ZMQ proxy has processed on its frontend/backend socket. The only possible way is using the "capture" socket but that seems overkill to just keep track of packets/bytes passed through the proxy.
A way to retrieve such information would be important, at the very least, for debugging purpose.

Solution:
Attached is the proposed patch to ZMQ master branch to add such feature.
The solution is just to increment counters in the proxy.cpp forward() function and add a new command on the proxy control socket to retrieve them.
```

Fixes https://github.com/zeromq/libzmq/issues/2736
