### PR TITLE
Problems: proxy stats test break 32bit build, not declared as draft

### DIFF
--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -386,16 +386,20 @@ int zmq::proxy (
                     if (msg.size () == 9 && memcmp (msg.data (), "TERMINATE", 9) == 0)
                         state = terminated;
                     else {
+#ifdef ZMQ_BUILD_DRAFT_API
                         if (msg.size () == 10 && memcmp (msg.data (), "STATISTICS", 10) == 0)
                         {
                             rc = reply_stats(control_, &frontend_stats, &backend_stats);
                             CHECK_RC_EXIT_ON_FAILURE ();
                         }
                         else {
+#endif
                             //  This is an API error, we assert
                             puts ("E: invalid command sent to proxy");
                             zmq_assert (false);
+#ifdef ZMQ_BUILD_DRAFT_API
                         }
+#endif
                     }
                 }
             control_in = false;
@@ -566,6 +570,7 @@ int zmq::proxy (
                     if (msg.size () == 9 && memcmp (msg.data (), "TERMINATE", 9) == 0)
                         state = terminated;
                     else {
+#ifdef ZMQ_BUILD_DRAFT_API
                         if (msg.size () == 10 && memcmp (msg.data (), "STATISTICS", 10) == 0)
                         {
                             rc = reply_stats(control_, &frontend_stats, &backend_stats);
@@ -573,10 +578,13 @@ int zmq::proxy (
                                 return close_and_return (&msg, -1);
                         }
                         else {
+#endif
                             //  This is an API error, we assert
                             puts ("E: invalid command sent to proxy");
                             zmq_assert (false);
+#ifdef ZMQ_BUILD_DRAFT_API
                         }
+#endif
                     }
         }
         //  Process a request

--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -451,9 +451,11 @@ int main (void)
     msleep(500); // Wait for all clients and workers to STOP
 
 
+#ifdef ZMQ_BUILD_DRAFT_API
     if (is_verbose)
         printf ("retrieving stats from the proxy\n");
     check_proxy_stats(control_proxy);
+#endif
 
     if (is_verbose)
         printf ("shutting down all clients and server workers\n");

--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -377,11 +377,15 @@ void check_proxy_stats(void *control_proxy)
     if (is_verbose)
     {
         printf ("frontend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
-                total_stats.frontend.msg_in, total_stats.frontend.bytes_in,
-                total_stats.frontend.msg_out, total_stats.frontend.bytes_out);
+                (unsigned long int)total_stats.frontend.msg_in,
+                (unsigned long int)total_stats.frontend.bytes_in,
+                (unsigned long int)total_stats.frontend.msg_out,
+                (unsigned long int)total_stats.frontend.bytes_out);
         printf ("backend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
-                total_stats.backend.msg_in, total_stats.backend.bytes_in,
-                total_stats.backend.msg_out, total_stats.backend.bytes_out);
+                (unsigned long int)total_stats.backend.msg_in,
+                (unsigned long int)total_stats.backend.bytes_in,
+                (unsigned long int)total_stats.backend.msg_out,
+                (unsigned long int)total_stats.backend.bytes_out);
 
         printf ("clients sent out %d requests\n", zmq_atomic_counter_value(g_clients_pkts_out));
         printf ("workers sent out %d replies\n", zmq_atomic_counter_value(g_workers_pkts_out));


### PR DESCRIPTION
Solution: cast the uint64_t to uint32_t to avoid portability nightmare in the test, and wrap response to STATISTICS zmq_proxy_steerable message in \#ifdef draft