### PR TITLE
[WIP][discussion] Adding _peer functions for zmq_poller #2623

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -858,7 +858,8 @@ test_apps += tests/test_poller \
 	tests/test_radio_dish \
 	tests/test_scatter_gather \
 	tests/test_dgram \
-	tests/test_app_meta
+	tests/test_app_meta \
+	tests/test_peer_funcs
 
 tests_test_poller_SOURCES = tests/test_poller.cpp
 tests_test_poller_LDADD = src/libzmq.la ${UNITY_LIBS}
@@ -888,6 +889,11 @@ tests_test_dgram_LDADD = src/libzmq.la
 tests_test_app_meta_SOURCES = tests/test_app_meta.cpp
 tests_test_app_meta_LDADD = src/libzmq.la ${UNITY_LIBS}
 tests_test_app_meta_CPPFLAGS = ${UNITY_CPPFLAGS}
+
+tests_test_peer_funcs_SOURCES = tests/test_peer_funcs.cpp
+tests_test_peer_funcs_LDADD = src/libzmq.la ${UNITY_LIBS}
+tests_test_peer_funcs_CPPFLAGS = ${UNITY_CPPFLAGS}
+
 endif
 
 if ENABLE_STATIC

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -266,6 +266,13 @@ ZMQ_EXPORT int zmq_msg_init_data (
   zmq_msg_t *msg, void *data, size_t size, zmq_free_fn *ffn, void *hint);
 ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg, void *s, int flags);
 ZMQ_EXPORT int zmq_msg_recv (zmq_msg_t *msg, void *s, int flags);
+
+#ifdef ZMQ_BUILD_DRAFT_API
+ZMQ_EXPORT int zmq_mute_peer (void *s_, const void *routing_id,
+				    const int routing_id_len,
+                                    int mute);
+#endif //ZMQ_BUILD_DRAFT_API
+
 ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_move (zmq_msg_t *dest, zmq_msg_t *src);
 ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest, zmq_msg_t *src);
@@ -376,6 +383,23 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 #define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
 #define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
 #define ZMQ_BINDTODEVICE 92
+
+#define ZMQ_PEER_EVENTS 93
+
+#ifdef ZMQ_BUILD_DRAFT_API
+
+/*  getsockopt additional struct to recover peer events                       */
+typedef struct zmq_gso_peer_events_t
+{
+    void *routing_id;
+    int routing_id_len;
+    short events;
+    short reserved;
+}  zmq_gso_peer_events_t;
+
+#define ZMQ_GSO_PEER_EVENTS_SIZE sizeof(zmq_gso_peer_events_t)
+
+#endif //ZMQ_BUILD_DRAFT_API
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
@@ -670,20 +694,41 @@ typedef struct zmq_poller_event_t
 #else
     int fd;
 #endif
+
+#ifdef ZMQ_BUILD_DRAFT_API
+    void *routing_id;
+    int routing_id_len;
+#endif //ZMQ_BUILD_DRAFT_API
+
     void *user_data;
     short events;
 } zmq_poller_event_t;
 
 ZMQ_EXPORT void *zmq_poller_new (void);
-ZMQ_EXPORT int zmq_poller_destroy (void **poller_p);
-ZMQ_EXPORT int
-zmq_poller_add (void *poller, void *socket, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify (void *poller, void *socket, short events);
-ZMQ_EXPORT int zmq_poller_remove (void *poller, void *socket);
-ZMQ_EXPORT int
-zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
-ZMQ_EXPORT int zmq_poller_wait_all (void *poller,
-                                    zmq_poller_event_t *events,
+ZMQ_EXPORT int  zmq_poller_destroy (void **poller_p);
+ZMQ_EXPORT int  zmq_poller_add (void *poller, void *socket, void *user_data,
+                                    short events);
+ZMQ_EXPORT int  zmq_poller_modify (void *poller, void *socket, short events);
+ZMQ_EXPORT int  zmq_poller_remove (void *poller, void *socket);
+
+#ifdef ZMQ_BUILD_DRAFT_API
+ZMQ_EXPORT int  zmq_poller_add_peer (void *poller, void *socket,
+                                    void *routing_id,
+                                    int routing_id_len,
+                                    void *user_data,
+                                    short events);
+ZMQ_EXPORT int  zmq_poller_modify_peer (void *poller, void *socket,
+                                    void *routing_id,
+                                    int routing_id_len,
+                                    short events);
+ZMQ_EXPORT int  zmq_poller_remove_peer (void *poller, void *socket,
+                                    void *routing_id,
+                                    int routing_id_len);
+#endif //ZMQ_BUILD_DRAFT_API
+
+ZMQ_EXPORT int  zmq_poller_wait (void *poller, zmq_poller_event_t *event,
+                                    long timeout);
+ZMQ_EXPORT int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events,
                                     int n_events,
                                     long timeout);
 
@@ -699,9 +744,11 @@ ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
 ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
 #endif
 
+#ifdef ZMQ_BUILD_DRAFT_API
 ZMQ_EXPORT int zmq_socket_get_peer_state (void *socket,
                                           const void *routing_id,
-                                          size_t routing_id_size);
+                                          const size_t routing_id_size);
+#endif //ZMQ_BUILD_DRAFT_API
 
 /******************************************************************************/
 /*  Scheduling timers                                                         */

--- a/src/fq.hpp
+++ b/src/fq.hpp
@@ -56,6 +56,11 @@ class fq_t
     bool has_in ();
     const blob_t &get_credential () const;
 
+#ifdef ZMQ_BUILD_DRAFT_API
+    int mute_peer (const void *routing_id, const int routing_id_len,
+                                const bool mute);
+#endif // ZMQ_BUILD_DRAFT_API
+
   private:
     //  Inbound pipes.
     typedef array_t<pipe_t, 1> pipes_t;

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -100,6 +100,9 @@ zmq::pipe_t::pipe_t (object_t *parent_,
     delay (true),
     server_socket_routing_id (0),
     conflate (conflate_)
+#ifdef ZMQ_BUILD_DRAFT_API
+    , in_mute(false)
+#endif // ZMQ_BUILD_DRAFT_API
 {
 }
 
@@ -155,6 +158,12 @@ bool zmq::pipe_t::check_read ()
     if (unlikely (state != active && state != waiting_for_delimiter))
         return false;
 
+#ifdef ZMQ_BUILD_DRAFT_API
+    //  Socket is muted (incoming direction)
+    if (in_mute)
+        return false;
+#endif // ZMQ_BUILD_DRAFT_API
+
     //  Check if there's an item in the pipe.
     if (!inpipe->check_read ()) {
         in_active = false;
@@ -182,6 +191,13 @@ bool zmq::pipe_t::read (msg_t *msg_)
         return false;
 
 read_message:
+
+#ifdef ZMQ_BUILD_DRAFT_API
+    //  Socket is muted (incoming direction)
+    if (in_mute)
+        return false;
+#endif // ZMQ_BUILD_DRAFT_API
+
     if (!inpipe->read (msg_)) {
         in_active = false;
         return false;

--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -143,6 +143,13 @@ class pipe_t : public object_t,
     //  Returns true if HWM is not reached
     bool check_hwm () const;
 
+#ifdef ZMQ_BUILD_DRAFT_API
+    void set_mute (const bool mute)
+    {
+        in_mute = mute;
+    };
+#endif // ZMQ_BUILD_DRAFT_API
+
   private:
     //  Type of the underlying lock-free pipe.
     typedef ypipe_base_t<msg_t> upipe_t;
@@ -248,6 +255,11 @@ class pipe_t : public object_t,
     static int compute_lwm (int hwm_);
 
     const bool conflate;
+
+#ifdef ZMQ_BUILD_DRAFT_API
+    //  Mute pipe (in)
+    bool in_mute;
+#endif // ZMQ_BUILD_DRAFT_API
 
     //  Disable copying.
     pipe_t (const pipe_t &);

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -443,6 +443,12 @@ const zmq::blob_t &zmq::router_t::get_credential () const
 }
 
 #ifdef ZMQ_BUILD_DRAFT_API
+int zmq::router_t::mute_peer (const void *routing_id, const int routing_id_len,
+                                const bool mute)
+{
+    return fq.mute_peer (routing_id, routing_id_len, mute);
+}
+
 int zmq::router_t::get_peer_state (const void *routing_id_,
                                    size_t routing_id_size_) const
 {

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -442,6 +442,7 @@ const zmq::blob_t &zmq::router_t::get_credential () const
     return fq.get_credential ();
 }
 
+#ifdef ZMQ_BUILD_DRAFT_API
 int zmq::router_t::get_peer_state (const void *routing_id_,
                                    size_t routing_id_size_) const
 {
@@ -462,6 +463,7 @@ int zmq::router_t::get_peer_state (const void *routing_id_,
 
     return res;
 }
+#endif // ZMQ_BUILD_DRAFT_API
 
 bool zmq::router_t::identify_peer (pipe_t *pipe_)
 {

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -62,6 +62,8 @@ class router_t : public socket_base_t
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);
 #ifdef ZMQ_BUILD_DRAFT_API
+    int mute_peer (const void *routing_id, const int routing_id_len,
+                                const bool mute);
     int get_peer_state (const void *identity, size_t identity_size) const;
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -61,7 +61,9 @@ class router_t : public socket_base_t
     void xread_activated (zmq::pipe_t *pipe_);
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);
+#ifdef ZMQ_BUILD_DRAFT_API
     int get_peer_state (const void *identity, size_t identity_size) const;
+#endif // ZMQ_BUILD_DRAFT_API
 
   protected:
     //  Rollback any message parts that were sent but not yet flushed.

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -228,16 +228,31 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_,
     }
 }
 
-int zmq::socket_base_t::get_peer_state (const void *routing_id_,
-                                        size_t routing_id_size_) const
-{
-    LIBZMQ_UNUSED (routing_id_);
-    LIBZMQ_UNUSED (routing_id_size_);
+#ifdef ZMQ_BUILD_DRAFT_API
+
+int zmq::socket_base_t::mute_peer (const void *routing_id,
+                                const int routing_id_size,
+                                const bool mute){
+    LIBZMQ_UNUSED (routing_id);
+    LIBZMQ_UNUSED (routing_id_size);
 
     //  Only ROUTER sockets support this
     errno = ENOTSUP;
     return -1;
 }
+
+int zmq::socket_base_t::get_peer_state (const void *routing_id,
+                                        size_t routing_id_size) const
+{
+    LIBZMQ_UNUSED (routing_id);
+    LIBZMQ_UNUSED (routing_id_size);
+
+    //  Only ROUTER sockets support this
+    errno = ENOTSUP;
+    return -1;
+}
+
+#endif // ZMQ_BUILD_DRAFT_API
 
 zmq::socket_base_t::~socket_base_t ()
 {
@@ -424,6 +439,11 @@ int zmq::socket_base_t::getsockopt (int option_,
         return do_getsockopt<int> (optval_, optvallen_,
                                    (has_out () ? ZMQ_POLLOUT : 0)
                                      | (has_in () ? ZMQ_POLLIN : 0));
+    }
+
+    if (option_ == ZMQ_PEER_EVENTS) {
+            errno = EINVAL;
+            return -1;
     }
 
     if (option_ == ZMQ_LAST_ENDPOINT) {

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -89,6 +89,13 @@ class socket_base_t : public own_t,
     int term_endpoint (const char *addr_);
     int send (zmq::msg_t *msg_, int flags_);
     int recv (zmq::msg_t *msg_, int flags_);
+
+#ifdef ZMQ_BUILD_DRAFT_API
+    //  Mute a specific routing-id
+    virtual int mute_peer (const void *routing_id, const int routing_id_len,
+                                const bool mute);
+#endif // ZMQ_BUILD_DRAFT_API
+
     void add_signaler (signaler_t *s);
     void remove_signaler (signaler_t *s);
     int close ();
@@ -137,10 +144,12 @@ class socket_base_t : public own_t,
     void event_handshake_failed_auth (const std::string &addr_, int err_);
     void event_handshake_succeeded (const std::string &addr_, int err_);
 
+#ifdef ZMQ_BUILD_DRAFT_API
     //  Query the state of a specific peer. The default implementation
     //  always returns an ENOTSUP error.
-    virtual int get_peer_state (const void *identity,
-                                size_t identity_size) const;
+    virtual int get_peer_state (const void *routing_id,
+                                 size_t routing_id_len) const;
+#endif // ZMQ_BUILD_DRAFT_API
 
   protected:
     socket_base_t (zmq::ctx_t *parent_,

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -64,13 +64,41 @@ class socket_poller_t
     {
         socket_base_t *socket;
         fd_t fd;
+#ifdef ZMQ_BUILD_DRAFT_API
+        void *routing_id;
+        int routing_id_len;
+#endif // ZMQ_BUILD_DRAFT_API
         void *user_data;
         short events;
     } event_t;
 
-    int add (socket_base_t *socket, void *user_data, short events);
-    int modify (socket_base_t *socket, short events);
-    int remove (socket_base_t *socket);
+    int add (socket_base_t *socket,
+#ifdef ZMQ_BUILD_DRAFT_API
+                    void *routing_id, int routing_id_len,
+#endif // ZMQ_BUILD_DRAFT_API
+                    void *user_data, short events);
+    int modify (socket_base_t *socket,
+#ifdef ZMQ_BUILD_DRAFT_API
+                    void *routing_id, int routing_id_len,
+#endif // ZMQ_BUILD_DRAFT_API
+                    short events);
+    int remove (socket_base_t *socket
+#ifdef ZMQ_BUILD_DRAFT_API
+                    , void *routing_id, int routing_id_len
+#endif // ZMQ_BUILD_DRAFT_API
+                    );
+
+#ifdef ZMQ_BUILD_DRAFT_API
+    inline int add (socket_base_t *socket, void *user_data, short events) {
+        return add(socket, NULL, 0, user_data, events);
+    };
+    inline int modify (socket_base_t *socket, short events) {
+        return modify(socket, NULL, 0, events);
+    };
+    inline int remove (socket_base_t *socket) {
+        return remove(socket, NULL, 0);
+    };
+#endif // ZMQ_BUILD_DRAFT_API
 
     int add_fd (fd_t fd, void *user_data, short events);
     int modify_fd (fd_t fd, short events);
@@ -115,6 +143,11 @@ class socket_poller_t
         fd_t fd;
         void *user_data;
         short events;
+#ifdef ZMQ_BUILD_DRAFT_API
+        void *routing_id;
+        int routing_id_len;
+#endif // ZMQ_BUILD_DRAFT_API
+
 #if defined ZMQ_POLL_BASED_ON_POLL
         int pollfd_index;
 #endif

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -496,6 +496,12 @@ int zmq_mute_peer (void *s_, const void *routing_id, const int routing_id_len,
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
         return -1;
+
+    if (!routing_id || routing_id_len == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
     return s->mute_peer (routing_id, routing_id_len, mute);
 }
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -488,6 +488,19 @@ int zmq_recv (void *s_, void *buf_, size_t len_, int flags_)
     return nbytes;
 }
 
+#ifdef ZMQ_BUILD_DRAFT_API
+
+int zmq_mute_peer (void *s_, const void *routing_id, const int routing_id_len,
+                                     int mute)
+{
+    zmq::socket_base_t *s = as_socket_base_t (s_);
+    if (!s)
+        return -1;
+    return s->mute_peer (routing_id, routing_id_len, mute);
+}
+
+#endif //ZMQ_BUILD_DRAFT_API
+
 // Receive a multi-part message
 //
 // Receives up to *count_ parts of a multi-part message.
@@ -1202,6 +1215,8 @@ int zmq_poller_add (void *poller_, void *s_, void *user_data_, short events_)
       ->add (socket, user_data_, events_);
 }
 
+
+
 #if defined _WIN32
 int zmq_poller_add_fd (void *poller_,
                        SOCKET fd_,
@@ -1241,7 +1256,6 @@ int zmq_poller_modify (void *poller_, void *s_, short events_)
     return ((zmq::socket_poller_t *) poller_)->modify (socket, events_);
 }
 
-
 #if defined _WIN32
 int zmq_poller_modify_fd (void *poller_, SOCKET fd_, short events_)
 #else
@@ -1276,6 +1290,94 @@ int zmq_poller_remove (void *poller_, void *s_)
 
     return ((zmq::socket_poller_t *) poller_)->remove (socket);
 }
+
+#ifdef ZMQ_BUILD_DRAFT_API
+
+int zmq_poller_add_peer (void *poller_, void *s_, void *routing_id,
+                                                  int routing_id_len,
+                                                  void *user_data_,
+                                                  short events_)
+{
+    if (!poller_ || !((zmq::socket_poller_t*)poller_)->check_tag ()) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    if (!s_ || !((zmq::socket_base_t*)s_)->check_tag ()) {
+        errno = ENOTSOCK;
+        return -1;
+    }
+
+    if (!routing_id || routing_id_len <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    //TODO: check right socket type
+
+    zmq::socket_base_t *socket = (zmq::socket_base_t*)s_;
+
+    return ((zmq::socket_poller_t*)poller_)->add (socket, routing_id,
+                                                  routing_id_len,
+                                                  user_data_,
+                                                  events_);
+}
+
+int zmq_poller_modify_peer (void *poller_, void *s_, void *routing_id,
+                                                  int routing_id_len,
+                                                  short events_)
+{
+    if (!poller_ || !((zmq::socket_poller_t*)poller_)->check_tag ()) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    if (!s_ || !((zmq::socket_base_t*)s_)->check_tag ()) {
+        errno = ENOTSOCK;
+        return -1;
+    }
+
+    if (!routing_id || routing_id_len <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    //TODO: check right socket type
+
+    zmq::socket_base_t *socket = (zmq::socket_base_t*)s_;
+
+    return ((zmq::socket_poller_t*)poller_)->modify (socket,
+                                                     routing_id,
+                                                     routing_id_len,
+                                                     events_);
+}
+
+int zmq_poller_remove_peer (void *poller_, void *s_, void *routing_id,
+                                                     int routing_id_len)
+{
+    if (!poller_ || !((zmq::socket_poller_t*)poller_)->check_tag ()) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    if (!s_ || !((zmq::socket_base_t*)s_)->check_tag ()) {
+        errno = ENOTSOCK;
+        return -1;
+    }
+
+    if (!routing_id || routing_id_len <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    //TODO: check right socket type
+
+    zmq::socket_base_t *socket = (zmq::socket_base_t*)s_;
+
+    return ((zmq::socket_poller_t*)poller_)->remove (socket, routing_id,
+                                                     routing_id_len);
+}
+#endif // ZMQ_BUILD_DRAFT_API
 
 #if defined _WIN32
 int zmq_poller_remove_fd (void *poller_, SOCKET fd_)
@@ -1341,11 +1443,12 @@ int zmq_poller_wait_all (void *poller_,
     return rc;
 }
 
+#ifdef ZMQ_BUILD_DRAFT_API
+
 //  Peer-specific state
 
-int zmq_socket_get_peer_state (void *s_,
-                               const void *routing_id_,
-                               size_t routing_id_size_)
+int zmq_socket_get_peer_state (void *s_, const void *routing_id_,
+                                         const size_t routing_id_size_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -1353,6 +1456,8 @@ int zmq_socket_get_peer_state (void *s_,
 
     return s->get_peer_state (routing_id_, routing_id_size_);
 }
+
+#endif // ZMQ_BUILD_DRAFT_API
 
 //  Timers
 

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -115,6 +115,14 @@ const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_MSG_PROPERTY_PEER_ADDRESS "Peer-Address"
 
 /******************************************************************************/
+/* Per peer functions                                                         */
+/******************************************************************************/
+
+int zmq_mute_peer (void *s_, const void *routing_id, const int routing_id_len,
+                                     int mute);
+
+
+/******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
 /******************************************************************************/
 
@@ -131,15 +139,20 @@ typedef struct zmq_poller_event_t
 } zmq_poller_event_t;
 
 void *zmq_poller_new (void);
-int zmq_poller_destroy (void **poller_p);
-int zmq_poller_add (void *poller, void *socket, void *user_data, short events);
-int zmq_poller_modify (void *poller, void *socket, short events);
-int zmq_poller_remove (void *poller, void *socket);
-int zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
-int zmq_poller_wait_all (void *poller,
-                         zmq_poller_event_t *events,
-                         int n_events,
-                         long timeout);
+int  zmq_poller_destroy (void **poller_p);
+int  zmq_poller_add (void *poller, void *socket, void *user_data, short events);
+int  zmq_poller_add_peer (void *poller, void *socket, void *zid, int zid_len,
+                              void *user_data, short events);
+int  zmq_poller_modify (void *poller, void *socket, short events);
+int  zmq_poller_modify_peer (void *poller, void *socket, void *zid, int zid_len,
+                              short events);
+int  zmq_poller_remove (void *poller, void *socket);
+int  zmq_poller_remove_peer (void *poller, void *socket, void *zid,
+                              int zid_len);
+int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
+int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events,
+                              int n_events,
+                              long timeout);
 
 #if defined _WIN32
 int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,7 @@ IF (ENABLE_DRAFTS)
         test_scatter_gather
         test_dgram
         test_app_meta
+        test_peer_funcs
     )
 ENDIF (ENABLE_DRAFTS)
 

--- a/tests/test_peer_funcs.cpp
+++ b/tests/test_peer_funcs.cpp
@@ -1,0 +1,157 @@
+/*
+    Copyright (c) 2007-2018 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+
+#include <unity.h>
+
+#ifndef ZMQ_BUILD_DRAFT_API
+#error This test HAS to run only with ZMQ_BUILD_DRAFT_API
+#endif //ZMQ_BUILD_DRAFT_API
+
+void setUp ()
+{
+    setup_test_context ();
+}
+
+void tearDown ()
+{
+    teardown_test_context ();
+}
+
+
+void test_mute_peer ()
+{
+    int rc;
+    size_t len = MAX_SOCKET_STRING;
+    char buffer[255];
+    char my_endpoint[MAX_SOCKET_STRING];
+    void *router = test_context_socket (ZMQ_ROUTER);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (router, "inproc://test_mute"));
+    TEST_ASSERT_SUCCESS_ERRNO (
+    zmq_getsockopt (router, ZMQ_LAST_ENDPOINT, my_endpoint, &len));
+
+
+    void *dealer1 = test_context_socket (ZMQ_DEALER);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (dealer1, ZMQ_ROUTING_ID, "X",
+									1));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (dealer1, my_endpoint));
+
+
+    void *dealer2 = test_context_socket (ZMQ_DEALER);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (dealer2, ZMQ_ROUTING_ID, "Y",
+									1));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (dealer2, my_endpoint));
+
+    //  Send 2 messages on each dealer* -> router
+    send_string_expect_success (dealer1, "HelloX", 0);
+    send_string_expect_success (dealer1, "HelloX", 0);
+
+    send_string_expect_success (dealer2, "HelloY", 0);
+    send_string_expect_success (dealer2, "HelloY", 0);
+
+    //  Reading 1+1 should give two different identities
+    int i = 0;
+    for (i = 0; i < 2; ++i) {
+	rc = zmq_recv (router, buffer, 255, 0);
+	assert (rc == 1);
+
+    bool d1 = strncmp(buffer, "X", strlen("X")) == 0;
+    rc = zmq_recv (router, buffer, 255, 0);
+    assert (rc == 6);
+	if(d1)
+	    assert (strncmp(buffer, "HelloX", strlen("HelloX")) == 0);
+	else
+	    assert (strncmp(buffer, "HelloY", strlen("HelloY")) == 0);
+    }
+
+    // Mute and unseen routing-id
+    rc = zmq_mute_peer (router, "Z", 1, 0x1);
+    assert (rc == -1);
+    assert (errno == EHOSTUNREACH);
+
+    //  Mute X
+    rc = zmq_mute_peer (router, "X", 1, 0x1);
+    assert (rc == 0);
+
+    //  Now we should only receive from Y
+    rc = zmq_recv (router, buffer, 255, 0);
+    assert (rc == 1);
+
+    assert (strncmp(buffer, "Y", 1) == 0);
+    rc = zmq_recv (router, buffer, 255, 0);
+    assert (strncmp(buffer, "HelloY", strlen("HelloY")) == 0);
+
+    //  This should block / return EAGAIN
+    rc = zmq_recv (router, buffer, 255, ZMQ_DONTWAIT);
+    assert (rc == -1);
+    assert (errno == EAGAIN);
+
+    //  Poller should NOT have IN events
+    zmq_pollitem_t poll_items[1] = {{router, 0, ZMQ_POLLIN, 0}};
+    rc = zmq_poll (poll_items, 1, 10);
+    assert (rc == 0);
+
+    //  Unmute X
+    rc = zmq_mute_peer (router, "X", 1, 0x0);
+    assert (rc == 0);
+
+    //  Poller should have IN events
+    rc = zmq_poll (poll_items, 1, 10);
+    assert (rc == 1);
+
+    //  Now we should only receive from X
+    rc = zmq_recv (router, buffer, 255, 0);
+    assert (rc == 1);
+
+    assert (strncmp(buffer, "X", 1) == 0);
+    rc = zmq_recv (router, buffer, 255, 0);
+    assert (strncmp(buffer, "HelloX", strlen("HelloX")) == 0);
+
+    //  Nothing left on the buffer
+    rc = zmq_recv (router, buffer, 255, ZMQ_DONTWAIT);
+    assert (rc == -1);
+    assert (errno == EAGAIN);
+
+    //  Poller should NOT have IN events
+    rc = zmq_poll (poll_items, 1, 10);
+    assert (rc == 0);
+}
+
+
+int main (void)
+{
+    setup_test_environment ();
+
+    UNITY_BEGIN ();
+    RUN_TEST (test_mute_peer);
+
+    return UNITY_END ();
+}


### PR DESCRIPTION
As recommended by @somdoron, opening this PR for discussion.

Here uou can find some preliminary, incomplete work here, but I think sufficient to trigger discussion. I will continue tomorrow, but I would appreciate early feedback before going any much further.

## Short summary

Key 4 additional methods are:

```
 +ZMQ_EXPORT int  zmq_poller_add_peer (void *poller, void *socket, void *zid,
 +                                                            int zid_len,
 +                                                            void *user_data,
 +                                                            short events);
 +ZMQ_EXPORT int  zmq_poller_modify_peer (void *poller, void *socket, void *zid,
 +                                                            int zid_len,
 +                                                            short events);
 +ZMQ_EXPORT int  zmq_poller_remove_peer (void *poller, void *socket, void *zid,
 +                                                            int zid_len);

 +ZMQ_EXPORT int zmq_recv_peer (void *s, void *zid, int zid_len, void *buf,
 +                                                               size_t len, 
 +                                                               int flags);
```

I think the usage is clear. One can use regular poller methods to add the entire socket or (or in addition) use _peer to add specific ZMQ identity poller items.

To read from a specific ZMQ identity, `zmq_recv_peer()`

There is probably a better name than `peer` (identity?). Open to suggestions.

## Missing

A lot:

* Validation in all `poller_peer()` methods to check that socket is multi-peer
* Implementation of `zmq_recv_peer()` and support for `ZMQ_PEER_EVENTS` in `getsockopt()` on sockets with multi-peer support
* Tests and validation
* Documentation

## What I don't like

I dislike using `getsockopt()` with an additional struct `zmq_gso_peer_events_t` for `ZMQ_PEER_EVENTS`. I was following the current approach.

I would very much prefer opening an API to the socket base to get that, and expose it through regular C bindings. Comments?

## Some other stuff, unrelated to this feature

* I removed duplicated blobs of code in here: https://github.com/zeromq/libzmq/blob/master/src/socket_poller.cpp#L633-L670 and here: https://github.com/zeromq/libzmq/blob/master/src/socket_poller.cpp#L672-L678 with `zmq::socket_poller_t::zero_trail_events()` and `zmq::socket_poller_t::check_events()`
*  I can't understand why poller and user items are different (but it is late here...). Is there any good reason for doing all this copy, ordering and mangling?

## Thoughts?