### PR TITLE
Problem: CentOS 6 build fails

### DIFF
--- a/packaging/redhat/zeromq.spec
+++ b/packaging/redhat/zeromq.spec
@@ -144,6 +144,8 @@ sed -i "s/openpgm-[0-9].[0-9]/%{openpgm_pc}/g" \
     configure*
 
 %build
+# Workaround for automake < 1.14 bug
+mkdir -p config
 autoreconf -fi
 %configure --enable-drafts=%{DRAFTS} \
     --with-pgm=%{PGM} \


### PR DESCRIPTION
Solution: use same autoconf workaround as for Debian 7, and manually
create the config directory