### PR TITLE
add __FreeBSD__ to ifdefs

### DIFF
--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -149,7 +149,7 @@ zmq::stream_engine_t::~stream_engine_t ()
         wsa_assert (rc != SOCKET_ERROR);
 #else
         int rc = close (s);
-#ifdef __FreeBSD_kernel__
+#if defined(__FreeBSD_kernel__) || defined (__FreeBSD__)
         // FreeBSD may return ECONNRESET on close() under load but this is not
         // an error.
         if (rc == -1 && errno == ECONNRESET)

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -152,7 +152,7 @@ void zmq::thread_t::setSchedulingParameters(int priority_, int schedulingPolicy_
 
     rc = pthread_setschedparam(descriptor, policy, &param);
 
-#ifdef __FreeBSD_kernel__
+#if defined(__FreeBSD_kernel__) || defined (__FreeBSD__)
     // If this feature is unavailable at run-time, don't abort.
     if(rc == ENOSYS) return;
 #endif


### PR DESCRIPTION
On FreeBSD the sysmbol __FreeBSD_kernel__ is only defines if a
specific param.h file is included, unlike Debian/kFreeBSD where this
symbol is always defined.  So also compile the FreeBSD specific code
if __FreeBSD__ is defined for FreeBSD 11 & 12 compatibility.

Signed-off-by: Christopher Hall <hsw@ms2.hinet.net>

# Pull Request Notice

Before sending a pull request make sure each commit solves one clear, minimal,
plausible problem. Further each commit should have the following format:

```
Problem: X is broken

Solution: do Y and Z to fix X
```

Please avoid sending a pull request with recursive merge nodes, as they
are impossible to fix once merged. Please rebase your branch on
zeromq/libzmq master instead of merging it.

git remote add upstream git@github.com:zeromq/libzmq.git
git fetch upstream
git rebase upstream/master
git push -f

In case you already merged instead of rebasing you can drop the merge commit.

git rebase -i HEAD~10

Now, find your merge commit and mark it as drop and save. Finally rebase!

If you are a new contributor please have a look at our contributing guidelines:
[CONTRIBUTING](http://zeromq.org/docs:contributing)
