### PR TITLE
fix build for msvc2017

### DIFF
--- a/builds/msvc/build/buildbase.bat
+++ b/builds/msvc/build/buildbase.bat
@@ -19,8 +19,12 @@ IF NOT EXIST %environment% GOTO no_tools
 
 @ECHO %ACTION% %solution%
 
+SET __CURRENT_DIR__=%CD%
 CALL %environment% x86 >%SystemDrive%\nul 2>&1
 ECHO Platform=x86 2> %log%
+CD /D %__CURRENT_DIR__%
+SET __CURRENT_DIR__=
+
 
 ECHO Configuration=DynDebug
 msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=Win32 %solution% %target%>> %log% || GOTO error
@@ -35,8 +39,12 @@ msbuild /m /v:n /p:Configuration=StaticDebug /p:Platform=Win32 %solution% %targe
 ECHO Configuration=StaticRelease
 msbuild /m /v:n /p:Configuration=StaticRelease /p:Platform=Win32 %solution% %target%>> %log% || GOTO error
 
+SET __CURRENT_DIR__=%CD%
 CALL %environment% x86_amd64 >%SystemDrive%\nul 2>&1
 ECHO Platform=x64
+CD /D %__CURRENT_DIR__%
+SET __CURRENT_DIR__=
+
 
 ECHO Configuration=DynDebug
 msbuild /m /v:n /p:Configuration=DynDebug /p:Platform=x64 %solution% %target%>> %log% || GOTO error

--- a/builds/msvc/vs2017/libzmq.sln
+++ b/builds/msvc/vs2017/libzmq.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libzmq", "libzmq\libzmq.vcxproj", "{641C5F36-32EE-4323-B740-992B651CF9D6}"
 EndProject


### PR DESCRIPTION
# Pull Request Notice

The build configuration for MSVC 2017 is corrected:
1. Visual Studio version fixed in .sln file
2. Workaround of changing directory / drive letter by vcvarsall.bat added to buildbase.bat 