### PR TITLE
Background threads enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ if (NOT CMAKE_CROSSCOMPILING)
   zmq_check_tcp_keepalive ()
   zmq_check_tcp_tipc ()
   zmq_check_pthread_setname ()
+  zmq_check_pthread_setaffinity ()
   zmq_check_getrandom ()
 endif ()
 

--- a/builds/cmake/Modules/ZMQSourceRunChecks.cmake
+++ b/builds/cmake/Modules/ZMQSourceRunChecks.cmake
@@ -265,6 +265,25 @@ int main(int argc, char *argv [])
   set(CMAKE_REQUIRED_FLAGS ${SAVE_CMAKE_REQUIRED_FLAGS})
 endmacro()
 
+macro(zmq_check_pthread_setaffinity)
+  message(STATUS "Checking pthread_setaffinity signature")
+  set(SAVE_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  set(CMAKE_REQUIRED_FLAGS "-D_GNU_SOURCE -Werror -pthread")
+  check_c_source_runs(
+    "
+#include <pthread.h>
+
+int main(int argc, char *argv [])
+{
+    cpu_set_t test; 
+    pthread_setaffinity_np (pthread_self(), sizeof(cpu_set_t), &test);
+    return 0;
+}
+"
+    ZMQ_HAVE_PTHREAD_SETAFFINITY)
+  set(CMAKE_REQUIRED_FLAGS ${SAVE_CMAKE_REQUIRED_FLAGS})
+endmacro()
+
 
 macro(zmq_check_getrandom)
   message(STATUS "Checking whether getrandom is supported")

--- a/configure.ac
+++ b/configure.ac
@@ -659,6 +659,22 @@ AC_COMPILE_IFELSE(
 		AC_MSG_RESULT([no])
 ])
 
+
+# pthread_setaffinity_np is non-posix:
+AC_MSG_CHECKING([whether pthread_setaffinity_np() exists])
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM(
+		[[#include <pthread.h>]],
+		[[cpu_set_t test; pthread_setaffinity_np (pthread_self(), sizeof(cpu_set_t), &test); return 0;]])
+	],[
+		AC_MSG_RESULT([yes])
+		AC_DEFINE(ZMQ_HAVE_PTHREAD_SET_AFFINITY, [1],
+		    [Whether pthread_setaffinity_np() exists])
+	],[
+		AC_MSG_RESULT([no])
+])
+
+
 LIBZMQ_CHECK_SOCK_CLOEXEC([
     AC_DEFINE([ZMQ_HAVE_SOCK_CLOEXEC],
         [1],

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -557,10 +557,6 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 
 #ifdef ZMQ_BUILD_DRAFT_API
 
-/* DRAFT Context options */
-#define ZMQ_THREAD_AFFINITY 6
-#define ZMQ_THREAD_AFFINITY_DFLT -1
-
 /*  DRAFT Socket types.                                                       */
 #define ZMQ_SERVER 12
 #define ZMQ_CLIENT 13
@@ -615,6 +611,8 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6
+#define ZMQ_THREAD_AFFINITY 7
+#define ZMQ_THREAD_AFFINITY_DFLT -1
 
 /*  DRAFT Socket methods.                                                     */
 ZMQ_EXPORT int zmq_join (void *s, const char *group);

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -557,6 +557,10 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 
 #ifdef ZMQ_BUILD_DRAFT_API
 
+/* DRAFT Context options */
+#define ZMQ_THREAD_AFFINITY 6
+#define ZMQ_THREAD_AFFINITY_DFLT -1
+
 /*  DRAFT Socket types.                                                       */
 #define ZMQ_SERVER 12
 #define ZMQ_CLIENT 13

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -214,6 +214,7 @@ namespace zmq
         //  Thread scheduling parameters.
         int thread_priority;
         int thread_sched_policy;
+        int thread_affinity;
 
         //  Synchronisation of access to context options.
         mutex_t opt_sync;

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -53,6 +53,9 @@ namespace zmq
         inline thread_t ()
             : tfn(NULL)
             , arg(NULL)
+            , thread_priority(ZMQ_THREAD_PRIORITY_DFLT)
+            , thread_sched_policy(ZMQ_THREAD_SCHED_POLICY_DFLT)
+            , thread_affinity(ZMQ_THREAD_AFFINITY_DFLT)
         {
         }
 
@@ -65,7 +68,7 @@ namespace zmq
 
         // Sets the thread scheduling parameters. Only implemented for
         // pthread. Has no effect on other platforms.
-        void setSchedulingParameters(int priority_, int schedulingPolicy_);
+        void setSchedulingParameters(int priority_, int schedulingPolicy_, int affinity_);
 
         // Sets the thread name, 16 characters max including terminating NUL.
         // Only implemented for pthread. Has no effect on other platforms.
@@ -73,6 +76,7 @@ namespace zmq
 
         //  These are internal members. They should be private, however then
         //  they would not be accessible from the main C routine of the thread.
+        void applySchedulingParameters();
         thread_fn *tfn;
         void *arg;
 
@@ -83,6 +87,11 @@ namespace zmq
 #else
         pthread_t descriptor;
 #endif
+
+        //  Thread scheduling parameters.
+        int thread_priority;
+        int thread_sched_policy;
+        int thread_affinity;
 
         thread_t (const thread_t&);
         const thread_t &operator = (const thread_t&);

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -91,6 +91,8 @@
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6
+#define ZMQ_THREAD_AFFINITY 7
+#define ZMQ_THREAD_AFFINITY_DFLT -1
 
 /*  DRAFT Socket methods.                                                     */
 int zmq_join (void *s, const char *group);

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -81,8 +81,10 @@ void test_ctx_thread_opts(void* ctx)
     assert (rc == -1 && errno == EINVAL);
     rc = zmq_ctx_set(ctx, ZMQ_THREAD_PRIORITY, ZMQ_THREAD_PRIORITY_DFLT);
     assert (rc == -1 && errno == EINVAL);
+#if ZMQ_BUILD_DRAFT_API
     rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, ZMQ_THREAD_AFFINITY_DFLT);
     assert (rc == -1 && errno == EINVAL);
+#endif
 
 
     // test scheduling policy:
@@ -111,6 +113,7 @@ void test_ctx_thread_opts(void* ctx)
     }
 
 
+#if ZMQ_BUILD_DRAFT_API
     // test affinity:
 
     int cpu_affinity_test = (1 << 0);
@@ -120,6 +123,7 @@ void test_ctx_thread_opts(void* ctx)
 
     rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, cpu_affinity_test);
     assert (rc == 0);
+#endif
 }
 
 

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -73,8 +73,10 @@ int main (void)
     rc = zmq_ctx_set(ctx, ZMQ_THREAD_PRIORITY, 1);
     assert (rc == 0);
 
-    int cpu_affinity_test = 2;          // this should result in background threads being placed only on the
-                                        // first CPU available on this system
+    int cpu_affinity_test = (1 << 0);
+         // this should result in background threads being placed only on the
+         // first CPU available on this system; try experimenting with other values
+         // (e.g., 1<<5 to use CPU index 5) and use "top -H" or "taskset -pc" to see the result
     rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, cpu_affinity_test);
     assert (rc == 0);
 
@@ -91,9 +93,9 @@ int main (void)
     rc = zmq_close (router);
     assert (rc == 0);
 
-
-
-    sleep(100);
+    // this is useful when you want to use an external tool (like top or taskset) to view
+    // properties of the background threads
+    //sleep(100);
     
     rc = zmq_ctx_set (ctx, ZMQ_BLOCKY, false);
     assert (zmq_ctx_get (ctx, ZMQ_BLOCKY) == 0);

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -32,20 +32,106 @@
 
 #define WAIT_FOR_BACKGROUND_THREAD_INSPECTION             (0)
 
-#if WAIT_FOR_BACKGROUND_THREAD_INSPECTION
+#ifdef ZMQ_HAVE_LINUX
+#include <sys/time.h>
+#include <sys/resource.h>
 #include <unistd.h>         // for sleep()
+
+#define TEST_POLICY                                       (SCHED_OTHER)    // NOTE: SCHED_OTHER is the default Linux scheduler
+
+bool is_allowed_to_raise_priority()
+{
+    // NOTE1: if setrlimit() fails with EPERM, this means that current user has not enough permissions.
+    // NOTE2: even for privileged users (e.g., root) getrlimit() would usually return 0 as nice limit; the only way to
+    //        discover if the user is able to increase the nice value is to actually try to change the rlimit:
+    struct rlimit rlim;
+    rlim.rlim_cur = 40;
+    rlim.rlim_max = 40;
+    if (setrlimit(RLIMIT_NICE, &rlim) == 0)
+    {
+        // rlim_cur == 40 means that this process is allowed to set a nice value of -20
+        if (WAIT_FOR_BACKGROUND_THREAD_INSPECTION)
+            printf ("This process has enough permissions to raise ZMQ background thread priority!\n");
+        return true;
+    }
+
+    if (WAIT_FOR_BACKGROUND_THREAD_INSPECTION)
+        printf ("This process has NOT enough permissions to raise ZMQ background thread priority.\n");
+    return false;
+}
+
+#else
+
+#define TEST_POLICY                                       (0)
+
+bool is_allowed_to_raise_priority()
+{
+    return false;
+}
+
 #endif
+
+
+void test_ctx_thread_opts(void* ctx)
+{
+    int rc;
+
+    // verify that setting negative values (e.g., default values) fail:
+    rc = zmq_ctx_set(ctx, ZMQ_THREAD_SCHED_POLICY, ZMQ_THREAD_SCHED_POLICY_DFLT);
+    assert (rc == -1 && errno == EINVAL);
+    rc = zmq_ctx_set(ctx, ZMQ_THREAD_PRIORITY, ZMQ_THREAD_PRIORITY_DFLT);
+    assert (rc == -1 && errno == EINVAL);
+    rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, ZMQ_THREAD_AFFINITY_DFLT);
+    assert (rc == -1 && errno == EINVAL);
+
+
+    // test scheduling policy:
+
+    // set context options that alter the background thread CPU scheduling/affinity settings;
+    // as of ZMQ 4.2.3 this has an effect only on POSIX systems (nothing happens on Windows, but still it should return success):
+    rc = zmq_ctx_set(ctx, ZMQ_THREAD_SCHED_POLICY, TEST_POLICY);
+    assert (rc == 0);
+
+
+    // test priority:
+
+    // in theory SCHED_OTHER supports only the static priority 0 but quoting the docs
+    //     http://man7.org/linux/man-pages/man7/sched.7.html
+    // "The thread to run is chosen from the static priority 0 list based on
+    // a dynamic priority that is determined only inside this list.  The
+    // dynamic priority is based on the nice value [...]
+    // The nice value can be modified using nice(2), setpriority(2), or sched_setattr(2)."
+    // ZMQ will internally use nice(2) to set the nice value when using SCHED_OTHER.
+    // However changing the nice value of a process requires appropriate permissions...
+    // check that the current effective user is able to do that:
+    if (is_allowed_to_raise_priority())
+    {
+        rc = zmq_ctx_set(ctx, ZMQ_THREAD_PRIORITY, 1 /* any positive value different than the default will be ok */);
+        assert (rc == 0);
+    }
+
+
+    // test affinity:
+
+    int cpu_affinity_test = (1 << 0);
+         // this should result in background threads being placed only on the
+         // first CPU available on this system; try experimenting with other values
+         // (e.g., 1<<5 to use CPU index 5) and use "top -H" or "taskset -pc" to see the result
+
+    rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, cpu_affinity_test);
+    assert (rc == 0);
+}
 
 
 int main (void)
 {
     setup_test_environment();
     int rc;
-    
+
     //  Set up our context and sockets
     void *ctx = zmq_ctx_new ();
     assert (ctx);
-    
+
     assert (zmq_ctx_get (ctx, ZMQ_MAX_SOCKETS) == ZMQ_MAX_SOCKETS_DFLT);
 #if defined(ZMQ_USE_SELECT)
     assert (zmq_ctx_get (ctx, ZMQ_SOCKET_LIMIT) == FD_SETSIZE - 1);
@@ -58,36 +144,11 @@ int main (void)
 #if defined (ZMQ_BUILD_DRAFT_AP)
     assert (zmq_ctx_get (ctx, ZMQ_MSG_T_SIZE) == sizeof (zmq_msg_t));
 #endif
-    
+
     rc = zmq_ctx_set (ctx, ZMQ_IPV6, true);
     assert (zmq_ctx_get (ctx, ZMQ_IPV6) == 1);
-    
 
-#ifdef SCHED_OTHER
-    // set context options that alter the background thread CPU scheduling/affinity settings:
-    // NOTE: SCHED_OTHER is the default Linux scheduler
-
-    rc = zmq_ctx_set(ctx, ZMQ_THREAD_SCHED_POLICY, SCHED_OTHER);
-    assert (rc == 0);
-#endif
-
-    // in theory SCHED_OTHER supports only the static priority 0 but quoting the docs
-    //     http://man7.org/linux/man-pages/man7/sched.7.html
-    // "The thread to run is chosen from the static priority 0 list based on
-    // a dynamic priority that is determined only inside this list.  The
-    // dynamic priority is based on the nice value [...]
-    // The nice value can be modified using nice(2), setpriority(2), or sched_setattr(2)."
-    // ZMQ will internally use nice(2) to set the nice value when using SCHED_OTHER
-    rc = zmq_ctx_set(ctx, ZMQ_THREAD_PRIORITY, 1);
-    assert (rc == 0);
-
-    int cpu_affinity_test = (1 << 0);
-         // this should result in background threads being placed only on the
-         // first CPU available on this system; try experimenting with other values
-         // (e.g., 1<<5 to use CPU index 5) and use "top -H" or "taskset -pc" to see the result
-    rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, cpu_affinity_test);
-    assert (rc == 0);
-
+    test_ctx_thread_opts(ctx);
 
     void *router = zmq_socket (ctx, ZMQ_ROUTER);
     int value;
@@ -104,6 +165,7 @@ int main (void)
 #if WAIT_FOR_BACKGROUND_THREAD_INSPECTION
     // this is useful when you want to use an external tool (like top or taskset) to view
     // properties of the background threads
+    printf ("Sleeping for 100sec. You can now use 'top -H -p $(pgrep -f test_ctx_options)' and 'taskset -pc <ZMQ background thread PID>' to view ZMQ background thread properties.\n");
     sleep(100);
 #endif
 

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -95,7 +95,7 @@ int main (void)
 
     // this is useful when you want to use an external tool (like top or taskset) to view
     // properties of the background threads
-    //sleep(100);
+    sleep(100);
     
     rc = zmq_ctx_set (ctx, ZMQ_BLOCKY, false);
     assert (zmq_ctx_get (ctx, ZMQ_BLOCKY) == 0);

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -28,10 +28,14 @@
 */
 
 #include <limits>
-#include <unistd.h>
 #include "testutil.hpp"
 
 #define WAIT_FOR_BACKGROUND_THREAD_INSPECTION             (0)
+
+#if WAIT_FOR_BACKGROUND_THREAD_INSPECTION
+#include <unistd.h>         // for sleep()
+#endif
+
 
 int main (void)
 {


### PR DESCRIPTION
# Pull Request Notice

Problem: 
 - right now there's no way to set background thread CPU affinity
 - right now it's impossible to set the NICE value of background threads when using SCHED_OTHER Linux default scheduling

Solution: 
 - add option ZMQ_THREAD_AFFINITY to allow setting CPU affinity
 - add special casing for SCHED_OTHER that triggers a call to the nice() syscall, to allow setting the NICE of background threads.
