### PR TITLE
Background thread names

### DIFF
--- a/doc/zmq_proxy_steerable.txt
+++ b/doc/zmq_proxy_steerable.txt
@@ -22,9 +22,20 @@ control flow provided by the socket passed as the fourth argument "control".
 If the control socket is not NULL, the proxy supports control flow. If 
 'PAUSE' is received on this socket, the proxy suspends its activities. If 
 'RESUME' is received, it goes on. If 'TERMINATE' is received, it terminates
-smoothly. At start, the proxy runs normally as if zmq_proxy was used.
+smoothly. If 'STATISTICS' is received, the proxy will reply on the control socket
+sending 8 unsigned integers 64-bit wide that provide the
+ - number of messages received by the frontend socket
+ - number of bytes received by the frontend socket
+ - number of messages sent out the frontend socket
+ - number of bytes sent out the frontend socket
+ - number of messages received by the backend socket
+ - number of bytes received by the backend socket
+ - number of messages sent out the backend socket
+ - number of bytes sent out the backend socket
 
-If the control socket is NULL, the function behave exactly as if zmq_proxy
+At start, the proxy runs normally as if zmq_proxy was used.
+
+If the control socket is NULL, the function behave exactly as if linkzmq:zmq_proxy[3]
 had been called.
 
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -613,6 +613,7 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_MSG_T_SIZE 6
 #define ZMQ_THREAD_AFFINITY 7
 #define ZMQ_THREAD_AFFINITY_DFLT -1
+#define ZMQ_THREAD_NAME_PREFIX 8
 
 /*  DRAFT Socket methods.                                                     */
 ZMQ_EXPORT int zmq_join (void *s, const char *group);

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -211,10 +211,11 @@ namespace zmq
         //  Is IPv6 enabled on this context?
         bool ipv6;
 
-        //  Thread scheduling parameters.
+        //  Thread parameters.
         int thread_priority;
         int thread_sched_policy;
         int thread_affinity;
+        std::string thread_name_prefix;
 
         //  Synchronisation of access to context options.
         mutex_t opt_sync;

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -93,6 +93,7 @@
 #define ZMQ_MSG_T_SIZE 6
 #define ZMQ_THREAD_AFFINITY 7
 #define ZMQ_THREAD_AFFINITY_DFLT -1
+#define ZMQ_THREAD_NAME_PREFIX 8
 
 /*  DRAFT Socket methods.                                                     */
 int zmq_join (void *s, const char *group);

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -124,6 +124,14 @@ void test_ctx_thread_opts(void* ctx)
     rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, cpu_affinity_test);
     assert (rc == 0);
 #endif
+
+
+#ifdef ZMQ_THREAD_NAME_PREFIX
+    // test thread name prefix:
+
+    rc = zmq_ctx_set(ctx, ZMQ_THREAD_NAME_PREFIX, 1234);
+    assert (rc == 0);
+#endif
 }
 
 


### PR DESCRIPTION
# Pull Request Notice

Problem: zeromq background thread names cannot be customized. It is difficult to understand which background thread is associated to which process.

Solution: allow the user to set a custom thread name prefix. Currently because of zmq_ctx_set() limitation it is just a number