### PR TITLE
added libiphlpapi to PKGCFG_LIBS_PRIVATE for static mingw builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,6 +288,7 @@ case "${host_os}" in
 
         if test "x$enable_static" = "xyes"; then
             CPPFLAGS="-DZMQ_STATIC $CPPFLAGS"
+            PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -liphlpapi"
         fi
 	# Set FD_SETSIZE to 16384
 	CPPFLAGS=" -DFD_SETSIZE=16384 $CPPFLAGS"


### PR DESCRIPTION
As discussed on IRC, added iphlpapi to PKGCFG_LIBS_PRIVATE for static mingw builds, which implements `if_indextoname` and `GetAdapterAddresses`.
