### PR TITLE
Problem: comment before sndtimeo/rcvtimeo does not specify dimension

### DIFF
--- a/src/options.hpp
+++ b/src/options.hpp
@@ -124,7 +124,7 @@ namespace zmq
         //  Maximal size of message to handle.
         int64_t maxmsgsize;
 
-        // The timeout for send/recv operations for this socket.
+        // The timeout for send/recv operations for this socket, in milliseconds.
         int rcvtimeo;
         int sndtimeo;
 


### PR DESCRIPTION
Solution: add "milliseconds"

