### PR TITLE
Problem: excessive memory allocations around blob_t

### DIFF
--- a/src/blob.hpp
+++ b/src/blob.hpp
@@ -30,108 +30,137 @@
 #ifndef __ZMQ_BLOB_HPP_INCLUDED__
 #define __ZMQ_BLOB_HPP_INCLUDED__
 
-#include <string>
+#include <stdlib.h>
 #include <string.h>
+#include <algorithm>
 
-// Borrowed from id3lib_strings.h:
-// They seem to be doing something for MSC, but since I only have gcc, I'll just do that
-// Assuming this is uneccessary on GCC 4
-// #if (defined(__GNUC__) && (__GNUC__ >= 3) || (defined(_MSC_VER) && _MSC_VER > 1000))
-#if (defined(__GNUC__) && (__GNUC__ >= 3) && (__GNUC__ <= 4))
-namespace std
-{
-  template<>
-    struct char_traits<unsigned char>
-    {
-      typedef unsigned char char_type;
-      // Unsigned as wint_t in unsigned.
-      typedef unsigned long int_type;
-      typedef streampos pos_type;
-      typedef streamoff off_type;
-      typedef mbstate_t state_type;
-
-      static void
-      assign(char_type& __c1, const char_type& __c2)
-      { __c1 = __c2; }
-
-      static bool
-      eq(const char_type& __c1, const char_type& __c2)
-      { return __c1 == __c2; }
-
-      static bool
-      lt(const char_type& __c1, const char_type& __c2)
-      { return __c1 < __c2; }
-
-      static int
-      compare(const char_type* __s1, const char_type* __s2, size_t __n)
-      {
-        for (size_t __i = 0; __i < __n; ++__i)
-          if (!eq(__s1[__i], __s2[__i]))
-            return lt(__s1[__i], __s2[__i]) ? -1 : 1;
-        return 0;
-      }
-
-      static size_t
-      length(const char_type* __s)
-      {
-        const char_type* __p = __s;
-          while (__p)
-            ++__p;
-        return (__p - __s);
-      }
-
-      static const char_type*
-      find(const char_type* __s, size_t __n, const char_type& __a)
-      {
-        for (const char_type* __p = __s; size_t(__p - __s) < __n; ++__p)
-          if (*__p == __a) return __p;
-        return 0;
-      }
-
-      static char_type*
-      move(char_type* __s1, const char_type* __s2, size_t __n)
-      { return (char_type*) memmove(__s1, __s2, __n * sizeof(char_type)); }
-
-      static char_type*
-      copy(char_type* __s1, const char_type* __s2, size_t __n)
-      { return (char_type*) memcpy(__s1, __s2, __n * sizeof(char_type)); }
-
-      static char_type*
-      assign(char_type* __s, size_t __n, char_type __a)
-      {
-        for (char_type* __p = __s; __p < __s + __n; ++__p)
-          assign(*__p, __a);
-        return __s;
-      }
-
-      static char_type
-      to_char_type(const int_type& __c)
-      { return char_type(__c); }
-
-      static int_type
-      to_int_type(const char_type& __c) { return int_type(__c); }
-
-      static bool
-      eq_int_type(const int_type& __c1, const int_type& __c2)
-      { return __c1 == __c2; }
-
-      static int_type
-      eof() { return static_cast<int_type>(-1); }
-
-      static int_type
-      not_eof(const int_type& __c)
-      { return eq_int_type(__c, eof()) ? int_type(0) : __c; }
-    };
-
-} // namespace std
-#endif // GCC version 3
-
+#if __cplusplus >= 201103L || defined(_MSC_VER) && _MSC_VER >= 1700
+#define ZMQ_HAS_MOVE_SEMANTICS
+#define ZMQ_MAP_INSERT_OR_EMPLACE(k, v) emplace (k,v)
+#define ZMQ_PUSH_OR_EMPLACE_BACK emplace_back
+#define ZMQ_MOVE(x) std::move (x)
+#else
+#define ZMQ_MAP_INSERT_OR_EMPLACE(k, v) insert (std::make_pair (k, v))
+#define ZMQ_PUSH_OR_EMPLACE_BACK push_back
+#define ZMQ_MOVE(x) (x)
+#endif
 
 namespace zmq
 {
+    struct reference_tag_t {};
 
     //  Object to hold dynamically allocated opaque binary data.
-    typedef std::basic_string <unsigned char> blob_t;
+    struct blob_t
+    {
+        blob_t () : data_ (0), size_ (0), owned_ (true) {}
+
+        blob_t (const size_t size)
+            : data_ ((unsigned char*)malloc (size))
+            , size_ (size)
+            , owned_ (true)
+        {
+        }
+
+        blob_t (const unsigned char * const data, const size_t size)
+            : data_ ((unsigned char*)malloc (size))
+            , size_ (size)
+            , owned_ (true)
+        {
+            memcpy(data_, data, size_);
+        }
+
+        blob_t (unsigned char * const data, const size_t size, reference_tag_t)
+            : data_ (data)
+            , size_ (size)
+            , owned_ (false)
+        {
+        }
+
+        size_t size () const { return size_;  }
+        
+        const unsigned char *data () const {
+            return data_;
+        }
+
+        unsigned char *data () {
+            return data_;
+        }
+
+        bool operator < (blob_t const &other) const {
+            int cmpres = memcmp (data_, other.data_, std::min (size_, other.size_));
+            return cmpres < 0 || (cmpres == 0 && size_ < other.size_);
+        }
+
+        void set_deep_copy (blob_t const &other)
+        {               
+            clear ();
+            data_ = (unsigned char*)malloc (other.size_);
+            size_ = other.size_;
+            owned_ = true;
+            memcpy (data_, other.data_, size_);
+        }
+
+        void set(const unsigned char * const data, const size_t size)
+        {
+            clear ();
+            data_ = (unsigned char*)malloc (size);
+            size_ = size;
+            owned_ = true;
+            memcpy (data_, data, size_);
+        }
+
+        void clear () {
+            if (owned_) { free (data_); }
+            data_ = 0; size_ = 0;
+        }
+
+        ~blob_t () {            
+            if (owned_) { free (data_);  }
+        }
+
+#ifdef ZMQ_HAS_MOVE_SEMANTICS
+        blob_t (const blob_t &) = delete;
+        blob_t &operator= (const blob_t &) = delete;
+        
+        blob_t (blob_t&& other) 
+            : data_ (other.data_)
+            , size_ (other.size_)
+            , owned_ (other.owned_)
+        {
+            other.owned_ = false;
+        }
+        blob_t &operator= (blob_t&& other) {
+            if (this != &other)
+            {
+                clear ();
+                data_ = other.data_;
+                size_ = other.size_;
+                owned_ = other.owned_;
+                other.owned_ = false;
+            }
+            return *this;
+        }
+#else
+        blob_t (const blob_t &other) 
+            : owned_(false)
+        {
+            set_deep_copy (other);
+        }
+        blob_t &operator= (const blob_t &other) {
+            if (this != &other)
+            {
+                clear ();
+                set_deep_copy (other);
+            }
+            return *this;
+    }
+#endif
+
+    private:
+        unsigned char *data_;
+        size_t size_;
+        bool owned_;
+    };
 
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -94,7 +94,7 @@ bool zmq::client_t::xhas_out ()
     return lb.has_out ();
 }
 
-zmq::blob_t zmq::client_t::get_credential () const
+const zmq::blob_t &zmq::client_t::get_credential () const
 {
     return fq.get_credential ();
 }

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -60,7 +60,7 @@ namespace zmq
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
         bool xhas_out ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
         void xread_activated (zmq::pipe_t *pipe_);
         void xwrite_activated (zmq::pipe_t *pipe_);
         void xpipe_terminated (zmq::pipe_t *pipe_);

--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -110,7 +110,7 @@ bool zmq::dealer_t::xhas_out ()
     return lb.has_out ();
 }
 
-zmq::blob_t zmq::dealer_t::get_credential () const
+const zmq::blob_t &zmq::dealer_t::get_credential () const
 {
     return fq.get_credential ();
 }

--- a/src/dealer.hpp
+++ b/src/dealer.hpp
@@ -61,7 +61,7 @@ namespace zmq
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
         bool xhas_out ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
         void xread_activated (zmq::pipe_t *pipe_);
         void xwrite_activated (zmq::pipe_t *pipe_);
         void xpipe_terminated (zmq::pipe_t *pipe_);

--- a/src/dgram.cpp
+++ b/src/dgram.cpp
@@ -69,7 +69,7 @@ void zmq::dgram_t::xpipe_terminated (pipe_t *pipe_)
 {
     if (pipe_ == pipe) {
         if (last_in == pipe) {
-            saved_credential = last_in->get_credential ();
+            saved_credential.set_deep_copy (last_in->get_credential ());
             last_in = NULL;
         }
         pipe = NULL;
@@ -171,7 +171,7 @@ bool zmq::dgram_t::xhas_out ()
     return pipe->check_write ();
 }
 
-zmq::blob_t zmq::dgram_t::get_credential () const
+const zmq::blob_t &zmq::dgram_t::get_credential () const
 {
     return last_in? last_in->get_credential (): saved_credential;
 }

--- a/src/dgram.hpp
+++ b/src/dgram.hpp
@@ -56,7 +56,7 @@ namespace zmq
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
         bool xhas_out ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
         void xread_activated (zmq::pipe_t *pipe_);
         void xwrite_activated (zmq::pipe_t *pipe_);
         void xpipe_terminated (zmq::pipe_t *pipe_);

--- a/src/dish.cpp
+++ b/src/dish.cpp
@@ -229,7 +229,7 @@ bool zmq::dish_t::xhas_in ()
     }
 }
 
-zmq::blob_t zmq::dish_t::get_credential () const
+const zmq::blob_t &zmq::dish_t::get_credential () const
 {
     return fq.get_credential ();
 }

--- a/src/dish.hpp
+++ b/src/dish.hpp
@@ -62,7 +62,7 @@ namespace zmq
         bool xhas_out ();
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
         void xread_activated (zmq::pipe_t *pipe_);
         void xwrite_activated (zmq::pipe_t *pipe_);
         void xhiccuped (pipe_t *pipe_);

--- a/src/fq.cpp
+++ b/src/fq.cpp
@@ -68,7 +68,7 @@ void zmq::fq_t::pipe_terminated (pipe_t *pipe_)
     pipes.erase (pipe_);
 
     if (last_in == pipe_) {
-        saved_credential = last_in->get_credential ();
+        saved_credential.set_deep_copy (last_in->get_credential ());
         last_in = NULL;
     }
 }
@@ -155,7 +155,7 @@ bool zmq::fq_t::has_in ()
     return false;
 }
 
-zmq::blob_t zmq::fq_t::get_credential () const
+const zmq::blob_t &zmq::fq_t::get_credential () const
 {
     return last_in?
         last_in->get_credential (): saved_credential;

--- a/src/fq.hpp
+++ b/src/fq.hpp
@@ -56,7 +56,7 @@ namespace zmq
         int recv (msg_t *msg_);
         int recvpipe (msg_t *msg_, pipe_t **pipe_);
         bool has_in ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
 
     private:
 

--- a/src/gather.cpp
+++ b/src/gather.cpp
@@ -88,7 +88,7 @@ bool zmq::gather_t::xhas_in ()
     return fq.has_in ();
 }
 
-zmq::blob_t zmq::gather_t::get_credential () const
+const zmq::blob_t &zmq::gather_t::get_credential () const
 {
     return fq.get_credential ();
 }

--- a/src/gather.hpp
+++ b/src/gather.hpp
@@ -56,7 +56,7 @@ namespace zmq
         void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
         void xread_activated (zmq::pipe_t *pipe_);
         void xpipe_terminated (zmq::pipe_t *pipe_);
 

--- a/src/mechanism.cpp
+++ b/src/mechanism.cpp
@@ -48,7 +48,7 @@ zmq::mechanism_t::~mechanism_t ()
 
 void zmq::mechanism_t::set_peer_routing_id (const void *id_ptr, size_t id_size)
 {
-    routing_id = blob_t (static_cast <const unsigned char*> (id_ptr), id_size);
+    routing_id.set (static_cast <const unsigned char*> (id_ptr), id_size);
 }
 
 void zmq::mechanism_t::peer_routing_id (msg_t *msg_)
@@ -61,12 +61,12 @@ void zmq::mechanism_t::peer_routing_id (msg_t *msg_)
 
 void zmq::mechanism_t::set_user_id (const void *data_, size_t size_)
 {
-    user_id = blob_t (static_cast <const unsigned char*> (data_), size_);
+    user_id.set (static_cast <const unsigned char*> (data_), size_);
     zap_properties.insert (metadata_t::dict_t::value_type (
       ZMQ_MSG_PROPERTY_USER_ID, std::string ((char *) data_, size_)));
 }
 
-zmq::blob_t zmq::mechanism_t::get_user_id () const
+const zmq::blob_t &zmq::mechanism_t::get_user_id () const
 {
     return user_id;
 }

--- a/src/mechanism.hpp
+++ b/src/mechanism.hpp
@@ -80,7 +80,7 @@ namespace zmq
 
         void set_user_id (const void *user_id, size_t size);
 
-        blob_t get_user_id () const;
+        const blob_t &get_user_id () const;
 
         const metadata_t::dict_t& get_zmtp_properties () {
             return zmtp_properties;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -65,7 +65,7 @@ void zmq::pair_t::xpipe_terminated (pipe_t *pipe_)
 {
     if (pipe_ == pipe) {
         if (last_in == pipe) {
-            saved_credential = last_in->get_credential ();
+            saved_credential.set_deep_copy (last_in->get_credential ());
             last_in = NULL;
         }
         pipe = NULL;
@@ -136,7 +136,7 @@ bool zmq::pair_t::xhas_out ()
     return pipe->check_write ();
 }
 
-zmq::blob_t zmq::pair_t::get_credential () const
+const zmq::blob_t &zmq::pair_t::get_credential () const
 {
     return last_in? last_in->get_credential (): saved_credential;
 }

--- a/src/pair.hpp
+++ b/src/pair.hpp
@@ -56,7 +56,7 @@ namespace zmq
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
         bool xhas_out ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
         void xread_activated (zmq::pipe_t *pipe_);
         void xwrite_activated (zmq::pipe_t *pipe_);
         void xpipe_terminated (zmq::pipe_t *pipe_);

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -127,15 +127,15 @@ uint32_t zmq::pipe_t::get_server_socket_routing_id ()
 
 void zmq::pipe_t::set_router_socket_routing_id (const blob_t &router_socket_routing_id_)
 {
-    router_socket_routing_id = router_socket_routing_id_;
+    router_socket_routing_id.set_deep_copy (router_socket_routing_id_);
 }
 
-zmq::blob_t zmq::pipe_t::get_routing_id ()
+const zmq::blob_t &zmq::pipe_t::get_routing_id ()
 {
     return router_socket_routing_id;
 }
 
-zmq::blob_t zmq::pipe_t::get_credential () const
+const zmq::blob_t &zmq::pipe_t::get_credential () const
 {
     return credential;
 }
@@ -182,7 +182,7 @@ read_message:
     //  If this is a credential, save a copy and receive next message.
     if (unlikely (msg_->is_credential ())) {
         const unsigned char *data = static_cast <const unsigned char *> (msg_->data ());
-        credential = blob_t (data, msg_->size ());
+        credential.set (data, msg_->size ());
         const int rc = msg_->close ();
         zmq_assert (rc == 0);
         goto read_message;

--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -90,9 +90,9 @@ namespace zmq
 
         //  Pipe endpoint can store an opaque ID to be used by its clients.
         void set_router_socket_routing_id (const blob_t &identity_);
-        blob_t get_routing_id ();
+        const blob_t &get_routing_id ();
 
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
 
         //  Returns true if there is at least one message to read in the pipe.
         bool check_read ();

--- a/src/pull.cpp
+++ b/src/pull.cpp
@@ -72,7 +72,7 @@ bool zmq::pull_t::xhas_in ()
     return fq.has_in ();
 }
 
-zmq::blob_t zmq::pull_t::get_credential () const
+const zmq::blob_t &zmq::pull_t::get_credential () const
 {
     return fq.get_credential ();
 }

--- a/src/pull.hpp
+++ b/src/pull.hpp
@@ -56,7 +56,7 @@ namespace zmq
         void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
         void xread_activated (zmq::pipe_t *pipe_);
         void xpipe_terminated (zmq::pipe_t *pipe_);
 

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -70,7 +70,7 @@ namespace zmq
 
         //  Rollback any message parts that were sent but not yet flushed.
         int rollback ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
 
     private:
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -178,7 +178,7 @@ bool zmq::server_t::xhas_out ()
     return true;
 }
 
-zmq::blob_t zmq::server_t::get_credential () const
+const zmq::blob_t &zmq::server_t::get_credential () const
 {
     return fq.get_credential ();
 }

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -66,7 +66,7 @@ namespace zmq
 
     protected:
 
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
 
     private:
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1491,9 +1491,11 @@ int zmq::socket_base_t::xrecv (msg_t *)
     return -1;
 }
 
-zmq::blob_t zmq::socket_base_t::get_credential () const
+static const zmq::blob_t empty_blob;
+
+const zmq::blob_t &zmq::socket_base_t::get_credential () const
 {
-    return blob_t ();
+    return empty_blob;
 }
 
 void zmq::socket_base_t::xread_activated (pipe_t *)

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -170,7 +170,7 @@ namespace zmq
         //  Returns the credential for the peer from which we have received
         //  the last message. If no message has been received yet,
         //  the function returns empty credential.
-        virtual blob_t get_credential () const;
+        virtual const blob_t &get_credential () const;
 
         //  i_pipe_events will be forwarded to these functions.
         virtual void xread_activated (pipe_t *pipe_);

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -901,7 +901,7 @@ int zmq::stream_engine_t::write_credential (msg_t *msg_)
     zmq_assert (mechanism != NULL);
     zmq_assert (session != NULL);
 
-    const blob_t credential = mechanism->get_user_id ();
+    const blob_t &credential = mechanism->get_user_id ();
     if (credential.size () > 0) {
         msg_t msg;
         int rc = msg.init_size (credential.size ());

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -324,11 +324,11 @@ void zmq::xpub_t::send_unsubscription (unsigned char *data_, size_t size_,
     if (self->options.type != ZMQ_PUB) {
         //  Place the unsubscription to the queue of pending (un)subscriptions
         //  to be retrieved by the user later on.
-        blob_t unsub (size_ + 1, 0);
-        unsub [0] = 0;
+        blob_t unsub (size_ + 1);
+        *unsub.data() = 0;
         if (size_ > 0)
-            memcpy (&unsub [1], data_, size_);
-        self->pending_data.push_back (unsub);
+            memcpy (unsub.data() + 1, data_, size_);
+        self->pending_data.ZMQ_PUSH_OR_EMPLACE_BACK (ZMQ_MOVE(unsub));
         self->pending_metadata.push_back (NULL);
         self->pending_flags.push_back (0);
 

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -113,7 +113,6 @@ namespace zmq
 
         //  List of pending (un)subscriptions, ie. those that were already
         //  applied to the trie, but not yet received by the user.
-        typedef std::basic_string <unsigned char> blob_t;
         std::deque <blob_t> pending_data;
         std::deque <metadata_t*> pending_metadata;
         std::deque <unsigned char> pending_flags;

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -210,7 +210,7 @@ bool zmq::xsub_t::xhas_in ()
     }
 }
 
-zmq::blob_t zmq::xsub_t::get_credential () const
+const zmq::blob_t &zmq::xsub_t::get_credential () const
 {
     return fq.get_credential ();
 }

--- a/src/xsub.hpp
+++ b/src/xsub.hpp
@@ -59,7 +59,7 @@ namespace zmq
         bool xhas_out ();
         int xrecv (zmq::msg_t *msg_);
         bool xhas_in ();
-        blob_t get_credential () const;
+        const blob_t &get_credential () const;
         void xread_activated (zmq::pipe_t *pipe_);
         void xwrite_activated (zmq::pipe_t *pipe_);
         void xhiccuped (pipe_t *pipe_);


### PR DESCRIPTION
Solution: redefine blob_t as a custom type, and use reference/move
semantics where possible

Fixes #2794 
