### PR TITLE
Change ZMQ_THREAD_AFFINITY to ZMQ_THREAD_AFFINITY_CPU_ADD/REMOVE

### DIFF
--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -76,15 +76,25 @@ This option only applies before creating any sockets on the context.
 Default value:: -1
 
 
-ZMQ_THREAD_AFFINITY: Set CPU affinity for I/O threads
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_THREAD_AFFINITY' argument sets CPU affinity for the internal
+ZMQ_THREAD_AFFINITY_CPU_ADD: Add a CPU to list of affinity for I/O threads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_THREAD_AFFINITY_CPU_ADD' argument adds a specific CPU to the affinity list for the internal
 context's thread pool. This option is only supported on Linux.
-On Linux, each bit of the 'option_value' argument will represent an enabled
-CPU in the corresponding cpu_set_t; for example the value 0x1 will set affinity
-of all context's thread pool to CPU 0; the value 0x110 will set affinity
-of all context's thread pool to CPU 1 and 2.
 This option only applies before creating any sockets on the context.
+The default affinity list is empty and means that no explicit CPU-affinity will be set on
+internal context's threads.
+
+[horizontal]
+Default value:: -1
+
+
+ZMQ_THREAD_AFFINITY_CPU_REMOVE: Remove a CPU to list of affinity for I/O threads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_THREAD_AFFINITY_CPU_REMOVE' argument removes a specific CPU to the affinity list for the internal
+context's thread pool. This option is only supported on Linux.
+This option only applies before creating any sockets on the context.
+The default affinity list is empty and means that no explicit CPU-affinity will be set on
+internal context's threads.
 
 [horizontal]
 Default value:: -1

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -610,9 +610,9 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6
-#define ZMQ_THREAD_AFFINITY 7
-#define ZMQ_THREAD_AFFINITY_DFLT -1
-#define ZMQ_THREAD_NAME_PREFIX 8
+#define ZMQ_THREAD_AFFINITY_CPU_ADD 7
+#define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
+#define ZMQ_THREAD_NAME_PREFIX 9
 
 /*  DRAFT Socket methods.                                                     */
 ZMQ_EXPORT int zmq_join (void *s, const char *group);

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -214,7 +214,7 @@ namespace zmq
         //  Thread parameters.
         int thread_priority;
         int thread_sched_policy;
-        int thread_affinity;
+        std::set<int> thread_affinity_cpus;
         std::string thread_name_prefix;
 
         //  Synchronisation of access to context options.

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -33,6 +33,7 @@
 #ifndef ZMQ_HAVE_WINDOWS
 #include <pthread.h>
 #endif
+#include <set>
 
 namespace zmq
 {
@@ -55,7 +56,6 @@ namespace zmq
             , arg(NULL)
             , thread_priority(ZMQ_THREAD_PRIORITY_DFLT)
             , thread_sched_policy(ZMQ_THREAD_SCHED_POLICY_DFLT)
-            , thread_affinity(ZMQ_THREAD_AFFINITY_DFLT)
         {
         }
 
@@ -68,7 +68,7 @@ namespace zmq
 
         // Sets the thread scheduling parameters. Only implemented for
         // pthread. Has no effect on other platforms.
-        void setSchedulingParameters(int priority_, int schedulingPolicy_, int affinity_);
+        void setSchedulingParameters(int priority_, int schedulingPolicy_, const std::set<int>& affinity_cpus_);
 
         // Sets the thread name, 16 characters max including terminating NUL.
         // Only implemented for pthread. Has no effect on other platforms.
@@ -91,7 +91,7 @@ namespace zmq
         //  Thread scheduling parameters.
         int thread_priority;
         int thread_sched_policy;
-        int thread_affinity;
+        std::set<int> thread_affinity_cpus;
 
         thread_t (const thread_t&);
         const thread_t &operator = (const thread_t&);

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -91,9 +91,9 @@
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6
-#define ZMQ_THREAD_AFFINITY 7
-#define ZMQ_THREAD_AFFINITY_DFLT -1
-#define ZMQ_THREAD_NAME_PREFIX 8
+#define ZMQ_THREAD_AFFINITY_CPU_ADD 7
+#define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
+#define ZMQ_THREAD_NAME_PREFIX 9
 
 /*  DRAFT Socket methods.                                                     */
 int zmq_join (void *s, const char *group);

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -81,10 +81,6 @@ void test_ctx_thread_opts(void* ctx)
     assert (rc == -1 && errno == EINVAL);
     rc = zmq_ctx_set(ctx, ZMQ_THREAD_PRIORITY, ZMQ_THREAD_PRIORITY_DFLT);
     assert (rc == -1 && errno == EINVAL);
-#ifdef ZMQ_THREAD_AFFINITY
-    rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, ZMQ_THREAD_AFFINITY_DFLT);
-    assert (rc == -1 && errno == EINVAL);
-#endif
 
 
     // test scheduling policy:
@@ -113,16 +109,27 @@ void test_ctx_thread_opts(void* ctx)
     }
 
 
-#ifdef ZMQ_THREAD_AFFINITY
+#ifdef ZMQ_THREAD_AFFINITY_CPU_ADD
     // test affinity:
 
-    int cpu_affinity_test = (1 << 0);
-         // this should result in background threads being placed only on the
-         // first CPU available on this system; try experimenting with other values
-         // (e.g., 1<<5 to use CPU index 5) and use "top -H" or "taskset -pc" to see the result
+     // this should result in background threads being placed only on the
+     // first CPU available on this system; try experimenting with other values
+     // (e.g., 5 to use CPU index 5) and use "top -H" or "taskset -pc" to see the result
 
-    rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY, cpu_affinity_test);
-    assert (rc == 0);
+    int cpus_add[] = { 0, 1 };
+    for (unsigned int idx=0; idx < sizeof(cpus_add)/sizeof(cpus_add[0]); idx++)
+    {
+        rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY_CPU_ADD, cpus_add[idx]);
+        assert (rc == 0);
+    }
+
+    // you can also remove CPUs from list of affinities:
+    int cpus_remove[] = { 1 };
+    for (unsigned int idx=0; idx < sizeof(cpus_remove)/sizeof(cpus_remove[0]); idx++)
+    {
+        rc = zmq_ctx_set(ctx, ZMQ_THREAD_AFFINITY_CPU_REMOVE, cpus_remove[idx]);
+        assert (rc == 0);
+    }
 #endif
 
 


### PR DESCRIPTION
Change ZMQ_THREAD_AFFINITY to ZMQ_THREAD_AFFINITY_CPU_ADD/ZMQ_THREAD_AFFINITY_CPU_REMOVE. 
Avoid prefix thread names when no prefix was set.
