### PR TITLE
Problem: Sometimes on OSX we get ETIMEDOUT instead of EAGAIN

### DIFF
--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -553,6 +553,10 @@ int zmq::socket_poller_t::wait (zmq::socket_poller_t::event_t *events_,
 #elif defined ZMQ_HAVE_ANDROID
         usleep (timeout_ * 1000);
         return -1;
+#elif defined ZMQ_HAVE_OSX
+        usleep (timeout_ * 1000);
+        errno = EAGAIN;
+        return -1;
 #else
         usleep (timeout_ * 1000);
         return -1;


### PR DESCRIPTION
Cannot reproduce/test this in libzmq. But i ran czmq/zloop self-test: https://github.com/zeromq/czmq/blob/ed902413453c0e50c65f887c40a5e9052619a224/src/zloop.c#L1  

If i print the "Value of zmq_error(): " here: 
https://github.com/zeromq/libzmq/blob/812e756264cc92d735dc56d91eaf8db2843f77ce/src/zmq.cpp#L783 i get:

```
Running czmq test 'zloop'...
 * zloop: D: 17-11-01 15:24:18 zloop: register timer id=1 delay=1000 times=1
D: 17-11-01 15:24:18 zloop: register timer id=2 delay=5 times=1
D: 17-11-01 15:24:18 zloop: register timer id=3 delay=20 times=1
D: 17-11-01 15:24:18 zloop: register PAIR reader
D: 17-11-01 15:24:18 zloop polling for 5 msec
Value of zmq_errno(): 35
D: 17-11-01 15:24:18 zloop: call timer handler id=2
D: 17-11-01 15:24:18 zloop: cancel timer id=1
D: 17-11-01 15:24:18 zloop polling for 14 msec
Value of zmq_errno(): 35
D: 17-11-01 15:24:18 zloop: call timer handler id=3
D: 17-11-01 15:24:18 zloop polling for 9976 msec
D: 17-11-01 15:24:18 zloop: call PAIR socket handler
Value of zmq_errno(): 60
Value of zmq_errno(): 60
OK
```