### PR TITLE
Add support for systems without accept4()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -617,7 +617,7 @@ AC_LANG_POP([C++])
 
 # Checks for library functions.
 AC_TYPE_SIGNAL
-AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs fork posix_memalign mkdtemp)
+AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs fork posix_memalign mkdtemp accept4)
 AC_CHECK_HEADERS([alloca.h])
 
 # pthread_setname is non-posix, and there are at least 4 different implementations

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -382,7 +382,7 @@ zmq::fd_t zmq::ipc_listener_t::accept ()
     //  The situation where connection cannot be accepted due to insufficient
     //  resources is considered valid and treated by ignoring the connection.
     zmq_assert (s != retired_fd);
-#if defined ZMQ_HAVE_SOCK_CLOEXEC
+#if defined ZMQ_HAVE_SOCK_CLOEXEC && defined HAVE_ACCEPT4
     fd_t sock = ::accept4 (s, NULL, NULL, SOCK_CLOEXEC);
 #else
     fd_t sock = ::accept (s, NULL, NULL);

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -281,7 +281,7 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
 #else
     socklen_t ss_len = sizeof (ss);
 #endif
-#if defined ZMQ_HAVE_SOCK_CLOEXEC
+#if defined ZMQ_HAVE_SOCK_CLOEXEC && defined HAVE_ACCEPT4
     fd_t sock = ::accept4 (s, (struct sockaddr *) &ss, &ss_len, SOCK_CLOEXEC);
 #else
     fd_t sock = ::accept (s, (struct sockaddr *) &ss, &ss_len);


### PR DESCRIPTION
The accept4() system call was originally introduced as a proprietary Linux
extension starting with Linux 2.6.28; support in glibc was available
starting with version 2.10. Others also introduced it later (e.g. FreeBSD
from 10.0).

This uses the same fallback to POSIX's accept() as already used for
systems without SOCK_CLOEXEC.

Tested with Linux 2.6.27, glibc 2.9.

# Pull Request Notice

Before sending a pull request make sure each commit solves one clear, minimal,
plausible problem. Further each commit should have the following format:

```
Problem: X is broken

Solution: do Y and Z to fix X
```

Please avoid sending a pull request with recursive merge nodes, as they
are impossible to fix once merged. Please rebase your branch on
zeromq/libzmq master instead of merging it.

git remote add upstream git@github.com:zeromq/libzmq.git
git fetch upstream
git rebase upstream/master
git push -f

In case you already merged instead of rebasing you can drop the merge commit.

git rebase -i HEAD~10

Now, find your merge commit and mark it as drop and save. Finally rebase!

If you are a new contributor please have a look at our contributing guidelines:
[CONTRIBUTING](http://zeromq.org/docs:contributing)
