### PR TITLE
Problem: REQ socket with ZMQ_REQ_RELAXED does not report ZMQ_POLLOUT when queried for events after first message.

### DIFF
--- a/src/req.cpp
+++ b/src/req.cpp
@@ -213,7 +213,7 @@ bool zmq::req_t::xhas_in ()
 
 bool zmq::req_t::xhas_out ()
 {
-    if (receiving_reply)
+    if (receiving_reply && strict)
         return false;
 
     return dealer_t::xhas_out ();


### PR DESCRIPTION
Solution: Check for strictness before returning false if no reply has been received.

Fixes #2824.