### PR TITLE
Problems: test_security_{zap|curve} often hangs, debian builds ignore test failures hiding issues

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -46,7 +46,7 @@ override_dh_auto_configure:
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 ifneq ($(DO_TEST), no)
-	-dh_auto_test -- VERBOSE=1
+	dh_auto_test -- VERBOSE=1
 else
 	-dh_auto_test -- VERBOSE=1
 endif


### PR DESCRIPTION
Solutions: let test failures fail Debian build, and set linger at the beginning of the test rather than the end.

As the commit message says this is a bandaid rather than a fix. There's an obvious race condition that needs a deeper fix, but at least stop the constant test failures for now.

Fixes #2733 