### PR TITLE
Problem: Build fails in Visual Studio 2008 without `stdint.h`

### DIFF
--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -63,7 +63,6 @@
 #include <signal.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/stdint.hpp
+++ b/src/stdint.hpp
@@ -60,6 +60,9 @@ typedef unsigned __int32 uint32_t;
 #ifndef uint64_t
 typedef unsigned __int64 uint64_t;
 #endif
+#ifndef UINT32_MAX
+#define UINT32_MAX   _UI32_MAX
+#endif
 
 #else
 

--- a/src/vmci.hpp
+++ b/src/vmci.hpp
@@ -30,7 +30,6 @@
 #ifndef __ZMQ_VMCI_HPP_INCLUDED__
 #define __ZMQ_VMCI_HPP_INCLUDED__
 
-#include <stdint.h>
 #include <string>
 
 #include "platform.hpp"

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -38,7 +38,6 @@
 #include "random.hpp"
 #include <assert.h>
 #include <new>
-#include <stdint.h>
 
 #if !defined ZMQ_HAVE_WINDOWS
 #include <unistd.h>


### PR DESCRIPTION
```
Problem: Build fails on Visual Studio 2008 without `stdint.h`

Solution: Cleaning include files which include `stdint.h` except `stdint.hpp`.
Define UINT32_MAX in `stdint.hpp`.
```

Please avoid sending a pull request with recursive merge nodes, as they
are impossible to fix once merged. Please rebase your branch on
zeromq/libzmq master instead of merging it.

git remote add upstream git@github.com:zeromq/libzmq.git
git fetch upstream
git rebase upstream/master
git push -f

In case you already merged instead of rebasing you can drop the merge commit.

git rebase -i HEAD~10

Now, find your merge commit and mark it as drop and save. Finally rebase!

If you are a new contributor please have a look at our contributing guidelines:
[CONTRIBUTING](http://zeromq.org/docs:contributing)
