### PR TITLE
Wrong ZMQ_LINGER default value

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -453,7 +453,7 @@ The following outlines the different behaviours:
 [horizontal]
 Option value type:: int
 Option value unit:: milliseconds
-Default value:: 30000 (thirty seconds)
+Default value:: -1 (infinite)
 Applicable socket types:: all
 
 


### PR DESCRIPTION
Problem: Wrong linger default value

Solution: correct documentation

Fixes #2845