### PR TITLE
Problem: Debian packages are missing zmq.hpp

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -52,6 +52,12 @@ else
 endif
 endif
 
+override_dh_auto_install:
+	dh_auto_install
+ifneq ("$(wildcard debian/zmq.hpp)","")
+	cp $(CURDIR)/debian/zmq.hpp $(CURDIR)/debian/tmp/usr/include/
+endif
+
 override_dh_strip:
 	dh_strip --dbg-package=libzmq5-dbg
 

--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -10,6 +10,18 @@
     <param name="filename">zeromq</param>
   </service>
 
+  <!-- embed zmq.hpp like Debian and Ubuntu do -->
+  <service name="download_url">
+    <param name="protocol">https</param>
+    <param name="host">github.com</param>
+    <param name="path">zeromq/cppzmq/archive/master.zip</param>
+  </service>
+  <service name="extract_file">
+    <param name="archive">*master.zip</param>
+    <param name="files">*/zmq.hpp</param>
+    <param name="outfilename">debian.zmq.hpp</param>
+  </service>
+
   <!-- extract redhat packaging -->
   <service name="extract_file">
     <param name="archive">*.tar</param>


### PR DESCRIPTION
Solution: install it if available. Download it from its repo as part
of the OBS source run.
Debian and Ubuntu always ship zmq.hpp in libzmq-dev, so do the same.
In the RPM world it is in its own separate package, so don't do the
same for RPM.