### PR TITLE
Problem: WIN32 CMAKECONFIG_INSTALL_DIR is broken

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -965,8 +965,12 @@ endif ()
 
 include(CMakePackageConfigHelpers)
 
-# GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
-set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
+if (WIN32)
+  set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "CMake" CACHE STRING "install path for ZeroMQConfig.cmake")
+else()
+  # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
+  set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
+endif()
 
 if (NOT CMAKE_VERSION VERSION_LESS 3.0)
   export(EXPORT ${PROJECT_NAME}-targets


### PR DESCRIPTION
Solution: set it to CMake instead of a subfolder of share.
See [cmake find_package documentation](https://cmake.org/cmake/help/v3.5/command/find_package.html) for further info.

View the commit diff without whitespace to see that the non-WIN32 settings haven't changed:

* https://github.com/zeromq/libzmq/commit/de5e7a39834500b924e156488aa63a5dbf874998?w=1