### PR TITLE
export ZMQ_STATIC compile flag to depending projects (MSVC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,6 +772,11 @@ if (MSVC)
       DEBUG_POSTFIX "${MSVC_TOOLSET}-mt-sgd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
       COMPILE_FLAGS "/DZMQ_STATIC"
       OUTPUT_NAME "libzmq")
+
+    target_compile_definitions(libzmq-static
+      PUBLIC ZMQ_STATIC
+      )
+
   endif()
 else ()
   # avoid building everything twice for shared + static


### PR DESCRIPTION
Problem: If libzmq is used as static library on windows all using projects need to define "ZMQ_STATIC".
In case libzmq is part of a larger project, this patch automatically exports the needed flag using cmake functionality.

Solution: export flag using target_compile_definitions
```