### PR TITLE
Problem: Jenkinsfile uses "any" agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent any
+    agent { label "linux || macosx || bsd || solaris || posix || windows" }
     parameters {
         // Use DEFAULT_DEPLOY_BRANCH_PATTERN and DEFAULT_DEPLOY_JOB_NAME if
         // defined in this jenkins setup -- in Jenkins Management Web-GUI


### PR DESCRIPTION
Solution: avoid using random infrastructure and default agents by requiring a reasonable label (like in GSL and zproject)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>