### PR TITLE
Problem: NuGet package versioning out of sync with releases.

### DIFF
--- a/packaging/nuget/package.config
+++ b/packaging/nuget/package.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- These values are populated into the package.gsl templates by package.bat. -->
 <!-- The target attribute controls path and file name only, id controls package naming. -->
-<package id="libzmq_vc120" target="libzmq" version = "4.2.30.0" pathversion="4_2_30_0" platformtoolset="v120">
+<package id="libzmq-vc120" target="libzmq" version = "4.2.3.0" pathversion="4_2_3_0" platformtoolset="v120">
   <!--<dependency id="libsodium_vc120" version="1.0.12.0" />-->
 </package>

--- a/packaging/nuget/package.nuspec
+++ b/packaging/nuget/package.nuspec
@@ -6,9 +6,9 @@
 -->
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
     <metadata minClientVersion="2.5">
-        <id>libzmq_vc120</id>
-        <version>4.2.30.0</version>
-        <title>libzmq_vc120</title>
+        <id>libzmq-vc120</id>
+        <version>4.2.3.0</version>
+        <title>libzmq-vc120</title>
         <authors>libzmq contributors</authors>
         <owners>Eric Voskuil</owners>
         <licenseUrl>https://raw.github.com/zeromq/libzmq/master/COPYING.LESSER</licenseUrl>
@@ -32,7 +32,7 @@
 
         <!-- targets -->
       
-        <file src="package.targets" target="build\native\libzmq_vc120.targets" />
+        <file src="package.targets" target="build\native\libzmq-vc120.targets" />
         <file src="package.xml" target="build\native\package.xml" />
         
         <!-- docs -->
@@ -43,52 +43,52 @@
         <!-- libraries -->
 
         <!-- x86 Dynamic libraries (.dll) -->
-        <file src="..\..\bin\Win32\Release\v120\dynamic\libzmq.dll" target="build\native\bin\libzmq-x86-v120-mt-4_2_30_0.dll" />
-        <file src="..\..\bin\Win32\Debug\v120\dynamic\libzmq.dll" target="build\native\bin\libzmq-x86-v120-mt-gd-4_2_30_0.dll" />
+        <file src="..\..\bin\Win32\Release\v120\dynamic\libzmq.dll" target="build\native\bin\libzmq-x86-v120-mt-4_2_3_0.dll" />
+        <file src="..\..\bin\Win32\Debug\v120\dynamic\libzmq.dll" target="build\native\bin\libzmq-x86-v120-mt-gd-4_2_3_0.dll" />
 
         <!-- x86 Debugging symbols (.pdb) -->
-        <!--<file src="..\..\bin\Win32\Release\v120\dynamic\libzmq.pdb" target="build\native\bin\libzmq-x86-v120-mt-4_2_30_0.pdb" />-->
-        <file src="..\..\bin\Win32\Debug\v120\dynamic\libzmq.pdb" target="build\native\bin\libzmq-x86-v120-mt-gd-4_2_30_0.pdb" />
+        <!--<file src="..\..\bin\Win32\Release\v120\dynamic\libzmq.pdb" target="build\native\bin\libzmq-x86-v120-mt-4_2_3_0.pdb" />-->
+        <file src="..\..\bin\Win32\Debug\v120\dynamic\libzmq.pdb" target="build\native\bin\libzmq-x86-v120-mt-gd-4_2_3_0.pdb" />
 
         <!-- x86 Import libraries (.imp.lib) -->
-        <file src="..\..\bin\Win32\Release\v120\dynamic\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-4_2_30_0.imp.lib" />
-        <file src="..\..\bin\Win32\Debug\v120\dynamic\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-gd-4_2_30_0.imp.lib" />
+        <file src="..\..\bin\Win32\Release\v120\dynamic\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-4_2_3_0.imp.lib" />
+        <file src="..\..\bin\Win32\Debug\v120\dynamic\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-gd-4_2_3_0.imp.lib" />
 
         <!-- x86 Export libraries (.exp) -->
-        <file src="..\..\bin\Win32\Release\v120\dynamic\libzmq.exp" target="build\native\bin\libzmq-x86-v120-mt-4_2_30_0.exp" />
-        <file src="..\..\bin\Win32\Debug\v120\dynamic\libzmq.exp" target="build\native\bin\libzmq-x86-v120-mt-gd-4_2_30_0.exp" />
+        <file src="..\..\bin\Win32\Release\v120\dynamic\libzmq.exp" target="build\native\bin\libzmq-x86-v120-mt-4_2_3_0.exp" />
+        <file src="..\..\bin\Win32\Debug\v120\dynamic\libzmq.exp" target="build\native\bin\libzmq-x86-v120-mt-gd-4_2_3_0.exp" />
 
         <!-- x86 Static libraries (.lib) -->
-        <file src="..\..\bin\Win32\Release\v120\static\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-s-4_2_30_0.lib" />
-        <file src="..\..\bin\Win32\Debug\v120\static\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-sgd-4_2_30_0.lib" />
+        <file src="..\..\bin\Win32\Release\v120\static\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-s-4_2_3_0.lib" />
+        <file src="..\..\bin\Win32\Debug\v120\static\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-sgd-4_2_3_0.lib" />
 
         <!-- x86 Static link time code generation libraries (.ltcg.lib) -->
-        <file src="..\..\bin\Win32\Release\v120\ltcg\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-s-4_2_30_0.ltcg.lib" />
-        <file src="..\..\bin\Win32\Debug\v120\ltcg\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-sgd-4_2_30_0.ltcg.lib" />
+        <file src="..\..\bin\Win32\Release\v120\ltcg\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-s-4_2_3_0.ltcg.lib" />
+        <file src="..\..\bin\Win32\Debug\v120\ltcg\libzmq.lib" target="build\native\bin\libzmq-x86-v120-mt-sgd-4_2_3_0.ltcg.lib" />
 
         <!-- x64 Dynamic libraries (.dll) -->
-        <file src="..\..\bin\x64\Release\v120\dynamic\libzmq.dll" target="build\native\bin\libzmq-x64-v120-mt-4_2_30_0.dll" />
-        <file src="..\..\bin\x64\Debug\v120\dynamic\libzmq.dll" target="build\native\bin\libzmq-x64-v120-mt-gd-4_2_30_0.dll" />
+        <file src="..\..\bin\x64\Release\v120\dynamic\libzmq.dll" target="build\native\bin\libzmq-x64-v120-mt-4_2_3_0.dll" />
+        <file src="..\..\bin\x64\Debug\v120\dynamic\libzmq.dll" target="build\native\bin\libzmq-x64-v120-mt-gd-4_2_3_0.dll" />
 
         <!-- x64 Debugging symbols (.pdb) -->
-        <!--<file src="..\..\bin\x64\Release\v120\dynamic\libzmq.pdb" target="build\native\bin\libzmq-x64-v120-mt-4_2_30_0.pdb" />-->
-        <file src="..\..\bin\x64\Debug\v120\dynamic\libzmq.pdb" target="build\native\bin\libzmq-x64-v120-mt-gd-4_2_30_0.pdb" />
+        <!--<file src="..\..\bin\x64\Release\v120\dynamic\libzmq.pdb" target="build\native\bin\libzmq-x64-v120-mt-4_2_3_0.pdb" />-->
+        <file src="..\..\bin\x64\Debug\v120\dynamic\libzmq.pdb" target="build\native\bin\libzmq-x64-v120-mt-gd-4_2_3_0.pdb" />
 
         <!-- x64 Import libraries (.imp.lib) -->
-        <file src="..\..\bin\x64\Release\v120\dynamic\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-4_2_30_0.imp.lib" />
-        <file src="..\..\bin\x64\Debug\v120\dynamic\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-gd-4_2_30_0.imp.lib" />
+        <file src="..\..\bin\x64\Release\v120\dynamic\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-4_2_3_0.imp.lib" />
+        <file src="..\..\bin\x64\Debug\v120\dynamic\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-gd-4_2_3_0.imp.lib" />
 
         <!-- x64 Export libraries (.exp) -->
-        <file src="..\..\bin\x64\Release\v120\dynamic\libzmq.exp" target="build\native\bin\libzmq-x64-v120-mt-4_2_30_0.exp" />
-        <file src="..\..\bin\x64\Debug\v120\dynamic\libzmq.exp" target="build\native\bin\libzmq-x64-v120-mt-gd-4_2_30_0.exp" />
+        <file src="..\..\bin\x64\Release\v120\dynamic\libzmq.exp" target="build\native\bin\libzmq-x64-v120-mt-4_2_3_0.exp" />
+        <file src="..\..\bin\x64\Debug\v120\dynamic\libzmq.exp" target="build\native\bin\libzmq-x64-v120-mt-gd-4_2_3_0.exp" />
 
         <!-- x64 Static libraries (.lib) -->
-        <file src="..\..\bin\x64\Release\v120\static\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-s-4_2_30_0.lib" />
-        <file src="..\..\bin\x64\Debug\v120\static\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-sgd-4_2_30_0.lib" />
+        <file src="..\..\bin\x64\Release\v120\static\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-s-4_2_3_0.lib" />
+        <file src="..\..\bin\x64\Debug\v120\static\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-sgd-4_2_3_0.lib" />
 
         <!-- x64 Static link time code generation libraries (.ltcg.lib) -->
-        <file src="..\..\bin\Win32\Release\v120\ltcg\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-s-4_2_30_0.ltcg.lib" />
-        <file src="..\..\bin\Win32\Debug\v120\ltcg\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-sgd-4_2_30_0.ltcg.lib" />
+        <file src="..\..\bin\Win32\Release\v120\ltcg\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-s-4_2_3_0.ltcg.lib" />
+        <file src="..\..\bin\Win32\Debug\v120\ltcg\libzmq.lib" target="build\native\bin\libzmq-x64-v120-mt-sgd-4_2_3_0.ltcg.lib" />
     </files>
 <!--
 #################################################################

--- a/packaging/nuget/package.targets
+++ b/packaging/nuget/package.targets
@@ -31,66 +31,66 @@
   <!-- static libraries -->
   <ItemDefinitionGroup Condition="'$(Platform)' == 'Win32' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'static' And $(Configuration.IndexOf('Release')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x86-v120-mt-s-4_2_30_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x86-v120-mt-s-4_2_3_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'Win32' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'static' And $(Configuration.IndexOf('Debug')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x86-v120-mt-sgd-4_2_30_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x86-v120-mt-sgd-4_2_3_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'x64' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'static' And $(Configuration.IndexOf('Release')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x64-v120-mt-s-4_2_30_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x64-v120-mt-s-4_2_3_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'x64' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'static' And $(Configuration.IndexOf('Debug')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x64-v120-mt-sgd-4_2_30_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x64-v120-mt-sgd-4_2_3_0.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 
   <!-- static ltcg libraries -->
   <ItemDefinitionGroup Condition="'$(Platform)' == 'Win32' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'ltcg' And $(Configuration.IndexOf('Release')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x86-v120-mt-s-4_2_30_0.ltcg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x86-v120-mt-s-4_2_3_0.ltcg.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'Win32' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'ltcg' And $(Configuration.IndexOf('Debug')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x86-v120-mt-sgd-4_2_30_0.ltcg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x86-v120-mt-sgd-4_2_3_0.ltcg.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'x64' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'ltcg' And $(Configuration.IndexOf('Release')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x64-v120-mt-s-4_2_30_0.ltcg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x64-v120-mt-s-4_2_3_0.ltcg.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'x64' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'ltcg' And $(Configuration.IndexOf('Debug')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x64-v120-mt-sgd-4_2_30_0.ltcg.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x64-v120-mt-sgd-4_2_3_0.ltcg.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   
   <!-- dynamic import libraries -->
   <ItemDefinitionGroup Condition="'$(Platform)' == 'Win32' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'dynamic' And $(Configuration.IndexOf('Release')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x86-v120-mt-4_2_30_0.imp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x86-v120-mt-4_2_3_0.imp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'Win32' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'dynamic' And $(Configuration.IndexOf('Debug')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x86-v120-mt-gd-4_2_30_0.imp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x86-v120-mt-gd-4_2_3_0.imp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'x64' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'dynamic' And $(Configuration.IndexOf('Release')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x64-v120-mt-4_2_30_0.imp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x64-v120-mt-4_2_3_0.imp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)' == 'x64' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'dynamic' And $(Configuration.IndexOf('Debug')) != -1">
     <Link>
-      <AdditionalDependencies>libzmq-x64-v120-mt-gd-4_2_30_0.imp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libzmq-x64-v120-mt-gd-4_2_3_0.imp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 
@@ -99,26 +99,26 @@
   <Target Name="libzmq_AfterBuild_Win32_v120_Dynamic_Release"
           Condition="'$(Platform)' == 'Win32' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'dynamic' And $(Configuration.IndexOf('Release')) != -1"
           AfterTargets="libzmq_AfterBuild">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x86-v120-mt-4_2_30_0.dll" DestinationFiles="$(TargetDir)libzmq.dll" SkipUnchangedFiles="true" />
-    <!--<Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x86-v120-mt-4_2_30_0.pdb" DestinationFiles="$(TargetDir)libzmq.pdb" SkipUnchangedFiles="true" />-->
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x86-v120-mt-4_2_3_0.dll" DestinationFiles="$(TargetDir)libzmq.dll" SkipUnchangedFiles="true" />
+    <!--<Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x86-v120-mt-4_2_3_0.pdb" DestinationFiles="$(TargetDir)libzmq.pdb" SkipUnchangedFiles="true" />-->
   </Target>
   <Target Name="libzmq_AfterBuild_Win32_v120_Dynamic_Debug"
           Condition="'$(Platform)' == 'Win32' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'dynamic' And $(Configuration.IndexOf('Debug')) != -1"
           AfterTargets="libzmq_AfterBuild">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x86-v120-mt-gd-4_2_30_0.dll" DestinationFiles="$(TargetDir)libzmq.dll" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x86-v120-mt-gd-4_2_30_0.pdb" DestinationFiles="$(TargetDir)libzmq.pdb" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x86-v120-mt-gd-4_2_3_0.dll" DestinationFiles="$(TargetDir)libzmq.dll" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x86-v120-mt-gd-4_2_3_0.pdb" DestinationFiles="$(TargetDir)libzmq.pdb" SkipUnchangedFiles="true" />
   </Target>
   <Target Name="libzmq_AfterBuild_x64_v120_Dynamic_Release"
           Condition="'$(Platform)' == 'x64' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'dynamic' And $(Configuration.IndexOf('Release')) != -1"
           AfterTargets="libzmq_AfterBuild">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x64-v120-mt-4_2_30_0.dll" DestinationFiles="$(TargetDir)libzmq.dll" SkipUnchangedFiles="true" />
-    <!--<Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x64-v120-mt-4_2_30_0.pdb" DestinationFiles="$(TargetDir)libzmq.pdb" SkipUnchangedFiles="true" />-->
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x64-v120-mt-4_2_3_0.dll" DestinationFiles="$(TargetDir)libzmq.dll" SkipUnchangedFiles="true" />
+    <!--<Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x64-v120-mt-4_2_3_0.pdb" DestinationFiles="$(TargetDir)libzmq.pdb" SkipUnchangedFiles="true" />-->
   </Target>
   <Target Name="libzmq_AfterBuild_x64_v120_Dynamic_Debug"
           Condition="'$(Platform)' == 'x64' And ('$(PlatformToolset)' == 'v120' Or '$(PlatformToolset)' == 'CTP_Nov2013') And '$(Linkage-libzmq)' == 'dynamic' And $(Configuration.IndexOf('Debug')) != -1"
           AfterTargets="libzmq_AfterBuild">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x64-v120-mt-gd-4_2_30_0.dll" DestinationFiles="$(TargetDir)libzmq.dll" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x64-v120-mt-gd-4_2_30_0.pdb" DestinationFiles="$(TargetDir)libzmq.pdb" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x64-v120-mt-gd-4_2_3_0.dll" DestinationFiles="$(TargetDir)libzmq.dll" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)bin\libzmq-x64-v120-mt-gd-4_2_3_0.pdb" DestinationFiles="$(TargetDir)libzmq.pdb" SkipUnchangedFiles="true" />
   </Target>
 
 <!--


### PR DESCRIPTION
Solution: Change the package name,  reset version sequence and regenerate.

This also makes the naming system consistent with boost packages. Old packages will be retained.