### PR TITLE
prevent duplicate connections from PUB sockets also 

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -823,7 +823,7 @@ int zmq::socket_base_t::connect (const char *addr_)
         return 0;
     }
     bool is_single_connect = (options.type == ZMQ_DEALER ||
-                              options.type == ZMQ_SUB ||
+                              options.type == ZMQ_SUB    || options.type == ZMQ_PUB ||
                               options.type == ZMQ_REQ);
     if (unlikely (is_single_connect)) {
         const endpoints_t::iterator it = endpoints.find (addr_);


### PR DESCRIPTION
(see https://github.com/zeromq/libzmq/issues/788)

The original fix for the duplicate connect issue only covered SUB connecting to PUB, but the same problem exists in the other direction.  (Irrespective of any other issues related to PUB connecting to SUB).

Note to Luca -- let me know if you need/want a test pgm for this, or if this behavior should be documented somewhere (e.g.in zmq_connect.txt?)