### PR TITLE
removing hard-coded path of librt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -870,7 +870,7 @@ if (BUILD_SHARED)
   endif ()
 
   if (RT_LIBRARY)
-    target_link_libraries (libzmq ${RT_LIBRARY})
+    target_link_libraries (libzmq -lrt)
   endif ()
 endif ()
 
@@ -894,7 +894,7 @@ if (BUILD_SHARED)
       target_link_libraries (${perf-tool} libzmq ${OPTIONAL_LIBRARIES})
 
       if (RT_LIBRARY)
-        target_link_libraries (${perf-tool} ${RT_LIBRARY})
+        target_link_libraries (${perf-tool} -lrt)
       endif ()
 
       if (ZMQ_BUILD_FRAMEWORK)


### PR DESCRIPTION
The full path to librt.so is hard-coded in the generated file ZeroMQTargets.cmake. While this is not problematic when installing from source, this may prevent to link with ZeroMQ if the package has been built on another machine with a different folder / system structure.

This behavior is the result of linking with the result of the `find_library` instruction, which returns a full path.