### PR TITLE
Problem: add_fd might be called with fd_ == retired_fd

### DIFF
--- a/src/poll.cpp
+++ b/src/poll.cpp
@@ -57,6 +57,8 @@ zmq::poll_t::~poll_t ()
 
 zmq::poll_t::handle_t zmq::poll_t::add_fd (fd_t fd_, i_poll_events *events_)
 {
+    zmq_assert (fd_ != retired_fd);
+
     //  If the file descriptor table is too small expand it.
     fd_table_t::size_type sz = fd_table.size ();
     if (sz <= (fd_table_t::size_type) fd_) {


### PR DESCRIPTION
Solution: add assertion

This is related to #2895, but it does not fix it. Rather, it attempts to simplify identifying the cause of the problem.
