### PR TITLE
Problem: in case of exhausted resources on creation of a context, assertions are triggered

### DIFF
--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -133,7 +133,10 @@ namespace zmq
 
         ~ctx_t ();
 
+        bool valid() const;
+
     private:
+        bool start();
 
         struct pending_connection_t
         {

--- a/src/mailbox.cpp
+++ b/src/mailbox.cpp
@@ -99,3 +99,8 @@ int zmq::mailbox_t::recv (command_t *cmd_, int timeout_)
     zmq_assert (ok);
     return 0;
 }
+
+bool zmq::mailbox_t::valid () const
+{
+    return signaler.valid ();
+}

--- a/src/mailbox.hpp
+++ b/src/mailbox.hpp
@@ -54,6 +54,8 @@ namespace zmq
         void send (const command_t &cmd_);
         int recv (command_t *cmd_, int timeout_);
 
+        bool valid () const;
+
 #ifdef HAVE_FORK
         // close the file descriptors in the signaller. This is used in a forked
         // child process to close the file descriptors so that they do not interfere

--- a/src/reaper.cpp
+++ b/src/reaper.cpp
@@ -36,9 +36,13 @@
 zmq::reaper_t::reaper_t (class ctx_t *ctx_, uint32_t tid_) :
     object_t (ctx_, tid_),
     mailbox_handle((poller_t::handle_t)NULL),
+    poller (NULL),
     sockets (0),
     terminating (false)
 {
+    if (!mailbox.valid ())
+        return;
+
     poller = new (std::nothrow) poller_t (*ctx_);
     alloc_assert (poller);
 
@@ -64,13 +68,17 @@ zmq::mailbox_t *zmq::reaper_t::get_mailbox ()
 
 void zmq::reaper_t::start ()
 {
+    zmq_assert (mailbox.valid ());
+
     //  Start the thread.
     poller->start ();
 }
 
 void zmq::reaper_t::stop ()
 {
-    send_stop ();
+    if (get_mailbox ()->valid ()) {
+        send_stop ();
+    }
 }
 
 void zmq::reaper_t::in_event ()

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -55,6 +55,7 @@ zmq::select_t::select_t (const zmq::ctx_t &ctx_) :
 #else
     maxfd (retired_fd),
 #endif
+    started (false),
     stopping (false)
 {
 #if defined ZMQ_HAVE_WINDOWS
@@ -65,7 +66,10 @@ zmq::select_t::select_t (const zmq::ctx_t &ctx_) :
 
 zmq::select_t::~select_t ()
 {
-    worker.stop ();
+    if (started) {
+        stop ();
+        worker.stop ();
+    }
 }
 
 zmq::select_t::handle_t zmq::select_t::add_fd (fd_t fd_, i_poll_events *events_)
@@ -257,6 +261,7 @@ void zmq::select_t::reset_pollout (handle_t handle_)
 void zmq::select_t::start ()
 {
     ctx.start_thread (worker, worker_routine, this);
+    started = true;
 }
 
 void zmq::select_t::stop ()

--- a/src/select.hpp
+++ b/src/select.hpp
@@ -166,6 +166,9 @@ class select_t : public poller_base_t
     static fd_entries_t::iterator
     find_fd_entry_by_handle (fd_entries_t &fd_entries, handle_t handle_);
 
+    //  If true, start has been called.
+    bool started;
+
     //  If true, thread is shutting down.
     bool stopping;
 

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -372,6 +372,11 @@ int zmq::signaler_t::recv_failable ()
     return 0;
 }
 
+bool zmq::signaler_t::valid () const
+{
+    return w != retired_fd;
+}
+
 #ifdef HAVE_FORK
 void zmq::signaler_t::forked ()
 {
@@ -398,7 +403,7 @@ int zmq::signaler_t::make_fdpair (fd_t *r_, fd_t *w_)
         errno_assert (errno == ENFILE || errno == EMFILE);
         *w_ = *r_ = -1;
         return -1;
-    }
+    } 
     else {
         *w_ = *r_ = fd;
         return 0;

--- a/src/signaler.hpp
+++ b/src/signaler.hpp
@@ -51,11 +51,15 @@ namespace zmq
         signaler_t ();
         ~signaler_t ();
 
+        // Returns the socket/file descriptor 
+        // May return retired_fd if the signaler could not be initialized.
         fd_t get_fd () const;
         void send ();
         int wait (int timeout_);
         void recv ();
         int recv_failable ();
+
+        bool valid () const;
 
 #ifdef HAVE_FORK
         // close the file descriptors in a forked child process so that they
@@ -70,7 +74,8 @@ namespace zmq
         static int make_fdpair (fd_t *r_, fd_t *w_);
 
         //  Underlying write & read file descriptor
-        //  Will be -1 if we exceeded number of available handles
+        //  Will be -1 if an error occurred during initialization, e.g. we 
+        //  exceeded the number of available handles
         fd_t w;
         fd_t r;
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -161,7 +161,12 @@ void *zmq_ctx_new (void)
 
     //  Create 0MQ context.
     zmq::ctx_t *ctx = new (std::nothrow) zmq::ctx_t;
-    alloc_assert (ctx);
+    if (ctx) {
+        if (!ctx->valid ()) {
+            delete ctx;
+            return NULL;
+        }
+    }
     return ctx;
 }
 


### PR DESCRIPTION
Solution: signal error to caller, and apply appropriate cleanup

Fixes #2895 (I hope)
