### PR TITLE
Revert "Problem: Windows Intel compiler build broken"

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -243,14 +243,14 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
  * zmq_msg_t on addresses aligned on a pointer-size boundary to avoid this issue.
  */
 typedef struct zmq_msg_t {
-#if defined (_MSC_VER) && (defined (_M_X64) || defined (_M_ARM64))
-    __declspec (align (8)) unsigned char _ [64];
-#elif defined (_MSC_VER) && (defined (_M_IX86) || defined (_M_ARM_ARMV7VE))
-    __declspec (align (4)) unsigned char _ [64];
-#elif defined (__GNUC__) || defined ( __INTEL_COMPILER) || \
+#if defined (__GNUC__) || defined ( __INTEL_COMPILER) || \
         (defined (__SUNPRO_C) && __SUNPRO_C >= 0x590) || \
         (defined (__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
     unsigned char _ [64] __attribute__ ((aligned (sizeof (void *))));
+#elif defined (_MSC_VER) && (defined (_M_X64) || defined (_M_ARM64))
+    __declspec (align (8)) unsigned char _ [64];
+#elif defined (_MSC_VER) && (defined (_M_IX86) || defined (_M_ARM_ARMV7VE))
+    __declspec (align (4)) unsigned char _ [64];
 #else
     unsigned char _ [64];
 #endif


### PR DESCRIPTION
Reverts zeromq/libzmq#2920

Temporarily revert so that #2908 can go in unchanged. Will be reapplied afterwards.