### PR TITLE
Problem: assertion failure in poller_base.cpp:42

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -541,8 +541,14 @@ ZMQ_EXPORT void zmq_atomic_counter_destroy (void **counter_p);
 /*  Starts the stopwatch. Returns the handle to the watch.                    */
 ZMQ_EXPORT void *zmq_stopwatch_start (void);
 
+#ifdef ZMQ_BUILD_DRAFT_API
+/*  Returns the number of microseconds elapsed since the stopwatch was        */
+/*  started, but does not stop or deallocate the stopwatch.                   */
+ZMQ_EXPORT unsigned long zmq_stopwatch_intermediate (void *watch_);
+#endif
+
 /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
-/*  the stopwatch was started.                                                */
+/*  the stopwatch was started, and deallocates that watch.                    */
 ZMQ_EXPORT unsigned long zmq_stopwatch_stop (void *watch_);
 
 /*  Sleeps for specified number of seconds.                                   */

--- a/src/poller_base.cpp
+++ b/src/poller_base.cpp
@@ -42,7 +42,7 @@ zmq::poller_base_t::~poller_base_t ()
     zmq_assert (get_load () == 0);
 }
 
-int zmq::poller_base_t::get_load ()
+int zmq::poller_base_t::get_load () const
 {
     return load.get ();
 }

--- a/src/poller_base.hpp
+++ b/src/poller_base.hpp
@@ -47,7 +47,7 @@ class poller_base_t
 
     //  Returns load of the poller. Note that this function can be
     //  invoked from a different thread!
-    int get_load ();
+    int get_load () const;
 
     //  Add a timeout to expire in timeout_ milliseconds. After the
     //  expiration timer_event on sink_ object will be called with

--- a/src/select.hpp
+++ b/src/select.hpp
@@ -166,10 +166,6 @@ class select_t : public poller_base_t
     static fd_entries_t::iterator
     find_fd_entry_by_handle (fd_entries_t &fd_entries, handle_t handle_);
 
-    static size_t
-    count_non_retired (const zmq::select_t::fd_entries_t &fd_entries);
-    void assert_load_consistent () const;
-
     //  If true, start has been called.
     bool started;
 

--- a/src/select.hpp
+++ b/src/select.hpp
@@ -119,7 +119,7 @@ class select_t : public poller_base_t
 
         fd_entries_t fd_entries;
         fds_set_t fds_set;
-        bool retired;
+        bool has_retired;
     };
 
     void select_family_entry (family_entry_t &family_entry_,
@@ -143,8 +143,8 @@ class select_t : public poller_base_t
     // See loop for details.
     family_entries_t::iterator current_family_entry_it;
 
-    bool try_remove_fd_entry (family_entries_t::iterator family_entry_it,
-                              zmq::fd_t &handle_);
+    int try_retire_fd_entry (family_entries_t::iterator family_entry_it,
+                             zmq::fd_t &handle_);
 
     static const size_t fd_family_cache_size = 8;
     std::pair<fd_t, u_short> fd_family_cache[fd_family_cache_size];
@@ -165,6 +165,10 @@ class select_t : public poller_base_t
 
     static fd_entries_t::iterator
     find_fd_entry_by_handle (fd_entries_t &fd_entries, handle_t handle_);
+
+    static size_t
+    count_non_retired (const zmq::select_t::fd_entries_t &fd_entries);
+    void assert_load_consistent () const;
 
     //  If true, start has been called.
     bool started;

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -37,6 +37,10 @@
 
 #ifndef ZMQ_BUILD_DRAFT_API
 
+/*  Returns the number of microseconds elapsed since the stopwatch was        */
+/*  started, but does not stop or deallocate the stopwatch.                   */
+unsigned long zmq_stopwatch_intermediate (void *watch_);
+
 /*  DRAFT Socket types.                                                       */
 #define ZMQ_SERVER 12
 #define ZMQ_CLIENT 13

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -66,12 +66,18 @@ void *zmq_stopwatch_start ()
     return (void *) watch;
 }
 
-unsigned long zmq_stopwatch_stop (void *watch_)
+unsigned long zmq_stopwatch_intermediate (void *watch_)
 {
     uint64_t end = zmq::clock_t::now_us ();
     uint64_t start = *(uint64_t *) watch_;
-    free (watch_);
     return (unsigned long) (end - start);
+}
+
+unsigned long zmq_stopwatch_stop (void *watch_)
+{
+    unsigned long res = zmq_stopwatch_intermediate (watch_);
+    free (watch_);
+    return res;
 }
 
 void *zmq_threadstart (zmq_thread_fn *func, void *arg)

--- a/tests/test_timers.cpp
+++ b/tests/test_timers.cpp
@@ -154,13 +154,22 @@ int main (void)
 
     bool timer_invoked = false;
 
-    int timer_id = zmq_timers_add (timers, 100, handler, &timer_invoked);
+    const int full_timeout = 100;
+    void *const stopwatch = zmq_stopwatch_start ();
+
+    int timer_id =
+      zmq_timers_add (timers, full_timeout, handler, &timer_invoked);
     assert (timer_id);
 
-    //  Timer should be invoked yet
+    //  Timer should not have been invoked yet
     int rc = zmq_timers_execute (timers);
     assert (rc == 0);
-    assert (!timer_invoked);
+
+#ifdef ZMQ_BUILD_DRAFT_API
+    if (zmq_stopwatch_intermediate (stopwatch) < full_timeout) {
+        assert (!timer_invoked);
+    }
+#endif
 
     //  Wait half the time and check again
     long timeout = zmq_timers_timeout (timers);
@@ -168,7 +177,11 @@ int main (void)
     msleep (timeout / 2);
     rc = zmq_timers_execute (timers);
     assert (rc == 0);
-    assert (!timer_invoked);
+#ifdef ZMQ_BUILD_DRAFT_API
+    if (zmq_stopwatch_intermediate (stopwatch) < full_timeout) {
+        assert (!timer_invoked);
+    }
+#endif
 
     // Wait until the end
     rc = sleep_and_execute (timers);
@@ -182,7 +195,11 @@ int main (void)
     msleep (timeout / 2);
     rc = zmq_timers_execute (timers);
     assert (rc == 0);
-    assert (!timer_invoked);
+#ifdef ZMQ_BUILD_DRAFT_API
+    if (zmq_stopwatch_intermediate (stopwatch) < 2 * full_timeout) {
+        assert (!timer_invoked);
+    }
+#endif
 
     // Reset timer and wait half of the time left
     rc = zmq_timers_reset (timers, timer_id);
@@ -190,7 +207,9 @@ int main (void)
     msleep (timeout / 2);
     rc = zmq_timers_execute (timers);
     assert (rc == 0);
-    assert (!timer_invoked);
+    if (zmq_stopwatch_stop (stopwatch) < 2 * full_timeout) {
+        assert (!timer_invoked);
+    }
 
     // Wait until the end
     rc = sleep_and_execute (timers);


### PR DESCRIPTION
Solution: wait until all fds have been unregistered before exiting select_t::loop

Fixes #2925 

This PR requires #2908 to be merged first.