### PR TITLE
fix Windows Intel compiler build failure

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -244,14 +244,14 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
  */
 typedef struct zmq_msg_t
 {
-#if defined(__GNUC__) || defined(__INTEL_COMPILER)                             \
-  || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
-  || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
-    unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
-#elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
     __declspec(align (8)) unsigned char _[64];
 #elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE))
     __declspec(align (4)) unsigned char _[64];
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
+  || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
+  || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
+    unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
 #else
     unsigned char _[64];
 #endif


### PR DESCRIPTION
Reapply #2920 after formatting was updated.