### PR TITLE
Problem: DRAFT build broken with GCC 4.7

### DIFF
--- a/tests/test_timers.cpp
+++ b/tests/test_timers.cpp
@@ -154,7 +154,7 @@ int main (void)
 
     bool timer_invoked = false;
 
-    const int full_timeout = 100;
+    const unsigned long full_timeout = 100;
     void *const stopwatch = zmq_stopwatch_start ();
 
     int timer_id =


### PR DESCRIPTION
Solution: change variable type in test_timers to match public API