### PR TITLE
Problem: regression with "select" on *nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ matrix:
   - env: BUILD_TYPE=default POLLER=select
     os: linux
 
-sudo: required
+sudo: false
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "android" ] ; then brew update; brew install binutils ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,10 @@ matrix:
         - llvm-toolchain-trusty-5.0
       packages:
         - clang-5.0
+  - env: BUILD_TYPE=default POLLER=poll
+    os: linux
+  - env: BUILD_TYPE=default POLLER=select
+    os: linux
 
 sudo: required
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -48,6 +48,10 @@ if [ $BUILD_TYPE == "default" ]; then
         CONFIG_OPTS+=("--with-norm=yes")
     fi
 
+    if [ -n "$POLLER" ]; then
+        CONFIG_OPTS+=("--with-poller=${POLLER}")
+    fi
+
     if [ -z $DRAFT ] || [ $DRAFT == "disabled" ]; then
         CONFIG_OPTS+=("--enable-drafts=no")
     elif [ $DRAFT == "enabled" ]; then

--- a/src/io_thread.cpp
+++ b/src/io_thread.cpp
@@ -38,7 +38,7 @@
 
 zmq::io_thread_t::io_thread_t (ctx_t *ctx_, uint32_t tid_) :
     object_t (ctx_, tid_),
-    mailbox_handle (NULL)
+    mailbox_handle ((poller_t::handle_t) NULL)
 {
     poller = new (std::nothrow) poller_t (*ctx_);
     alloc_assert (poller);

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -213,7 +213,7 @@ void zmq::select_t::rm_fd (handle_t handle_)
 #else
     fd_entries_t::iterator fd_entry_it =
       find_fd_entry_by_handle (family_entry.fd_entries, handle_);
-    assert (fd_entry_it != fd_entries.end ());
+    assert (fd_entry_it != family_entry.fd_entries.end ());
 
     zmq_assert (fd_entry_it->fd != retired_fd);
     fd_entry_it->fd = retired_fd;

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -48,6 +48,8 @@
 #include "i_poll_events.hpp"
 
 #include <algorithm>
+#include <limits>
+#include <climits>
 
 zmq::select_t::select_t (const zmq::ctx_t &ctx_) :
     ctx (ctx_),

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -323,8 +323,6 @@ void zmq::select_t::loop ()
                              (long) (timeout % 1000 * 1000)};
 #endif
 
-        int rc = 0;
-
 #if defined ZMQ_HAVE_WINDOWS
         /*
             On Windows select does not allow to mix descriptors from different
@@ -342,6 +340,7 @@ void zmq::select_t::loop ()
         */
 
         //  If there is just one family, there is no reason to use WSA events.
+        int rc = 0;
         const bool use_wsa_events = family_entries.size () > 1;
         if (use_wsa_events) {
             // TODO: I don't really understand why we are doing this. If any of

--- a/src/select.hpp
+++ b/src/select.hpp
@@ -115,7 +115,11 @@ class select_t : public poller_base_t
 
     struct family_entry_t
     {
+#ifndef ZMQ_HAVE_WINDOWS
+        family_entry_t () {};
+#else
         family_entry_t ();
+#endif
 
         fd_entries_t fd_entries;
         fds_set_t fds_set;


### PR DESCRIPTION
@sigiesec using select does not work anymore since recent changes, it works fine with 4.2.2 though.

There is still one weird linking problem left:

```
  CXXLD    tools/curve_keygen
src/.libs/libzmq.so: undefined reference to `zmq::select_t::family_entry_t::family_entry_t()'
collect2: error: ld returned 1 exit status
```

I think it's cause by this line: https://github.com/zeromq/libzmq/blob/master/src/select.hpp#L118

Is that perhaps a Windows compiler specific thing?

EDIT: I think the constructor was missing the body and GCC is not happy about that - tests still fail though