### PR TITLE
Fix build break when SIO_LOOPBACK_FAST_PATH is not defined (i.e. in VS2010)

### DIFF
--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -335,7 +335,7 @@ void zmq::tcp_assert_tuning_error (zmq::fd_t s_, int rc_)
 
 void zmq::tcp_tune_loopback_fast_path (const fd_t socket_)
 {
-#if defined ZMQ_HAVE_WINDOWS
+#if defined ZMQ_HAVE_WINDOWS && defined SIO_LOOPBACK_FAST_PATH
     int sio_loopback_fastpath = 1;
     DWORD numberOfBytesReturned = 0;
 


### PR DESCRIPTION
Problem: build is broken on Windows when SIO_LOOPBACK_FAST_PATH is not defined (i.e. in VS2010, even on Windows 10, even with Windows 10 SDK installed, as VS2010 won't detect/use it)

Solution: add one more condition to #if.
