### PR TITLE
Problem: Tests for different TIPC address types missing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -773,7 +773,8 @@ test_apps += \
 	tests/test_router_mandatory_tipc \
 	tests/test_shutdown_stress_tipc \
 	tests/test_sub_forward_tipc \
-	tests/test_term_endpoint_tipc
+	tests/test_term_endpoint_tipc \
+	tests/test_address_tipc
 
 tests_test_connect_delay_tipc_SOURCES = tests/test_connect_delay_tipc.cpp
 tests_test_connect_delay_tipc_LDADD = src/libzmq.la
@@ -798,6 +799,10 @@ tests_test_sub_forward_tipc_LDADD = src/libzmq.la
 
 tests_test_term_endpoint_tipc_SOURCES = tests/test_term_endpoint_tipc.cpp
 tests_test_term_endpoint_tipc_LDADD = src/libzmq.la
+
+tests_test_address_tipc_SOURCES = tests/test_address_tipc.cpp
+tests_test_address_tipc_LDADD = src/libzmq.la ${UNITY_LIBS}
+tests_test_address_tipc_CPPFLAGS = ${UNITY_CPPFLAGS}
 
 endif
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -936,6 +936,13 @@ int zmq::socket_base_t::connect (const char *addr_)
             LIBZMQ_DELETE (paddr);
             return -1;
         }
+        sockaddr_tipc *saddr = (sockaddr_tipc *) paddr->resolved.tipc_addr->addr();
+        // Cannot connect to random Port Identity
+        if (saddr->addrtype == TIPC_ADDR_ID && paddr->resolved.tipc_addr->is_random()){
+            LIBZMQ_DELETE(paddr);
+            errno = EINVAL;
+            return -1;
+        }
     }
 #endif
 #if defined ZMQ_HAVE_VMCI

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -936,10 +936,12 @@ int zmq::socket_base_t::connect (const char *addr_)
             LIBZMQ_DELETE (paddr);
             return -1;
         }
-        sockaddr_tipc *saddr = (sockaddr_tipc *) paddr->resolved.tipc_addr->addr();
+        sockaddr_tipc *saddr =
+          (sockaddr_tipc *) paddr->resolved.tipc_addr->addr ();
         // Cannot connect to random Port Identity
-        if (saddr->addrtype == TIPC_ADDR_ID && paddr->resolved.tipc_addr->is_random()){
-            LIBZMQ_DELETE(paddr);
+        if (saddr->addrtype == TIPC_ADDR_ID
+            && paddr->resolved.tipc_addr->is_random ()) {
+            LIBZMQ_DELETE (paddr);
             errno = EINVAL;
             return -1;
         }

--- a/src/tipc_address.cpp
+++ b/src/tipc_address.cpp
@@ -83,28 +83,26 @@ int zmq::tipc_address_t::resolve (const char *name)
     unsigned int z = 1, c = 0, n = 0;
     char eof;
     const char *domain;
-    int res = sscanf (name, "{%u,%u,%u}", &type, &lower, &upper);
+    int res;
 
-    if (res == 0)
-        goto portid;
+
+    if (strncmp (name, "<*>", 3) == 0) {
+        set_random ();
+        address.family = AF_TIPC;
+        address.addrtype = TIPC_ADDR_ID;
+        address.addr.id.node = 0;
+        address.addr.id.ref = 0;
+        address.scope = 0;
+        return 0;
+    }
+
+    res = sscanf (name, "{%u,%u,%u}", &type, &lower, &upper);
     /* Fetch optional domain suffix. */
     if ((domain = strchr (name, '@'))) {
         if (sscanf (domain, "@%u.%u.%u%c", &z, &c, &n, &eof) != 3)
             return EINVAL;
     }
-    if (res == 3)
-        goto nameseq;
-    else if (res == 2 && type > TIPC_RESERVED_TYPES) {
-        address.family = AF_TIPC;
-        address.addrtype = TIPC_ADDR_NAME;
-        address.addr.name.name.type = type;
-        address.addr.name.name.instance = lower;
-        address.addr.name.domain = tipc_addr (z, c, n);
-        address.scope = 0;
-        return 0;
-    } else
-        return EINVAL;
-nameseq:
+    if (res == 3) {
     if (type < TIPC_RESERVED_TYPES || upper < lower)
         return EINVAL;
     address.family = AF_TIPC;
@@ -114,7 +112,15 @@ nameseq:
     address.addr.nameseq.upper = upper;
     address.scope = TIPC_ZONE_SCOPE;
     return 0;
-portid:
+    } else if (res == 2 && type > TIPC_RESERVED_TYPES) {
+        address.family = AF_TIPC;
+        address.addrtype = TIPC_ADDR_NAME;
+        address.addr.name.name.type = type;
+        address.addr.name.name.instance = lower;
+        address.addr.name.domain = tipc_addr (z, c, n);
+        address.scope = 0;
+        return 0;
+    } else if (res == 0) {
     res = sscanf (name, "<%u.%u.%u:%u>", &z, &c, &n, &ref);
     if (res == 4) {
         address.family = AF_TIPC;
@@ -123,15 +129,8 @@ portid:
         address.addr.id.ref = ref;
         address.scope = 0;
         return 0;
-    } else if (strncmp (name, "<*>", 3) == 0) {
-        set_random ();
-        address.family = AF_TIPC;
-        address.addrtype = TIPC_ADDR_ID;
-        address.addr.id.node = 0;
-        address.addr.id.ref = 0;
-        address.scope = 0;
-        return 0;
-    } else
+        }
+    }
         return EINVAL;
 }
 
@@ -149,20 +148,16 @@ int zmq::tipc_address_t::to_string (std::string &addr_)
         s << ", " << address.addr.nameseq.lower;
         s << ", " << address.addr.nameseq.upper << "}";
         addr_ = s.str ();
-    } else if (address.addrtype == TIPC_ADDR_ID) {
+    } else if (address.addrtype == TIPC_ADDR_ID || is_random ()) {
         s << "tipc://"
           << "<" << tipc_zone (address.addr.id.node);
         s << "." << tipc_cluster (address.addr.id.node);
         s << "." << tipc_node (address.addr.id.node);
         s << ":" << address.addr.id.ref << ">";
         addr_ = s.str ();
-    } else if (is_random ()) {
-        s << "tipc://"
-          << "<" << tipc_zone (address.addr.id.node);
-        s << "." << tipc_cluster (address.addr.id.node);
-        s << "." << tipc_node (address.addr.id.node);
-        s << ":" << address.addr.id.ref << ">";
-        addr_ = s.str ();
+    } else {
+        addr_.clear ();
+        return -1;
     }
     return 0;
 }

--- a/src/tipc_address.cpp
+++ b/src/tipc_address.cpp
@@ -103,15 +103,15 @@ int zmq::tipc_address_t::resolve (const char *name)
             return EINVAL;
     }
     if (res == 3) {
-    if (type < TIPC_RESERVED_TYPES || upper < lower)
-        return EINVAL;
-    address.family = AF_TIPC;
-    address.addrtype = TIPC_ADDR_NAMESEQ;
-    address.addr.nameseq.type = type;
-    address.addr.nameseq.lower = lower;
-    address.addr.nameseq.upper = upper;
-    address.scope = TIPC_ZONE_SCOPE;
-    return 0;
+        if (type < TIPC_RESERVED_TYPES || upper < lower)
+            return EINVAL;
+        address.family = AF_TIPC;
+        address.addrtype = TIPC_ADDR_NAMESEQ;
+        address.addr.nameseq.type = type;
+        address.addr.nameseq.lower = lower;
+        address.addr.nameseq.upper = upper;
+        address.scope = TIPC_ZONE_SCOPE;
+        return 0;
     } else if (res == 2 && type > TIPC_RESERVED_TYPES) {
         address.family = AF_TIPC;
         address.addrtype = TIPC_ADDR_NAME;
@@ -121,17 +121,17 @@ int zmq::tipc_address_t::resolve (const char *name)
         address.scope = 0;
         return 0;
     } else if (res == 0) {
-    res = sscanf (name, "<%u.%u.%u:%u>", &z, &c, &n, &ref);
-    if (res == 4) {
-        address.family = AF_TIPC;
-        address.addrtype = TIPC_ADDR_ID;
-        address.addr.id.node = tipc_addr (z, c, n);
-        address.addr.id.ref = ref;
-        address.scope = 0;
-        return 0;
+        res = sscanf (name, "<%u.%u.%u:%u>", &z, &c, &n, &ref);
+        if (res == 4) {
+            address.family = AF_TIPC;
+            address.addrtype = TIPC_ADDR_ID;
+            address.addr.id.node = tipc_addr (z, c, n);
+            address.addr.id.ref = ref;
+            address.scope = 0;
+            return 0;
         }
     }
-        return EINVAL;
+    return EINVAL;
 }
 
 int zmq::tipc_address_t::to_string (std::string &addr_)

--- a/src/tipc_listener.cpp
+++ b/src/tipc_listener.cpp
@@ -128,23 +128,30 @@ int zmq::tipc_listener_t::get_address (std::string &addr_)
 
 int zmq::tipc_listener_t::set_address (const char *addr_)
 {
-    //convert str to address struct
+    // Convert str to address struct
     int rc = address.resolve (addr_);
     if (rc != 0)
         return -1;
+
+    // Cannot bind non-random Port Identity
+    struct sockaddr_tipc *a = (sockaddr_tipc *) address.addr ();
+    if (!address.is_random () && a->addrtype == TIPC_ADDR_ID) {
+        errno = EINVAL;
+        return -1;
+    }
+
     //  Create a listening socket.
     s = open_socket (AF_TIPC, SOCK_STREAM, 0);
     if (s == -1)
         return -1;
 
-    // If address was randomly assigned, update address object to reflect the actual address
+    // If random Port Identity, update address object to reflect the assigned address
     if (address.is_random ()) {
         struct sockaddr_storage ss;
         socklen_t sl = sizeof (ss);
         int rc = getsockname (s, (sockaddr *) &ss, &sl);
-        if (rc != 0) {
-            return rc;
-        }
+        if (rc != 0)
+            goto error;
 
         tipc_address_t addr ((struct sockaddr *) &ss, sl);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,7 @@ if(NOT WIN32)
     )
     if(ZMQ_HAVE_TIPC)
       list(APPEND tests
+            test_address_tipc
             test_pair_tipc
             test_reqrep_device_tipc
             test_reqrep_tipc

--- a/tests/test_address_tipc.cpp
+++ b/tests/test_address_tipc.cpp
@@ -1,0 +1,140 @@
+/*
+    Copyright (c) 2007-2018 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+#include <unity.h>
+
+void *ctx;
+
+void setUp ()
+{
+    ctx = zmq_ctx_new ();
+}
+void tearDown ()
+{
+    zmq_ctx_term (ctx);
+    ctx = NULL;
+}
+
+void test_tipc_port_name_and_domain ()
+{
+    TEST_ASSERT_NOT_NULL (ctx);
+
+    // test Port Name addressing
+    void *sb = zmq_socket (ctx, ZMQ_REP);
+    TEST_ASSERT_NOT_NULL (sb);
+    int rc = zmq_bind (sb, "tipc://{5560,0,0}");
+    TEST_ASSERT_EQUAL_INT (0, rc);
+
+    void *sc = zmq_socket (ctx, ZMQ_REQ);
+    TEST_ASSERT_NOT_NULL (sc);
+    rc = zmq_connect (sc, "tipc://{5560,0}@0.0.0");
+    TEST_ASSERT_EQUAL_INT (0, rc);
+
+    bounce (sb, sc);
+
+    rc = zmq_close (sc);
+    TEST_ASSERT_EQUAL_INT (0, rc);
+
+    rc = zmq_close (sb);
+    TEST_ASSERT_EQUAL_INT (0, rc);
+}
+
+void test_tipc_port_identity ()
+{
+    char endpoint[256];
+    size_t size = 256;
+    unsigned int z, c, n, ref;
+
+    TEST_ASSERT_NOT_NULL (ctx);
+
+    void *sb = zmq_socket (ctx, ZMQ_REP);
+    TEST_ASSERT_NOT_NULL (sb);
+
+    void *sc = zmq_socket (ctx, ZMQ_REQ);
+    TEST_ASSERT_NOT_NULL (sc);
+
+    // Test binding to random Port Identity
+    int rc = zmq_bind (sb, "tipc://<*>");
+    TEST_ASSERT_EQUAL_INT (0, rc);
+
+    // Test resolving assigned address, should return a properly formatted string
+    rc = zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, &endpoint[0], &size);
+    TEST_ASSERT_EQUAL_INT (0, rc);
+
+    rc = sscanf (&endpoint[0], "tipc://<%u.%u.%u:%u>", &z, &c, &n, &ref);
+    TEST_ASSERT_EQUAL_INT (4, rc);
+
+    rc = zmq_connect (sc, endpoint);
+    TEST_ASSERT_EQUAL_INT (0, rc);
+
+    bounce (sb, sc);
+
+    rc = zmq_close (sc);
+    TEST_ASSERT_EQUAL_INT (0, rc);
+
+    rc = zmq_close (sb);
+    TEST_ASSERT_EQUAL_INT (0, rc);
+}
+
+void test_tipc_bad_addresses ()
+{
+    TEST_ASSERT_NOT_NULL (ctx);
+
+    // Test Port Name addressing
+    void *sb = zmq_socket (ctx, ZMQ_REP);
+    TEST_ASSERT_NOT_NULL (sb);
+
+    // Test binding to a fixed address, should fail
+    int rc = zmq_bind (sb, "tipc://<1.2.3:123123>");
+    TEST_ASSERT_EQUAL_INT (-1, rc);
+    TEST_ASSERT_EQUAL_INT (EINVAL, errno);
+
+    // Test connecting to random identity, should fail
+    rc = zmq_connect (sb, "tipc://<*>");
+    TEST_ASSERT_EQUAL_INT (-1, rc);
+    TEST_ASSERT_EQUAL_INT (EINVAL, errno);
+
+    // Clean up
+    rc = zmq_close (sb);
+    TEST_ASSERT_EQUAL_INT (0, rc);
+}
+
+
+int main ()
+{
+    setup_test_environment ();
+
+    UNITY_BEGIN ();
+    RUN_TEST (test_tipc_port_name_and_domain);
+    RUN_TEST (test_tipc_port_identity);
+    RUN_TEST (test_tipc_bad_addresses);
+
+    return UNITY_END ();
+}


### PR DESCRIPTION
Solution: 
Add tests for binding/connecting with different TIPC address types, and error checks misused addresses.