### PR TITLE
Fix gcc 8 build warning/error with -O3.

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -536,7 +536,7 @@ const char *zmq::msg_t::group ()
 
 int zmq::msg_t::set_group (const char *group_)
 {
-    return set_group (group_, strlen (group_));
+    return set_group (group_, ZMQ_GROUP_MAX_LENGTH);
 }
 
 int zmq::msg_t::set_group (const char *group_, size_t length_)


### PR DESCRIPTION
Hi,

I have a small build error/warning when building with gcc 8 and -O3 in CFLAGS/CXXFLAGS:

```
In member function ‘zmq::msg_t::set_group(char const*, unsigned long)’,
    inlined from ‘zmq::msg_t::set_group(char const*)’ at src/msg.cpp:549:22:
src/msg.cpp:560:13: error: ‘strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
     strncpy (u.base.group, group_, length_);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/msg.cpp: In member function ‘zmq::msg_t::set_group(char const*)’:
src/msg.cpp:549:22: note: length computed here
     return set_group (group_, strlen (group_));
            ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
```

Here we don't actually need to call `strlen(group_)`, since `strncpy` will already stop at the end of the string, and this is what gcc tries to complain about in his cryptic message. Replacing it with the maximum length that fits for a group silences the warning, and has the same end result, without computing the string length both in `strlen` and `strncpy`.

Cheers,
Romain