### PR TITLE
Problem: unittest_mtrie fails on 32bit *nix

### DIFF
--- a/unittests/unittest_mtrie.cpp
+++ b/unittests/unittest_mtrie.cpp
@@ -380,8 +380,8 @@ void check_count (zmq::generic_mtrie_t<int>::prefix_t data_,
                   size_t len_,
                   int *count_)
 {
-    --count_;
-    TEST_ASSERT_GREATER_OR_EQUAL (0, count_);
+    --(*count_);
+    TEST_ASSERT_GREATER_OR_EQUAL (0, *count_);
 }
 
 void add_duplicate_entry (zmq::generic_mtrie_t<int> &mtrie, int (&pipes)[2])


### PR DESCRIPTION
Solution: correctly dereference pointer in test.

@sigiesec - just a small error that was not visible on 64bit (I guess the pointer there evaluates as greater than 0, but on 32bit it's negative)