### PR TITLE
Problem: pthread condvar timeouts are broken

### DIFF
--- a/src/condition_variable.hpp
+++ b/src/condition_variable.hpp
@@ -181,7 +181,12 @@ class condition_variable_t
   public:
     inline condition_variable_t ()
     {
-        int rc = pthread_cond_init (&cond, NULL);
+        pthread_condattr_t attr;
+        pthread_condattr_init (&attr);
+#ifndef ZMQ_HAVE_OSX
+        pthread_condattr_setclock (&attr, CLOCK_MONOTONIC);
+#endif
+        int rc = pthread_cond_init (&cond, &attr);
         posix_assert (rc);
     }
 
@@ -198,9 +203,9 @@ class condition_variable_t
         if (timeout_ != -1) {
             struct timespec timeout;
 
-#if defined ZMQ_HAVE_OSX                                                       \
-  && __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // less than macOS 10.12
-            alt_clock_gettime (SYSTEM_CLOCK, &timeout);
+#ifdef ZMQ_HAVE_OSX
+            timeout.tv_sec = 0;
+            timeout.tv_nsec = 0;
 #else
             clock_gettime (CLOCK_MONOTONIC, &timeout);
 #endif
@@ -212,8 +217,11 @@ class condition_variable_t
                 timeout.tv_sec++;
                 timeout.tv_nsec -= 1000000000;
             }
-
+#ifdef ZMQ_HAVE_OSX
+            rc = pthread_cond_timedwait_relative_np (&cond, mutex_->get_mutex (), &timeout);
+#else
             rc = pthread_cond_timedwait (&cond, mutex_->get_mutex (), &timeout);
+#endif
         } else
             rc = pthread_cond_wait (&cond, mutex_->get_mutex ());
 


### PR DESCRIPTION
Problem: pthread condvar timeouts are broken

Solution:
- Use `pthread_cond_timedwait_relative_np()` on macOS
- Use `pthread_condattr_setclock(CLOCK_MONOTONIC)` on other platforms

Context: https://github.com/zeromq/czmq/issues/1873#issuecomment-370279244