### PR TITLE
Problem: mis-detection of threadsafe_static_init causes test failures

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -92,9 +92,8 @@ uint32_t zmq::generate_random ()
 //    configurable via config.h
 
 //  TODO this should probably be done via config.h
-#if __cplusplus >= 201103L                                                     \
-  || (defined(__cpp_threadsafe_static_init)                                    \
-      && __cpp_threadsafe_static_init >= 200806)                               \
+#if (defined(__cpp_threadsafe_static_init)                                     \
+     && __cpp_threadsafe_static_init >= 200806)                                \
   || (defined(_MSC_VER) && _MSC_VER >= 1900)
 #define ZMQ_HAVE_THREADSAFE_STATIC_LOCAL_INIT 1
 //  TODO this might probably also be set if a sufficiently recent gcc is used


### PR DESCRIPTION
Solution: do not rely __cplusplus >= 201103L to detect whether the
compiler supports thread safe static initialisation, but check only
the proper feature preprocessor macro.
GCC introduced it in version 8, and Clang in version 6.