### PR TITLE
Revert "Problem: mis-detection of threadsafe_static_init causes test failures"

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -92,8 +92,9 @@ uint32_t zmq::generate_random ()
 //    configurable via config.h
 
 //  TODO this should probably be done via config.h
-#if (defined(__cpp_threadsafe_static_init)                                     \
-     && __cpp_threadsafe_static_init >= 200806)                                \
+#if __cplusplus >= 201103L                                                     \
+  || (defined(__cpp_threadsafe_static_init)                                    \
+      && __cpp_threadsafe_static_init >= 200806)                               \
   || (defined(_MSC_VER) && _MSC_VER >= 1900)
 #define ZMQ_HAVE_THREADSAFE_STATIC_LOCAL_INIT 1
 //  TODO this might probably also be set if a sufficiently recent gcc is used


### PR DESCRIPTION
Reverts zeromq/libzmq#2974

#2974 was based on wrong assumptions. The problem in czmq/malamute was unrelated to thread-safety; and while gcc/clang support the feature *macro* __cpp_threadsafe_static_init only in recent versions, they support the actual feature for a long time (gcc since at least 4.3.0). Probably, the condition could be even more relaxed based on the gcc version number.