### PR TITLE
Fixed issue #2979

### DIFF
--- a/src/mtrie.hpp
+++ b/src/mtrie.hpp
@@ -32,7 +32,7 @@
 
 #include "generic_mtrie.hpp"
 
-#if __cplusplus >= 201103L || defined(_MSC_VER)
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER > 1600)
 #define ZMQ_HAS_EXTERN_TEMPLATE 1
 #else
 #define ZMQ_HAS_EXTERN_TEMPLATE 0


### PR DESCRIPTION
```
Problem: VS2010 build is broken

Solution: Update macro guarding ZMQ_HAS_EXTERN_TEMPLATE to set it to 0 under VS2010
```
