### PR TITLE
Partial fix for issue 2963

### DIFF
--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -444,7 +444,7 @@ void zmq::socks_connecter_t::close ()
     const int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (endpoint, (int) s);
+    socket->event_closed (endpoint, s);
     s = retired_fd;
 }
 

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -158,7 +158,7 @@ void zmq::socks_connecter_t::in_event ()
                 //  Attach the engine to the corresponding session object.
                 send_attach (session, engine);
 
-                socket->event_connected (endpoint, (int) s);
+                socket->event_connected (endpoint, s);
 
                 rm_fd (handle);
                 s = -1;

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -978,7 +978,7 @@ void zmq::stream_engine_t::error (error_reason_t reason)
         socket->event_handshake_failed_no_detail (endpoint, err);
     }
 #endif
-    socket->event_disconnected (endpoint, (int) s);
+    socket->event_disconnected (endpoint, s);
     session->flush ();
     session->engine_error (reason);
     unplug ();

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -435,6 +435,6 @@ void zmq::tcp_connecter_t::close ()
     const int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (endpoint, (int) s);
+    socket->event_closed (endpoint, s);
     s = retired_fd;
 }

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -160,7 +160,7 @@ void zmq::tcp_connecter_t::out_event ()
     //  Shut the connecter down.
     terminate ();
 
-    socket->event_connected (endpoint, (int) fd);
+    socket->event_connected (endpoint, fd);
 }
 
 void zmq::tcp_connecter_t::rm_handle ()

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -179,7 +179,7 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
 
     if (options.use_fd != -1) {
         s = options.use_fd;
-        socket->event_listening (endpoint, (int) s);
+        socket->event_listening (endpoint, s);
         return 0;
     }
 

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -144,7 +144,7 @@ void zmq::tcp_listener_t::close ()
     int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (endpoint, (int) s);
+    socket->event_closed (endpoint, s);
     s = retired_fd;
 }
 

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -275,7 +275,7 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
         goto error;
 #endif
 
-    socket->event_listening (endpoint, (int) s);
+    socket->event_listening (endpoint, s);
     return 0;
 
 error:


### PR DESCRIPTION
Problem: issues found during static code analysis.
This PR addresses 8 similar issues where method's 2nd argument is of zmq:fd_t type, and value passed is of the same type, but for some reason is cast to int, causing static analysis to tag it as suspicious cast for 64bit mode. 

Solution: remove cast
