### PR TITLE
Fix for #2997

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -158,6 +158,10 @@ target_compile_definitions (unity PUBLIC "UNITY_USE_COMMAND_LINE_ARGS" "UNITY_EX
 target_include_directories (unity
     PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../external/unity")
 
+IF (MSVC_VERSION LESS 1700)
+    SET_SOURCE_FILES_PROPERTIES("${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.c" PROPERTIES LANGUAGE CXX)
+ENDIF()
+
 # add library and include dirs for all targets
 if (BUILD_SHARED)
 link_libraries(libzmq ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)


### PR DESCRIPTION
Problem: VS2010 build is broken due to lack of VS2010's C99+ support require by bundled Unity
Solution: force VS2010 to compile Unity as C++
