### PR TITLE
Problems: some APIs have met stable conditions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,13 @@
 * The following DRAFT APIs have been marked as STABLE and will not change
   anymore:
   - ZMQ_MSG_T_SIZE context option (see doc/zmq_ctx_get.txt)
+  - ZMQ_GSSAPI_PRINCIPAL_NAMETYPE and ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE
+    socket options, for the corresponding GSSAPI features. Additional
+    definitions for principal name types:
+    - ZMQ_GSSAPI_NT_HOSTBASED
+    - ZMQ_GSSAPI_NT_USER_NAME
+    - ZMQ_GSSAPI_NT_KRB5_PRINCIPAL
+    See doc/zmq_gssapi.txt for details.
 
 
 0MQ version 4.2.4 stable, released on 2018/03/21

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
-0MQ version 4.2.5 stable, released on 20xx/xx/xx
+0MQ version 4.3.1 stable, released on 20xx/xx/xx
 ================================================
+
+* The following DRAFT APIs have been marked as STABLE and will not change
+  anymore:
+  - ZMQ_MSG_T_SIZE context option (see doc/zmq_ctx_get.txt)
 
 
 0MQ version 4.2.4 stable, released on 2018/03/21

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@
     - ZMQ_GSSAPI_NT_USER_NAME
     - ZMQ_GSSAPI_NT_KRB5_PRINCIPAL
     See doc/zmq_gssapi.txt for details.
+  - ZMQ_BINDTODEVICE socket option (Linux only), which will bind the
+    socket(s) to the specified interface. Allows to use Linux VRF, see:
+    https://www.kernel.org/doc/Documentation/networking/vrf.txt
+    NOTE: requires the program to be ran as root OR with CAP_NET_RAW
 
 
 0MQ version 4.2.4 stable, released on 2018/03/21

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_SUBST(PACKAGE_VERSION)
 # ZeroMQ version 4.2.2: 6:2:1 (ABI version 5)
 # ZeroMQ version 4.2.3: 6:3:1 (ABI version 5)
 # ZeroMQ version 4.2.4: 6:4:1 (ABI version 5)
-# ZeroMQ version 4.2.5: 6:5:1 (ABI version 5)
+# ZeroMQ version 4.3.1: 6:5:1 (ABI version 5)
 #
 # libzmq -version-info current:revision:age
 LTVER="6:5:1"

--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -68,7 +68,6 @@ ZMQ_MSG_T_SIZE: Get the zmq_msg_t size at runtime
 The 'ZMQ_MSG_T_SIZE' argument returns the size of the zmq_msg_t structure at
 runtime, as defined in the include/zmq.h public header.
 This is useful for example for FFI bindings that can't simply do a sizeof().
-NOTE: in DRAFT state, not yet available in stable releases.
 
 
 RETURN VALUE

--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -43,6 +43,7 @@ ZMQ_ZERO_COPY_RCV: Get message decoding strategy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_ZERO_COPY_RCV' argument return whether message decoder uses a zero copy
 strategy when receiving messages. Default value is 1.
+NOTE: in DRAFT state, not yet available in stable releases.
 
 
 ZMQ_SOCKET_LIMIT: Get largest configurable number of sockets

--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -134,6 +134,7 @@ use a zero copy strategy when receiving messages. The zero copy strategy can
 lead to increased memory usage in some cases. This option allows you to use the
 older copying strategy. You can query the value of this option with
 linkzmq:zmq_ctx_get[3] using the 'ZMQ_ZERO_COPY_RECV' option.
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Default value:: 1

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -40,8 +40,8 @@
 
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
-#define ZMQ_VERSION_MINOR 2
-#define ZMQ_VERSION_PATCH 5
+#define ZMQ_VERSION_MINOR 3
+#define ZMQ_VERSION_PATCH 1
 
 #define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
     ((major) *10000 + (minor) *100 + (patch))
@@ -215,6 +215,7 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 #define ZMQ_THREAD_PRIORITY 3
 #define ZMQ_THREAD_SCHED_POLICY 4
 #define ZMQ_MAX_MSGSZ 5
+#define ZMQ_MSG_T_SIZE 6
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT 1
@@ -625,7 +626,6 @@ ZMQ_EXPORT void zmq_threadclose (void *thread);
 #define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 
 /*  DRAFT Context options                                                     */
-#define ZMQ_MSG_T_SIZE 6
 #define ZMQ_THREAD_AFFINITY_CPU_ADD 7
 #define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
 #define ZMQ_THREAD_NAME_PREFIX 9

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -373,6 +373,8 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
 #define ZMQ_USE_FD 89
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
@@ -406,6 +408,15 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 
 /*  Deprecated Message options                                                */
 #define ZMQ_SRCFD 2
+
+/******************************************************************************/
+/*  GSSAPI definitions                                                        */
+/******************************************************************************/
+
+/*  GSSAPI principal name types                                               */
+#define ZMQ_GSSAPI_NT_HOSTBASED 0
+#define ZMQ_GSSAPI_NT_USER_NAME 1
+#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 /******************************************************************************/
 /*  0MQ socket events and monitoring                                          */
@@ -581,8 +592,6 @@ ZMQ_EXPORT void zmq_threadclose (void *thread);
 #define ZMQ_DGRAM 18
 
 /*  DRAFT Socket options.                                                     */
-#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
-#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
 #define ZMQ_BINDTODEVICE 92
 #define ZMQ_ZAP_ENFORCE_DOMAIN 93
 #define ZMQ_LOOPBACK_FASTPATH 94
@@ -712,15 +721,6 @@ zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
 ZMQ_EXPORT int zmq_timers_reset (void *timers, int timer_id);
 ZMQ_EXPORT long zmq_timers_timeout (void *timers);
 ZMQ_EXPORT int zmq_timers_execute (void *timers);
-
-/******************************************************************************/
-/*  GSSAPI definitions                                                        */
-/******************************************************************************/
-
-/*  GSSAPI principal name types                                               */
-#define ZMQ_GSSAPI_NT_HOSTBASED 0
-#define ZMQ_GSSAPI_NT_USER_NAME 1
-#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -375,6 +375,7 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 #define ZMQ_USE_FD 89
 #define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
 #define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
+#define ZMQ_BINDTODEVICE 92
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
@@ -592,7 +593,6 @@ ZMQ_EXPORT void zmq_threadclose (void *thread);
 #define ZMQ_DGRAM 18
 
 /*  DRAFT Socket options.                                                     */
-#define ZMQ_BINDTODEVICE 92
 #define ZMQ_ZAP_ENFORCE_DOMAIN 93
 #define ZMQ_LOOPBACK_FASTPATH 94
 #define ZMQ_METADATA 95

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-zeromq (4.2.5) UNRELEASED; urgency=low
+zeromq (4.3.1) UNRELEASED; urgency=low
 
   * Initial packaging.
 

--- a/packaging/debian/zeromq.dsc.obs
+++ b/packaging/debian/zeromq.dsc.obs
@@ -2,7 +2,7 @@ Format: 3.0 (quilt)
 Source: zeromq
 Binary: libzmq5, libzmq3-dev, libzmq5-dbg
 Architecture: any
-Version: 4.2.5
+Version: 4.3.1
 Maintainer: libzmq Developers <zeromq-dev@lists.zeromq.org>
 Homepage: http://www.zeromq.org/
 Standards-Version: 3.9.8

--- a/packaging/redhat/zeromq.spec
+++ b/packaging/redhat/zeromq.spec
@@ -10,7 +10,7 @@
 %endif
 %define lib_name libzmq5
 Name:          zeromq
-Version:       4.2.5
+Version:       4.3.1
 Release:       1%{?dist}
 Summary:       The ZeroMQ messaging library
 Group:         Applications/Internet

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -51,8 +51,6 @@ unsigned long zmq_stopwatch_intermediate (void *watch_);
 #define ZMQ_DGRAM 18
 
 /*  DRAFT Socket options.                                                     */
-#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
-#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
 #define ZMQ_BINDTODEVICE 92
 #define ZMQ_ZAP_ENFORCE_DOMAIN 93
 #define ZMQ_LOOPBACK_FASTPATH 94
@@ -175,15 +173,6 @@ int zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
 int zmq_timers_reset (void *timers, int timer_id);
 long zmq_timers_timeout (void *timers);
 int zmq_timers_execute (void *timers);
-
-/******************************************************************************/
-/*  GSSAPI definitions                                                        */
-/******************************************************************************/
-
-/*  GSSAPI principal name types                                               */
-#define ZMQ_GSSAPI_NT_HOSTBASED 0
-#define ZMQ_GSSAPI_NT_USER_NAME 1
-#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -51,7 +51,6 @@ unsigned long zmq_stopwatch_intermediate (void *watch_);
 #define ZMQ_DGRAM 18
 
 /*  DRAFT Socket options.                                                     */
-#define ZMQ_BINDTODEVICE 92
 #define ZMQ_ZAP_ENFORCE_DOMAIN 93
 #define ZMQ_LOOPBACK_FASTPATH 94
 #define ZMQ_METADATA 95

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -96,7 +96,6 @@ unsigned long zmq_stopwatch_intermediate (void *watch_);
 #define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 
 /*  DRAFT Context options                                                     */
-#define ZMQ_MSG_T_SIZE 6
 #define ZMQ_THREAD_AFFINITY_CPU_ADD 7
 #define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
 #define ZMQ_THREAD_NAME_PREFIX 9

--- a/tests/test_security_gssapi.cpp
+++ b/tests/test_security_gssapi.cpp
@@ -156,12 +156,10 @@ void test_valid_creds (void *ctx,
     assert (rc == 0);
     rc = zmq_setsockopt (client, ZMQ_GSSAPI_PRINCIPAL, name, strlen (name) + 1);
     assert (rc == 0);
-#ifdef ZMQ_BUILD_DRAFT_API
     int name_type = ZMQ_GSSAPI_NT_HOSTBASED;
     rc = zmq_setsockopt (client, ZMQ_GSSAPI_PRINCIPAL_NAMETYPE, &name_type,
                          sizeof (name_type));
     assert (rc == 0);
-#endif
     rc = zmq_connect (client, endpoint);
     assert (rc == 0);
 
@@ -190,12 +188,10 @@ void test_unauth_creds (void *ctx,
     assert (rc == 0);
     rc = zmq_setsockopt (client, ZMQ_GSSAPI_PRINCIPAL, name, strlen (name) + 1);
     assert (rc == 0);
-#ifdef ZMQ_BUILD_DRAFT_API
     int name_type = ZMQ_GSSAPI_NT_HOSTBASED;
     rc = zmq_setsockopt (client, ZMQ_GSSAPI_PRINCIPAL_NAMETYPE, &name_type,
                          sizeof (name_type));
     assert (rc == 0);
-#endif
     zap_deny_all = 1;
     rc = zmq_connect (client, endpoint);
     assert (rc == 0);
@@ -316,12 +312,10 @@ int main (void)
     assert (rc == 0);
     rc = zmq_setsockopt (server, ZMQ_GSSAPI_PRINCIPAL, name, strlen (name) + 1);
     assert (rc == 0);
-#ifdef ZMQ_BUILD_DRAFT_API
     int name_type = ZMQ_GSSAPI_NT_HOSTBASED;
     rc = zmq_setsockopt (server, ZMQ_GSSAPI_PRINCIPAL_NAMETYPE, &name_type,
                          sizeof (name_type));
     assert (rc == 0);
-#endif
     rc = zmq_bind (server, "tcp://127.0.0.1:*");
     assert (rc == 0);
     rc = zmq_getsockopt (server, ZMQ_LAST_ENDPOINT, my_endpoint, &len);


### PR DESCRIPTION
Solution: mark them as stable and bump API versions (ABI stays the same as it's just preprocessor defines changes for now)