### PR TITLE
Fix gcc build problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,9 @@ endif ()
 
 if (LIBZMQ_WERROR)
   zmq_check_cxx_flag_prepend ("-Werror")
-  zmq_check_cxx_flag_prepend ("-errwarn=%all")
+  if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    zmq_check_cxx_flag_prepend ("-errwarn=%all")
+  endif()
 endif ()
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^sparc")


### PR DESCRIPTION
Fixed gcc-related build problem resulting from `-errwarn=%all` switch.

Fixes #3012.