### PR TITLE
Problem: regression in 4.2.3 needs to be fixed before 4.3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,20 +1,5 @@
-0MQ version 4.3.1 stable, released on 20xx/xx/xx
+0MQ version 4.2.5 stable, released on 20xx/xx/xx
 ================================================
-
-* The following DRAFT APIs have been marked as STABLE and will not change
-  anymore:
-  - ZMQ_MSG_T_SIZE context option (see doc/zmq_ctx_get.txt)
-  - ZMQ_GSSAPI_PRINCIPAL_NAMETYPE and ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE
-    socket options, for the corresponding GSSAPI features. Additional
-    definitions for principal name types:
-    - ZMQ_GSSAPI_NT_HOSTBASED
-    - ZMQ_GSSAPI_NT_USER_NAME
-    - ZMQ_GSSAPI_NT_KRB5_PRINCIPAL
-    See doc/zmq_gssapi.txt for details.
-  - ZMQ_BINDTODEVICE socket option (Linux only), which will bind the
-    socket(s) to the specified interface. Allows to use Linux VRF, see:
-    https://www.kernel.org/doc/Documentation/networking/vrf.txt
-    NOTE: requires the program to be ran as root OR with CAP_NET_RAW
 
 
 0MQ version 4.2.4 stable, released on 2018/03/21

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,16 @@
 0MQ version 4.2.5 stable, released on 20xx/xx/xx
 ================================================
 
+* Fixed #3018 - fix backward-incompatible change in the NULL auth
+                mechanism that slipped in 4.2.3 and made connections
+                with a ZAP domain set on a socket but without a working
+                ZAP handler fail. See ZMQ_ZAP_ENFORCE_DOMAIN and RFC27.
+
+* Fixed #3016 - clarify in zmq_close manpage that the operation will
+                complete asynchronously.
+
+* Fixed #3012 - fix CMake build problem when using LIBZMQ_WERROR and a
+                compiler other than GCC.
 
 0MQ version 4.2.4 stable, released on 2018/03/21
 ================================================

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_SUBST(PACKAGE_VERSION)
 # ZeroMQ version 4.2.2: 6:2:1 (ABI version 5)
 # ZeroMQ version 4.2.3: 6:3:1 (ABI version 5)
 # ZeroMQ version 4.2.4: 6:4:1 (ABI version 5)
-# ZeroMQ version 4.3.1: 6:5:1 (ABI version 5)
+# ZeroMQ version 4.2.5: 6:5:1 (ABI version 5)
 #
 # libzmq -version-info current:revision:age
 LTVER="6:5:1"

--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -69,6 +69,7 @@ ZMQ_MSG_T_SIZE: Get the zmq_msg_t size at runtime
 The 'ZMQ_MSG_T_SIZE' argument returns the size of the zmq_msg_t structure at
 runtime, as defined in the include/zmq.h public header.
 This is useful for example for FFI bindings that can't simply do a sizeof().
+NOTE: in DRAFT state, not yet available in stable releases.
 
 
 RETURN VALUE

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -71,6 +71,8 @@ packets received from that interface are processed by the socket. If device
 is a VRF device, then subsequent binds/connects to that socket use addresses
 in the VRF routing table.
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: character string
 Option value unit:: N/A
@@ -257,6 +259,8 @@ a local user name.  A value of 'ZMQ_GSSAPI_NT_KRB5_PRINCIPAL' (2) means it
 is interpreted as an unparsed principal name string (valid only with the
 krb5 GSSAPI mechanism).
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: 0, 1, 2
@@ -272,6 +276,8 @@ name.  A value of 'ZMQ_GSSAPI_NT_USER_NAME' (1) means it is interpreted as
 a local user name.  A value of 'ZMQ_GSSAPI_NT_KRB5_PRINCIPAL' (2) means it
 is interpreted as an unparsed principal name string (valid only with the
 krb5 GSSAPI mechanism).
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -79,6 +79,7 @@ is a VRF device, then subsequent binds/connects to that socket use addresses
 in the VRF routing table.
 
 NOTE: requires setting CAP_NET_RAW on the compiled program.
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: character string
@@ -282,6 +283,8 @@ of 'ZMQ_GSSAPI_NT_USER_NAME' (1) means it is interpreted as a local user name.
 A value of 'ZMQ_GSSAPI_NT_KRB5_PRINCIPAL' (2) means it is interpreted as an
 unparsed principal name string (valid only with the krb5 GSSAPI mechanism).
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: 0, 1, 2
@@ -296,6 +299,8 @@ Sets the name type of the GSSAPI principal.  A value of
 'ZMQ_GSSAPI_NT_USER_NAME' (1) means it is interpreted as a local user name.
 A value of 'ZMQ_GSSAPI_NT_KRB5_PRINCIPAL' (2) means it is interpreted as an
 unparsed principal name string (valid only with the krb5 GSSAPI mechanism).
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -40,8 +40,8 @@
 
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
-#define ZMQ_VERSION_MINOR 3
-#define ZMQ_VERSION_PATCH 1
+#define ZMQ_VERSION_MINOR 2
+#define ZMQ_VERSION_PATCH 5
 
 #define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
     ((major) *10000 + (minor) *100 + (patch))
@@ -215,7 +215,6 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 #define ZMQ_THREAD_PRIORITY 3
 #define ZMQ_THREAD_SCHED_POLICY 4
 #define ZMQ_MAX_MSGSZ 5
-#define ZMQ_MSG_T_SIZE 6
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT 1
@@ -373,9 +372,6 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
 #define ZMQ_USE_FD 89
-#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
-#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
-#define ZMQ_BINDTODEVICE 92
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
@@ -409,15 +405,6 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 
 /*  Deprecated Message options                                                */
 #define ZMQ_SRCFD 2
-
-/******************************************************************************/
-/*  GSSAPI definitions                                                        */
-/******************************************************************************/
-
-/*  GSSAPI principal name types                                               */
-#define ZMQ_GSSAPI_NT_HOSTBASED 0
-#define ZMQ_GSSAPI_NT_USER_NAME 1
-#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 /******************************************************************************/
 /*  0MQ socket events and monitoring                                          */
@@ -593,6 +580,9 @@ ZMQ_EXPORT void zmq_threadclose (void *thread);
 #define ZMQ_DGRAM 18
 
 /*  DRAFT Socket options.                                                     */
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
+#define ZMQ_BINDTODEVICE 92
 #define ZMQ_ZAP_ENFORCE_DOMAIN 93
 #define ZMQ_LOOPBACK_FASTPATH 94
 #define ZMQ_METADATA 95
@@ -635,6 +625,7 @@ ZMQ_EXPORT void zmq_threadclose (void *thread);
 #define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 
 /*  DRAFT Context options                                                     */
+#define ZMQ_MSG_T_SIZE 6
 #define ZMQ_THREAD_AFFINITY_CPU_ADD 7
 #define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
 #define ZMQ_THREAD_NAME_PREFIX 9
@@ -721,6 +712,15 @@ zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
 ZMQ_EXPORT int zmq_timers_reset (void *timers, int timer_id);
 ZMQ_EXPORT long zmq_timers_timeout (void *timers);
 ZMQ_EXPORT int zmq_timers_execute (void *timers);
+
+/******************************************************************************/
+/*  GSSAPI definitions                                                        */
+/******************************************************************************/
+
+/*  GSSAPI principal name types                                               */
+#define ZMQ_GSSAPI_NT_HOSTBASED 0
+#define ZMQ_GSSAPI_NT_USER_NAME 1
+#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-zeromq (4.3.1) UNRELEASED; urgency=low
+zeromq (4.2.5) UNRELEASED; urgency=low
 
   * Initial packaging.
 

--- a/packaging/debian/zeromq.dsc.obs
+++ b/packaging/debian/zeromq.dsc.obs
@@ -2,7 +2,7 @@ Format: 3.0 (quilt)
 Source: zeromq
 Binary: libzmq5, libzmq3-dev, libzmq5-dbg
 Architecture: any
-Version: 4.3.1
+Version: 4.2.5
 Maintainer: libzmq Developers <zeromq-dev@lists.zeromq.org>
 Homepage: http://www.zeromq.org/
 Standards-Version: 3.9.8

--- a/packaging/redhat/zeromq.spec
+++ b/packaging/redhat/zeromq.spec
@@ -10,7 +10,7 @@
 %endif
 %define lib_name libzmq5
 Name:          zeromq
-Version:       4.3.1
+Version:       4.2.5
 Release:       1%{?dist}
 Summary:       The ZeroMQ messaging library
 Group:         Applications/Internet

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -51,6 +51,9 @@ unsigned long zmq_stopwatch_intermediate (void *watch_);
 #define ZMQ_DGRAM 18
 
 /*  DRAFT Socket options.                                                     */
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
+#define ZMQ_BINDTODEVICE 92
 #define ZMQ_ZAP_ENFORCE_DOMAIN 93
 #define ZMQ_LOOPBACK_FASTPATH 94
 #define ZMQ_METADATA 95
@@ -93,6 +96,7 @@ unsigned long zmq_stopwatch_intermediate (void *watch_);
 #define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 
 /*  DRAFT Context options                                                     */
+#define ZMQ_MSG_T_SIZE 6
 #define ZMQ_THREAD_AFFINITY_CPU_ADD 7
 #define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
 #define ZMQ_THREAD_NAME_PREFIX 9
@@ -172,6 +176,15 @@ int zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
 int zmq_timers_reset (void *timers, int timer_id);
 long zmq_timers_timeout (void *timers);
 int zmq_timers_execute (void *timers);
+
+/******************************************************************************/
+/*  GSSAPI definitions                                                        */
+/******************************************************************************/
+
+/*  GSSAPI principal name types                                               */
+#define ZMQ_GSSAPI_NT_HOSTBASED 0
+#define ZMQ_GSSAPI_NT_USER_NAME 1
+#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/tests/test_security_gssapi.cpp
+++ b/tests/test_security_gssapi.cpp
@@ -156,10 +156,12 @@ void test_valid_creds (void *ctx,
     assert (rc == 0);
     rc = zmq_setsockopt (client, ZMQ_GSSAPI_PRINCIPAL, name, strlen (name) + 1);
     assert (rc == 0);
+#ifdef ZMQ_BUILD_DRAFT_API
     int name_type = ZMQ_GSSAPI_NT_HOSTBASED;
     rc = zmq_setsockopt (client, ZMQ_GSSAPI_PRINCIPAL_NAMETYPE, &name_type,
                          sizeof (name_type));
     assert (rc == 0);
+#endif
     rc = zmq_connect (client, endpoint);
     assert (rc == 0);
 
@@ -188,10 +190,12 @@ void test_unauth_creds (void *ctx,
     assert (rc == 0);
     rc = zmq_setsockopt (client, ZMQ_GSSAPI_PRINCIPAL, name, strlen (name) + 1);
     assert (rc == 0);
+#ifdef ZMQ_BUILD_DRAFT_API
     int name_type = ZMQ_GSSAPI_NT_HOSTBASED;
     rc = zmq_setsockopt (client, ZMQ_GSSAPI_PRINCIPAL_NAMETYPE, &name_type,
                          sizeof (name_type));
     assert (rc == 0);
+#endif
     zap_deny_all = 1;
     rc = zmq_connect (client, endpoint);
     assert (rc == 0);
@@ -312,10 +316,12 @@ int main (void)
     assert (rc == 0);
     rc = zmq_setsockopt (server, ZMQ_GSSAPI_PRINCIPAL, name, strlen (name) + 1);
     assert (rc == 0);
+#ifdef ZMQ_BUILD_DRAFT_API
     int name_type = ZMQ_GSSAPI_NT_HOSTBASED;
     rc = zmq_setsockopt (server, ZMQ_GSSAPI_PRINCIPAL_NAMETYPE, &name_type,
                          sizeof (name_type));
     assert (rc == 0);
+#endif
     rc = zmq_bind (server, "tcp://127.0.0.1:*");
     assert (rc == 0);
     rc = zmq_getsockopt (server, ZMQ_LAST_ENDPOINT, my_endpoint, &len);


### PR DESCRIPTION
Solution: temporarily revert API changes, restore next version to 4.2.5 and compile changelog

After tagging 4.2.5 I'll restore the API changes and 4.3