### PR TITLE
Problem: `make dist` results are not tested

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -944,6 +944,7 @@ EXTRA_DIST = \
 	autogen.sh	\
 	version.sh	\
 	src/libzmq.pc.cmake.in \
+	ci_build.sh \
 	src/libzmq.vers \
 	src/version.rc.in \
 	tests/CMakeLists.txt \

--- a/builds/Makefile.am
+++ b/builds/Makefile.am
@@ -15,15 +15,20 @@ EXTRA_DIST = \
 	cygwin/Makefile.cygwin \
 	mingw32/Makefile.mingw32 \
 	mingw32/platform.hpp \
+	cmake/ci_build.sh \
 	cmake/Modules \
 	cmake/NSIS.template32.in \
 	cmake/NSIS.template64.in \
 	cmake/ZeroMQConfig.cmake.in \
+	cmake/clang-format-check.sh.in \
 	cmake/platform.hpp.in \
+	valgrind/ci_build.sh \
 	valgrind/valgrind.supp \
 	valgrind/vg \
 	nuget/readme.nuget \
 	nuget/libzmq.autopkg \
+	android/Dockerfile \
+	android/README.md \
 	android/android_build_helper.sh \
 	android/ci_build.sh \
 	android/build.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -3,6 +3,16 @@
 set -x
 set -e
 
+# always run tests from dist
+# to make sure that `make dist` doesn't omit any files required for the tests
+./autogen.sh
+./configure
+make -j5 dist-gzip
+V=$(./version.sh)
+tar -xzf zeromq-$V.tar.gz
+cd zeromq-$V
+
+
 if [ $BUILD_TYPE == "default" ]; then
     mkdir tmp
     BUILD_PREFIX=$PWD/tmp

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -70,14 +70,17 @@ if [ $BUILD_TYPE == "default" ]; then
         make VERBOSE=1 -j5 distcheck
     ) || exit 1
 else
-    # always install from dist
+    # always install custom builds from dist
     # to make sure that `make dist` doesn't omit any files required to build & test
-    ./autogen.sh
-    ./configure
-    make -j5 dist-gzip
-    V=$(./version.sh)
-    tar -xzf zeromq-$V.tar.gz
-    cd zeromq-$V
+    # coverage, valgrind are special-case tests that aren't meant to be runnable from releases
+    if [ ${BUILD_TYPE} != "coverage" ] && [ ${BUILD_TYPE} != "valgrind" ]; then
+        ./autogen.sh
+        ./configure
+        make -j5 dist-gzip
+        V=$(./version.sh)
+        tar -xzf zeromq-$V.tar.gz
+        cd zeromq-$V
+    fi
 
     # start the actual build
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -3,16 +3,6 @@
 set -x
 set -e
 
-# always run tests from dist
-# to make sure that `make dist` doesn't omit any files required for the tests
-./autogen.sh
-./configure
-make -j5 dist-gzip
-V=$(./version.sh)
-tar -xzf zeromq-$V.tar.gz
-cd zeromq-$V
-
-
 if [ $BUILD_TYPE == "default" ]; then
     mkdir tmp
     BUILD_PREFIX=$PWD/tmp
@@ -80,5 +70,15 @@ if [ $BUILD_TYPE == "default" ]; then
         make VERBOSE=1 -j5 distcheck
     ) || exit 1
 else
+    # always install from dist
+    # to make sure that `make dist` doesn't omit any files required to build & test
+    ./autogen.sh
+    ./configure
+    make -j5 dist-gzip
+    V=$(./version.sh)
+    tar -xzf zeromq-$V.tar.gz
+    cd zeromq-$V
+
+    # start the actual build
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -82,6 +82,6 @@ else
         cd zeromq-$V
     fi
 
-    # start the actual build
+    # start the actual build from inside the dist
     cd ./builds/${BUILD_TYPE} && ./ci_build.sh
 fi


### PR DESCRIPTION
Solution: Always run test builds from the result of `make dist`.

Ensures that tests will not pass if needed files are omitted from releases

closes #3023 by adding files required for cmake builds

I'm not sure exactly what files are needed to be added to fix these issues, but cmake tests shouldn't be passing if zeromq releases can't be installed with cmake, which is the current state of things.