### PR TITLE
Factorize poller

### DIFF
--- a/src/devpoll.cpp
+++ b/src/devpoll.cpp
@@ -46,6 +46,9 @@
 #include "config.hpp"
 #include "i_poll_events.hpp"
 
+const zmq::devpoll_base_t::handle_t zmq::devpoll_base_t::handle_invalid =
+    (zmq::devpoll_base_t::handle_t)(intptr_t)zmq::retired_fd;
+
 zmq::devpoll_t::devpoll_t (const zmq::thread_ctx_t &ctx_) :
     ctx (ctx_),
     stopping (false)
@@ -182,15 +185,15 @@ void zmq::devpoll_t::loop ()
             if (!fd_ptr->valid || !fd_ptr->accepted)
                 continue;
             if (ev_buf[i].revents & (POLLERR | POLLHUP))
-                fd_ptr->reactor->in_event ();
+                fd_ptr->reactor->err_event (ev_buf[i].fd);
             if (!fd_ptr->valid || !fd_ptr->accepted)
                 continue;
             if (ev_buf[i].revents & POLLOUT)
-                fd_ptr->reactor->out_event ();
+                fd_ptr->reactor->out_event (ev_buf[i].fd);
             if (!fd_ptr->valid || !fd_ptr->accepted)
                 continue;
             if (ev_buf[i].revents & POLLIN)
-                fd_ptr->reactor->in_event ();
+                fd_ptr->reactor->in_event (ev_buf[i].fd);
         }
     }
 }

--- a/src/devpoll.hpp
+++ b/src/devpoll.hpp
@@ -51,6 +51,7 @@ class devpoll_t : public poller_base_t
 {
   public:
     typedef fd_t handle_t;
+    static const handle_t handle_invalid;
 
     devpoll_t (const thread_ctx_t &ctx_);
     ~devpoll_t ();

--- a/src/epoll.hpp
+++ b/src/epoll.hpp
@@ -50,13 +50,13 @@ struct i_poll_events;
 //  This class implements socket polling mechanism using the Linux-specific
 //  epoll mechanism.
 
-class epoll_t : public worker_poller_base_t
+class epoll_base_t : public virtual poller_base_t
 {
   public:
     typedef void *handle_t;
 
-    epoll_t (const thread_ctx_t &ctx_);
-    ~epoll_t ();
+    epoll_base_t ();
+    virtual ~epoll_base_t ();
 
     //  "poller" concept.
     handle_t add_fd (fd_t fd_, zmq::i_poll_events *events_);
@@ -65,13 +65,13 @@ class epoll_t : public worker_poller_base_t
     void reset_pollin (handle_t handle_);
     void set_pollout (handle_t handle_);
     void reset_pollout (handle_t handle_);
-    void stop ();
 
     static int max_fds ();
 
+    virtual int wait (int timeout);
+
   private:
-    //  Main event loop.
-    void loop ();
+    virtual void check_thread ();
 
     //  Main epoll file descriptor
     fd_t epoll_fd;
@@ -87,17 +87,29 @@ class epoll_t : public worker_poller_base_t
     typedef std::vector<poll_entry_t *> retired_t;
     retired_t retired;
 
-    //  Handle of the physical thread doing the I/O work.
-    thread_t worker;
-
     //  Synchronisation of retired event sources
     mutex_t retired_sync;
 
-    epoll_t (const epoll_t &);
-    const epoll_t &operator= (const epoll_t &);
+    epoll_base_t (const epoll_base_t &);
+    const epoll_base_t &operator= (const epoll_base_t &);
+};
+
+class epoll_t : public worker_poller_base_t, public epoll_base_t
+{
+  public:
+    epoll_t (const thread_ctx_t &ctx_);
+    virtual ~epoll_t ();
+
+    void stop ();
+
+  private:
+    //  Main event loop.
+    virtual void loop ();
+    virtual void check_thread ();
 };
 
 typedef epoll_t poller_t;
+typedef epoll_base_t base_poller_t;
 }
 
 #endif

--- a/src/epoll.hpp
+++ b/src/epoll.hpp
@@ -54,6 +54,7 @@ class epoll_base_t : public virtual poller_base_t
 {
   public:
     typedef void *handle_t;
+    static const handle_t handle_invalid;
 
     epoll_base_t ();
     virtual ~epoll_base_t ();

--- a/src/i_poll_events.hpp
+++ b/src/i_poll_events.hpp
@@ -30,6 +30,8 @@
 #ifndef __ZMQ_I_POLL_EVENTS_HPP_INCLUDED__
 #define __ZMQ_I_POLL_EVENTS_HPP_INCLUDED__
 
+#include "fd.hpp"
+
 namespace zmq
 {
 // Virtual interface to be exposed by object that want to be notified
@@ -37,13 +39,21 @@ namespace zmq
 
 struct i_poll_events
 {
+    typedef void * handle_t;
+
     virtual ~i_poll_events () {}
 
     // Called by I/O thread when file descriptor is ready for reading.
-    virtual void in_event () = 0;
+    virtual void in_event (handle_t handle_) = 0;
 
     // Called by I/O thread when file descriptor is ready for writing.
-    virtual void out_event () = 0;
+    virtual void out_event (handle_t handle_) = 0;
+
+    // Called by I/O thread when file descriptor has error.
+    virtual void err_event (handle_t handle_) = 0;
+
+    // Called by I/O thread when file descriptor is ready (priority).
+    virtual void pri_event (handle_t handle_) = 0;
 
     // Called when timer expires.
     virtual void timer_event (int id_) = 0;

--- a/src/io_object.cpp
+++ b/src/io_object.cpp
@@ -100,12 +100,22 @@ void zmq::io_object_t::cancel_timer (int id_)
     poller->cancel_timer (this, id_);
 }
 
-void zmq::io_object_t::in_event ()
+void zmq::io_object_t::in_event (i_poll_events::handle_t handle_)
 {
     zmq_assert (false);
 }
 
-void zmq::io_object_t::out_event ()
+void zmq::io_object_t::out_event (i_poll_events::handle_t handle_)
+{
+    zmq_assert (false);
+}
+
+void zmq::io_object_t::err_event (i_poll_events::handle_t handle_)
+{
+    zmq_assert (false);
+}
+
+void zmq::io_object_t::pri_event (i_poll_events::handle_t handle_)
 {
     zmq_assert (false);
 }

--- a/src/io_object.hpp
+++ b/src/io_object.hpp
@@ -69,9 +69,11 @@ class io_object_t : public i_poll_events
     void cancel_timer (int id_);
 
     //  i_poll_events interface implementation.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
   private:
     poller_t *poller;

--- a/src/io_thread.cpp
+++ b/src/io_thread.cpp
@@ -75,7 +75,7 @@ int zmq::io_thread_t::get_load ()
     return poller->get_load ();
 }
 
-void zmq::io_thread_t::in_event ()
+void zmq::io_thread_t::in_event (i_poll_events::handle_t handle_)
 {
     //  TODO: Do we want to limit number of commands I/O thread can
     //  process in a single go?
@@ -92,10 +92,20 @@ void zmq::io_thread_t::in_event ()
     errno_assert (rc != 0 && errno == EAGAIN);
 }
 
-void zmq::io_thread_t::out_event ()
+void zmq::io_thread_t::out_event (i_poll_events::handle_t handle_)
 {
     //  We are never polling for POLLOUT here. This function is never called.
     zmq_assert (false);
+}
+
+void zmq::io_thread_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::io_thread_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
 }
 
 void zmq::io_thread_t::timer_event (int)

--- a/src/io_thread.hpp
+++ b/src/io_thread.hpp
@@ -64,9 +64,11 @@ class io_thread_t : public object_t, public i_poll_events
     mailbox_t *get_mailbox ();
 
     //  i_poll_events implementation.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
     //  Used by io_objects to retrieve the associated poller object.
     poller_t *get_poller ();

--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -105,15 +105,15 @@ void zmq::ipc_connecter_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::ipc_connecter_t::in_event ()
+void zmq::ipc_connecter_t::in_event (i_poll_events::handle_t handle_)
 {
     //  We are not polling for incoming data, so we are actually called
     //  because of error here. However, we can get error on out event as well
     //  on some platforms, so we'll simply handle both events in the same way.
-    out_event ();
+    out_event (handle_);
 }
 
-void zmq::ipc_connecter_t::out_event ()
+void zmq::ipc_connecter_t::out_event (i_poll_events::handle_t handle_)
 {
     fd_t fd = connect ();
     rm_fd (handle);
@@ -139,6 +139,16 @@ void zmq::ipc_connecter_t::out_event ()
     socket->event_connected (endpoint, fd);
 }
 
+void zmq::ipc_connecter_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::ipc_connecter_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
 void zmq::ipc_connecter_t::timer_event (int id_)
 {
     zmq_assert (id_ == reconnect_timer_id);
@@ -155,7 +165,7 @@ void zmq::ipc_connecter_t::start_connecting ()
     if (rc == 0) {
         handle = add_fd (s);
         handle_valid = true;
-        out_event ();
+        out_event (handle);
     }
 
     //  Connection establishment may be delayed. Poll for its completion.

--- a/src/ipc_connecter.hpp
+++ b/src/ipc_connecter.hpp
@@ -68,9 +68,11 @@ class ipc_connecter_t : public own_t, public io_object_t
     void process_term (int linger_);
 
     //  Handlers for I/O events.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
     //  Internal function to start the actual connection establishment.
     void start_connecting ();

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -161,7 +161,7 @@ void zmq::ipc_listener_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::ipc_listener_t::in_event ()
+void zmq::ipc_listener_t::in_event (i_poll_events::handle_t handle_)
 {
     fd_t fd = accept ();
 
@@ -190,6 +190,16 @@ void zmq::ipc_listener_t::in_event ()
     launch_child (session);
     send_attach (session, engine, false);
     socket->event_accepted (endpoint, fd);
+}
+
+void zmq::ipc_listener_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::ipc_listener_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
 }
 
 int zmq::ipc_listener_t::get_address (std::string &addr_)

--- a/src/ipc_listener.hpp
+++ b/src/ipc_listener.hpp
@@ -65,7 +65,9 @@ class ipc_listener_t : public own_t, public io_object_t
     void process_term (int linger_);
 
     //  Handlers for I/O events.
-    void in_event ();
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
 
     //  Close the listening socket.
     int close ();

--- a/src/kqueue.cpp
+++ b/src/kqueue.cpp
@@ -53,6 +53,9 @@
 #else
 #define kevent_udata_t void *
 #endif
+
+const zmq::kqueue_base_t::handle_t zmq::kqueue_base_t::handle_invalid = NULL;
+
 zmq::kqueue_t::kqueue_t (const zmq::thread_ctx_t &ctx_) :
     worker_poller_base_t (ctx_),
     kqueue_base_t ()
@@ -133,7 +136,7 @@ zmq::kqueue_base_t::handle_t zmq::kqueue_base_t::add_fd (fd_t fd_,
 
     adjust_load (1);
 
-    return pe;
+    return (handle_t) (intptr_t) pe;
 }
 
 void zmq::kqueue_base_t::rm_fd (handle_t handle_)
@@ -228,15 +231,15 @@ int zmq::kqueue_base_t::wait (int timeout)
         if (pe->fd == retired_fd)
             continue;
         if (ev_buf[i].flags & EV_EOF)
-            pe->reactor->in_event ();
+            pe->reactor->err_event ((i_poll_events::handle_t)pe);
         if (pe->fd == retired_fd)
             continue;
         if (ev_buf[i].filter == EVFILT_WRITE)
-            pe->reactor->out_event ();
+            pe->reactor->out_event ((i_poll_events::handle_t)pe);
         if (pe->fd == retired_fd)
             continue;
         if (ev_buf[i].filter == EVFILT_READ)
-            pe->reactor->in_event ();
+            pe->reactor->in_event ((i_poll_events::handle_t)pe);
     }
 
     //  Destroy retired event sources.

--- a/src/kqueue.hpp
+++ b/src/kqueue.hpp
@@ -53,6 +53,7 @@ class kqueue_base_t : public virtual poller_base_t
 {
   public:
     typedef void *handle_t;
+    static const handle_t handle_invalid;
 
     kqueue_base_t ();
     virtual ~kqueue_base_t ();

--- a/src/kqueue.hpp
+++ b/src/kqueue.hpp
@@ -49,13 +49,13 @@ struct i_poll_events;
 //  Implements socket polling mechanism using the BSD-specific
 //  kqueue interface.
 
-class kqueue_t : public worker_poller_base_t
+class kqueue_base_t : public virtual poller_base_t
 {
   public:
     typedef void *handle_t;
 
-    kqueue_t (const thread_ctx_t &ctx_);
-    ~kqueue_t ();
+    kqueue_base_t ();
+    virtual ~kqueue_base_t ();
 
     //  "poller" concept.
     handle_t add_fd (fd_t fd_, zmq::i_poll_events *events_);
@@ -64,13 +64,13 @@ class kqueue_t : public worker_poller_base_t
     void reset_pollin (handle_t handle_);
     void set_pollout (handle_t handle_);
     void reset_pollout (handle_t handle_);
-    void stop ();
 
     static int max_fds ();
 
+    virtual int wait (int timeout);
+
   private:
-    //  Main event loop.
-    void loop ();
+    virtual void check_thread ();
 
     //  File descriptor referring to the kernel event queue.
     fd_t kqueue_fd;
@@ -93,8 +93,8 @@ class kqueue_t : public worker_poller_base_t
     typedef std::vector<poll_entry_t *> retired_t;
     retired_t retired;
 
-    kqueue_t (const kqueue_t &);
-    const kqueue_t &operator= (const kqueue_t &);
+    kqueue_base_t (const kqueue_base_t &);
+    const kqueue_base_t &operator= (const kqueue_base_t &);
 
 #ifdef HAVE_FORK
     // the process that created this context. Used to detect forking.
@@ -102,7 +102,22 @@ class kqueue_t : public worker_poller_base_t
 #endif
 };
 
+class kqueue_t : public worker_poller_base_t, public kqueue_base_t
+{
+  public:
+    kqueue_t (const thread_ctx_t &ctx_);
+    virtual ~kqueue_t ();
+
+    void stop ();
+
+  private:
+    //  Main event loop.
+    virtual void loop ();
+    virtual void check_thread ();
+};
+
 typedef kqueue_t poller_t;
+typedef kqueue_base_t base_poller_t;
 }
 
 #endif

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -325,7 +325,7 @@ void zmq::norm_engine_t::send_data ()
     } // end while (zmq_output_ready && norm_tx_ready)
 } // end zmq::norm_engine_t::send_data()
 
-void zmq::norm_engine_t::in_event ()
+void zmq::norm_engine_t::in_event (i_poll_events::handle_t handle_)
 {
     // This means a NormEvent is pending, so call NormGetNextEvent() and handle
     NormEvent event;
@@ -381,6 +381,16 @@ void zmq::norm_engine_t::in_event ()
             break;
     }
 } // zmq::norm_engine_t::in_event()
+
+void zmq::norm_engine_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
+}
+
+void zmq::norm_engine_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
+}
 
 void zmq::norm_engine_t::restart_input ()
 {

--- a/src/norm_engine.hpp
+++ b/src/norm_engine.hpp
@@ -51,7 +51,9 @@ class norm_engine_t : public io_object_t, public i_engine
     // i_poll_events interface implementation.
     // (we only need in_event() for NormEvent notification)
     // (i.e., don't have any output events or timers (yet))
-    void in_event ();
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
 
   private:
     void unplug ();

--- a/src/pgm_receiver.cpp
+++ b/src/pgm_receiver.cpp
@@ -158,7 +158,7 @@ const char *zmq::pgm_receiver_t::get_endpoint () const
     return "";
 }
 
-void zmq::pgm_receiver_t::in_event ()
+void zmq::pgm_receiver_t::in_event (i_poll_events::handle_t handle_)
 {
     // Read data from the underlying pgm_socket.
     const pgm_tsi_t *tsi = NULL;
@@ -259,6 +259,16 @@ void zmq::pgm_receiver_t::in_event ()
 
     //  Flush any messages decoder may have produced.
     session->flush ();
+}
+
+void zmq::pgm_receiver_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
+}
+
+void zmq::pgm_receiver_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
 }
 
 int zmq::pgm_receiver_t::process_input (v1_decoder_t *decoder)

--- a/src/pgm_receiver.hpp
+++ b/src/pgm_receiver.hpp
@@ -63,8 +63,10 @@ class pgm_receiver_t : public io_object_t, public i_engine
     const char *get_endpoint () const;
 
     //  i_poll_events interface implementation.
-    void in_event ();
-    void timer_event (int token);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int token);
 
   private:
     //  Unplug the engine from the session.

--- a/src/pgm_sender.cpp
+++ b/src/pgm_sender.cpp
@@ -154,7 +154,7 @@ zmq::pgm_sender_t::~pgm_sender_t ()
     }
 }
 
-void zmq::pgm_sender_t::in_event ()
+void zmq::pgm_sender_t::in_event (i_poll_events::handle_t handle_)
 {
     if (has_rx_timer) {
         cancel_timer (rx_timer_id);
@@ -170,7 +170,7 @@ void zmq::pgm_sender_t::in_event ()
     }
 }
 
-void zmq::pgm_sender_t::out_event ()
+void zmq::pgm_sender_t::out_event (i_poll_events::handle_t handle_)
 {
     //  POLLOUT event from send socket. If write buffer is empty,
     //  try to read new data from the encoder.
@@ -231,6 +231,16 @@ void zmq::pgm_sender_t::out_event ()
         } else
             errno_assert (errno == EBUSY);
     }
+}
+
+void zmq::pgm_sender_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
+}
+
+void zmq::pgm_sender_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
 }
 
 void zmq::pgm_sender_t::timer_event (int token)

--- a/src/pgm_sender.hpp
+++ b/src/pgm_sender.hpp
@@ -62,9 +62,11 @@ class pgm_sender_t : public io_object_t, public i_engine
     const char *get_endpoint () const;
 
     //  i_poll_events interface implementation.
-    void in_event ();
-    void out_event ();
-    void timer_event (int token);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int token);
 
   private:
     //  Unplug the engine from the session.

--- a/src/poll.cpp
+++ b/src/poll.cpp
@@ -45,7 +45,7 @@
 
 zmq::poll_t::poll_t (const zmq::thread_ctx_t &ctx_) :
     worker_poller_base_t (ctx_),
-    retired (false)
+    poll_base_t ()
 {
 }
 
@@ -54,7 +54,39 @@ zmq::poll_t::~poll_t ()
     stop_worker ();
 }
 
-zmq::poll_t::handle_t zmq::poll_t::add_fd (fd_t fd_, i_poll_events *events_)
+void zmq::poll_t::stop ()
+{
+    check_thread ();
+    //  no-op... thread is stopped when no more fds or timers are registered
+}
+
+void zmq::poll_t::loop ()
+{
+    int timeout;
+    do
+    {
+      //  Execute any due timers.
+      timeout = (int) execute_timers ();
+      timeout = timeout ? timeout : -1;
+    }
+    while (wait (timeout) != -2);
+}
+
+void zmq::poll_t::check_thread ()
+{
+    worker_poller_base_t::check_thread();
+}
+
+zmq::poll_base_t::poll_base_t () :
+    retired (false)
+{
+}
+
+zmq::poll_base_t::~poll_base_t ()
+{
+}
+
+zmq::poll_base_t::handle_t zmq::poll_base_t::add_fd (fd_t fd_, i_poll_events *events_)
 {
     check_thread ();
     zmq_assert (fd_ != retired_fd);
@@ -82,7 +114,7 @@ zmq::poll_t::handle_t zmq::poll_t::add_fd (fd_t fd_, i_poll_events *events_)
     return fd_;
 }
 
-void zmq::poll_t::rm_fd (handle_t handle_)
+void zmq::poll_base_t::rm_fd (handle_t handle_)
 {
     check_thread ();
     fd_t index = fd_table[handle_].index;
@@ -97,98 +129,88 @@ void zmq::poll_t::rm_fd (handle_t handle_)
     adjust_load (-1);
 }
 
-void zmq::poll_t::set_pollin (handle_t handle_)
+void zmq::poll_base_t::set_pollin (handle_t handle_)
 {
     check_thread ();
     fd_t index = fd_table[handle_].index;
     pollset[index].events |= POLLIN;
 }
 
-void zmq::poll_t::reset_pollin (handle_t handle_)
+void zmq::poll_base_t::reset_pollin (handle_t handle_)
 {
     check_thread ();
     fd_t index = fd_table[handle_].index;
     pollset[index].events &= ~((short) POLLIN);
 }
 
-void zmq::poll_t::set_pollout (handle_t handle_)
+void zmq::poll_base_t::set_pollout (handle_t handle_)
 {
     check_thread ();
     fd_t index = fd_table[handle_].index;
     pollset[index].events |= POLLOUT;
 }
 
-void zmq::poll_t::reset_pollout (handle_t handle_)
+void zmq::poll_base_t::reset_pollout (handle_t handle_)
 {
     check_thread ();
     fd_t index = fd_table[handle_].index;
     pollset[index].events &= ~((short) POLLOUT);
 }
 
-void zmq::poll_t::stop ()
-{
-    check_thread ();
-    //  no-op... thread is stopped when no more fds or timers are registered
-}
-
-int zmq::poll_t::max_fds ()
+int zmq::poll_base_t::max_fds ()
 {
     return -1;
 }
 
-void zmq::poll_t::loop ()
+int zmq::poll_base_t::wait (int timeout)
 {
-    while (true) {
-        //  Execute any due timers.
-        int timeout = (int) execute_timers ();
+    cleanup_retired ();
 
-        cleanup_retired ();
+    if (pollset.empty ()) {
+        zmq_assert (get_load () == 0);
 
-        if (pollset.empty ()) {
-            zmq_assert (get_load () == 0);
+        if (timeout <= 0)
+            return -2;
 
-            if (timeout == 0)
-                break;
+        // TODO sleep for timeout
+        return 0;
+    }
 
-            // TODO sleep for timeout
-            continue;
-        }
-
-        //  Wait for events.
-        int rc = poll (&pollset[0], pollset.size (), timeout ? timeout : -1);
-#ifdef ZMQ_HAVE_WINDOWS
-        wsa_assert (rc != SOCKET_ERROR);
+    //  Wait for events.
+    int rc = poll (&pollset[0], pollset.size (), timeout);
+#if ZMQ_HAVE_WINDOWS
+    wsa_assert (rc != SOCKET_ERROR);
 #else
-        if (rc == -1) {
-            errno_assert (errno == EINTR);
-            continue;
-        }
+    if (rc == -1) {
+        errno_assert (errno == EINTR);
+        return -1;
+    }
 #endif
 
-        //  If there are no events (i.e. it's a timeout) there's no point
-        //  in checking the pollset.
-        if (rc == 0)
-            continue;
+    //  If there are no events (i.e. it's a timeout) there's no point
+    //  in checking the pollset.
+    if (rc == 0)
+        return rc;
 
-        for (pollset_t::size_type i = 0; i != pollset.size (); i++) {
-            zmq_assert (!(pollset[i].revents & POLLNVAL));
-            if (pollset[i].fd == retired_fd)
-                continue;
-            if (pollset[i].revents & (POLLERR | POLLHUP))
-                fd_table[pollset[i].fd].events->in_event ();
-            if (pollset[i].fd == retired_fd)
-                continue;
-            if (pollset[i].revents & POLLOUT)
-                fd_table[pollset[i].fd].events->out_event ();
-            if (pollset[i].fd == retired_fd)
-                continue;
-            if (pollset[i].revents & POLLIN)
-                fd_table[pollset[i].fd].events->in_event ();
-        }
+    for (pollset_t::size_type i = 0; i != pollset.size (); i++) {
+        zmq_assert (!(pollset[i].revents & POLLNVAL));
+        if (pollset[i].fd == retired_fd)
+            continue;
+        if (pollset[i].revents & (POLLERR | POLLHUP))
+            fd_table[pollset[i].fd].events->in_event ();
+        if (pollset[i].fd == retired_fd)
+            continue;
+        if (pollset[i].revents & POLLOUT)
+            fd_table[pollset[i].fd].events->out_event ();
+        if (pollset[i].fd == retired_fd)
+            continue;
+        if (pollset[i].revents & POLLIN)
+            fd_table[pollset[i].fd].events->in_event ();
     }
+    return rc;
 }
 
-void zmq::poll_t::cleanup_retired ()
+void zmq::poll_base_t::cleanup_retired ()
 {
     //  Clean up the pollset and update the fd_table accordingly.
     if (retired) {
@@ -203,6 +225,10 @@ void zmq::poll_t::cleanup_retired ()
         }
         retired = false;
     }
+}
+
+void zmq::poll_base_t::check_thread ()
+{
 }
 
 

--- a/src/poll.hpp
+++ b/src/poll.hpp
@@ -52,13 +52,13 @@ struct i_poll_events;
 //  Implements socket polling mechanism using the POSIX.1-2001
 //  poll() system call.
 
-class poll_t : public worker_poller_base_t
+class poll_base_t : public virtual poller_base_t
 {
   public:
     typedef fd_t handle_t;
 
-    poll_t (const thread_ctx_t &ctx_);
-    ~poll_t ();
+    poll_base_t ();
+    virtual ~poll_base_t ();
 
     //  "poller" concept.
     //  These methods may only be called from an event callback; add_fd may also be called before start.
@@ -68,13 +68,13 @@ class poll_t : public worker_poller_base_t
     void reset_pollin (handle_t handle_);
     void set_pollout (handle_t handle_);
     void reset_pollout (handle_t handle_);
-    void stop ();
 
     static int max_fds ();
 
+    virtual int wait (int timeout);
+
   private:
-    //  Main event loop.
-    virtual void loop ();
+    virtual void check_thread ();
 
     void cleanup_retired ();
 
@@ -95,11 +95,26 @@ class poll_t : public worker_poller_base_t
     //  If true, there's at least one retired event source.
     bool retired;
 
-    poll_t (const poll_t &);
-    const poll_t &operator= (const poll_t &);
+    poll_base_t (const poll_base_t &);
+    const poll_base_t &operator= (const poll_base_t &);
+};
+
+class poll_t : public worker_poller_base_t, public poll_base_t
+{
+  public:
+    poll_t (const thread_ctx_t &ctx_);
+    virtual ~poll_t ();
+
+    void stop ();
+
+  private:
+    //  Main event loop.
+    virtual void loop ();
+    virtual void check_thread ();
 };
 
 typedef poll_t poller_t;
+typedef poll_base_t base_poller_t;
 }
 
 #endif

--- a/src/poll.hpp
+++ b/src/poll.hpp
@@ -55,7 +55,8 @@ struct i_poll_events;
 class poll_base_t : public virtual poller_base_t
 {
   public:
-    typedef fd_t handle_t;
+    typedef void* handle_t;
+    static const handle_t handle_invalid;
 
     poll_base_t ();
     virtual ~poll_base_t ();

--- a/src/poller_base.hpp
+++ b/src/poller_base.hpp
@@ -130,6 +130,8 @@ class poller_base_t
     void add_timer (int timeout_, zmq::i_poll_events *sink_, int id_);
     void cancel_timer (zmq::i_poll_events *sink_, int id_);
 
+    virtual int wait (int timeout) = 0;
+
   protected:
     //  Called by individual poller implementations to manage the load.
     void adjust_load (int amount_);
@@ -160,7 +162,7 @@ class poller_base_t
 };
 
 //  Base class for a poller with a single worker thread.
-class worker_poller_base_t : public poller_base_t
+class worker_poller_base_t : public virtual poller_base_t
 {
   public:
     worker_poller_base_t (const thread_ctx_t &ctx_);

--- a/src/pollset.cpp
+++ b/src/pollset.cpp
@@ -42,6 +42,8 @@
 #include "config.hpp"
 #include "i_poll_events.hpp"
 
+const zmq::pollset_base_t::handle_t zmq::pollset_base_t::handle_invalid = NULL;
+
 zmq::pollset_t::pollset_t (const zmq::thread_ctx_t &ctx_) :
     ctx (ctx_),
     stopping (false)
@@ -227,15 +229,15 @@ void zmq::pollset_t::loop ()
             if (pe->fd == retired_fd)
                 continue;
             if (polldata_array[i].revents & (POLLERR | POLLHUP))
-                pe->events->in_event ();
+                pe->events->err_event (pe->fd);
             if (pe->fd == retired_fd)
                 continue;
             if (polldata_array[i].revents & POLLOUT)
-                pe->events->out_event ();
+                pe->events->out_event (pe->fd);
             if (pe->fd == retired_fd)
                 continue;
             if (polldata_array[i].revents & POLLIN)
-                pe->events->in_event ();
+                pe->events->in_event (pe->fd);
         }
 
         //  Destroy retired event sources.

--- a/src/pollset.hpp
+++ b/src/pollset.hpp
@@ -54,6 +54,7 @@ class pollset_t : public poller_base_t
 {
   public:
     typedef void *handle_t;
+    static const handle_t handle_invalid;
 
     pollset_t (const thread_ctx_t &ctx_);
     ~pollset_t ();

--- a/src/reaper.cpp
+++ b/src/reaper.cpp
@@ -81,7 +81,7 @@ void zmq::reaper_t::stop ()
     }
 }
 
-void zmq::reaper_t::in_event ()
+void zmq::reaper_t::in_event (i_poll_events::handle_t handle_)
 {
     while (true) {
 #ifdef HAVE_FORK
@@ -105,9 +105,19 @@ void zmq::reaper_t::in_event ()
     }
 }
 
-void zmq::reaper_t::out_event ()
+void zmq::reaper_t::out_event (i_poll_events::handle_t handle_)
 {
     zmq_assert (false);
+}
+
+void zmq::reaper_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::reaper_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
 }
 
 void zmq::reaper_t::timer_event (int)

--- a/src/reaper.hpp
+++ b/src/reaper.hpp
@@ -52,9 +52,11 @@ class reaper_t : public object_t, public i_poll_events
     void stop ();
 
     //  i_poll_events implementation.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
   private:
     //  Command handlers.

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -406,12 +406,15 @@ int zmq::select_base_t::wait (int timeout)
         }
 
         rc = WSAWaitForMultipleEvents (4, wsa_events.events, FALSE,
-                                       timeout >= 0 ? timeout : INFINITE, FALSE);
+                                       timeout >= 0 ? timeout : INFINITE, TRUE);
         wsa_assert (rc != (int) WSA_WAIT_FAILED);
-            zmq_assert (rc != WSA_WAIT_IO_COMPLETION);
 
         if (rc == WSA_WAIT_TIMEOUT)
             return 0;
+        if (rc == WSA_WAIT_IO_COMPLETION) {
+            errno = EINTR;
+            return -1;
+        }
     }
 
     rc = 0;

--- a/src/select.cpp
+++ b/src/select.cpp
@@ -57,6 +57,39 @@
 
 zmq::select_t::select_t (const zmq::thread_ctx_t &ctx_) :
     worker_poller_base_t (ctx_),
+    select_base_t ()
+{
+}
+
+zmq::select_t::~select_t ()
+{
+    stop_worker ();
+}
+
+void zmq::select_t::stop ()
+{
+    check_thread ();
+    //  no-op... thread is stopped when no more fds or timers are registered
+}
+
+void zmq::select_t::loop ()
+{
+    int timeout;
+    do
+    {
+      //  Execute any due timers.
+      timeout = (int) execute_timers ();
+      timeout = timeout ? timeout : -1;
+    }
+    while (wait (timeout) != -2);
+}
+
+void zmq::select_t::check_thread ()
+{
+    worker_poller_base_t::check_thread();
+}
+
+zmq::select_base_t::select_base_t () :
 #if defined ZMQ_HAVE_WINDOWS
     //  Fine as long as map is not cleared.
     current_family_entry_it (family_entries.end ())
@@ -70,12 +103,11 @@ zmq::select_t::select_t (const zmq::thread_ctx_t &ctx_) :
 #endif
 }
 
-zmq::select_t::~select_t ()
+zmq::select_base_t::~select_base_t ()
 {
-    stop_worker ();
 }
 
-zmq::select_t::handle_t zmq::select_t::add_fd (fd_t fd_, i_poll_events *events_)
+zmq::select_base_t::handle_t zmq::select_base_t::add_fd (fd_t fd_, i_poll_events *events_)
 {
     check_thread ();
     zmq_assert (fd_ != retired_fd);
@@ -102,8 +134,8 @@ zmq::select_t::handle_t zmq::select_t::add_fd (fd_t fd_, i_poll_events *events_)
     return fd_;
 }
 
-zmq::select_t::fd_entries_t::iterator
-zmq::select_t::find_fd_entry_by_handle (fd_entries_t &fd_entries,
+zmq::select_base_t::fd_entries_t::iterator
+zmq::select_base_t::find_fd_entry_by_handle (fd_entries_t &fd_entries,
                                         handle_t handle_)
 {
     fd_entries_t::iterator fd_entry_it;
@@ -115,7 +147,7 @@ zmq::select_t::find_fd_entry_by_handle (fd_entries_t &fd_entries,
     return fd_entry_it;
 }
 
-void zmq::select_t::trigger_events (const fd_entries_t &fd_entries_,
+void zmq::select_base_t::trigger_events (const fd_entries_t &fd_entries_,
                                     const fds_set_t &local_fds_set_,
                                     int event_count_)
 {
@@ -157,7 +189,7 @@ void zmq::select_t::trigger_events (const fd_entries_t &fd_entries_,
 }
 
 #if defined ZMQ_HAVE_WINDOWS
-int zmq::select_t::try_retire_fd_entry (
+int zmq::select_base_t::try_retire_fd_entry (
   family_entries_t::iterator family_entry_it, zmq::fd_t &handle_)
 {
     family_entry_t &family_entry = family_entry_it->second;
@@ -178,7 +210,7 @@ int zmq::select_t::try_retire_fd_entry (
         family_entry.fd_entries.erase (fd_entry_it);
     } else {
         //  Otherwise mark removed entries as retired. It will be cleaned up
-        //  at the end of the iteration. See zmq::select_t::loop
+        //  at the end of the iteration. See zmq::select_base_t::loop
         fd_entry.fd = retired_fd;
         family_entry.has_retired = true;
     }
@@ -187,7 +219,7 @@ int zmq::select_t::try_retire_fd_entry (
 }
 #endif
 
-void zmq::select_t::rm_fd (handle_t handle_)
+void zmq::select_base_t::rm_fd (handle_t handle_)
 {
     check_thread ();
     int retired = 0;
@@ -236,7 +268,7 @@ void zmq::select_t::rm_fd (handle_t handle_)
     adjust_load (-1);
 }
 
-void zmq::select_t::set_pollin (handle_t handle_)
+void zmq::select_base_t::set_pollin (handle_t handle_)
 {
     check_thread ();
 #if defined ZMQ_HAVE_WINDOWS
@@ -247,7 +279,7 @@ void zmq::select_t::set_pollin (handle_t handle_)
     FD_SET (handle_, &family_entry.fds_set.read);
 }
 
-void zmq::select_t::reset_pollin (handle_t handle_)
+void zmq::select_base_t::reset_pollin (handle_t handle_)
 {
     check_thread ();
 #if defined ZMQ_HAVE_WINDOWS
@@ -258,7 +290,7 @@ void zmq::select_t::reset_pollin (handle_t handle_)
     FD_CLR (handle_, &family_entry.fds_set.read);
 }
 
-void zmq::select_t::set_pollout (handle_t handle_)
+void zmq::select_base_t::set_pollout (handle_t handle_)
 {
     check_thread ();
 #if defined ZMQ_HAVE_WINDOWS
@@ -269,7 +301,7 @@ void zmq::select_t::set_pollout (handle_t handle_)
     FD_SET (handle_, &family_entry.fds_set.write);
 }
 
-void zmq::select_t::reset_pollout (handle_t handle_)
+void zmq::select_base_t::reset_pollout (handle_t handle_)
 {
     check_thread ();
 #if defined ZMQ_HAVE_WINDOWS
@@ -280,140 +312,137 @@ void zmq::select_t::reset_pollout (handle_t handle_)
     FD_CLR (handle_, &family_entry.fds_set.write);
 }
 
-void zmq::select_t::stop ()
-{
-    check_thread ();
-    //  no-op... thread is stopped when no more fds or timers are registered
-}
-
-int zmq::select_t::max_fds ()
+int zmq::select_base_t::max_fds ()
 {
     return FD_SETSIZE;
 }
 
-void zmq::select_t::loop ()
+int zmq::select_base_t::wait (int timeout)
 {
-    while (true) {
-        //  Execute any due timers.
-        int timeout = (int) execute_timers ();
-
-        cleanup_retired ();
+    cleanup_retired ();
 
 #ifdef _WIN32
-        if (family_entries.empty ()) {
+    if (family_entries.empty ()) {
 #else
-        if (family_entry.fd_entries.empty ()) {
+    if (family_entry.fd_entries.empty ()) {
 #endif
-            zmq_assert (get_load () == 0);
+        zmq_assert (get_load () == 0);
 
-            if (timeout == 0)
-                break;
+        if (timeout <= 0)
+            return -2;
 
-            // TODO sleep for timeout
-            continue;
-        }
+        // TODO sleep for timeout
+        return 0;
+    }
 
 #if defined ZMQ_HAVE_OSX
-        struct timeval tv = {(long) (timeout / 1000), timeout % 1000 * 1000};
+    struct timeval tv = {(long) (timeout / 1000), timeout % 1000 * 1000};
 #else
-        struct timeval tv = {(long) (timeout / 1000),
-                             (long) (timeout % 1000 * 1000)};
+    struct timeval tv = {(long) (timeout / 1000),
+                         (long) (timeout % 1000 * 1000)};
 #endif
 
 #if defined ZMQ_HAVE_WINDOWS
-        /*
-            On Windows select does not allow to mix descriptors from different
-            service providers. It seems to work for AF_INET and AF_INET6,
-            but fails for AF_INET and VMCI. The workaround is to use
-            WSAEventSelect and WSAWaitForMultipleEvents to wait, then use
-            select to find out what actually changed. WSAWaitForMultipleEvents
-            cannot be used alone, because it does not support more than 64 events
-            which is not enough.
+    /*
+        On Windows select does not allow to mix descriptors from different
+        service providers. It seems to work for AF_INET and AF_INET6,
+        but fails for AF_INET and VMCI. The workaround is to use
+        WSAEventSelect and WSAWaitForMultipleEvents to wait, then use
+        select to find out what actually changed. WSAWaitForMultipleEvents
+        cannot be used alone, because it does not support more than 64 events
+        which is not enough.
 
-            To reduce unnecessary overhead, WSA is only used when there are more
-            than one family. Moreover, AF_INET and AF_INET6 are considered the same
-            family because Windows seems to handle them properly.
-            See get_fd_family for details.
-        */
+        To reduce unnecessary overhead, WSA is only used when there are more
+        than one family. Moreover, AF_INET and AF_INET6 are considered the same
+        family because Windows seems to handle them properly.
+        See get_fd_family for details.
+    */
 
-        //  If there is just one family, there is no reason to use WSA events.
-        int rc = 0;
-        const bool use_wsa_events = family_entries.size () > 1;
-        if (use_wsa_events) {
-            // TODO: I don't really understand why we are doing this. If any of
-            // the events was signaled, we will call select for each fd_family
-            // afterwards. The only benefit is if none of the events was
-            // signaled, then we continue early.
-            // IMHO, either WSAEventSelect/WSAWaitForMultipleEvents or select
-            // should be used, but not both
+    //  If there is just one family, there is no reason to use WSA events.
+    int rc = 0;
+    const bool use_wsa_events = family_entries.size () > 1;
+    if (use_wsa_events) {
+        // TODO: I don't really understand why we are doing this. If any of
+        // the events was signaled, we will call select for each fd_family
+        // afterwards. The only benefit is if none of the events was
+        // signaled, then we continue early.
+        // IMHO, either WSAEventSelect/WSAWaitForMultipleEvents or select
+        // should be used, but not both
 
-            wsa_events_t wsa_events;
+        wsa_events_t wsa_events;
 
-            for (family_entries_t::iterator family_entry_it =
-                   family_entries.begin ();
-                 family_entry_it != family_entries.end (); ++family_entry_it) {
-                family_entry_t &family_entry = family_entry_it->second;
+        for (family_entries_t::iterator family_entry_it =
+               family_entries.begin ();
+             family_entry_it != family_entries.end (); ++family_entry_it) {
+            family_entry_t &family_entry = family_entry_it->second;
 
-                for (fd_entries_t::iterator fd_entry_it =
-                       family_entry.fd_entries.begin ();
-                     fd_entry_it != family_entry.fd_entries.end ();
-                     ++fd_entry_it) {
-                    fd_t fd = fd_entry_it->fd;
+            for (fd_entries_t::iterator fd_entry_it =
+                   family_entry.fd_entries.begin ();
+                 fd_entry_it != family_entry.fd_entries.end ();
+                 ++fd_entry_it) {
+                fd_t fd = fd_entry_it->fd;
 
-                    //  http://stackoverflow.com/q/35043420/188530
-                    if (FD_ISSET (fd, &family_entry.fds_set.read)
-                        && FD_ISSET (fd, &family_entry.fds_set.write))
-                        rc =
-                          WSAEventSelect (fd, wsa_events.events[3],
-                                          FD_READ | FD_ACCEPT | FD_CLOSE
-                                            | FD_WRITE | FD_CONNECT | FD_OOB);
-                    else if (FD_ISSET (fd, &family_entry.fds_set.read))
-                        rc = WSAEventSelect (fd, wsa_events.events[0],
-                                             FD_READ | FD_ACCEPT | FD_CLOSE
-                                               | FD_OOB);
-                    else if (FD_ISSET (fd, &family_entry.fds_set.write))
-                        rc = WSAEventSelect (fd, wsa_events.events[1],
-                                             FD_WRITE | FD_CONNECT | FD_OOB);
-                    else if (FD_ISSET (fd, &family_entry.fds_set.error))
-                        rc = WSAEventSelect (fd, wsa_events.events[2], FD_OOB);
-                    else
-                        rc = 0;
+                //  http://stackoverflow.com/q/35043420/188530
+                if (FD_ISSET (fd, &family_entry.fds_set.read)
+                    && FD_ISSET (fd, &family_entry.fds_set.write))
+                    rc =
+                      WSAEventSelect (fd, wsa_events.events[3],
+                                      FD_READ | FD_ACCEPT | FD_CLOSE
+                                        | FD_WRITE | FD_CONNECT | FD_OOB);
+                else if (FD_ISSET (fd, &family_entry.fds_set.read))
+                    rc = WSAEventSelect (fd, wsa_events.events[0],
+                                         FD_READ | FD_ACCEPT | FD_CLOSE
+                                           | FD_OOB);
+                else if (FD_ISSET (fd, &family_entry.fds_set.write))
+                    rc = WSAEventSelect (fd, wsa_events.events[1],
+                                         FD_WRITE | FD_CONNECT | FD_OOB);
+                else if (FD_ISSET (fd, &family_entry.fds_set.error))
+                    rc = WSAEventSelect (fd, wsa_events.events[2], FD_OOB);
+                else
+                    rc = 0;
 
-                    wsa_assert (rc != SOCKET_ERROR);
-                }
+                wsa_assert (rc != SOCKET_ERROR);
             }
+        }
 
-            rc = WSAWaitForMultipleEvents (4, wsa_events.events, FALSE,
-                                           timeout ? timeout : INFINITE, FALSE);
-            wsa_assert (rc != (int) WSA_WAIT_FAILED);
+        rc = WSAWaitForMultipleEvents (4, wsa_events.events, FALSE,
+                                       timeout >= 0 ? timeout : INFINITE, FALSE);
+        wsa_assert (rc != (int) WSA_WAIT_FAILED);
             zmq_assert (rc != WSA_WAIT_IO_COMPLETION);
 
-            if (rc == WSA_WAIT_TIMEOUT)
-                continue;
-        }
-
-        for (current_family_entry_it = family_entries.begin ();
-             current_family_entry_it != family_entries.end ();
-             ++current_family_entry_it) {
-            family_entry_t &family_entry = current_family_entry_it->second;
-
-
-            if (use_wsa_events) {
-                //  There is no reason to wait again after WSAWaitForMultipleEvents.
-                //  Simply collect what is ready.
-                struct timeval tv_nodelay = {0, 0};
-                select_family_entry (family_entry, 0, true, tv_nodelay);
-            } else {
-                select_family_entry (family_entry, 0, timeout > 0, tv);
-            }
-        }
-#else
-        select_family_entry (family_entry, maxfd + 1, timeout > 0, tv);
-#endif
+        if (rc == WSA_WAIT_TIMEOUT)
+            return 0;
     }
+
+    rc = 0;
+    for (current_family_entry_it = family_entries.begin ();
+         current_family_entry_it != family_entries.end ();
+         ++current_family_entry_it) {
+        family_entry_t &family_entry = current_family_entry_it->second;
+
+
+        if (use_wsa_events) {
+            //  There is no reason to wait again after WSAWaitForMultipleEvents.
+            //  Simply collect what is ready.
+            struct timeval tv_nodelay = {0, 0};
+            int rc_t = select_family_entry (family_entry, 0, true, tv_nodelay);
+            if (rc_t < 0)
+                return rc_t;
+            rc += rc_t;
+        } else {
+            int rc_t = select_family_entry (family_entry, 0, timeout >= 0, tv);
+            if (rc_t < 0)
+                return rc_t;
+            rc += rc_t;
+        }
+    }
+    return rc;
+#else
+    return select_family_entry (family_entry, maxfd + 1, timeout >= 0, tv);
+#endif
 }
 
-void zmq::select_t::select_family_entry (family_entry_t &family_entry_,
+int zmq::select_base_t::select_family_entry (family_entry_t &family_entry_,
                                          const int max_fd_,
                                          const bool use_timeout_,
                                          struct timeval &tv_)
@@ -421,7 +450,7 @@ void zmq::select_t::select_family_entry (family_entry_t &family_entry_,
     //  select will fail when run with empty sets.
     fd_entries_t &fd_entries = family_entry_.fd_entries;
     if (fd_entries.empty ())
-        return;
+        return 0;
 
     fds_set_t local_fds_set = family_entry_.fds_set;
     int rc = select (max_fd_, &local_fds_set.read, &local_fds_set.write,
@@ -432,23 +461,25 @@ void zmq::select_t::select_family_entry (family_entry_t &family_entry_,
 #else
     if (rc == -1) {
         errno_assert (errno == EINTR);
-        return;
+        return -1;
     }
 #endif
 
     trigger_events (fd_entries, local_fds_set, rc);
 
     cleanup_retired (family_entry_);
+
+    return rc;
 }
 
-zmq::select_t::fds_set_t::fds_set_t ()
+zmq::select_base_t::fds_set_t::fds_set_t ()
 {
     FD_ZERO (&read);
     FD_ZERO (&write);
     FD_ZERO (&error);
 }
 
-zmq::select_t::fds_set_t::fds_set_t (const fds_set_t &other_)
+zmq::select_base_t::fds_set_t::fds_set_t (const fds_set_t &other_)
 {
 #if defined ZMQ_HAVE_WINDOWS
     // On Windows we don't need to copy the whole fd_set.
@@ -471,7 +502,7 @@ zmq::select_t::fds_set_t::fds_set_t (const fds_set_t &other_)
 #endif
 }
 
-zmq::select_t::fds_set_t &zmq::select_t::fds_set_t::
+zmq::select_base_t::fds_set_t &zmq::select_base_t::fds_set_t::
 operator= (const fds_set_t &other_)
 {
 #if defined ZMQ_HAVE_WINDOWS
@@ -496,14 +527,14 @@ operator= (const fds_set_t &other_)
     return *this;
 }
 
-void zmq::select_t::fds_set_t::remove_fd (const fd_t &fd_)
+void zmq::select_base_t::fds_set_t::remove_fd (const fd_t &fd_)
 {
     FD_CLR (fd_, &read);
     FD_CLR (fd_, &write);
     FD_CLR (fd_, &error);
 }
 
-bool zmq::select_t::cleanup_retired (family_entry_t &family_entry_)
+bool zmq::select_base_t::cleanup_retired (family_entry_t &family_entry_)
 {
     if (family_entry_.has_retired) {
         family_entry_.has_retired = false;
@@ -515,7 +546,7 @@ bool zmq::select_t::cleanup_retired (family_entry_t &family_entry_)
     return family_entry_.fd_entries.empty ();
 }
 
-void zmq::select_t::cleanup_retired ()
+void zmq::select_base_t::cleanup_retired ()
 {
 #ifdef _WIN32
     for (family_entries_t::iterator it = family_entries.begin ();
@@ -530,18 +561,22 @@ void zmq::select_t::cleanup_retired ()
 #endif
 }
 
-bool zmq::select_t::is_retired_fd (const fd_entry_t &entry)
+bool zmq::select_base_t::is_retired_fd (const fd_entry_t &entry)
 {
     return (entry.fd == retired_fd);
 }
 
-zmq::select_t::family_entry_t::family_entry_t () : has_retired (false)
+zmq::select_base_t::family_entry_t::family_entry_t () : has_retired (false)
+{
+}
+
+void zmq::select_base_t::check_thread ()
 {
 }
 
 
 #if defined ZMQ_HAVE_WINDOWS
-u_short zmq::select_t::get_fd_family (fd_t fd_)
+u_short zmq::select_base_t::get_fd_family (fd_t fd_)
 {
     // cache the results of determine_fd_family, as this is frequently called
     // for the same sockets, and determine_fd_family is expensive
@@ -568,7 +603,7 @@ u_short zmq::select_t::get_fd_family (fd_t fd_)
     return res.second;
 }
 
-u_short zmq::select_t::determine_fd_family (fd_t fd_)
+u_short zmq::select_base_t::determine_fd_family (fd_t fd_)
 {
     //  Use sockaddr_storage instead of sockaddr to accommodate different structure sizes
     sockaddr_storage addr = {0};
@@ -596,7 +631,7 @@ u_short zmq::select_t::determine_fd_family (fd_t fd_)
     return AF_UNSPEC;
 }
 
-zmq::select_t::wsa_events_t::wsa_events_t ()
+zmq::select_base_t::wsa_events_t::wsa_events_t ()
 {
     events[0] = WSACreateEvent ();
     wsa_assert (events[0] != WSA_INVALID_EVENT);
@@ -608,7 +643,7 @@ zmq::select_t::wsa_events_t::wsa_events_t ()
     wsa_assert (events[3] != WSA_INVALID_EVENT);
 }
 
-zmq::select_t::wsa_events_t::~wsa_events_t ()
+zmq::select_base_t::wsa_events_t::~wsa_events_t ()
 {
     wsa_assert (WSACloseEvent (events[0]));
     wsa_assert (WSACloseEvent (events[1]));

--- a/src/select.hpp
+++ b/src/select.hpp
@@ -58,13 +58,13 @@ struct i_poll_events;
 //  Implements socket polling mechanism using POSIX.1-2001 select()
 //  function.
 
-class select_t : public worker_poller_base_t
+class select_base_t : public virtual poller_base_t
 {
   public:
     typedef fd_t handle_t;
 
-    select_t (const thread_ctx_t &ctx_);
-    ~select_t ();
+    select_base_t ();
+    virtual ~select_base_t ();
 
     //  "poller" concept.
     handle_t add_fd (fd_t fd_, zmq::i_poll_events *events_);
@@ -73,13 +73,12 @@ class select_t : public worker_poller_base_t
     void reset_pollin (handle_t handle_);
     void set_pollout (handle_t handle_);
     void reset_pollout (handle_t handle_);
-    void stop ();
 
     static int max_fds ();
 
+    virtual int wait (int timeout);
   private:
-    //  Main event loop.
-    void loop ();
+    virtual void check_thread ();
 
     //  Internal state.
     struct fds_set_t
@@ -115,7 +114,7 @@ class select_t : public worker_poller_base_t
         bool has_retired;
     };
 
-    void select_family_entry (family_entry_t &family_entry_,
+    int select_family_entry (family_entry_t &family_entry_,
                               int max_fd_,
                               bool use_timeout_,
                               struct timeval &tv_);
@@ -161,11 +160,26 @@ class select_t : public worker_poller_base_t
     static fd_entries_t::iterator
     find_fd_entry_by_handle (fd_entries_t &fd_entries, handle_t handle_);
 
-    select_t (const select_t &);
-    const select_t &operator= (const select_t &);
+    select_base_t (const select_base_t &);
+    const select_base_t &operator= (const select_base_t &);
+};
+
+class select_t : public worker_poller_base_t, public select_base_t
+{
+  public:
+    select_t (const thread_ctx_t &ctx_);
+    virtual ~select_t ();
+
+    void stop();
+
+  private:
+    //  Main event loop.
+    virtual void loop ();
+    virtual void check_thread ();
 };
 
 typedef select_t poller_t;
+typedef select_base_t base_poller_t;
 }
 
 #endif

--- a/src/select.hpp
+++ b/src/select.hpp
@@ -61,7 +61,8 @@ struct i_poll_events;
 class select_base_t : public virtual poller_base_t
 {
   public:
-    typedef fd_t handle_t;
+    typedef void* handle_t;
+    static const handle_t handle_invalid;
 
     select_base_t ();
     virtual ~select_base_t ();
@@ -136,7 +137,7 @@ class select_base_t : public virtual poller_base_t
     family_entries_t::iterator current_family_entry_it;
 
     int try_retire_fd_entry (family_entries_t::iterator family_entry_it,
-                             zmq::fd_t &handle_);
+                             handle_t &handle_);
 
     static const size_t fd_family_cache_size = 8;
     std::pair<fd_t, u_short> fd_family_cache[fd_family_cache_size];

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -115,7 +115,7 @@ class session_base_t : public own_t, public io_object_t, public i_pipe_events
     void process_term (int linger_);
 
     //  i_poll_events handlers.
-    void timer_event (int id_);
+    virtual void timer_event (int id_);
 
     //  Remove any half processed messages. Flush unflushed messages.
     //  Call this function when engine disconnect to get rid of leftovers.

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -239,8 +239,17 @@ void zmq::signaler_t::send ()
 #endif
 }
 
+int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_);
+
 int zmq::signaler_t::wait (int timeout_)
 {
+#if defined ZMQ_HAVE_POLLER
+    zmq_pollitem_t items[1];
+    items[0].socket = NULL;
+    items[0].fd = r;
+    items[0].events = ZMQ_POLLIN;
+    return zmq_poller_poll (items, 1, timeout_);
+#else
 #ifdef HAVE_FORK
     if (unlikely (pid != getpid ())) {
         // we have forked and the file descriptor is closed. Emulate an interrupt
@@ -305,6 +314,7 @@ int zmq::signaler_t::wait (int timeout_)
 
 #else
 #error
+#endif
 #endif
 }
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1482,7 +1482,7 @@ void zmq::socket_base_t::xhiccuped (pipe_t *)
     zmq_assert (false);
 }
 
-void zmq::socket_base_t::in_event ()
+void zmq::socket_base_t::in_event (i_poll_events::handle_t handle_)
 {
     //  This function is invoked only once the socket is running in the context
     //  of the reaper thread. Process any commands from other threads/sockets
@@ -1500,9 +1500,19 @@ void zmq::socket_base_t::in_event ()
     check_destroy ();
 }
 
-void zmq::socket_base_t::out_event ()
+void zmq::socket_base_t::out_event (i_poll_events::handle_t handle_)
 {
     zmq_assert (false);
+}
+
+void zmq::socket_base_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::socket_base_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
 }
 
 void zmq::socket_base_t::timer_event (int)

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -108,9 +108,11 @@ class socket_base_t : public own_t,
 
     //  i_poll_events implementation. This interface is used when socket
     //  is handled by the poller in the reaper thread.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
     //  i_pipe_events interface implementation.
     void read_activated (pipe_t *pipe_);

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -113,7 +113,7 @@ void zmq::socks_connecter_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::socks_connecter_t::in_event ()
+void zmq::socks_connecter_t::in_event (i_poll_events::handle_t handle_)
 {
     zmq_assert (status != unplugged && status != waiting_for_reconnect_time);
 
@@ -172,7 +172,7 @@ void zmq::socks_connecter_t::in_event ()
         error ();
 }
 
-void zmq::socks_connecter_t::out_event ()
+void zmq::socks_connecter_t::out_event (i_poll_events::handle_t handle_)
 {
     zmq_assert (status == waiting_for_proxy_connection
                 || status == sending_greeting || status == sending_request);
@@ -206,6 +206,16 @@ void zmq::socks_connecter_t::out_event ()
             status = waiting_for_response;
         }
     }
+}
+
+void zmq::socks_connecter_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::socks_connecter_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
 }
 
 void zmq::socks_connecter_t::initiate_connect ()

--- a/src/socks_connecter.hpp
+++ b/src/socks_connecter.hpp
@@ -84,8 +84,10 @@ class socks_connecter_t : public own_t, public io_object_t
     virtual void process_term (int linger_);
 
     //  Handlers for I/O events.
-    virtual void in_event ();
-    virtual void out_event ();
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
     virtual void timer_event (int id_);
 
     //  Internal function to start the actual connection establishment.

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -82,9 +82,11 @@ class stream_engine_t : public io_object_t, public i_engine
     const char *get_endpoint () const;
 
     //  i_poll_events interface implementation.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
   private:
     //  Unplug the engine from the session.

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -123,15 +123,15 @@ void zmq::tcp_connecter_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::tcp_connecter_t::in_event ()
+void zmq::tcp_connecter_t::in_event (i_poll_events::handle_t handle_)
 {
     //  We are not polling for incoming data, so we are actually called
     //  because of error here. However, we can get error on out event as well
     //  on some platforms, so we'll simply handle both events in the same way.
-    out_event ();
+    out_event (handle_);
 }
 
-void zmq::tcp_connecter_t::out_event ()
+void zmq::tcp_connecter_t::out_event (i_poll_events::handle_t handle_)
 {
     if (connect_timer_started) {
         cancel_timer (connect_timer_id);
@@ -163,6 +163,16 @@ void zmq::tcp_connecter_t::out_event ()
     socket->event_connected (endpoint, fd);
 }
 
+void zmq::tcp_connecter_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event (handle_);
+}
+
+void zmq::tcp_connecter_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event (handle_);
+}
+
 void zmq::tcp_connecter_t::rm_handle ()
 {
     rm_fd (handle);
@@ -191,7 +201,7 @@ void zmq::tcp_connecter_t::start_connecting ()
     //  Connect may succeed in synchronous manner.
     if (rc == 0) {
         handle = add_fd (s);
-        out_event ();
+        out_event (handle);
     }
 
     //  Connection establishment may be delayed. Poll for its completion.

--- a/src/tcp_connecter.hpp
+++ b/src/tcp_connecter.hpp
@@ -66,9 +66,11 @@ class tcp_connecter_t : public own_t, public io_object_t
     void process_term (int linger_);
 
     //  Handlers for I/O events.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
     //  Removes the handle from the poller.
     void rm_handle ();

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -92,7 +92,7 @@ void zmq::tcp_listener_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::tcp_listener_t::in_event ()
+void zmq::tcp_listener_t::in_event (i_poll_events::handle_t handle_)
 {
     fd_t fd = accept ();
 
@@ -132,6 +132,16 @@ void zmq::tcp_listener_t::in_event ()
     launch_child (session);
     send_attach (session, engine, false);
     socket->event_accepted (endpoint, (int) fd);
+}
+
+void zmq::tcp_listener_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::tcp_listener_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
 }
 
 void zmq::tcp_listener_t::close ()

--- a/src/tcp_listener.hpp
+++ b/src/tcp_listener.hpp
@@ -61,7 +61,9 @@ class tcp_listener_t : public own_t, public io_object_t
     void process_term (int linger_);
 
     //  Handlers for I/O events.
-    void in_event ();
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
 
     //  Close the listening socket.
     void close ();

--- a/src/tipc_connecter.cpp
+++ b/src/tipc_connecter.cpp
@@ -107,15 +107,15 @@ void zmq::tipc_connecter_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::tipc_connecter_t::in_event ()
+void zmq::tipc_connecter_t::in_event (i_poll_events::handle_t handle_)
 {
     //  We are not polling for incoming data, so we are actually called
     //  because of error here. However, we can get error on out event as well
     //  on some platforms, so we'll simply handle both events in the same way.
-    out_event ();
+    out_event (handle_);
 }
 
-void zmq::tipc_connecter_t::out_event ()
+void zmq::tipc_connecter_t::out_event (i_poll_events::handle_t handle_)
 {
     fd_t fd = connect ();
     rm_fd (handle);
@@ -141,6 +141,16 @@ void zmq::tipc_connecter_t::out_event ()
     socket->event_connected (endpoint, fd);
 }
 
+void zmq::tipc_connecter_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::tipc_connecter_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
 void zmq::tipc_connecter_t::timer_event (int id_)
 {
     zmq_assert (id_ == reconnect_timer_id);
@@ -157,7 +167,7 @@ void zmq::tipc_connecter_t::start_connecting ()
     if (rc == 0) {
         handle = add_fd (s);
         handle_valid = true;
-        out_event ();
+        out_event (handle);
     }
 
     //  Connection establishment may be delayed. Poll for its completion.

--- a/src/tipc_connecter.hpp
+++ b/src/tipc_connecter.hpp
@@ -69,9 +69,11 @@ class tipc_connecter_t : public own_t, public io_object_t
     void process_term (int linger_);
 
     //  Handlers for I/O events.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
     //  Internal function to start the actual connection establishment.
     void start_connecting ();

--- a/src/tipc_listener.cpp
+++ b/src/tipc_listener.cpp
@@ -85,7 +85,7 @@ void zmq::tipc_listener_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::tipc_listener_t::in_event ()
+void zmq::tipc_listener_t::in_event (i_poll_events::handle_t handle_)
 {
     fd_t fd = accept ();
 
@@ -114,6 +114,16 @@ void zmq::tipc_listener_t::in_event ()
     launch_child (session);
     send_attach (session, engine, false);
     socket->event_accepted (endpoint, fd);
+}
+
+void zmq::tipc_listener_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::tipc_listener_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
 }
 
 int zmq::tipc_listener_t::get_address (std::string &addr_)

--- a/src/tipc_listener.hpp
+++ b/src/tipc_listener.hpp
@@ -67,7 +67,9 @@ class tipc_listener_t : public own_t, public io_object_t
     void process_term (int linger_);
 
     //  Handlers for I/O events.
-    void in_event ();
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
 
     //  Close the listening socket.
     void close ();

--- a/src/tweetnacl.c
+++ b/src/tweetnacl.c
@@ -46,7 +46,7 @@
 #pragma warning(disable : 4018 4244 4146)
 #endif
 
-// clang-format off
+/* clang-format off */
 
 #include "tweetnacl.h"
 
@@ -926,8 +926,8 @@ void randombytes (unsigned char *x,unsigned long long xlen)
 {
     int i;
 #ifndef ZMQ_HAVE_GETRANDOM
-    //  Require that random_open has already been called, to avoid
-    //  race conditions.
+    /*  Require that random_open has already been called, to avoid
+        race conditions. */
     assert (fd != -1);
 #endif
     while (xlen > 0) {
@@ -950,7 +950,7 @@ void randombytes (unsigned char *x,unsigned long long xlen)
     }
 }
 
-//  Do not call manually! Use random_close from random.hpp
+/*  Do not call manually! Use random_close from random.hpp */
 int randombytes_close (void)
 {
     int rc = -1;
@@ -959,11 +959,11 @@ int randombytes_close (void)
         fd = -1;
         rc = 0;
     }
-#endif // ZMQ_HAVE_GETRANDOM
+#endif /* ZMQ_HAVE_GETRANDOM */
     return rc;
 }
 
-//  Do not call manually! Use random_open from random.hpp
+/*  Do not call manually! Use random_open from random.hpp */
 int sodium_init (void)
 {
 #ifndef ZMQ_HAVE_GETRANDOM
@@ -983,11 +983,11 @@ int sodium_init (void)
         assert (rc != -1);
 #endif
     }
-#endif // ZMQ_HAVE_GETRANDOM
+#endif /* ZMQ_HAVE_GETRANDOM */
     return 0;
 }
 
 #endif
 
 #endif
-// clang-format on
+/* clang-format on */

--- a/src/tweetnacl.h
+++ b/src/tweetnacl.h
@@ -52,9 +52,9 @@ typedef i64 gf[16];
 extern "C" {
 #endif
 void randombytes (unsigned char *, unsigned long long);
-//  Do not call manually! Use random_close from random.hpp
+/*  Do not call manually! Use random_close from random.hpp */
 int randombytes_close (void);
-//  Do not call manually! Use random_open from random.hpp
+/*  Do not call manually! Use random_open from random.hpp */
 int sodium_init (void);
 
 int crypto_box_keypair (u8 *y, u8 *x);

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -240,7 +240,7 @@ int zmq::udp_engine_t::resolve_raw_address (char *name_, size_t length_)
     return 0;
 }
 
-void zmq::udp_engine_t::out_event ()
+void zmq::udp_engine_t::out_event (i_poll_events::handle_t handle_)
 {
     msg_t group_msg;
     int rc = session->pull_msg (&group_msg);
@@ -316,11 +316,11 @@ void zmq::udp_engine_t::restart_output ()
             msg.close ();
     } else {
         set_pollout (handle);
-        out_event ();
+        out_event (handle);
     }
 }
 
-void zmq::udp_engine_t::in_event ()
+void zmq::udp_engine_t::in_event (i_poll_events::handle_t handle_)
 {
     struct sockaddr_in in_address;
     socklen_t in_addrlen = sizeof (sockaddr_in);
@@ -412,11 +412,21 @@ void zmq::udp_engine_t::in_event ()
     session->flush ();
 }
 
+void zmq::udp_engine_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
+void zmq::udp_engine_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(handle_);
+}
+
 void zmq::udp_engine_t::restart_input ()
 {
     if (!recv_enabled)
         return;
 
     set_pollin (handle);
-    in_event ();
+    in_event (handle);
 }

--- a/src/udp_engine.hpp
+++ b/src/udp_engine.hpp
@@ -41,8 +41,10 @@ class udp_engine_t : public io_object_t, public i_engine
 
     void zap_msg_available (){};
 
-    void in_event ();
-    void out_event ();
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
 
     const char *get_endpoint () const;
 

--- a/src/vmci_connecter.cpp
+++ b/src/vmci_connecter.cpp
@@ -100,15 +100,15 @@ void zmq::vmci_connecter_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::vmci_connecter_t::in_event ()
+void zmq::vmci_connecter_t::in_event (i_poll_events::handle_t handle_)
 {
     //  We are not polling for incoming data, so we are actually called
     //  because of error here. However, we can get error on out event as well
     //  on some platforms, so we'll simply handle both events in the same way.
-    out_event ();
+    out_event (i_poll_events::handle_t handle_);
 }
 
-void zmq::vmci_connecter_t::out_event ()
+void zmq::vmci_connecter_t::out_event (i_poll_events::handle_t handle_)
 {
     fd_t fd = connect ();
     rm_fd (handle);
@@ -147,6 +147,16 @@ void zmq::vmci_connecter_t::out_event ()
     terminate ();
 
     socket->event_connected (endpoint, fd);
+}
+
+void zmq::vmci_connecter_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
+}
+
+void zmq::vmci_connecter_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
 }
 
 void zmq::vmci_connecter_t::timer_event (int id_)

--- a/src/vmci_connecter.hpp
+++ b/src/vmci_connecter.hpp
@@ -69,9 +69,11 @@ class vmci_connecter_t : public own_t, public io_object_t
     void process_term (int linger_);
 
     //  Handlers for I/O events.
-    void in_event ();
-    void out_event ();
-    void timer_event (int id_);
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void out_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
+    virtual void timer_event (int id_);
 
     //  Internal function to start the actual connection establishment.
     void start_connecting ();

--- a/src/vmci_listener.cpp
+++ b/src/vmci_listener.cpp
@@ -81,7 +81,7 @@ void zmq::vmci_listener_t::process_term (int linger_)
     own_t::process_term (linger_);
 }
 
-void zmq::vmci_listener_t::in_event ()
+void zmq::vmci_listener_t::in_event (i_poll_events::handle_t handle_)
 {
     fd_t fd = accept ();
 
@@ -123,6 +123,16 @@ void zmq::vmci_listener_t::in_event ()
     launch_child (session);
     send_attach (session, engine, false);
     socket->event_accepted (endpoint, fd);
+}
+
+void zmq::vmci_listener_t::err_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
+}
+
+void zmq::vmci_listener_t::pri_event (i_poll_events::handle_t handle_)
+{
+    in_event(fd_);
 }
 
 int zmq::vmci_listener_t::get_address (std::string &addr_)

--- a/src/vmci_listener.hpp
+++ b/src/vmci_listener.hpp
@@ -66,7 +66,9 @@ class vmci_listener_t : public own_t, public io_object_t
     void process_term (int linger_);
 
     //  Handlers for I/O events.
-    void in_event ();
+    virtual void in_event (i_poll_events::handle_t handle_);
+    virtual void err_event (i_poll_events::handle_t handle_);
+    virtual void pri_event (i_poll_events::handle_t handle_);
 
     //  Close the listening socket.
     void close ();

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -688,7 +688,7 @@ const char *zmq_msg_gets (const zmq_msg_t *msg_, const char *property_)
     // Polling.
 
 #if defined ZMQ_HAVE_POLLER
-inline int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
+int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
 {
     // implement zmq_poll on top of zmq_poller
     int rc;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -216,6 +216,11 @@ if(ZMQ_HAVE_CURVE)
   set_tests_properties(test_security_curve PROPERTIES TIMEOUT 60)
 endif()
 
+if(WIN32)
+  set_tests_properties(test_shutdown_stress PROPERTIES TIMEOUT 15)
+  set_tests_properties(test_router_mandatory PROPERTIES TIMEOUT 15)
+endif()
+
 if(WIN32 AND ${POLLER} MATCHES "poll")
   set_tests_properties(test_many_sockets PROPERTIES TIMEOUT 30)
   set_tests_properties(test_immediate PROPERTIES TIMEOUT 30)

--- a/unittests/unittest_poller.cpp
+++ b/unittests/unittest_poller.cpp
@@ -61,7 +61,7 @@ struct test_events_t : zmq::i_poll_events
     {
     }
 
-    virtual void in_event ()
+    virtual void in_event (zmq::i_poll_events::handle_t handle_)
     {
         poller.rm_fd (handle);
         handle = (zmq::poller_t::handle_t) NULL;
@@ -71,11 +71,20 @@ struct test_events_t : zmq::i_poll_events
     }
 
 
-    virtual void out_event ()
+    virtual void out_event (zmq::i_poll_events::handle_t handle_)
     {
         // TODO
     }
 
+    virtual void err_event (zmq::i_poll_events::handle_t handle_)
+    {
+        in_event(handle_);
+    }
+
+    virtual void pri_event (zmq::i_poll_events::handle_t handle_)
+    {
+        in_event(handle_);
+    }
 
     virtual void timer_event (int id_)
     {


### PR DESCRIPTION
This is not the final PR, I will wait for feedbacks before formatting each commits

I start with this issue https://github.com/zeromq/czmq/issues/1881
TLDR; We need a way to interrupt the select poller on Windows. On Windows CTRL+C doesn't interrupt select like unix system. The best way to do that is to call QueueUserAPC on each thread which will interrupt some functions(https://msdn.microsoft.com/fr-fr/library/windows/desktop/ms684954(v=vs.85).aspx) with WAIT_IO_COMPLETION (that should work https://github.com/diorcety/czmq/commit/794a0e616519ed4ebb9c284ab9b14b0a7786aa0a).
For that we need to use WSA correctly.
The issue is that in multiple place in code where there is a select(or poll) implementations.
This PR goal is to factorize that code (using poller implementations) in order to allow in the future (soon) to use WSA in place of select on Windows.

I have tested it on Linux: epoll(only shutdown test doesn't pass), poll, select
and on Windows: select
There is certainly performance drawbacks. 
I'am opened to suggestions