### PR TITLE
CMake: Linker PDB install rule does not work when Visual Studio generators are used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build script for ZeroMQ
 
-cmake_minimum_required (VERSION 3.1.3)
+cmake_minimum_required (VERSION 2.8.12)
 project (ZeroMQ)
 
 list (INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -478,6 +478,9 @@ if (MSVC)
   # Parallel make.
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
+  # Compile the static lib with debug information included
+  string (REGEX REPLACE "/Z." "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
   # Optimization flags.
   # http://msdn.microsoft.com/en-us/magazine/cc301698.aspx
   if (NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
@@ -890,6 +893,8 @@ if (MSVC)
   # Suppress linker warnings caused by #ifdef omission
   # of file content.
   set( CMAKE_STATIC_LINKER_FLAGS /ignore:4221 )
+  set (PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
+  set (PDB_NAME "libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}")
   if (BUILD_SHARED)
     add_library (libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
     set_target_properties (libzmq PROPERTIES
@@ -1115,7 +1120,11 @@ if (MSVC)
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           COMPONENT SDK)
-  install (FILES $<TARGET_PDB_FILE:libzmq> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL COMPONENT SDK)
+  if (MSVC_IDE)
+    install (FILES ${PDB_OUTPUT_DIRECTORY}/\${CMAKE_INSTALL_CONFIG_NAME}/${PDB_NAME}.pdb DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT SDK OPTIONAL)
+  else()
+    install (FILES ${PDB_OUTPUT_DIRECTORY}/${PDB_NAME}.pdb DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT SDK OPTIONAL)
+  endif()
   if (BUILD_SHARED)
     install (TARGETS libzmq
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,7 +988,7 @@ endforeach()
 
 if (BUILD_SHARED)
   target_link_libraries (libzmq ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-  
+
   if (SODIUM_FOUND)
     target_link_libraries (libzmq ${SODIUM_LIBRARIES})
 	# On Solaris, libsodium depends on libssp
@@ -996,7 +996,7 @@ if (BUILD_SHARED)
       target_link_libraries (libzmq ssp)
     endif ()
   endif ()
-  
+
   if (HAVE_WS2_32)
     target_link_libraries (libzmq ws2_32)
   elseif (HAVE_WS2)
@@ -1018,7 +1018,7 @@ endif ()
 
 if (BUILD_STATIC)
   target_link_libraries (libzmq-static ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-  
+
   if (SODIUM_FOUND)
     target_link_libraries (libzmq-static ${SODIUM_LIBRARIES})
     # On Solaris, libsodium depends on libssp
@@ -1026,7 +1026,7 @@ if (BUILD_STATIC)
       target_link_libraries (libzmq-static ssp)
     endif ()
   endif ()
-  
+
   if (HAVE_WS2_32)
     target_link_libraries (libzmq-static ws2_32)
   elseif (HAVE_WS2)
@@ -1115,22 +1115,7 @@ if (MSVC)
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           COMPONENT SDK)
-  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    install (TARGETS ${target_outputs}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            COMPONENT SDK)
-    if (NOT CMAKE_PDB_OUTPUT_DIRECTORY AND BUILD_SHARED)
-      install (FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}.pdb DESTINATION lib
-            COMPONENT SDK)
-    endif ()
-  elseif (BUILD_SHARED)
-    install (TARGETS libzmq
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            COMPONENT Runtime)
-  endif ()
+  install (FILES $<TARGET_PDB_FILE:libzmq> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL COMPONENT SDK)
 else ()
   install (TARGETS ${target_outputs}
           EXPORT ${PROJECT_NAME}-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build script for ZeroMQ
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.1.3)
 project (ZeroMQ)
 
 list (INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -1116,6 +1116,12 @@ if (MSVC)
           PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           COMPONENT SDK)
   install (FILES $<TARGET_PDB_FILE:libzmq> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL COMPONENT SDK)
+  if (BUILD_SHARED)
+    install (TARGETS libzmq
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            COMPONENT Runtime)
+  endif ()
 else ()
   install (TARGETS ${target_outputs}
           EXPORT ${PROJECT_NAME}-targets


### PR DESCRIPTION
Problem: When CMake Visual Studio generators are used, the install rule for the linker PDB does not work.

Solution: Fixed install rules to work with single and multi-configuration generators under MSVC.

I previously opened the pull request #2988 to fix this problem. The solution back then included an update of the CMake version to 3.x which was not an option. Hence, I adapted the solution to work with CMake 2.8.12. Please note that the fix changes both the PDB of the shared library and of the static library. In the static case, I added /Z7 to add the compile info to the static lib directly. The reason for this was, that there are no CMake variables in 2.8.x that allow for a smooth installation of the PDB of the static lib.

This solves #2989