### PR TITLE
configure.ac: serach for dladdr only on libunwind

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,11 +175,6 @@ case "${host_os}" in
         AC_DEFINE(ZMQ_HAVE_LINUX, 1, [Have Linux OS])
         libzmq_on_linux="yes"
 
-        # dladdr/dlopen is in libdl on glibc
-        AC_SEARCH_LIBS([dladdr], [dl dld], [], [
-          AC_MSG_ERROR([unable to find the dladdr() function])
-        ])
-
         if test "x$libzmq_tipc_support" = "xyes"; then
             AC_DEFINE(ZMQ_HAVE_TIPC, 1, [Have TIPC support])
         fi
@@ -784,7 +779,7 @@ if test "x$enable_libunwind" != "xno"; then
             AC_DEFINE(HAVE_LIBUNWIND, 1, [The libunwind library is to be used])
             AC_SUBST([LIBUNWIND_CFLAGS])
             AC_SUBST([LIBUNWIND_LIBS])
-            AC_CHECK_LIB([dl], [dladdr])
+            AC_SEARCH_LIBS([dladdr], [dl dld])
         ],
         [
             if test "x$enable_libunwind" = "xyes"; then


### PR DESCRIPTION
The original configure.ac tries to check for dladdr, but it actually needs
it only in case we have libunwind (which has a another section and checks for it
too).
This can fail the build on systems without dynamic linking support.
Therefore, the dladdr check has to be preformed only when checking libunwind.

Signed-off-by: Asaf Kahlon <asafka7@gmail.com>