### PR TITLE
Allow EBADF on iOS #3046

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -66,6 +66,10 @@
 #include <pgm/pgm.h>
 #endif
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 zmq::fd_t zmq::open_socket (int domain_, int type_, int protocol_)
 {
     int rc;
@@ -167,7 +171,11 @@ int zmq::get_peer_ip_address (fd_t sockfd_, std::string &ip_addr_)
     }
 #else
     if (rc == -1) {
+#if !defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE
         errno_assert (errno != EBADF && errno != EFAULT && errno != ENOTSOCK);
+#else
+        errno_assert (errno != EFAULT && errno != ENOTSOCK);
+#endif
         return 0;
     }
 #endif

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -48,6 +48,10 @@
 #include <ioctl.h>
 #endif
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 int zmq::tune_tcp_socket (fd_t s_)
 {
     //  Disable Nagle's algorithm. We are doing data batching on 0MQ level,
@@ -238,10 +242,17 @@ int zmq::tcp_write (fd_t s_, const void *data_, size_t size_)
 
     //  Signalise peer failure.
     if (nbytes == -1) {
+#if !defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE
         errno_assert (errno != EACCES && errno != EBADF && errno != EDESTADDRREQ
                       && errno != EFAULT && errno != EISCONN
                       && errno != EMSGSIZE && errno != ENOMEM
                       && errno != ENOTSOCK && errno != EOPNOTSUPP);
+#else
+        errno_assert (errno != EACCES && errno != EDESTADDRREQ
+                      && errno != EFAULT && errno != EISCONN
+                      && errno != EMSGSIZE && errno != ENOMEM
+                      && errno != ENOTSOCK && errno != EOPNOTSUPP);
+#endif
         return -1;
     }
 
@@ -282,8 +293,12 @@ int zmq::tcp_read (fd_t s_, void *data_, size_t size_)
     //  be able to read a single byte from the socket. Also, SIGSTOP issued
     //  by a debugging tool can result in EINTR error.
     if (rc == -1) {
+#if !defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE
         errno_assert (errno != EBADF && errno != EFAULT && errno != ENOMEM
                       && errno != ENOTSOCK);
+#else
+        errno_assert (errno != EFAULT && errno != ENOMEM && errno != ENOTSOCK);
+#endif
         if (errno == EWOULDBLOCK || errno == EINTR)
             errno = EAGAIN;
     }

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -60,6 +60,10 @@
 #endif
 #endif
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 zmq::tcp_connecter_t::tcp_connecter_t (class io_thread_t *io_thread_,
                                        class session_base_t *session_,
                                        const options_t &options_,
@@ -403,8 +407,13 @@ zmq::fd_t zmq::tcp_connecter_t::connect ()
         err = errno;
     if (err != 0) {
         errno = err;
+#if !defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE
         errno_assert (errno != EBADF && errno != ENOPROTOOPT
                       && errno != ENOTSOCK && errno != ENOBUFS);
+#else
+        errno_assert (errno != ENOPROTOOPT && errno != ENOTSOCK
+                      && errno != ENOBUFS);
+#endif
         return retired_fd;
     }
 #endif

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -51,6 +51,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define IPV6_ADD_MEMBERSHIP IPV6_JOIN_GROUP
 #endif
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 zmq::udp_engine_t::udp_engine_t (const options_t &options_) :
     plugged (false),
     fd (-1),
@@ -448,8 +452,13 @@ void zmq::udp_engine_t::in_event ()
     int nbytes = recvfrom (fd, in_buffer, MAX_UDP_MSG, 0,
                            (sockaddr *) &in_address, &in_addrlen);
     if (nbytes == -1) {
+#if !defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE
         errno_assert (errno != EBADF && errno != EFAULT && errno != ENOMEM
                       && errno != ENOTSOCK);
+#else
+        errno_assert (errno != EBADF && errno != EFAULT && errno != ENOMEM
+                      && errno != ENOTSOCK);
+#endif
         return;
     }
 #endif


### PR DESCRIPTION
Problem: Aborts when iOS returns EBADF to indicate a socket was reclaimed while the app slept.

Solution: When compiling for iOS, remove asserts on EBADF.

EBADF behavior documented here: https://developer.apple.com/library/content/technotes/tn2277/_index.html#//apple_ref/doc/uid/DTS40010841-CH1-SUBSECTION3
