### PR TITLE
Fix fd_t variable casting on Windows platform

### DIFF
--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -131,7 +131,7 @@ void zmq::tcp_listener_t::in_event ()
     session->inc_seqnum ();
     launch_child (session);
     send_attach (session, engine, false);
-    socket->event_accepted (endpoint, (int) fd);
+    socket->event_accepted (endpoint, fd);
 }
 
 void zmq::tcp_listener_t::close ()


### PR DESCRIPTION
event_accepted() already accepts fd_t type and there is no reason to cast it to int type
Moreover, on Windows x64 this leads to truncation memsize -> int