### PR TITLE
Problem: heartbeat commands break REP session, unclear documentation

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -344,7 +344,7 @@ traffic will cancel the timeout.
 [horizontal]
 Option value type:: int
 Option value unit:: milliseconds
-Default value:: 0
+Default value:: 0 normally, ZMQ_HEARTBEAT_IVL if it is set
 Applicable socket types:: all, when using connection-oriented transports
 
 

--- a/src/req.cpp
+++ b/src/req.cpp
@@ -285,6 +285,11 @@ zmq::req_session_t::~req_session_t ()
 
 int zmq::req_session_t::push_msg (msg_t *msg_)
 {
+    //  Ignore commands, they are processed by the engine and should not
+    //  affect the state machine.
+    if (unlikely (msg_->flags () & msg_t::command))
+        return 0;
+
     switch (state) {
         case bottom:
             if (msg_->flags () == msg_t::more) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -215,6 +215,7 @@ endforeach()
 if(ZMQ_HAVE_CURVE)
   set_tests_properties(test_security_curve PROPERTIES TIMEOUT 60)
 endif()
+set_tests_properties(test_heartbeats PROPERTIES TIMEOUT 60)
 
 if(WIN32 AND ${POLLER} MATCHES "poll")
   set_tests_properties(test_many_sockets PROPERTIES TIMEOUT 30)


### PR DESCRIPTION
Solution: ignore commands in the REP session manager, as they are handled by the engine, and clarify default values in the documentation. Also add more test coverage for heartbeats.

Fixes: #3060