### PR TITLE
More attempts to speed up Appveyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,7 @@ endif ()
 if (MSVC)
   # Parallel make.
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
 
   # Compile the static lib with debug information included
   string (REGEX REPLACE "/Z." "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,5 +102,5 @@ after_build:
 
 test_script:
   - cmd: cd "%LIBZMQ_BUILDDIR%"
-  - cmd: ctest -C "%Configuration%" -V
+  - cmd: ctest -C "%Configuration%" -V -j5
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,16 +70,26 @@ init:
   - msbuild /version
   - cmd: reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp" /v UserAuthentication /t REG_DWORD /d 0 /f
 
+cache:
+    - C:\projects\libsodium
+
 install:
   - cmd: if "%Platform%"=="x64" set "CMAKE_GENERATOR=%CMAKE_GENERATOR% Win64"
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%Platform%'"
   - cmd: if "%WITH_LIBSODIUM%"=="ON" set LIBSODIUMDIR=C:\projects\libsodium
-  - cmd: if "%WITH_LIBSODIUM%"=="ON" git clone --branch stable --depth 1 --quiet "https://github.com/jedisct1/libsodium.git" %LIBSODIUMDIR%
+  - if "%WITH_LIBSODIUM%"=="ON" (
+      if not exist "%LIBSODIUMDIR%" (
+      git clone --branch stable --depth 1 --quiet "https://github.com/jedisct1/libsodium.git" %LIBSODIUMDIR%
+      ) else (
+      cd "%LIBSODIUMDIR%" &&
+      git pull
+      )
+    )
   - cmd: if "%WITH_LIBSODIUM%"=="ON" msbuild /v:minimal /maxcpucount:%NUMBER_OF_PROCESSORS% /p:Configuration=%Configuration%DLL %LIBSODIUMDIR%\builds\msvc\%MSVCYEAR%\libsodium\libsodium.vcxproj
   - cmd: if "%WITH_LIBSODIUM%"=="ON" set SODIUM_LIBRARY_DIR="%LIBSODIUMDIR%\bin\%Platform%\%Configuration%\%MSVCVERSION%\dynamic"
   - cmd: if "%WITH_LIBSODIUM%"=="ON" set SODIUM_INCLUDE_DIR="%LIBSODIUMDIR%\src\libsodium\include"
-  - cmd: if "%WITH_LIBSODIUM%"=="ON" move "%SODIUM_LIBRARY_DIR%\libsodium.lib" "%SODIUM_LIBRARY_DIR%\sodium.lib"
+  - ps: if (${env:WITH_LIBSODIUM} -eq "ON") { Copy-Item "C:\projects\libsodium\bin\${env:Platform}\${env:Configuration}\${env:MSVCVERSION}\dynamic\libsodium.lib" -Destination "C:\projects\libsodium\bin\${env:Platform}\${env:Configuration}\${env:MSVCVERSION}\dynamic\sodium.lib" }
 
 clone_folder: C:\projects\libzmq
 


### PR DESCRIPTION
Small difference, but better than nothing. Compilation time is still the dominant factor, I wonder if the paralle builds are working - it doesn't seem like following the live logs.

@sigiesec do you know if the way to do parallel builds with the generated visual studio solutions by cmake changed with VS2015?
The VS2013 builds take just a couple of minutes, but the 2015 and 2017 one take 4 times as much, which would seem consistent with a sequential vs parallel build with 4 cores