### PR TITLE
Add ip_resolver.cpp and ip_resolver.hpp for vs2015 libzmq project

### DIFF
--- a/builds/msvc/vs2015/libzmq/libzmq.vcxproj
+++ b/builds/msvc/vs2015/libzmq/libzmq.vcxproj
@@ -107,6 +107,7 @@
     <ClInclude Include="..\..\..\..\src\io_object.hpp" />
     <ClInclude Include="..\..\..\..\src\io_thread.hpp" />
     <ClInclude Include="..\..\..\..\src\ip.hpp" />
+    <ClInclude Include="..\..\..\..\src\ip_resolver.hpp" />
     <ClInclude Include="..\..\..\..\src\ipc_address.hpp" />
     <ClInclude Include="..\..\..\..\src\ipc_connecter.hpp" />
     <ClInclude Include="..\..\..\..\src\ipc_listener.hpp" />
@@ -198,6 +199,7 @@
     <ClCompile Include="..\..\..\..\src\io_object.cpp" />
     <ClCompile Include="..\..\..\..\src\io_thread.cpp" />
     <ClCompile Include="..\..\..\..\src\ip.cpp" />
+    <ClCompile Include="..\..\..\..\src\ip_resolver.cpp" />
     <ClCompile Include="..\..\..\..\src\ipc_address.cpp" />
     <ClCompile Include="..\..\..\..\src\ipc_connecter.cpp" />
     <ClCompile Include="..\..\..\..\src\ipc_listener.cpp" />


### PR DESCRIPTION
Fixes #3079 for VS2015 Solution

Problem: VS2015 solution does not include ip_resolver.cpp and ip_resolver.hpp

Solution: added .cpp and .hpp to vcxproj