### PR TITLE
Problem: getrandom test does not check if it's working

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -883,7 +883,8 @@ AC_DEFUN([LIBZMQ_CHECK_GETRANDOM], [{
 int main (int argc, char *argv [])
 {
     char buf[4];
-    getrandom(buf, 4, 0);
+    int rc = getrandom(buf, 4, 0);
+    return rc == -1 ? 1 : 0;
 }
         ],
         [libzmq_cv_getrandom="yes"],

--- a/builds/cmake/Modules/ZMQSourceRunChecks.cmake
+++ b/builds/cmake/Modules/ZMQSourceRunChecks.cmake
@@ -287,7 +287,8 @@ macro(zmq_check_getrandom)
 int main (int argc, char *argv [])
 {
     char buf[4];
-    getrandom(buf, 4, 0);
+    int rc = getrandom(buf, 4, 0);
+    return rc == -1 ? 1 : 0;
 }
 "
     ZMQ_HAVE_GETRANDOM)


### PR DESCRIPTION
Solution: check return value in autoconf and CMake. On some platforms
the function is available but not implemented (eg: GNU/Hurd).