### PR TITLE
Problem: test helper recv_string_expect_success ignores flags

### DIFF
--- a/tests/testutil_unity.hpp
+++ b/tests/testutil_unity.hpp
@@ -86,8 +86,8 @@ void recv_string_expect_success (void *socket, const char *str, int flags)
                                        "used for strings longer than 255 "
                                        "characters");
 
-    const int rc =
-      TEST_ASSERT_SUCCESS_ERRNO (zmq_recv (socket, buffer, sizeof (buffer), 0));
+    const int rc = TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_recv (socket, buffer, sizeof (buffer), flags));
     TEST_ASSERT_EQUAL_INT ((int) len, rc);
     if (str)
         TEST_ASSERT_EQUAL_STRING_LEN (str, buffer, len);


### PR DESCRIPTION
I started looking into that because I wanted to silence a distracting warning. I don't know if the flags were ignored on purpose but I can't really imagine why that would be. At any rate the only code that actually passes non-0 flags is test_get_peer_state in test_router_mandatory.cpp:

https://github.com/zeromq/libzmq/blob/3c2656eb5233fea480a6ead357159d2ec85412e3/tests/test_router_mandatory.cpp#L138