### PR TITLE
Problem: warnings in MSVC builds around size_t/int

### DIFF
--- a/src/ip_resolver.cpp
+++ b/src/ip_resolver.cpp
@@ -51,7 +51,7 @@ const struct sockaddr *zmq::ip_addr_t::as_sockaddr () const
     return &generic;
 }
 
-size_t zmq::ip_addr_t::sockaddr_len () const
+socklen_t zmq::ip_addr_t::sockaddr_len () const
 {
     if (family () == AF_INET6) {
         return sizeof (ipv6);

--- a/src/ip_resolver.hpp
+++ b/src/ip_resolver.hpp
@@ -48,7 +48,7 @@ union ip_addr_t
     uint16_t port () const;
 
     const struct sockaddr *as_sockaddr () const;
-    size_t sockaddr_len () const;
+    socklen_t sockaddr_len () const;
 
     void set_port (uint16_t);
 

--- a/src/mechanism.cpp
+++ b/src/mechanism.cpp
@@ -184,13 +184,14 @@ size_t zmq::mechanism_t::add_basic_properties (unsigned char *buf,
 size_t zmq::mechanism_t::basic_properties_len () const
 {
     const char *socket_type = socket_type_string (options.type);
-    int meta_len = 0;
+    size_t meta_len = 0;
 
     for (std::map<std::string, std::string>::const_iterator it =
            options.app_metadata.begin ();
-         it != options.app_metadata.end (); ++it)
+         it != options.app_metadata.end (); ++it) {
         meta_len +=
           property_len (it->first.c_str (), strlen (it->second.c_str ()));
+    }
 
     return property_len (ZMTP_PROPERTY_SOCKET_TYPE, strlen (socket_type))
            + meta_len


### PR DESCRIPTION
Solution: use proper types
