### PR TITLE
ZMTP 3.1 PING Context not implemented

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -651,7 +651,8 @@ tests_test_setsockopt_SOURCES = tests/test_setsockopt.cpp
 tests_test_setsockopt_LDADD = src/libzmq.la
 
 tests_test_heartbeats_SOURCES = tests/test_heartbeats.cpp
-tests_test_heartbeats_LDADD = src/libzmq.la
+tests_test_heartbeats_LDADD = src/libzmq.la ${UNITY_LIBS}
+tests_test_heartbeats_CPPFLAGS = ${UNITY_CPPFLAGS}
 
 tests_test_stream_exceeds_buffer_SOURCES = tests/test_stream_exceeds_buffer.cpp
 tests_test_stream_exceeds_buffer_LDADD = src/libzmq.la

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -98,6 +98,8 @@ zmq::stream_engine_t::stream_engine_t (fd_t fd_,
 {
     int rc = tx_msg.init ();
     errno_assert (rc == 0);
+    rc = pong_msg.init ();
+    errno_assert (rc == 0);
 
     //  Put the socket into non-blocking mode.
     unblock_socket (s);
@@ -1059,11 +1061,8 @@ int zmq::stream_engine_t::produce_pong_message (msg_t *msg_)
     int rc = 0;
     zmq_assert (mechanism != NULL);
 
-    rc = msg_->init_size (5);
+    rc = msg_->move (pong_msg);
     errno_assert (rc == 0);
-    msg_->set_flags (msg_t::command);
-
-    memcpy (msg_->data (), "\4PONG", 5);
 
     rc = mechanism->encode (msg_);
     next_msg = &stream_engine_t::pull_and_encode;
@@ -1085,6 +1084,20 @@ int zmq::stream_engine_t::process_heartbeat_message (msg_t *msg_)
             add_timer (remote_heartbeat_ttl, heartbeat_ttl_timer_id);
             has_ttl_timer = true;
         }
+
+        //  As per ZMTP 3.1 the PING command might contain an up to 16 bytes
+        //  context which needs to be PONGed back, so build the pong message
+        //  here and store it. Truncate it if it's too long.
+        //  Given the engine goes straight to out_event, sequential PINGs will
+        //  not be a problem.
+        size_t context_len = msg_->size () - 7 > 16 ? 16 : msg_->size () - 7;
+        int rc = pong_msg.init_size (5 + context_len);
+        errno_assert (rc == 0);
+        pong_msg.set_flags (msg_t::command);
+        memcpy (pong_msg.data (), "\4PONG", 5);
+        if (context_len > 0)
+            memcpy (((uint8_t *) pong_msg.data ()) + 5,
+                    ((uint8_t *) msg_->data ()) + 7, context_len);
 
         next_msg = &stream_engine_t::produce_pong_message;
         out_event ();

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -935,9 +935,7 @@ int zmq::stream_engine_t::decode_and_push (msg_t *msg_)
     }
 
     if (msg_->flags () & msg_t::command) {
-        uint8_t cmd_id = *((uint8_t *) msg_->data ());
-        if (cmd_id == 4)
-            process_heartbeat_message (msg_);
+        process_command_message (msg_);
     }
 
     if (metadata)
@@ -1091,6 +1089,22 @@ int zmq::stream_engine_t::process_heartbeat_message (msg_t *msg_)
         next_msg = &stream_engine_t::produce_pong_message;
         out_event ();
     }
+
+    return 0;
+}
+
+int zmq::stream_engine_t::process_command_message (msg_t *msg_)
+{
+    uint8_t cmd_name_size = *((uint8_t *) msg_->data ());
+    //  Malformed command
+    if (msg_->size () < cmd_name_size + sizeof (cmd_name_size))
+        return -1;
+
+    uint8_t *cmd_name = ((uint8_t *) msg_->data ()) + 1;
+    if (cmd_name_size == 4
+        && (memcmp (cmd_name, "PING", cmd_name_size) == 0
+            || memcmp (cmd_name, "PONG", cmd_name_size) == 0))
+        return process_heartbeat_message (msg_);
 
     return 0;
 }

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -127,6 +127,7 @@ class stream_engine_t : public io_object_t, public i_engine
     typedef metadata_t::dict_t properties_t;
     bool init_properties (properties_t &properties);
 
+    int process_command_message (msg_t *msg_);
     int produce_ping_message (msg_t *msg_);
     int process_heartbeat_message (msg_t *msg_);
     int produce_pong_message (msg_t *msg_);

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -139,6 +139,8 @@ class stream_engine_t : public io_object_t, public i_engine
     bool as_server;
 
     msg_t tx_msg;
+    //  Need to store PING payload for PONG
+    msg_t pong_msg;
 
     handle_t handle;
 

--- a/tests/test_heartbeats.cpp
+++ b/tests/test_heartbeats.cpp
@@ -29,6 +29,19 @@ typedef SOCKET raw_socket;
 typedef int raw_socket;
 #endif
 
+#include <unity.h>
+
+void setUp ()
+{
+    //    setup_test_context ();
+}
+
+void tearDown ()
+{
+    //    teardown_test_context ();
+}
+
+
 //  Read one event off the monitor socket; return value and address
 //  by reference, if not null, and event number by value. Returns -1
 //  in case of error.
@@ -340,29 +353,62 @@ test_heartbeat_notimeout (int is_curve, int client_type, int server_type)
     assert (rc == 0);
 }
 
+void test_heartbeat_timeout_router ()
+{
+    test_heartbeat_timeout (ZMQ_ROUTER);
+}
+
+void test_heartbeat_timeout_rep ()
+{
+    test_heartbeat_timeout (ZMQ_REP);
+}
+
+#define DEFINE_TESTS(first, second, first_define, second_define)               \
+    void test_heartbeat_ttl_##first##_##second ()                              \
+    {                                                                          \
+        test_heartbeat_ttl (first_define, second_define);                      \
+    }                                                                          \
+    void test_heartbeat_notimeout_##first##_##second ()                        \
+    {                                                                          \
+        test_heartbeat_notimeout (0, first_define, second_define);             \
+    }                                                                          \
+    void test_heartbeat_notimeout_##first##_##second##_with_curve ()           \
+    {                                                                          \
+        test_heartbeat_notimeout (1, first_define, second_define);             \
+    }
+
+DEFINE_TESTS (dealer, router, ZMQ_DEALER, ZMQ_ROUTER)
+DEFINE_TESTS (req, rep, ZMQ_REQ, ZMQ_REP)
+DEFINE_TESTS (pull, push, ZMQ_PULL, ZMQ_PUSH)
+DEFINE_TESTS (sub, pub, ZMQ_SUB, ZMQ_PUB)
+DEFINE_TESTS (pair, pair, ZMQ_PAIR, ZMQ_PAIR)
+
 int main (void)
 {
     setup_test_environment ();
 
-    test_heartbeat_timeout (ZMQ_ROUTER);
-    test_heartbeat_timeout (ZMQ_REP);
+    UNITY_BEGIN ();
 
-    test_heartbeat_ttl (ZMQ_DEALER, ZMQ_ROUTER);
-    test_heartbeat_ttl (ZMQ_REQ, ZMQ_REP);
-    test_heartbeat_ttl (ZMQ_PULL, ZMQ_PUSH);
-    test_heartbeat_ttl (ZMQ_SUB, ZMQ_PUB);
-    test_heartbeat_ttl (ZMQ_PAIR, ZMQ_PAIR);
+    RUN_TEST (test_heartbeat_timeout_router);
+    RUN_TEST (test_heartbeat_timeout_rep);
 
-    // Run this test without curve
-    test_heartbeat_notimeout (0, ZMQ_DEALER, ZMQ_ROUTER);
-    test_heartbeat_notimeout (0, ZMQ_REQ, ZMQ_REP);
-    test_heartbeat_notimeout (0, ZMQ_PULL, ZMQ_PUSH);
-    test_heartbeat_notimeout (0, ZMQ_SUB, ZMQ_PUB);
-    test_heartbeat_notimeout (0, ZMQ_PAIR, ZMQ_PAIR);
-    // Then rerun it with curve
-    test_heartbeat_notimeout (1, ZMQ_DEALER, ZMQ_ROUTER);
-    test_heartbeat_notimeout (1, ZMQ_REQ, ZMQ_REP);
-    test_heartbeat_notimeout (1, ZMQ_PULL, ZMQ_PUSH);
-    test_heartbeat_notimeout (1, ZMQ_SUB, ZMQ_PUB);
-    test_heartbeat_notimeout (1, ZMQ_PAIR, ZMQ_PAIR);
+    RUN_TEST (test_heartbeat_ttl_dealer_router);
+    RUN_TEST (test_heartbeat_ttl_req_rep);
+    RUN_TEST (test_heartbeat_ttl_pull_push);
+    RUN_TEST (test_heartbeat_ttl_sub_pub);
+    RUN_TEST (test_heartbeat_ttl_pair_pair);
+
+    RUN_TEST (test_heartbeat_notimeout_dealer_router);
+    RUN_TEST (test_heartbeat_notimeout_req_rep);
+    RUN_TEST (test_heartbeat_notimeout_pull_push);
+    RUN_TEST (test_heartbeat_notimeout_sub_pub);
+    RUN_TEST (test_heartbeat_notimeout_pair_pair);
+
+    RUN_TEST (test_heartbeat_notimeout_dealer_router_with_curve);
+    RUN_TEST (test_heartbeat_notimeout_req_rep_with_curve);
+    RUN_TEST (test_heartbeat_notimeout_pull_push_with_curve);
+    RUN_TEST (test_heartbeat_notimeout_sub_pub_with_curve);
+    RUN_TEST (test_heartbeat_notimeout_pair_pair_with_curve);
+
+    return UNITY_END ();
 }

--- a/tests/test_heartbeats.cpp
+++ b/tests/test_heartbeats.cpp
@@ -85,10 +85,6 @@ static void recv_with_retry (raw_socket fd, char *buffer, int bytes)
         assert (received <= bytes);
         if (received == bytes)
             break;
-        // ZMQ_REP READY message is shorter, check the actual socket type
-        if (received >= 3 && buffer[received - 1] == 'P'
-            && buffer[received - 2] == 'E' && buffer[received - 3] == 'R')
-            break;
     }
 }
 
@@ -358,11 +354,6 @@ void test_heartbeat_timeout_router ()
     test_heartbeat_timeout (ZMQ_ROUTER);
 }
 
-void test_heartbeat_timeout_rep ()
-{
-    test_heartbeat_timeout (ZMQ_REP);
-}
-
 #define DEFINE_TESTS(first, second, first_define, second_define)               \
     void test_heartbeat_ttl_##first##_##second ()                              \
     {                                                                          \
@@ -390,7 +381,6 @@ int main (void)
     UNITY_BEGIN ();
 
     RUN_TEST (test_heartbeat_timeout_router);
-    RUN_TEST (test_heartbeat_timeout_rep);
 
     RUN_TEST (test_heartbeat_ttl_dealer_router);
     RUN_TEST (test_heartbeat_ttl_req_rep);

--- a/tests/testutil_unity.hpp
+++ b/tests/testutil_unity.hpp
@@ -57,11 +57,36 @@ int test_assert_success_message_errno_helper (int rc,
     return rc;
 }
 
+int test_assert_success_message_raw_errno_helper (int rc,
+                                                  const char *msg,
+                                                  const char *expr)
+{
+    if (rc == -1) {
+#if defined ZMQ_HAVE_WINDOWS
+        int current_errno = WSAGetLastError ();
+#else
+        int current_errno = errno;
+#endif
+
+        char buffer[512];
+        buffer[sizeof (buffer) - 1] =
+          0; // to ensure defined behavior with VC++ <= 2013
+        snprintf (buffer, sizeof (buffer) - 1, "%s failed%s%s%s, errno = %i",
+                  expr, msg ? " (additional info: " : "", msg ? msg : "",
+                  msg ? ")" : "", current_errno);
+        TEST_FAIL_MESSAGE (buffer);
+    }
+    return rc;
+}
+
 #define TEST_ASSERT_SUCCESS_MESSAGE_ERRNO(expr, msg)                           \
     test_assert_success_message_errno_helper (expr, msg, #expr)
 
 #define TEST_ASSERT_SUCCESS_ERRNO(expr)                                        \
     test_assert_success_message_errno_helper (expr, NULL, #expr)
+
+#define TEST_ASSERT_SUCCESS_RAW_ERRNO(expr)                                    \
+    test_assert_success_message_raw_errno_helper (expr, NULL, #expr)
 
 #define TEST_ASSERT_FAILURE_ERRNO(error_code, expr)                            \
     {                                                                          \


### PR DESCRIPTION
Solution: if a PING message contains a context, echo it back in the
PONG message. In order to do so, create the PONG message when PING
is received and store it in the engine.
After the PING the engine goes straight to encoding and sending, so
there can always be at most one pending PING.
Add tests for various contexts.

Fixes #3061