### PR TITLE
Fixed compilation with ZMQ_ATOMIC_PTR_MUTEX

### DIFF
--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -280,11 +280,7 @@ struct atomic_value_t
 #endif
 
 #if defined ZMQ_ATOMIC_PTR_MUTEX
-#if defined ZMQ_HAVE_VXWORKS
     mutable mutex_t sync;
-#else
-    mutex_t sync;
-#endif
 #endif
 
   private:


### PR DESCRIPTION
Compilation fails with ZMQ_ATOMIC_PTR_MUTEX defined. Fixes issue #3042.