### PR TITLE
Add static analysis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,407 @@
+Checks:        "*,\
+# not currently a coding convention, but conceivable,\
+-llvm-include-order,\
+# currently the coding convention deliberately produces violations of these,\
+# rules, but it may make sense to reconsider,\
+-readability-implicit-bool-conversion,\
+-readability-braces-around-statements,\
+-readability-named-parameter,\
+-fuchsia-default-arguments,\
+-google-readability-todo,\
+-cppcoreguidelines-pro-type-member-init,\
+# not currently a coding convention, C++11-specific, but conceivable,\
+-modernize-use-nullptr,\
+-modernize-use-equals-default,\
+-modernize-deprecated-headers,\
+# not currently a coding convention, C++11-specific and hard to implement,\
+-modernize-pass-by-value,\
+-modernize-loop-convert,\
+-modernize-use-auto,\
+-modernize-use-using,\
+-modernize-return-braced-init-list,\
+-cppcoreguidelines-owning-memory,\
+-cppcoreguidelines-pro-type-union-access,\
+-cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
+-cppcoreguidelines-pro-bounds-constant-array-index,\
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,\
+# not easily possible to implement (maybe replace by specific exclusions),\
+-cppcoreguidelines-pro-type-vararg,\
+-cppcoreguidelines-pro-type-reinterpret-cast,\
+# duplicates,\
+-google-readability-braces-around-statements,\
+-cppcoreguidelines-pro-type-cstyle-cast,\
+-hicpp-braces-around-statements,\
+-hicpp-use-equals-default,\
+-hicpp-deprecated-headers,\
+-hicpp-no-assembler,\
+-hicpp-vararg,\
+-hicpp-use-auto,\
+-hicpp-use-nullptr,\
+-hicpp-no-array-decay,\
+-hicpp-member-init"
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+# AnalyzeTemporaryDtors: false
+# CheckOptions:    
+  # - key:             cert-dcl59-cpp.HeaderFileExtensions
+    # value:           h,hh,hpp,hxx
+  # - key:             cert-err61-cpp.CheckThrowTemporaries
+    # value:           '1'
+  # - key:             cert-oop11-cpp.IncludeStyle
+    # value:           llvm
+  # - key:             cert-oop11-cpp.UseCERTSemantics
+    # value:           '1'
+  # - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    # value:           ''
+  # - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
+    # value:           '0'
+  # - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    # value:           '0'
+  # - key:             google-build-namespaces.HeaderFileExtensions
+    # value:           h,hh,hpp,hxx
+  # - key:             google-global-names-in-headers.HeaderFileExtensions
+    # value:           h
+  # - key:             google-readability-braces-around-statements.ShortStatementLines
+    # value:           '1'
+  # - key:             google-readability-function-size.BranchThreshold
+    # value:           '4294967295'
+  # - key:             google-readability-function-size.LineThreshold
+    # value:           '4294967295'
+  # - key:             google-readability-function-size.StatementThreshold
+    # value:           '800'
+  # - key:             google-readability-namespace-comments.ShortNamespaceLines
+    # value:           '10'
+  # - key:             google-readability-namespace-comments.SpacesBeforeComments
+    # value:           '2'
+  # - key:             google-runtime-int.SignedTypePrefix
+    # value:           int
+  # - key:             google-runtime-int.TypeSuffix
+    # value:           ''
+  # - key:             google-runtime-int.UnsignedTypePrefix
+    # value:           uint
+  # - key:             llvm-namespace-comment.ShortNamespaceLines
+    # value:           '1'
+  # - key:             llvm-namespace-comment.SpacesBeforeComments
+    # value:           '1'
+  # - key:             misc-assert-side-effect.AssertMacros
+    # value:           assert
+  # - key:             misc-assert-side-effect.CheckFunctionCalls
+    # value:           '0'
+  # - key:             misc-dangling-handle.HandleClasses
+    # value:           'std::basic_string_view;std::experimental::basic_string_view'
+  # - key:             misc-definitions-in-headers.HeaderFileExtensions
+    # value:           ',h,hh,hpp,hxx'
+  # - key:             misc-definitions-in-headers.UseHeaderFileExtension
+    # value:           '1'
+  # - key:             misc-misplaced-widening-cast.CheckImplicitCasts
+    # value:           '1'
+  # - key:             misc-move-constructor-init.IncludeStyle
+    # value:           llvm
+  # - key:             misc-move-constructor-init.UseCERTSemantics
+    # value:           '0'
+  # - key:             misc-sizeof-expression.WarnOnSizeOfCompareToConstant
+    # value:           '1'
+  # - key:             misc-sizeof-expression.WarnOnSizeOfConstant
+    # value:           '1'
+  # - key:             misc-sizeof-expression.WarnOnSizeOfThis
+    # value:           '1'
+  # - key:             misc-string-constructor.LargeLengthThreshold
+    # value:           '8388608'
+  # - key:             misc-string-constructor.WarnOnLargeLength
+    # value:           '1'
+  # - key:             misc-suspicious-missing-comma.MaxConcatenatedTokens
+    # value:           '5'
+  # - key:             misc-suspicious-missing-comma.RatioThreshold
+    # value:           '0.200000'
+  # - key:             misc-suspicious-missing-comma.SizeThreshold
+    # value:           '5'
+  # - key:             misc-suspicious-string-compare.StringCompareLikeFunctions
+    # value:           ''
+  # - key:             misc-suspicious-string-compare.WarnOnImplicitComparison
+    # value:           '1'
+  # - key:             misc-suspicious-string-compare.WarnOnLogicalNotComparison
+    # value:           '0'
+  # - key:             misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
+    # value:           '1'
+  # - key:             modernize-loop-convert.MaxCopySize
+    # value:           '16'
+  # - key:             modernize-loop-convert.MinConfidence
+    # value:           reasonable
+  # - key:             modernize-loop-convert.NamingStyle
+    # value:           CamelCase
+  # - key:             modernize-pass-by-value.IncludeStyle
+    # value:           llvm
+  # - key:             modernize-replace-auto-ptr.IncludeStyle
+    # value:           llvm
+  # - key:             modernize-use-nullptr.NullMacros
+    # value:           'NULL'
+  # - key:             performance-faster-string-find.StringLikeClasses
+    # value:           'std::basic_string'
+  # - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    # value:           '0'
+  # - key:             readability-braces-around-statements.ShortStatementLines
+    # value:           '1'
+  # - key:             readability-function-size.BranchThreshold
+    # value:           '4294967295'
+  # - key:             readability-function-size.LineThreshold
+    # value:           '4294967295'
+  # - key:             readability-function-size.StatementThreshold
+    # value:           '800'
+  # - key:             readability-identifier-naming.AbstractClassCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.AbstractClassPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.AbstractClassSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ClassCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ClassConstantCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ClassConstantPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ClassConstantSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ClassMemberCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ClassMemberPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ClassMemberSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ClassMethodCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ClassMethodPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ClassMethodSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ClassPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ClassSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstantCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ConstantMemberCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ConstantMemberPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstantMemberSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstantParameterCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ConstantParameterPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstantParameterSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstantPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstantSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstexprFunctionCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ConstexprFunctionPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstexprFunctionSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstexprMethodCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ConstexprMethodPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstexprMethodSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstexprVariableCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ConstexprVariablePrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ConstexprVariableSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.EnumCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.EnumConstantCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.EnumConstantPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.EnumConstantSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.EnumPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.EnumSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.FunctionCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.FunctionPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.FunctionSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.GlobalConstantCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.GlobalConstantPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.GlobalConstantSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.GlobalFunctionCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.GlobalFunctionPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.GlobalFunctionSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.GlobalVariableCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.GlobalVariablePrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.GlobalVariableSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.IgnoreFailedSplit
+    # value:           '0'
+  # - key:             readability-identifier-naming.InlineNamespaceCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.InlineNamespacePrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.InlineNamespaceSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.LocalConstantCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.LocalConstantPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.LocalConstantSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.LocalVariableCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.LocalVariablePrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.LocalVariableSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.MemberCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.MemberPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.MemberSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.MethodCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.MethodPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.MethodSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.NamespaceCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.NamespacePrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.NamespaceSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ParameterCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ParameterPackCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ParameterPackPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ParameterPackSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ParameterPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ParameterSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.PrivateMemberCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.PrivateMemberPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.PrivateMemberSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.PrivateMethodCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.PrivateMethodPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.PrivateMethodSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ProtectedMemberCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ProtectedMemberPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ProtectedMemberSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ProtectedMethodCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ProtectedMethodPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ProtectedMethodSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.PublicMemberCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.PublicMemberPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.PublicMemberSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.PublicMethodCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.PublicMethodPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.PublicMethodSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.StaticConstantCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.StaticConstantPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.StaticConstantSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.StaticVariableCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.StaticVariablePrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.StaticVariableSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.StructCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.StructPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.StructSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.TemplateParameterCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.TemplateParameterPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.TemplateParameterSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.TemplateTemplateParameterCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.TemplateTemplateParameterPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.TemplateTemplateParameterSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.TypeTemplateParameterCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.TypeTemplateParameterPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.TypeTemplateParameterSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.TypedefCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.TypedefPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.TypedefSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.UnionCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.UnionPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.UnionSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.ValueTemplateParameterCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.ValueTemplateParameterPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.ValueTemplateParameterSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.VariableCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.VariablePrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.VariableSuffix
+    # value:           ''
+  # - key:             readability-identifier-naming.VirtualMethodCase
+    # value:           aNy_CasE
+  # - key:             readability-identifier-naming.VirtualMethodPrefix
+    # value:           ''
+  # - key:             readability-identifier-naming.VirtualMethodSuffix
+    # value:           ''
+  # - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    # value:           '0'
+  # - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    # value:           '0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,18 @@ matrix:
         - llvm-toolchain-trusty-5.0
       packages:
         - clang-5.0
+  - env: BUILD_TYPE=cmake CLANG_TIDY=/usr/bin/clang-tidy-6.0 CC=clang-6.0 CXX=clang++-6.0
+    os: linux
+    compiler: clang
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-6.0
+        packages:
+          - clang-6.0
+          - clang-tools-6.0
+          - clang-tidy-6.0
   - env: BUILD_TYPE=default POLLER=poll
     os: linux
   - env: BUILD_TYPE=default POLLER=select
@@ -103,6 +115,14 @@ sudo: false
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "android" ] ; then brew update; brew install binutils ; fi
 - if [ $TRAVIS_OS_NAME == "osx" -a $CURVE == "libsodium" ] ; then brew update; brew install libsodium ; fi
+- if [ -n "$CLANG_TIDY" ] ; then
+    curl -L https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip -o build-wrapper-linux-x86.zip ;
+    unzip build-wrapper-linux-x86.zip ;
+    export SONARCLOUD_BUILD_WRAPPER_PATH="$(pwd)/build-wrapper-linux-x86/" ;
+    curl -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.1.0.1141-linux.zip -o sonar-scanner-cli.zip ;
+    unzip sonar-scanner-cli.zip ;
+    export SONAR_SCANNER_CLI_PATH="$(pwd)/sonar-scanner-3.1.0.1141-linux/bin/" ;
+  fi
 
 before_script:
 # ZMQ stress tests need more open socket (files) than the usual default

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,8 @@ matrix:
         - llvm-toolchain-trusty-5.0
       packages:
         - clang-5.0
-  - env: BUILD_TYPE=cmake CLANG_TIDY=/usr/bin/clang-tidy-6.0 CC=clang-6.0 CXX=clang++-6.0
+  - if: type = cron OR (branch =~ analyze$ AND type = push)
+    env: BUILD_TYPE=cmake CLANG_TIDY=/usr/bin/clang-tidy-6.0 CC=clang-6.0 CXX=clang++-6.0
     os: linux
     compiler: clang
     addons:
@@ -109,7 +110,7 @@ matrix:
     os: linux
   - env: BUILD_TYPE=default POLLER=select
     os: linux
-
+    
 sudo: false
 
 before_install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,9 +302,32 @@ macro (zmq_check_cxx_flag_prepend flag)
   endif ()
 endmacro ()
 
+OPTION (ENABLE_ANALYSIS "Build with static analysis (make take very long)" OFF)
 
 if (MSVC)
-  zmq_check_cxx_flag_prepend ("/W3")
+  if (ENABLE_ANALYSIS)  
+    zmq_check_cxx_flag_prepend ("/W4")
+
+    zmq_check_cxx_flag_prepend ("/analyze")
+    
+    # C++11/14/17-specific, but maybe possible via conditional defines
+    zmq_check_cxx_flag_prepend ("/wd26440") # Function '...' can be declared 'noexcept' 
+    zmq_check_cxx_flag_prepend ("/wd26432") # If you define or delete any default operation in the type '...', define or delete them all
+    zmq_check_cxx_flag_prepend ("/wd26439") # This kind of function may not throw. Declare it 'noexcept' 
+    zmq_check_cxx_flag_prepend ("/wd26447") # The function is declared 'noexcept' but calls function '...' which may throw exceptions
+    zmq_check_cxx_flag_prepend ("/wd26433") # Function '...' should be marked with 'override'
+    zmq_check_cxx_flag_prepend ("/wd26409") # Avoid calling new and delete explicitly, use std::make_unique<T> instead
+    # Requires GSL
+    zmq_check_cxx_flag_prepend ("/wd26429") # Symbol '...' is never tested for nullness, it can be marked as not_null
+    zmq_check_cxx_flag_prepend ("/wd26446") # Prefer to use gsl::at()
+    zmq_check_cxx_flag_prepend ("/wd26481") # Don't use pointer arithmetic. Use span instead
+    zmq_check_cxx_flag_prepend ("/wd26472") # Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narow
+    zmq_check_cxx_flag_prepend ("/wd26448") # Consider using gsl::finally if final action is intended
+    zmq_check_cxx_flag_prepend ("/wd26400") # Do not assign the result of an allocation or a function call with an owner<T> return value to a raw pointer, use owner<T> instead    
+    zmq_check_cxx_flag_prepend ("/wd26485") # Expression '...': No array to pointer decay (bounds.3)
+  else()
+    zmq_check_cxx_flag_prepend ("/W3")
+  endif()
 
   if (MSVC_IDE)
     set (MSVC_TOOLSET "-${CMAKE_VS_PLATFORM_TOOLSET}")
@@ -941,8 +964,17 @@ if (MSVC)
   set( CMAKE_STATIC_LINKER_FLAGS /ignore:4221 )
   set (PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
   set (PDB_NAME "libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}")
+  function(enable_vs_guideline_checker target)
+    set_target_properties(${target} PROPERTIES
+        VS_GLOBAL_EnableCppCoreCheck true
+        VS_GLOBAL_CodeAnalysisRuleSet CppCoreCheckRules.ruleset
+        VS_GLOBAL_RunCodeAnalysis true)
+  endfunction()
   if (BUILD_SHARED)
     add_library (libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+    if(ENABLE_ANALYSIS)
+        enable_vs_guideline_checker (libzmq)
+    endif()
     set_target_properties (libzmq PROPERTIES
       PUBLIC_HEADER "${public_headers}"
       RELEASE_POSTFIX "${MSVC_TOOLSET}-mt-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,6 +75,7 @@ cache:
     - C:\projects\libsodium
 
 install:
+  - cmd: if "%ENABLE_ANALYSIS%"=="ON" ( if "%APPVEYOR_PULL_REQUEST_NUMBER%" NEQ "" appveyor exit )
   - cmd: if "%Platform%"=="x64" set "CMAKE_GENERATOR=%CMAKE_GENERATOR% Win64"
   - cmd: echo "Generator='%CMAKE_GENERATOR%'"
   - cmd: echo "Platform='%Platform%'"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,15 @@ environment:
       configuration: Release
       WITH_LIBSODIUM: ON
       ENABLE_CURVE: ON
+      ENABLE_ANALYSIS: ON
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CMAKE_GENERATOR: "Visual Studio 15 2017"
+      MSVCVERSION: "v141"
+      MSVCYEAR: "vs2017"
+    - platform: Win32
+      configuration: Release
+      WITH_LIBSODIUM: ON
+      ENABLE_CURVE: ON
     - platform: Win32
       configuration: Release
       API_POLLER: poll
@@ -95,17 +104,41 @@ install:
 clone_folder: C:\projects\libzmq
 
 before_build:
+  - cmd: set LIBZMQ_SRCDIR=%cd%
   - cmd: set LIBZMQ_BUILDDIR=C:\projects\build_libzmq
+  # TODO this does not work with sonarcloud.io, as it misses the sonar-cxx plugin
+  # - cmd: curl -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.1.0.1141-windows.zip -o sonar-scanner-cli-3.1.0.1141-windows.zip
+  # - cmd: unzip sonar-scanner-cli-3.1.0.1141-windows.zip
+  # - cmd: set BUILDLOG="%LIBZMQ_SRCDIR%\build.log"
   - cmd: md "%LIBZMQ_BUILDDIR%"
   - cd "%LIBZMQ_BUILDDIR%"
-  - cmd: cmake -D CMAKE_INCLUDE_PATH="%SODIUM_INCLUDE_DIR%" -D CMAKE_LIBRARY_PATH="%SODIUM_LIBRARY_DIR%" -D WITH_LIBSODIUM="%WITH_LIBSODIUM%" -D ENABLE_DRAFTS="ON" -D ENABLE_CURVE="%ENABLE_CURVE%" -D API_POLLER="%API_POLLER%" -D POLLER="%POLLER%" -D CMAKE_C_FLAGS_RELEASE="/MT" -D CMAKE_C_FLAGS_DEBUG="/MTd" -D WITH_LIBSODIUM="%WITH_LIBSODIUM%" -D LIBZMQ_WERROR="ON" -G "%CMAKE_GENERATOR%" "%APPVEYOR_BUILD_FOLDER%"
+  - cmd: cmake -D CMAKE_INCLUDE_PATH="%SODIUM_INCLUDE_DIR%" -D CMAKE_LIBRARY_PATH="%SODIUM_LIBRARY_DIR%" -D WITH_LIBSODIUM="%WITH_LIBSODIUM%" -D ENABLE_DRAFTS="ON" -D ENABLE_ANALYSIS="%ENABLE_ANALYSIS%" -D ENABLE_CURVE="%ENABLE_CURVE%" -D API_POLLER="%API_POLLER%" -D POLLER="%POLLER%" -D CMAKE_C_FLAGS_RELEASE="/MT" -D CMAKE_C_FLAGS_DEBUG="/MTd" -D WITH_LIBSODIUM="%WITH_LIBSODIUM%" -G "%CMAKE_GENERATOR%" "%APPVEYOR_BUILD_FOLDER%"
+  - cmd: cd "%LIBZMQ_SRCDIR%"
 
 build:
   parallel: true
   project: C:\projects\build_libzmq\ZeroMQ.sln
   verbosity: minimal
 
+# TODO this does not work with sonarcloud.io, as it misses the sonar-cxx plugin
+# build_script:
+  # - cmd: msbuild %LIBZMQ_BUILDDIR%\ZeroMQ.sln /verbosity:detailed >%BUILDLOG%
+
 after_build:
+  # TODO this does not work with sonarcloud.io, as it misses the sonar-cxx plugin
+  # - cmd: cd "%LIBZMQ_SRCDIR%"
+  # - cmd: dir
+  # - cmd: sonar-scanner-3.1.0.1141-windows\bin\sonar-scanner 
+            # -Dsonar.scm.provider=git 
+            # -Dsonar.projectKey=libzmq-msvc 
+            # -Dsonar.organization=sigiesec-github 
+            # -Dsonar.sources=include,src,tests,unittests 
+            # -Dsonar.host.url=https://sonarcloud.io 
+            # -Dsonar.login=%SONARQUBE_TOKEN% 
+            # -Dsonar.cxx.compiler.parser="Visual C++" 
+            # -Dsonar.cxx.compiler.reportPath=build.log 
+            # -Dsonar.cxx.compiler.charset=UTF-8 
+            # -Dsonar.cxx.compiler.regex=^(?<filename>.*)\\((?<line>[0-9]+)\\):\\x20warning\\x20(?<id>C\\d\\d\\d\\d):(?<message>.*)$
   - cmd: cd %LIBZMQ_BUILDDIR%\bin\%Configuration%"
   - cmd: if "%WITH_LIBSODIUM%"=="ON" copy "%SODIUM_LIBRARY_DIR%\libsodium.dll" .
   - cmd: 7z a -y -bd -mx=9 libzmq.zip *.exe *.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,15 +15,6 @@ environment:
       configuration: Release
       WITH_LIBSODIUM: ON
       ENABLE_CURVE: ON
-      ENABLE_ANALYSIS: ON
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      CMAKE_GENERATOR: "Visual Studio 15 2017"
-      MSVCVERSION: "v141"
-      MSVCYEAR: "vs2017"
-    - platform: Win32
-      configuration: Release
-      WITH_LIBSODIUM: ON
-      ENABLE_CURVE: ON
     - platform: Win32
       configuration: Release
       API_POLLER: poll
@@ -148,3 +139,20 @@ test_script:
   - cmd: cd "%LIBZMQ_BUILDDIR%"
   - cmd: ctest -C "%Configuration%" -V -j5
 
+for:
+-
+    branches:
+        only:
+            - master
+            - /.*analyze$/
+    environment:
+        matrix:
+            - platform: Win32
+              configuration: Release
+              WITH_LIBSODIUM: ON
+              ENABLE_CURVE: ON
+              ENABLE_ANALYSIS: ON
+              APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+              CMAKE_GENERATOR: "Visual Studio 15 2017"
+              MSVCVERSION: "v141"
+              MSVCYEAR: "vs2017"


### PR DESCRIPTION
I have added static analysis builds experimentally:
- Under Linux on travis-ci
-- clang-tidy/clang-static-analyzer (currently 6.0, but should be easy to update to 7.0)
-- sonar-scanner
- Under Windows on appveyor
-- Visual Studio 2017 Static Analyzer
-- Visual Studio 2017 C++ Core Guidelines Check

I would like to get some feedback on this? Does it make sense? I think it could be a good idea to run these as scheduled builds, e.g. on a weekly basis.

The sonar-scanner results are published to sonarcloud.io (https://sonarcloud.io/dashboard?id=libzmq-clang, but I am not sure if this is publicly accessible, if not and you have/create an account on sonarcloud.io, I can give you access).

The other results are currently only visible in the build log, e.g. here:
* https://travis-ci.org/sigiesec/libzmq/jobs/380206165
* https://ci.appveyor.com/project/sigiesec/libzmq/build/build-628/job/5bi0inexkp6rsn7b

Originally, I thought I could publish these to sonarcloud.io as well. There is ta plugin for SonarQube, sonar-cxx, which supports this, but it is not available on sonarcloud.io, unfortunately.

I have already disabled some checks, which do not make sense on the current codebase, but this requires some more fine-tuning.

Many things are style issues, and primarily affect readability/maintainability.

The Visual Studio Static Analyzer shows several warnings, which sound like false positives:
* C6001: Using uninitialized memory
* C6387: 'data_' could be '0'
* C6385: Reading invalid data
* C6386: Buffer overrun
If the false positive rate is really that large, these checks should probably be disabled.

However, the clang-static-analyzer shows a small number of similar errors, which sound actually like bugs to me (at least it is not obvious that these situations cannot happen):
* decoder_allocators.cpp:121:5: warning: Use of memory after it is freed [clang-analyzer-unix.Malloc] (I already fixed this)
* generic_mtrie_impl.hpp:144:13: warning: Branch condition evaluates to a garbage value [clang-analyzer-core.uninitialized.Branch]
* stream_engine.cpp:815:9: warning: Use of memory after it is freed [clang-analyzer-cplusplus.NewDelete]
* ypipe.hpp:165:9: warning: Called C++ object pointer is null [clang-analyzer-core.CallAndMessage]
* proxy.cpp:376:14: warning: Called C++ object pointer is null [clang-analyzer-core.CallAndMessage]

Before this could be merged, at least the following would need to be done:
- [x] Set up sonarqube for zeromq org
- [x] Fine-tune active checks
- [x] Make execution of static analysis builds conditional (on specifically named branches, or on daily/weekly builds on zeromq/master)
