### PR TITLE
Problem: autoconf checks tautological compiler flag only for C++

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -813,8 +813,14 @@ AM_CONDITIONAL([WITH_CLANG_FORMAT], [$WITH_CLANG_FORMAT])
 AM_CONDITIONAL(ENABLE_STATIC, test "x$enable_static" = "xyes")
 
 # clang 6 has a warning that does not make sense on multi-platform code
+AC_LANG_PUSH([C])
 AX_CHECK_COMPILE_FLAG([-Wno-tautological-constant-compare],
-    [CFLAGS+=" -Wno-tautological-constant-compare" CXXFLAGS+=" -Wno-tautological-constant-compare"],
+    [CFLAGS+=" -Wno-tautological-constant-compare"],
+    [],
+    [-Werror])
+AC_LANG_POP([C])
+AX_CHECK_COMPILE_FLAG([-Wno-tautological-constant-compare],
+    [CXXFLAGS+=" -Wno-tautological-constant-compare"],
     [],
     [-Werror])
 


### PR DESCRIPTION
Solution: check for C as well and set the flags separately

Breaks compilation when CC is set to clang but CXX is not (at least one case in czmq's Travis builds)