### PR TITLE
wepoll integration fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -259,7 +259,8 @@ src_libzmq_la_SOURCES = \
 
 if USE_WEPOLL
 src_libzmq_la_SOURCES += \
-	external/wepoll/wepoll.c
+	external/wepoll/wepoll.c \
+	external/wepoll/wepoll.h
 endif
 
 if USE_TWEETNACL
@@ -974,6 +975,9 @@ endif
 EXTRA_DIST = \
 	external/unity/license.txt \
 	external/unity/version.txt \
+	external/wepoll/license.txt \
+	external/wepoll/version.txt \
+	external/wepoll/README.md \
 	CMakeLists.txt \
 	autogen.sh	\
 	version.sh	\

--- a/src/epoll.cpp
+++ b/src/epoll.cpp
@@ -54,7 +54,7 @@ const zmq::epoll_t::epoll_fd_t zmq::epoll_t::epoll_retired_fd =
 zmq::epoll_t::epoll_t (const zmq::thread_ctx_t &ctx_) :
     worker_poller_base_t (ctx_)
 {
-#ifdef ZMQ_USE_EPOLL_CLOEXEC
+#ifdef ZMQ_IOTHREAD_POLLER_USE_EPOLL_CLOEXEC
     //  Setting this option result in sane behaviour when exec() functions
     //  are used. Old sockets are closed and don't block TCP ports, avoid
     //  leaks, etc.


### PR DESCRIPTION
- ensure all files in external/wepoll get bundled up in dist
- EPOLL_CLOEXEC inadvertently disabled in d326434b371b94c4a98f66df69566f5a28070fcd
