### PR TITLE
use cmake compile the unittest

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -23,6 +23,7 @@ if(WIN32)
 endif()
 
 include_directories("${CMAKE_SOURCE_DIR}/include" "${CMAKE_SOURCE_DIR}/src" "${CMAKE_BINARY_DIR}")
+include_directories("${CMAKE_SOURCE_DIR}/external/unity")
 
 foreach(test ${unittests})
   # target_sources not supported before CMake 3.1


### PR DESCRIPTION
Problem: 
use the `builds/cmake/ci_build.sh` build the project, and An error occurred.
can't found the unity.h

Solution: 
add the include path
