### PR TITLE
Problem: epoll_t employs an unnecessary mutex

### DIFF
--- a/src/epoll.cpp
+++ b/src/epoll.cpp
@@ -112,9 +112,7 @@ void zmq::epoll_t::rm_fd (handle_t handle_)
     int rc = epoll_ctl (_epoll_fd, EPOLL_CTL_DEL, pe->fd, &pe->ev);
     errno_assert (rc != -1);
     pe->fd = retired_fd;
-    _retired_sync.lock ();
     _retired.push_back (pe);
-    _retired_sync.unlock ();
 
     //  Decrease the load metric of the thread.
     adjust_load (-1);
@@ -209,13 +207,11 @@ void zmq::epoll_t::loop ()
         }
 
         //  Destroy retired event sources.
-        _retired_sync.lock ();
         for (retired_t::iterator it = _retired.begin (); it != _retired.end ();
              ++it) {
             LIBZMQ_DELETE (*it);
         }
         _retired.clear ();
-        _retired_sync.unlock ();
     }
 }
 

--- a/src/epoll.hpp
+++ b/src/epoll.hpp
@@ -106,9 +106,6 @@ class epoll_t : public worker_poller_base_t
     //  Handle of the physical thread doing the I/O work.
     thread_t _worker;
 
-    //  Synchronisation of retired event sources
-    mutex_t _retired_sync;
-
     epoll_t (const epoll_t &);
     const epoll_t &operator= (const epoll_t &);
 };


### PR DESCRIPTION
Solution: remove the mutex

Note: the mutex is unnecessary as all uses must come from the same thread anyway, and this is already checked by check_thread
