### PR TITLE
Problem: connecter classes do not handle ZMQ_RECONNECT_IVL of -1

### DIFF
--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -176,10 +176,12 @@ void zmq::ipc_connecter_t::start_connecting ()
 
 void zmq::ipc_connecter_t::add_reconnect_timer ()
 {
-    int rc_ivl = get_new_reconnect_ivl ();
-    add_timer (rc_ivl, reconnect_timer_id);
-    socket->event_connect_retried (endpoint, rc_ivl);
-    timer_started = true;
+	if (options.reconnect_ivl != -1) {
+		int rc_ivl = get_new_reconnect_ivl ();
+		add_timer (rc_ivl, reconnect_timer_id);
+		socket->event_connect_retried (endpoint, rc_ivl);
+		timer_started = true;
+	}
 }
 
 int zmq::ipc_connecter_t::get_new_reconnect_ivl ()

--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -176,12 +176,12 @@ void zmq::ipc_connecter_t::start_connecting ()
 
 void zmq::ipc_connecter_t::add_reconnect_timer ()
 {
-	if (options.reconnect_ivl != -1) {
-		int rc_ivl = get_new_reconnect_ivl ();
-		add_timer (rc_ivl, reconnect_timer_id);
-		socket->event_connect_retried (endpoint, rc_ivl);
-		timer_started = true;
-	}
+    if (options.reconnect_ivl != -1) {
+        int rc_ivl = get_new_reconnect_ivl ();
+        add_timer (rc_ivl, reconnect_timer_id);
+        socket->event_connect_retried (endpoint, rc_ivl);
+        timer_started = true;
+    }
 }
 
 int zmq::ipc_connecter_t::get_new_reconnect_ivl ()

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -268,10 +268,12 @@ void zmq::socks_connecter_t::error ()
 
 void zmq::socks_connecter_t::start_timer ()
 {
-    const int interval = get_new_reconnect_ivl ();
-    add_timer (interval, reconnect_timer_id);
-    _status = waiting_for_reconnect_time;
-    _socket->event_connect_retried (_endpoint, interval);
+	if (options.reconnect_ivl != -1) {
+		const int interval = get_new_reconnect_ivl ();
+		add_timer (interval, reconnect_timer_id);
+		_status = waiting_for_reconnect_time;
+		_socket->event_connect_retried (_endpoint, interval);
+	}
 }
 
 int zmq::socks_connecter_t::get_new_reconnect_ivl ()

--- a/src/socks_connecter.cpp
+++ b/src/socks_connecter.cpp
@@ -268,12 +268,12 @@ void zmq::socks_connecter_t::error ()
 
 void zmq::socks_connecter_t::start_timer ()
 {
-	if (options.reconnect_ivl != -1) {
-		const int interval = get_new_reconnect_ivl ();
-		add_timer (interval, reconnect_timer_id);
-		_status = waiting_for_reconnect_time;
-		_socket->event_connect_retried (_endpoint, interval);
-	}
+    if (options.reconnect_ivl != -1) {
+        const int interval = get_new_reconnect_ivl ();
+        add_timer (interval, reconnect_timer_id);
+        _status = waiting_for_reconnect_time;
+        _socket->event_connect_retried (_endpoint, interval);
+    }
 }
 
 int zmq::socks_connecter_t::get_new_reconnect_ivl ()

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -226,12 +226,12 @@ void zmq::tcp_connecter_t::add_connect_timer ()
 
 void zmq::tcp_connecter_t::add_reconnect_timer ()
 {
-	if (options.reconnect_ivl != -1) {
-		const int interval = get_new_reconnect_ivl ();
-		add_timer (interval, reconnect_timer_id);
-		_socket->event_connect_retried (_endpoint, interval);
-		_reconnect_timer_started = true;
-	}
+    if (options.reconnect_ivl != -1) {
+        const int interval = get_new_reconnect_ivl ();
+        add_timer (interval, reconnect_timer_id);
+        _socket->event_connect_retried (_endpoint, interval);
+        _reconnect_timer_started = true;
+    }
 }
 
 int zmq::tcp_connecter_t::get_new_reconnect_ivl ()

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -226,10 +226,12 @@ void zmq::tcp_connecter_t::add_connect_timer ()
 
 void zmq::tcp_connecter_t::add_reconnect_timer ()
 {
-    const int interval = get_new_reconnect_ivl ();
-    add_timer (interval, reconnect_timer_id);
-    _socket->event_connect_retried (_endpoint, interval);
-    _reconnect_timer_started = true;
+	if (options.reconnect_ivl != -1) {
+		const int interval = get_new_reconnect_ivl ();
+		add_timer (interval, reconnect_timer_id);
+		_socket->event_connect_retried (_endpoint, interval);
+		_reconnect_timer_started = true;
+	}
 }
 
 int zmq::tcp_connecter_t::get_new_reconnect_ivl ()

--- a/src/tipc_connecter.cpp
+++ b/src/tipc_connecter.cpp
@@ -178,12 +178,12 @@ void zmq::tipc_connecter_t::start_connecting ()
 
 void zmq::tipc_connecter_t::add_reconnect_timer ()
 {
-	if (options.reconnect_ivl != -1) {
-		int rc_ivl = get_new_reconnect_ivl ();
-		add_timer (rc_ivl, reconnect_timer_id);
-		socket->event_connect_retried (endpoint, rc_ivl);
-		timer_started = true;
-	}
+    if (options.reconnect_ivl != -1) {
+        int rc_ivl = get_new_reconnect_ivl ();
+        add_timer (rc_ivl, reconnect_timer_id);
+        socket->event_connect_retried (endpoint, rc_ivl);
+        timer_started = true;
+    }
 }
 
 int zmq::tipc_connecter_t::get_new_reconnect_ivl ()

--- a/src/tipc_connecter.cpp
+++ b/src/tipc_connecter.cpp
@@ -178,10 +178,12 @@ void zmq::tipc_connecter_t::start_connecting ()
 
 void zmq::tipc_connecter_t::add_reconnect_timer ()
 {
-    int rc_ivl = get_new_reconnect_ivl ();
-    add_timer (rc_ivl, reconnect_timer_id);
-    socket->event_connect_retried (endpoint, rc_ivl);
-    timer_started = true;
+	if (options.reconnect_ivl != -1) {
+		int rc_ivl = get_new_reconnect_ivl ();
+		add_timer (rc_ivl, reconnect_timer_id);
+		socket->event_connect_retried (endpoint, rc_ivl);
+		timer_started = true;
+	}
 }
 
 int zmq::tipc_connecter_t::get_new_reconnect_ivl ()

--- a/src/vmci_connecter.cpp
+++ b/src/vmci_connecter.cpp
@@ -178,10 +178,12 @@ void zmq::vmci_connecter_t::start_connecting ()
 
 void zmq::vmci_connecter_t::add_reconnect_timer ()
 {
-    int rc_ivl = get_new_reconnect_ivl ();
-    add_timer (rc_ivl, reconnect_timer_id);
-    socket->event_connect_retried (endpoint, rc_ivl);
-    timer_started = true;
+	if (options.reconnect_ivl != -1) {
+		int rc_ivl = get_new_reconnect_ivl ();
+		add_timer (rc_ivl, reconnect_timer_id);
+		socket->event_connect_retried (endpoint, rc_ivl);
+		timer_started = true;
+	}
 }
 
 int zmq::vmci_connecter_t::get_new_reconnect_ivl ()

--- a/src/vmci_connecter.cpp
+++ b/src/vmci_connecter.cpp
@@ -178,12 +178,12 @@ void zmq::vmci_connecter_t::start_connecting ()
 
 void zmq::vmci_connecter_t::add_reconnect_timer ()
 {
-	if (options.reconnect_ivl != -1) {
-		int rc_ivl = get_new_reconnect_ivl ();
-		add_timer (rc_ivl, reconnect_timer_id);
-		socket->event_connect_retried (endpoint, rc_ivl);
-		timer_started = true;
-	}
+    if (options.reconnect_ivl != -1) {
+        int rc_ivl = get_new_reconnect_ivl ();
+        add_timer (rc_ivl, reconnect_timer_id);
+        socket->event_connect_retried (endpoint, rc_ivl);
+        timer_started = true;
+    }
 }
 
 int zmq::vmci_connecter_t::get_new_reconnect_ivl ()


### PR DESCRIPTION
Solution: Add guards to prevent a reconnect timer from starting if ZMQ_RECONNECT_IVL is -1
(Issue 3158)