### PR TITLE
update pair doc

### DIFF
--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -358,6 +358,11 @@ high water mark for the connected peer, or if no peer is connected, then
 any linkzmq:zmq_send[3] operations on the socket shall block until the peer
 becomes available for sending; messages are not discarded.
 
+While 'ZMQ_PAIR' sockets can be used over transports other than linkzmq:zmq_inproc[7],
+their inability to auto-reconnect coupled with the fact new incoming connections will
+be terminated while any previous connections (including ones in a closing state)
+exist makes them unsuitable in most cases.
+
 NOTE: 'ZMQ_PAIR' sockets are designed for inter-thread communication across
 the linkzmq:zmq_inproc[7] transport and do not implement functionality such
 as auto-reconnection.

--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -361,7 +361,7 @@ becomes available for sending; messages are not discarded.
 While 'ZMQ_PAIR' sockets can be used over transports other than linkzmq:zmq_inproc[7],
 their inability to auto-reconnect coupled with the fact new incoming connections will
 be terminated while any previous connections (including ones in a closing state)
-exist makes them unsuitable in most cases.
+exist makes them unsuitable for TCP in most cases.
 
 NOTE: 'ZMQ_PAIR' sockets are designed for inter-thread communication across
 the linkzmq:zmq_inproc[7] transport and do not implement functionality such


### PR DESCRIPTION
Problem: ZMQ_PAIR not suitable all transports

Solution: Add documentation to discourage using ZMQ_PAIR for reconnecting transports
