### PR TITLE
[RFC][WIP] Problem: libzmq does not send ZMTP 3.1 sub/cancel commands

### DIFF
--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -108,6 +108,8 @@ class msg_t
     int init_delimiter ();
     int init_join ();
     int init_leave ();
+    int init_subscribe (const size_t size_, const unsigned char *topic);
+    int init_cancel (const size_t size_, const unsigned char *topic);
     int close ();
     int move (msg_t &src_);
     int copy (msg_t &src_);
@@ -150,6 +152,9 @@ class msg_t
     const char *group ();
     int set_group (const char *group_);
     int set_group (const char *, size_t length_);
+
+    //  Sets a new size. Does not change anything else. MUST be smaller.
+    void shrink (const size_t new_size_);
 
     //  After calling this function you can copy the message in POD-style
     //  refs_ times. No need to call copy.

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -541,7 +541,7 @@ bool zmq::stream_engine_t::handshake ()
                     || _greeting_recv[10] == ZMTP_2_0)
                     _outpos[_outsize++] = _options.type;
                 else {
-                    _outpos[_outsize++] = 0; //  Minor version number
+                    _outpos[_outsize++] = 1; //  Minor version number
                     memset (_outpos + _outsize, 0, 20);
 
                     zmq_assert (_options.mechanism == ZMQ_NULL

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -228,6 +228,9 @@ class stream_engine_t : public io_object_t, public i_engine
     bool _has_heartbeat_timer;
     int _heartbeat_timeout;
 
+    //  Whether to use commands to subscribe/cancel (ZMTP 3.1)
+    bool _sub_cancel_as_commands;
+
     // Socket
     zmq::socket_base_t *_socket;
 

--- a/src/sub.cpp
+++ b/src/sub.cpp
@@ -56,15 +56,15 @@ int zmq::sub_t::xsetsockopt (int option_,
 
     //  Create the subscription message.
     msg_t msg;
-    int rc = msg.init_size (optvallen_ + 1);
-    errno_assert (rc == 0);
-    unsigned char *data = static_cast<unsigned char *> (msg.data ());
-    *data = (option_ == ZMQ_SUBSCRIBE);
-    //  We explicitly allow a NULL subscription with size zero
-    if (optvallen_) {
-        assert (optval_);
-        memcpy (data + 1, optval_, optvallen_);
+    int rc;
+    const unsigned char *data = static_cast<const unsigned char *> (optval_);
+    if (option_ == ZMQ_SUBSCRIBE) {
+        rc = msg.init_subscribe (optvallen_, data);
+    } else {
+        rc = msg.init_cancel (optvallen_, data);
     }
+    errno_assert (rc == 0);
+
     //  Pass it further on in the stack.
     rc = xsub_t::xsend (&msg);
     return close_and_return (&msg, rc);

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -241,16 +241,8 @@ void zmq::xsub_t::send_subscription (unsigned char *data_,
 
     //  Create the subscription message.
     msg_t msg;
-    int rc = msg.init_size (size_ + 1);
+    int rc = msg.init_subscribe (size_, data_);
     errno_assert (rc == 0);
-    unsigned char *data = static_cast<unsigned char *> (msg.data ());
-    data[0] = 1;
-
-    //  We explicitly allow a NULL subscription with size zero
-    if (size_) {
-        assert (data_);
-        memcpy (data + 1, data_, size_);
-    }
 
     //  Send it to the pipe.
     bool sent = pipe->write (&msg);

--- a/tests/test_mock_pub_sub.cpp
+++ b/tests/test_mock_pub_sub.cpp
@@ -86,7 +86,7 @@ static void recv_with_retry (raw_socket fd_, char *buffer_, int bytes_)
     }
 }
 
-static void mock_handshake (raw_socket fd_)
+static void mock_handshake (raw_socket fd_, bool sub_command, bool mock_pub)
 {
     const uint8_t zmtp_greeting[33] = {0xff, 0, 0, 0,   0,   0,   0,   0, 0,
                                        0x7f, 3, 0, 'N', 'U', 'L', 'L', 0};
@@ -94,31 +94,44 @@ static void mock_handshake (raw_socket fd_)
     memset (buffer, 0, sizeof (buffer));
     memcpy (buffer, zmtp_greeting, sizeof (zmtp_greeting));
 
+    //  Mock ZMTP 3.1 which uses commands
+    if (sub_command) {
+        buffer[11] = 1;
+    }
     int rc = TEST_ASSERT_SUCCESS_RAW_ERRNO (send (fd_, buffer, 64, 0));
     TEST_ASSERT_EQUAL_INT (64, rc);
 
     recv_with_retry (fd_, buffer, 64);
 
-    const uint8_t zmtp_ready[27] = {
-      4,   25,  5,   'R', 'E', 'A', 'D', 'Y', 11, 'S', 'o', 'c', 'k', 'e',
-      't', '-', 'T', 'y', 'p', 'e', 0,   0,   0,  3,   'S', 'U', 'B'};
+    if (!mock_pub) {
+        const uint8_t zmtp_ready[27] = {
+          4,   25,  5,   'R', 'E', 'A', 'D', 'Y', 11, 'S', 'o', 'c', 'k', 'e',
+          't', '-', 'T', 'y', 'p', 'e', 0,   0,   0,  3,   'S', 'U', 'B'};
+        rc = TEST_ASSERT_SUCCESS_RAW_ERRNO (
+          send (fd_, (const char *) zmtp_ready, 27, 0));
+        TEST_ASSERT_EQUAL_INT (27, rc);
+    } else {
+        const uint8_t zmtp_ready[28] = {
+          4,   26,  5,   'R', 'E', 'A', 'D', 'Y', 11, 'S', 'o', 'c', 'k', 'e',
+          't', '-', 'T', 'y', 'p', 'e', 0,   0,   0,  4,   'X', 'P', 'U', 'B'};
+        rc = TEST_ASSERT_SUCCESS_RAW_ERRNO (
+          send (fd_, (const char *) zmtp_ready, 28, 0));
+        TEST_ASSERT_EQUAL_INT (28, rc);
+    }
 
+    //  greeting - XPUB has one extra byte
     memset (buffer, 0, sizeof (buffer));
-    memcpy (buffer, zmtp_ready, 27);
-    rc = TEST_ASSERT_SUCCESS_RAW_ERRNO (send (fd_, buffer, 27, 0));
-    TEST_ASSERT_EQUAL_INT (27, rc);
-
-    //  greeting - XPUB so one extra byte
-    recv_with_retry (fd_, buffer, 28);
+    recv_with_retry (fd_, buffer, mock_pub ? 27 : 28);
 }
 
 static void prep_server_socket (void **server_out_,
                                 void **mon_out_,
                                 char *endpoint_,
-                                size_t ep_length_)
+                                size_t ep_length_,
+                                int socket_type)
 {
     //  We'll be using this socket in raw mode
-    void *server = test_context_socket (ZMQ_XPUB);
+    void *server = test_context_socket (socket_type);
 
     int value = 0;
     TEST_ASSERT_SUCCESS_ERRNO (
@@ -141,13 +154,14 @@ static void prep_server_socket (void **server_out_,
     *mon_out_ = server_mon;
 }
 
-static void test_mock_sub (bool sub_command)
+static void test_mock_pub_sub (bool sub_command, bool mock_pub)
 {
     int rc;
     char my_endpoint[MAX_SOCKET_STRING];
 
     void *server, *server_mon;
-    prep_server_socket (&server, &server_mon, my_endpoint, MAX_SOCKET_STRING);
+    prep_server_socket (&server, &server_mon, my_endpoint, MAX_SOCKET_STRING,
+                        mock_pub ? ZMQ_SUB : ZMQ_XPUB);
 
     struct sockaddr_in ip4addr;
     raw_socket s;
@@ -166,36 +180,62 @@ static void test_mock_sub (bool sub_command)
     TEST_ASSERT_GREATER_THAN_INT (-1, rc);
 
     // Mock a ZMTP 3 client so we can forcibly try sub commands
-    mock_handshake (s);
+    mock_handshake (s, sub_command, mock_pub);
 
     // By now everything should report as connected
     rc = get_monitor_event (server_mon);
     TEST_ASSERT_EQUAL_INT (ZMQ_EVENT_ACCEPTED, rc);
 
-    if (sub_command) {
-        const uint8_t sub[13] = {4,   11,  9,   'S', 'U', 'B', 'S',
-                                 'C', 'R', 'I', 'B', 'E', 'A'};
-        rc =
-          TEST_ASSERT_SUCCESS_RAW_ERRNO (send (s, (const char *) sub, 13, 0));
-        TEST_ASSERT_EQUAL_INT (13, rc);
-    } else {
-        const uint8_t sub[4] = {0, 2, 1, 'A'};
-        rc = TEST_ASSERT_SUCCESS_RAW_ERRNO (send (s, (const char *) sub, 4, 0));
+    char buffer[32];
+    memset (buffer, 0, sizeof (buffer));
+
+    if (mock_pub) {
+        rc = zmq_setsockopt (server, ZMQ_SUBSCRIBE, "A", 1);
+        TEST_ASSERT_EQUAL_INT (0, rc);
+        //  SUB binds, let its state machine run
+        zmq_recv (server, buffer, 16, ZMQ_DONTWAIT);
+
+        if (sub_command) {
+            recv_with_retry (s, buffer, 13);
+            TEST_ASSERT_EQUAL_INT (0,
+                                   memcmp (buffer, "\4\xb\x9SUBSCRIBEA", 13));
+        } else {
+            recv_with_retry (s, buffer, 4);
+            TEST_ASSERT_EQUAL_INT (0, memcmp (buffer, "\0\2\1A", 4));
+        }
+
+        memcpy (buffer, "\0\4ALOL", 6);
+        rc = TEST_ASSERT_SUCCESS_RAW_ERRNO (send (s, buffer, 6, 0));
+        TEST_ASSERT_EQUAL_INT (6, rc);
+
+        memset (buffer, 0, sizeof (buffer));
+        rc = zmq_recv (server, buffer, 4, 0);
         TEST_ASSERT_EQUAL_INT (4, rc);
+        TEST_ASSERT_EQUAL_INT (0, memcmp (buffer, "ALOL", 4));
+    } else {
+        if (sub_command) {
+            const uint8_t sub[13] = {4,   11,  9,   'S', 'U', 'B', 'S',
+                                     'C', 'R', 'I', 'B', 'E', 'A'};
+            rc = TEST_ASSERT_SUCCESS_RAW_ERRNO (
+              send (s, (const char *) sub, 13, 0));
+            TEST_ASSERT_EQUAL_INT (13, rc);
+        } else {
+            const uint8_t sub[4] = {0, 2, 1, 'A'};
+            rc = TEST_ASSERT_SUCCESS_RAW_ERRNO (
+              send (s, (const char *) sub, 4, 0));
+            TEST_ASSERT_EQUAL_INT (4, rc);
+        }
+        rc = zmq_recv (server, buffer, 2, 0);
+        TEST_ASSERT_EQUAL_INT (2, rc);
+        TEST_ASSERT_EQUAL_INT (0, memcmp (buffer, "\1A", 2));
+
+        rc = zmq_send (server, "ALOL", 4, 0);
+        TEST_ASSERT_EQUAL_INT (4, rc);
+
+        memset (buffer, 0, sizeof (buffer));
+        recv_with_retry (s, buffer, 6);
+        TEST_ASSERT_EQUAL_INT (0, memcmp (buffer, "\0\4ALOL", 6));
     }
-
-    char buffer[16];
-    memset (buffer, 0, sizeof (buffer));
-    rc = zmq_recv (server, buffer, 2, 0);
-    TEST_ASSERT_EQUAL_INT (2, rc);
-    TEST_ASSERT_EQUAL_INT (0, memcmp (buffer, "\1A", 2));
-
-    rc = zmq_send (server, "ALOL", 4, 0);
-    TEST_ASSERT_EQUAL_INT (4, rc);
-
-    memset (buffer, 0, sizeof (buffer));
-    recv_with_retry (s, buffer, 6);
-    TEST_ASSERT_EQUAL_INT (0, memcmp (buffer, "\0\4ALOL", 6));
 
     close (s);
 
@@ -205,12 +245,22 @@ static void test_mock_sub (bool sub_command)
 
 void test_mock_sub_command ()
 {
-    test_mock_sub (true);
+    test_mock_pub_sub (true, false);
 }
 
 void test_mock_sub_legacy ()
 {
-    test_mock_sub (false);
+    test_mock_pub_sub (false, false);
+}
+
+void test_mock_pub_command ()
+{
+    test_mock_pub_sub (true, true);
+}
+
+void test_mock_pub_legacy ()
+{
+    test_mock_pub_sub (false, true);
 }
 
 int main (void)
@@ -221,6 +271,8 @@ int main (void)
 
     RUN_TEST (test_mock_sub_command);
     RUN_TEST (test_mock_sub_legacy);
+    RUN_TEST (test_mock_pub_command);
+    RUN_TEST (test_mock_pub_legacy);
 
     return UNITY_END ();
 }

--- a/tests/test_stream.cpp
+++ b/tests/test_stream.cpp
@@ -35,7 +35,7 @@ typedef unsigned char byte;
 typedef struct
 {
     byte signature[10]; //  0xFF 8*0x00 0x7F
-    byte version[2];    //  0x03 0x00 for ZMTP/3.0
+    byte version[2];    //  0x03 0x01 for ZMTP/3.1
     byte mechanism[20]; //  "NULL"
     byte as_server;
     byte filler[31];
@@ -47,7 +47,7 @@ typedef struct
 //  8-byte size is set to 1 for backwards compatibility
 
 static zmtp_greeting_t greeting = {
-  {0xFF, 0, 0, 0, 0, 0, 0, 0, 1, 0x7F}, {3, 0}, {'N', 'U', 'L', 'L'}, 0, {0}};
+  {0xFF, 0, 0, 0, 0, 0, 0, 0, 1, 0x7F}, {3, 1}, {'N', 'U', 'L', 'L'}, 0, {0}};
 
 static void test_stream_to_dealer (void)
 {
@@ -148,7 +148,7 @@ static void test_stream_to_dealer (void)
 
     //  First two bytes are major and minor version numbers.
     assert (buffer[0] == 3); //  ZMTP/3.0
-    assert (buffer[1] == 0);
+    assert (buffer[1] == 1);
 
     //  Mechanism is "NULL"
     assert (memcmp (buffer + 2, "NULL\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 20)


### PR DESCRIPTION
This one is tricky, and the workaround to be backward-compatible means that subscription messages with a topic > 32 bytes get duplicated for each ZMTP < 3.1 peer, which might be a huge performance hog. The details of the hack are commented inline.
On the other hand, I really don't want to make the choice manual - it's a protocol detail, users should not care one bit.

Any ideas?