### PR TITLE
Switched android platform check to official form

### DIFF
--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -55,7 +55,7 @@
   #define ZMQ_HAVE_AIX
 #endif
 
-#if defined ANDROID
+#if defined __ANDROID__
   #define ZMQ_HAVE_ANDROID
 #endif
 


### PR DESCRIPTION
The define macro to detect whether or not an android compiler is being used is outdated and breaks on certain setups with certain API levels. 

This changes it to use the officially supported preprocessor macro.