### PR TITLE
Race condition with received message causes ZMQ_CONNECT_ROUTING_ID to be assigned to wrong socket

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -43,9 +43,12 @@ zmq::client_t::~client_t ()
 {
 }
 
-void zmq::client_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::client_t::xattach_pipe (pipe_t *pipe_,
+                                  bool subscribe_to_all_,
+                                  bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_);
 

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -49,7 +49,9 @@ class client_t : public socket_base_t
 
   protected:
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();

--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -44,9 +44,12 @@ zmq::dealer_t::~dealer_t ()
 {
 }
 
-void zmq::dealer_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::dealer_t::xattach_pipe (pipe_t *pipe_,
+                                  bool subscribe_to_all_,
+                                  bool locally_initated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initated_);
 
     zmq_assert (pipe_);
 

--- a/src/dealer.hpp
+++ b/src/dealer.hpp
@@ -51,7 +51,9 @@ class dealer_t : public socket_base_t
 
   protected:
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsetsockopt (int option_, const void *optval_, size_t optvallen_);
     int xsend (zmq::msg_t *msg_);
     int xrecv (zmq::msg_t *msg_);

--- a/src/dgram.cpp
+++ b/src/dgram.cpp
@@ -51,9 +51,12 @@ zmq::dgram_t::~dgram_t ()
     zmq_assert (!_pipe);
 }
 
-void zmq::dgram_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::dgram_t::xattach_pipe (pipe_t *pipe_,
+                                 bool subscribe_to_all_,
+                                 bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_);
 

--- a/src/dgram.hpp
+++ b/src/dgram.hpp
@@ -48,7 +48,9 @@ class dgram_t : public socket_base_t
     ~dgram_t ();
 
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();

--- a/src/dish.cpp
+++ b/src/dish.cpp
@@ -54,9 +54,12 @@ zmq::dish_t::~dish_t ()
     errno_assert (rc == 0);
 }
 
-void zmq::dish_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::dish_t::xattach_pipe (pipe_t *pipe_,
+                                bool subscribe_to_all_,
+                                bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_);
     _fq.attach (pipe_);

--- a/src/dish.hpp
+++ b/src/dish.hpp
@@ -52,7 +52,9 @@ class dish_t : public socket_base_t
 
   protected:
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     bool xhas_out ();
     int xrecv (zmq::msg_t *msg_);

--- a/src/gather.cpp
+++ b/src/gather.cpp
@@ -44,9 +44,12 @@ zmq::gather_t::~gather_t ()
 {
 }
 
-void zmq::gather_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::gather_t::xattach_pipe (pipe_t *pipe_,
+                                  bool subscribe_to_all_,
+                                  bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_);
     _fq.attach (pipe_);

--- a/src/gather.hpp
+++ b/src/gather.hpp
@@ -47,7 +47,9 @@ class gather_t : public socket_base_t
 
   protected:
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
     const blob_t &get_credential () const;

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -47,9 +47,12 @@ zmq::pair_t::~pair_t ()
     zmq_assert (!_pipe);
 }
 
-void zmq::pair_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::pair_t::xattach_pipe (pipe_t *pipe_,
+                                bool subscribe_to_all_,
+                                bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_ != NULL);
 

--- a/src/pair.hpp
+++ b/src/pair.hpp
@@ -48,7 +48,9 @@ class pair_t : public socket_base_t
     ~pair_t ();
 
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();

--- a/src/pub.cpp
+++ b/src/pub.cpp
@@ -43,7 +43,9 @@ zmq::pub_t::~pub_t ()
 {
 }
 
-void zmq::pub_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::pub_t::xattach_pipe (pipe_t *pipe_,
+                               bool subscribe_to_all_,
+                               bool locally_initiated_)
 {
     zmq_assert (pipe_);
 
@@ -51,7 +53,7 @@ void zmq::pub_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
     //  to receive the delimiter.
     pipe_->set_nodelay ();
 
-    xpub_t::xattach_pipe (pipe_, subscribe_to_all_);
+    xpub_t::xattach_pipe (pipe_, subscribe_to_all_, locally_initiated_);
 }
 
 int zmq::pub_t::xrecv (class msg_t *)

--- a/src/pub.hpp
+++ b/src/pub.hpp
@@ -46,7 +46,9 @@ class pub_t : public xpub_t
     ~pub_t ();
 
     //  Implementations of virtual functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_ = false);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_ = false,
+                       bool locally_initiated_ = false);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
 

--- a/src/pull.cpp
+++ b/src/pull.cpp
@@ -44,9 +44,12 @@ zmq::pull_t::~pull_t ()
 {
 }
 
-void zmq::pull_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::pull_t::xattach_pipe (pipe_t *pipe_,
+                                bool subscribe_to_all_,
+                                bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_);
     _fq.attach (pipe_);

--- a/src/pull.hpp
+++ b/src/pull.hpp
@@ -49,7 +49,9 @@ class pull_t : public socket_base_t
 
   protected:
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
     const blob_t &get_credential () const;

--- a/src/push.cpp
+++ b/src/push.cpp
@@ -44,9 +44,12 @@ zmq::push_t::~push_t ()
 {
 }
 
-void zmq::push_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::push_t::xattach_pipe (pipe_t *pipe_,
+                                bool subscribe_to_all_,
+                                bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     //  Don't delay pipe termination as there is no one
     //  to receive the delimiter.

--- a/src/push.hpp
+++ b/src/push.hpp
@@ -49,7 +49,9 @@ class push_t : public socket_base_t
 
   protected:
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     bool xhas_out ();
     void xwrite_activated (zmq::pipe_t *pipe_);

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -47,9 +47,12 @@ zmq::radio_t::~radio_t ()
 {
 }
 
-void zmq::radio_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::radio_t::xattach_pipe (pipe_t *pipe_,
+                                 bool subscribe_to_all_,
+                                 bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_);
 

--- a/src/radio.hpp
+++ b/src/radio.hpp
@@ -52,7 +52,9 @@ class radio_t : public socket_base_t
     ~radio_t ();
 
     //  Implementations of virtual functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_ = false);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_ = false,
+                       bool locally_initiated_ = false);
     int xsend (zmq::msg_t *msg_);
     bool xhas_out ();
     int xrecv (zmq::msg_t *msg_);

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -52,7 +52,9 @@ class router_t : public routing_socket_base_t
     ~router_t ();
 
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsetsockopt (int option_, const void *optval_, size_t optvallen_);
     int xsend (zmq::msg_t *msg_);
     int xrecv (zmq::msg_t *msg_);
@@ -69,7 +71,7 @@ class router_t : public routing_socket_base_t
 
   private:
     //  Receive peer id and update lookup map
-    bool identify_peer (pipe_t *pipe_);
+    bool identify_peer (pipe_t *pipe_, bool locally_initiated);
 
     //  Fair queueing object for inbound pipes.
     fq_t _fq;

--- a/src/scatter.cpp
+++ b/src/scatter.cpp
@@ -44,9 +44,12 @@ zmq::scatter_t::~scatter_t ()
 {
 }
 
-void zmq::scatter_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::scatter_t::xattach_pipe (pipe_t *pipe_,
+                                   bool subscribe_to_all_,
+                                   bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     //  Don't delay pipe termination as there is no one
     //  to receive the delimiter.

--- a/src/scatter.hpp
+++ b/src/scatter.hpp
@@ -49,7 +49,9 @@ class scatter_t : public socket_base_t
 
   protected:
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     bool xhas_out ();
     void xwrite_activated (zmq::pipe_t *pipe_);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -48,9 +48,12 @@ zmq::server_t::~server_t ()
     zmq_assert (_out_pipes.empty ());
 }
 
-void zmq::server_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::server_t::xattach_pipe (pipe_t *pipe_,
+                                  bool subscribe_to_all_,
+                                  bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_);
 

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -52,7 +52,9 @@ class server_t : public socket_base_t
     ~server_t ();
 
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -150,7 +150,8 @@ class socket_base_t : public own_t,
     //  Concrete algorithms for the x- methods are to be defined by
     //  individual socket types.
     virtual void xattach_pipe (zmq::pipe_t *pipe_,
-                               bool subscribe_to_all_ = false) = 0;
+                               bool subscribe_to_all_ = false,
+                               bool locally_initiated_ = false) = 0;
 
     //  The default implementation assumes there are no specific socket
     //  options for the particular socket type. If not so, override this
@@ -234,7 +235,9 @@ class socket_base_t : public own_t,
     int check_protocol (const std::string &protocol_);
 
     //  Register the pipe with this socket.
-    void attach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_ = false);
+    void attach_pipe (zmq::pipe_t *pipe_,
+                      bool subscribe_to_all_ = false,
+                      bool locally_initiated_ = false);
 
     //  Processes commands sent to this socket (if any). If timeout is -1,
     //  returns only after at least one command was processed.
@@ -311,6 +314,7 @@ class routing_socket_base_t : public socket_base_t
 
     // own methods
     std::string extract_connect_routing_id ();
+    bool connect_routing_id_is_set ();
 
     struct out_pipe_t
     {

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -57,13 +57,15 @@ zmq::stream_t::~stream_t ()
     _prefetched_msg.close ();
 }
 
-void zmq::stream_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::stream_t::xattach_pipe (pipe_t *pipe_,
+                                  bool subscribe_to_all_,
+                                  bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
 
     zmq_assert (pipe_);
 
-    identify_peer (pipe_);
+    identify_peer (pipe_, locally_initiated_);
     _fq.attach (pipe_);
 }
 
@@ -264,14 +266,14 @@ bool zmq::stream_t::xhas_out ()
     return true;
 }
 
-void zmq::stream_t::identify_peer (pipe_t *pipe_)
+void zmq::stream_t::identify_peer (pipe_t *pipe_, bool locally_initiated_)
 {
     //  Always assign routing id for raw-socket
     unsigned char buffer[5];
     buffer[0] = 0;
     blob_t routing_id;
-    const std::string connect_routing_id = extract_connect_routing_id ();
-    if (!connect_routing_id.empty ()) {
+    if (locally_initiated_ && connect_routing_id_is_set ()) {
+        const std::string connect_routing_id = extract_connect_routing_id ();
         routing_id.set (
           reinterpret_cast<const unsigned char *> (connect_routing_id.c_str ()),
           connect_routing_id.length ());

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -46,7 +46,9 @@ class stream_t : public routing_socket_base_t
     ~stream_t ();
 
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
@@ -57,7 +59,7 @@ class stream_t : public routing_socket_base_t
 
   private:
     //  Generate peer's id and update lookup map
-    void identify_peer (pipe_t *pipe_);
+    void identify_peer (pipe_t *pipe_, bool locally_initiated_);
 
     //  Fair queueing object for inbound pipes.
     fq_t _fq;

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -57,8 +57,12 @@ zmq::xpub_t::~xpub_t ()
     _welcome_msg.close ();
 }
 
-void zmq::xpub_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::xpub_t::xattach_pipe (pipe_t *pipe_,
+                                bool subscribe_to_all_,
+                                bool locally_initiated_)
 {
+    LIBZMQ_UNUSED (locally_initiated_);
+
     zmq_assert (pipe_);
     _dist.attach (pipe_);
 

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -51,7 +51,9 @@ class xpub_t : public socket_base_t
     ~xpub_t ();
 
     //  Implementations of virtual functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_ = false);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_ = false,
+                       bool locally_initiated_ = false);
     int xsend (zmq::msg_t *msg_);
     bool xhas_out ();
     int xrecv (zmq::msg_t *msg_);

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -55,9 +55,12 @@ zmq::xsub_t::~xsub_t ()
     errno_assert (rc == 0);
 }
 
-void zmq::xsub_t::xattach_pipe (pipe_t *pipe_, bool subscribe_to_all_)
+void zmq::xsub_t::xattach_pipe (pipe_t *pipe_,
+                                bool subscribe_to_all_,
+                                bool locally_initiated_)
 {
     LIBZMQ_UNUSED (subscribe_to_all_);
+    LIBZMQ_UNUSED (locally_initiated_);
 
     zmq_assert (pipe_);
     _fq.attach (pipe_);

--- a/src/xsub.hpp
+++ b/src/xsub.hpp
@@ -50,7 +50,9 @@ class xsub_t : public socket_base_t
 
   protected:
     //  Overrides of functions from socket_base_t.
-    void xattach_pipe (zmq::pipe_t *pipe_, bool subscribe_to_all_);
+    void xattach_pipe (zmq::pipe_t *pipe_,
+                       bool subscribe_to_all_,
+                       bool locally_initiated_);
     int xsend (zmq::msg_t *msg_);
     bool xhas_out ();
     int xrecv (zmq::msg_t *msg_);


### PR DESCRIPTION
Problem: ZMQ_CONNECT_ROUTING_ID can be assigned to incoming socket connection (Issue #3191)

Solution: Add an identifier parameter for local attach to zmq::socket_base_t::attach_pipe