### PR TITLE
cmake: Install pkgconfig in correct lib directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -900,7 +900,7 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/src/libzmq.pc.cmake.in ${CMAKE_CURRE
 set (zmq-pkgconfig ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc)
 
 if (NOT ZMQ_BUILD_FRAMEWORK)
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc DESTINATION lib/pkgconfig)
+  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif ()
 
 if (MSVC)


### PR DESCRIPTION
With autotools, the pkgconfig file goes into the correct lib/lib64
directory, but it always goes in lib with cmake. This fixes cmake to be
consistent with autotools.