### PR TITLE
Problem: stream_engine_t instance may access its fields after it deleted itself

### DIFF
--- a/src/i_engine.hpp
+++ b/src/i_engine.hpp
@@ -50,7 +50,10 @@ struct i_engine
 
     //  This method is called by the session to signalise that more
     //  messages can be written to the pipe.
-    virtual void restart_input () = 0;
+    //  Returns false if the engine was deleted due to an error.
+    //  TODO it is probably better to change the design such that the engine
+    //  does not delete itself
+    virtual bool restart_input () = 0;
 
     //  This method is called by the session to signalise that there
     //  are messages to send available.

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -382,7 +382,7 @@ void zmq::norm_engine_t::in_event ()
     }
 } // zmq::norm_engine_t::in_event()
 
-void zmq::norm_engine_t::restart_input ()
+bool zmq::norm_engine_t::restart_input ()
 {
     // TBD - should we check/assert that zmq_input_ready was false???
     zmq_input_ready = true;
@@ -390,6 +390,7 @@ void zmq::norm_engine_t::restart_input ()
     if (!msg_ready_list.IsEmpty ())
         recv_data (NORM_OBJECT_INVALID);
 
+    return true;
 } // end zmq::norm_engine_t::restart_input()
 
 void zmq::norm_engine_t::recv_data (NormObjectHandle object)

--- a/src/norm_engine.hpp
+++ b/src/norm_engine.hpp
@@ -39,7 +39,7 @@ class norm_engine_t : public io_object_t, public i_engine
 
     //  This method is called by the session to signalise that more
     //  messages can be written to the pipe.
-    virtual void restart_input ();
+    virtual bool restart_input ();
 
     //  This method is called by the session to signalise that there
     //  are messages to send available.

--- a/src/pgm_receiver.cpp
+++ b/src/pgm_receiver.cpp
@@ -116,7 +116,7 @@ void zmq::pgm_receiver_t::restart_output ()
     drop_subscriptions ();
 }
 
-void zmq::pgm_receiver_t::restart_input ()
+bool zmq::pgm_receiver_t::restart_input ()
 {
     zmq_assert (session != NULL);
     zmq_assert (active_tsi != NULL);
@@ -135,7 +135,7 @@ void zmq::pgm_receiver_t::restart_input ()
             //  HWM reached; we will try later.
             if (errno == EAGAIN) {
                 session->flush ();
-                return;
+                return true;
             }
             //  Data error. Delete message decoder, mark the
             //  peer as not joined and drop remaining data.
@@ -151,6 +151,8 @@ void zmq::pgm_receiver_t::restart_input ()
 
     active_tsi = NULL;
     in_event ();
+
+    return true;
 }
 
 const char *zmq::pgm_receiver_t::get_endpoint () const

--- a/src/pgm_receiver.hpp
+++ b/src/pgm_receiver.hpp
@@ -57,7 +57,7 @@ class pgm_receiver_t : public io_object_t, public i_engine
     //  i_engine interface implementation.
     void plug (zmq::io_thread_t *io_thread_, zmq::session_base_t *session_);
     void terminate ();
-    void restart_input ();
+    bool restart_input ();
     void restart_output ();
     void zap_msg_available () {}
     const char *get_endpoint () const;

--- a/src/pgm_sender.cpp
+++ b/src/pgm_sender.cpp
@@ -137,9 +137,10 @@ void zmq::pgm_sender_t::restart_output ()
     out_event ();
 }
 
-void zmq::pgm_sender_t::restart_input ()
+bool zmq::pgm_sender_t::restart_input ()
 {
     zmq_assert (false);
+    return true;
 }
 
 const char *zmq::pgm_sender_t::get_endpoint () const

--- a/src/pgm_sender.hpp
+++ b/src/pgm_sender.hpp
@@ -56,7 +56,7 @@ class pgm_sender_t : public io_object_t, public i_engine
     //  i_engine interface implementation.
     void plug (zmq::io_thread_t *io_thread_, zmq::session_base_t *session_);
     void terminate ();
-    void restart_input ();
+    bool restart_input ();
     void restart_output ();
     void zap_msg_available () {}
     const char *get_endpoint () const;

--- a/src/stream_engine.hpp
+++ b/src/stream_engine.hpp
@@ -76,7 +76,7 @@ class stream_engine_t : public io_object_t, public i_engine
     //  i_engine interface implementation.
     void plug (zmq::io_thread_t *io_thread_, zmq::session_base_t *session_);
     void terminate ();
-    void restart_input ();
+    bool restart_input ();
     void restart_output ();
     void zap_msg_available ();
     const char *get_endpoint () const;

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -537,11 +537,12 @@ void zmq::udp_engine_t::in_event ()
     _session->flush ();
 }
 
-void zmq::udp_engine_t::restart_input ()
+bool zmq::udp_engine_t::restart_input ()
 {
-    if (!_recv_enabled)
-        return;
+    if (_recv_enabled) {
+        set_pollin (_handle);
+        in_event ();
+    }
 
-    set_pollin (_handle);
-    in_event ();
+    return true;
 }

--- a/src/udp_engine.hpp
+++ b/src/udp_engine.hpp
@@ -32,7 +32,7 @@ class udp_engine_t : public io_object_t, public i_engine
 
     //  This method is called by the session to signalise that more
     //  messages can be written to the pipe.
-    void restart_input ();
+    bool restart_input ();
 
     //  This method is called by the session to signalise that there
     //  are messages to send available.


### PR DESCRIPTION
Solution: prevent access to data if the object was deleted

Fixes issue detected by clang static analyzer-: https://travis-ci.org/zeromq/libzmq/jobs/411364097#L2126