### PR TITLE
Add ZMQ_ROUTER_NOTIFY draft socket option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -887,7 +887,8 @@ test_apps += tests/test_poller \
 	tests/test_radio_dish \
 	tests/test_scatter_gather \
 	tests/test_dgram \
-	tests/test_app_meta
+	tests/test_app_meta \
+	tests/test_router_notify
 
 tests_test_poller_SOURCES = tests/test_poller.cpp
 tests_test_poller_LDADD = src/libzmq.la ${UNITY_LIBS}
@@ -917,6 +918,10 @@ tests_test_dgram_LDADD = src/libzmq.la
 tests_test_app_meta_SOURCES = tests/test_app_meta.cpp
 tests_test_app_meta_LDADD = src/libzmq.la ${UNITY_LIBS}
 tests_test_app_meta_CPPFLAGS = ${UNITY_CPPFLAGS}
+
+tests_test_router_notify_SOURCES = tests/test_router_notify.cpp
+tests_test_router_notify_LDADD = src/libzmq.la ${UNITY_LIBS}
+tests_test_router_notify_CPPFLAGS = ${UNITY_CPPFLAGS}
 endif
 
 if ENABLE_STATIC

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -904,6 +904,23 @@ Option value unit:: 0, 1
 Default value:: 1
 Applicable socket types:: ZMQ_RADIO, when using UDP multicast transport
 
+
+ZMQ_ROUTER_NOTIFY: Retrieve router socket notification settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Retrieve the current notification settings of a router socket. The returned
+value is a bitmask composed of ZMQ_NOTIFY_CONNECT and ZMQ_NOTIFY_DISCONNECT
+flags, meaning connect and disconnect notifications are enabled, respectively.
+A value of '0' means the notifications are off.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, ZMQ_NOTIFY_CONNECT, ZMQ_NOTIFY_DISCONNECT, ZMQ_NOTIFY_CONNECT|ZMQ_NOTIFY_DISCONNECT
+Default value:: 0
+Applicable socket types:: ZMQ_ROUTER
+
+
 RETURN VALUE
 ------------
 The _zmq_getsockopt()_ function shall return zero if successful. Otherwise it

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -906,7 +906,7 @@ Applicable socket types:: ZMQ_RADIO, when using UDP multicast transport
 
 
 ZMQ_ROUTER_NOTIFY: Retrieve router socket notification settings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Retrieve the current notification settings of a router socket. The returned
 value is a bitmask composed of ZMQ_NOTIFY_CONNECT and ZMQ_NOTIFY_DISCONNECT
 flags, meaning connect and disconnect notifications are enabled, respectively.

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1302,8 +1302,8 @@ NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int
-Option value unit:: 0, ZMQ_NOTIFY_CONNECT, ZMQ_NOTIFY_DISCONNECT
-Default value:: 1
+Option value unit:: 0, ZMQ_NOTIFY_CONNECT, ZMQ_NOTIFY_DISCONNECT, ZMQ_NOTIFY_CONNECT|ZMQ_NOTIFY_DISCONNECT
+Default value:: 0
 Applicable socket types:: ZMQ_ROUTER
 
 

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1289,6 +1289,24 @@ Option value unit:: 0, 1
 Default value:: 1
 Applicable socket types:: ZMQ_RADIO, when using UDP multicast transport
 
+
+ZMQ_ROUTER_NOTIFY: Send connect and disconnect notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Enable connect and disconnect notifications on a ROUTER socket.
+When enabled, the socket delivers a zero-length message (with routing-id
+as first frame) when a peer connects or disconnects. It's possible
+to notify both events for a peer by OR-ing the flag values. This option
+only applies to stream oriented (tcp, ipc) transports.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, ZMQ_NOTIFY_CONNECT, ZMQ_NOTIFY_DISCONNECT
+Default value:: 1
+Applicable socket types:: ZMQ_ROUTER
+
+
 RETURN VALUE
 ------------
 The _zmq_setsockopt()_ function shall return zero if successful. Otherwise it

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -618,6 +618,8 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_LOOPBACK_FASTPATH 94
 #define ZMQ_METADATA 95
 #define ZMQ_MULTICAST_LOOP 96
+#define ZMQ_ROUTER_NOTIFY 97
+
 
 /*  DRAFT 0MQ socket events and monitoring                                    */
 /*  Unspecified system errors during handshake. Event value is an errno.      */
@@ -677,6 +679,10 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_MSG_PROPERTY_SOCKET_TYPE "Socket-Type"
 #define ZMQ_MSG_PROPERTY_USER_ID "User-Id"
 #define ZMQ_MSG_PROPERTY_PEER_ADDRESS "Peer-Address"
+
+/*  Router notify options                                                     */
+#define ZMQ_NOTIFY_CONNECT 1
+#define ZMQ_NOTIFY_DISCONNECT 2
 
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -243,7 +243,8 @@ zmq::options_t::options_t () :
     zap_enforce_domain (false),
     loopback_fastpath (false),
     multicast_loop (true),
-    zero_copy (true)
+    zero_copy (true),
+    router_notify (0)
 {
     memset (curve_public_key, 0, CURVE_KEYSIZE);
     memset (curve_secret_key, 0, CURVE_KEYSIZE);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1150,6 +1150,16 @@ int zmq::options_t::getsockopt (int option_,
             }
             break;
 
+#ifdef ZMQ_BUILD_DRAFT_API
+        case ZMQ_ROUTER_NOTIFY:
+            if (is_int) {
+                *value = router_notify;
+                return 0;
+            }
+            break;
+#endif
+
+
         default:
 #if defined(ZMQ_ACT_MILITANT)
             malformed = false;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -261,7 +261,7 @@ struct options_t
     // Use zero copy strategy for storing message content when decoding.
     bool zero_copy;
 
-    // Router socket connect(1)/disconnect(2) notifications
+    // Router socket ZMQ_NOTIFY_CONNECT/ZMQ_NOTIFY_DISCONNECT notifications
     int router_notify;
 
     // Application metadata

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -261,6 +261,9 @@ struct options_t
     // Use zero copy strategy for storing message content when decoding.
     bool zero_copy;
 
+    // Router socket connect(1)/disconnect(2) notifications
+    int router_notify;
+
     // Application metadata
     std::map<std::string, std::string> app_metadata;
 };

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -141,7 +141,8 @@ int zmq::router_t::xsetsockopt (int option_,
 
 #ifdef ZMQ_BUILD_DRAFT_API
         case ZMQ_ROUTER_NOTIFY:
-            if (is_int && value >= 0 && value <= (ZMQ_NOTIFY_CONNECT|ZMQ_NOTIFY_DISCONNECT)) {
+            if (is_int && value >= 0
+                && value <= (ZMQ_NOTIFY_CONNECT | ZMQ_NOTIFY_DISCONNECT)) {
                 options.router_notify = value;
                 return 0;
             }

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -139,6 +139,15 @@ int zmq::router_t::xsetsockopt (int option_,
             }
             break;
 
+#ifdef ZMQ_BUILD_DRAFT_API
+        case ZMQ_ROUTER_NOTIFY:
+            if (is_int && value >= 0 && value <= 3) {
+                options.router_notify = value;
+                return 0;
+            }
+            break;
+#endif
+
         default:
             return routing_socket_base_t::xsetsockopt (option_, optval_,
                                                        optvallen_);

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -141,7 +141,7 @@ int zmq::router_t::xsetsockopt (int option_,
 
 #ifdef ZMQ_BUILD_DRAFT_API
         case ZMQ_ROUTER_NOTIFY:
-            if (is_int && value >= 0 && value <= 3) {
+            if (is_int && value >= 0 && value <= (ZMQ_NOTIFY_CONNECT|ZMQ_NOTIFY_DISCONNECT)) {
                 options.router_notify = value;
                 return 0;
             }

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -217,6 +217,12 @@ void zmq::session_base_t::flush ()
         _pipe->flush ();
 }
 
+void zmq::session_base_t::rollback ()
+{
+    if (_pipe)
+        _pipe->rollback ();
+}
+
 void zmq::session_base_t::clean_pipes ()
 {
     zmq_assert (_pipe != NULL);

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -60,6 +60,7 @@ class session_base_t : public own_t, public io_object_t, public i_pipe_events
     //  Following functions are the interface exposed towards the engine.
     virtual void reset ();
     void flush ();
+    void rollback ();
     void engine_error (zmq::stream_engine_t::error_reason_t reason_);
 
     //  i_pipe_events interface implementation.

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -55,6 +55,7 @@ unsigned long zmq_stopwatch_intermediate (void *watch_);
 #define ZMQ_LOOPBACK_FASTPATH 94
 #define ZMQ_METADATA 95
 #define ZMQ_MULTICAST_LOOP 96
+#define ZMQ_ROUTER_NOTIFY 97
 
 /*  DRAFT 0MQ socket events and monitoring                                    */
 /*  Unspecified system errors during handshake. Event value is an errno.      */
@@ -114,6 +115,10 @@ const char *zmq_msg_group (zmq_msg_t *msg_);
 #define ZMQ_MSG_PROPERTY_SOCKET_TYPE "Socket-Type"
 #define ZMQ_MSG_PROPERTY_USER_ID "User-Id"
 #define ZMQ_MSG_PROPERTY_PEER_ADDRESS "Peer-Address"
+
+/*  Router notify options                                                     */
+#define ZMQ_NOTIFY_CONNECT 1
+#define ZMQ_NOTIFY_DISCONNECT 2
 
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,6 +136,7 @@ IF (ENABLE_DRAFTS)
         test_scatter_gather
         test_dgram
         test_app_meta
+        test_router_notify
     )
 ENDIF (ENABLE_DRAFTS)
 

--- a/tests/test_router_notify.cpp
+++ b/tests/test_router_notify.cpp
@@ -1,0 +1,219 @@
+/*
+    Copyright (c) 2007-2017 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+
+#include <unity.h>
+
+void setUp ()
+{
+    setup_test_context ();
+}
+
+void tearDown ()
+{
+    teardown_test_context ();
+}
+
+void test_setsockopt_router_notify ()
+{
+    void *router = test_context_socket (ZMQ_ROUTER);
+    int notify_opt;
+
+    // valid values
+    notify_opt = 0;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      router, ZMQ_ROUTER_NOTIFY, &notify_opt, sizeof (notify_opt)));
+
+    notify_opt = ZMQ_NOTIFY_CONNECT;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      router, ZMQ_ROUTER_NOTIFY, &notify_opt, sizeof (notify_opt)));
+
+    notify_opt = ZMQ_NOTIFY_DISCONNECT;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      router, ZMQ_ROUTER_NOTIFY, &notify_opt, sizeof (notify_opt)));
+
+    notify_opt = ZMQ_NOTIFY_CONNECT | ZMQ_NOTIFY_DISCONNECT;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      router, ZMQ_ROUTER_NOTIFY, &notify_opt, sizeof (notify_opt)));
+
+    // value boundary
+    notify_opt = -1;
+    TEST_ASSERT_FAILURE_ERRNO (
+      EINVAL, zmq_setsockopt (router, ZMQ_ROUTER_NOTIFY, &notify_opt,
+                              sizeof (notify_opt)));
+
+    notify_opt = (ZMQ_NOTIFY_CONNECT | ZMQ_NOTIFY_DISCONNECT) + 1;
+    TEST_ASSERT_FAILURE_ERRNO (
+      EINVAL, zmq_setsockopt (router, ZMQ_ROUTER_NOTIFY, &notify_opt,
+                              sizeof (notify_opt)));
+
+    test_context_socket_close (router);
+
+    //check a non-router socket type
+    void *dealer = test_context_socket (ZMQ_DEALER);
+    notify_opt = ZMQ_NOTIFY_CONNECT;
+    TEST_ASSERT_FAILURE_ERRNO (
+      EINVAL, zmq_setsockopt (dealer, ZMQ_ROUTER_NOTIFY, &notify_opt,
+                              sizeof (notify_opt)));
+    test_context_socket_close (dealer);
+}
+
+
+void test_router_notify_helper (int notify_opt)
+{
+    void *router = test_context_socket (ZMQ_ROUTER);
+    int opt_more;
+    size_t opt_more_length = sizeof (opt_more);
+    int opt_events;
+    size_t opt_events_length = sizeof (opt_events);
+
+
+    // valid values
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      router, ZMQ_ROUTER_NOTIFY, &notify_opt, sizeof (notify_opt)));
+
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (router, ENDPOINT_0));
+
+    void *dealer = test_context_socket (ZMQ_DEALER);
+    const char *dealer_routing_id = "X";
+
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (dealer, ZMQ_ROUTING_ID, dealer_routing_id, 1));
+
+    // dealer connects
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (dealer, ENDPOINT_0));
+
+    // connection notification msg
+    if (notify_opt & ZMQ_NOTIFY_CONNECT) {
+        // routing-id only message of the connect
+        recv_string_expect_success (router, dealer_routing_id,
+                                    0);             // 1st part: routing-id
+        recv_string_expect_success (router, "", 0); // 2nd part: empty
+        TEST_ASSERT_SUCCESS_ERRNO (
+          zmq_getsockopt (router, ZMQ_RCVMORE, &opt_more, &opt_more_length));
+        TEST_ASSERT_EQUAL (0, opt_more);
+    }
+
+    // test message from the dealer
+    send_string_expect_success (dealer, "Hello", 0);
+    recv_string_expect_success (router, dealer_routing_id, 0);
+    recv_string_expect_success (router, "Hello", 0);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_getsockopt (router, ZMQ_RCVMORE, &opt_more, &opt_more_length));
+    TEST_ASSERT_EQUAL (0, opt_more);
+
+    // dealer disconnects
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_disconnect (dealer, ENDPOINT_0));
+
+    // need one more process_commands() (???)
+    msleep (SETTLE_TIME);
+    zmq_getsockopt (dealer, ZMQ_EVENTS, &opt_events, &opt_events_length);
+
+    // connection notification msg
+    if (notify_opt & ZMQ_NOTIFY_DISCONNECT) {
+        // routing-id only message of the connect
+        printf ("ehe\n");
+        recv_string_expect_success (router, dealer_routing_id,
+                                    0);             // 1st part: routing-id
+        recv_string_expect_success (router, "", 0); // 2nd part: empty
+        TEST_ASSERT_SUCCESS_ERRNO (
+          zmq_getsockopt (router, ZMQ_RCVMORE, &opt_more, &opt_more_length));
+        TEST_ASSERT_EQUAL (0, opt_more);
+    }
+
+    test_context_socket_close (dealer);
+    test_context_socket_close (router);
+}
+
+
+void test_router_notify_connect ()
+{
+    test_router_notify_helper (ZMQ_NOTIFY_CONNECT);
+}
+
+
+void test_router_notify_disconnect ()
+{
+    test_router_notify_helper (ZMQ_NOTIFY_DISCONNECT);
+}
+
+
+void test_router_notify_both ()
+{
+    test_router_notify_helper (ZMQ_NOTIFY_CONNECT | ZMQ_NOTIFY_DISCONNECT);
+}
+
+
+void test_handshake_fail ()
+{
+    void *router = test_context_socket (ZMQ_ROUTER);
+    int opt_timeout = 200;
+    int opt_notify = ZMQ_NOTIFY_CONNECT | ZMQ_NOTIFY_DISCONNECT;
+
+    // valid values
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      router, ZMQ_ROUTER_NOTIFY, &opt_notify, sizeof (opt_notify)));
+
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      router, ZMQ_RCVTIMEO, &opt_timeout, sizeof (opt_timeout)));
+
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (router, ENDPOINT_0));
+
+    // send something on raw tcp
+    void *stream = test_context_socket (ZMQ_STREAM);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (stream, ENDPOINT_0));
+
+    send_string_expect_success (stream, "not-a-handshake", 0);
+
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_disconnect (stream, ENDPOINT_0));
+    test_context_socket_close (stream);
+
+    // no notification delivered
+    char buffer[255];
+    TEST_ASSERT_FAILURE_ERRNO (EAGAIN,
+                               zmq_recv (router, buffer, sizeof (buffer), 0));
+
+    test_context_socket_close (router);
+}
+
+int main (void)
+{
+    setup_test_environment ();
+
+    UNITY_BEGIN ();
+    RUN_TEST (test_setsockopt_router_notify);
+    RUN_TEST (test_router_notify_connect);
+    RUN_TEST (test_router_notify_disconnect);
+    RUN_TEST (test_router_notify_both);
+    RUN_TEST (test_handshake_fail);
+
+    return UNITY_END ();
+}


### PR DESCRIPTION
# New feature: ZMQ_ROUTER_NOTIFY socket option
This PR proposes a new feature for ROUTER sockets on stream oriented transports: configurable connect/disconnect notifications. Related issue/discussion: #3201 

The implementation follows the already existing ZMQ_STREAM_NOTIFY option, notifications are sent close  to the `handshake_succeded` and `disconnected` monitor events.


