### PR TITLE
Problem: unused get_credential methods and associated fields

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -96,11 +96,6 @@ bool zmq::client_t::xhas_out ()
     return _lb.has_out ();
 }
 
-const zmq::blob_t &zmq::client_t::get_credential () const
-{
-    return _fq.get_credential ();
-}
-
 void zmq::client_t::xread_activated (pipe_t *pipe_)
 {
     _fq.activated (pipe_);

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -56,7 +56,6 @@ class client_t : public socket_base_t
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
     bool xhas_out ();
-    const blob_t &get_credential () const;
     void xread_activated (zmq::pipe_t *pipe_);
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);

--- a/src/dealer.cpp
+++ b/src/dealer.cpp
@@ -117,12 +117,6 @@ bool zmq::dealer_t::xhas_out ()
     return _lb.has_out ();
 }
 
-const zmq::blob_t &zmq::dealer_t::get_credential () const
-{
-    return _fq.get_credential ();
-}
-
-
 void zmq::dealer_t::xread_activated (pipe_t *pipe_)
 {
     _fq.activated (pipe_);

--- a/src/dealer.hpp
+++ b/src/dealer.hpp
@@ -59,7 +59,6 @@ class dealer_t : public socket_base_t
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
     bool xhas_out ();
-    const blob_t &get_credential () const;
     void xread_activated (zmq::pipe_t *pipe_);
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);

--- a/src/dgram.cpp
+++ b/src/dgram.cpp
@@ -72,7 +72,6 @@ void zmq::dgram_t::xpipe_terminated (pipe_t *pipe_)
 {
     if (pipe_ == _pipe) {
         if (_last_in == _pipe) {
-            _saved_credential.set_deep_copy (_last_in->get_credential ());
             _last_in = NULL;
         }
         _pipe = NULL;
@@ -170,9 +169,4 @@ bool zmq::dgram_t::xhas_out ()
         return false;
 
     return _pipe->check_write ();
-}
-
-const zmq::blob_t &zmq::dgram_t::get_credential () const
-{
-    return _last_in ? _last_in->get_credential () : _saved_credential;
 }

--- a/src/dgram.hpp
+++ b/src/dgram.hpp
@@ -55,7 +55,6 @@ class dgram_t : public socket_base_t
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
     bool xhas_out ();
-    const blob_t &get_credential () const;
     void xread_activated (zmq::pipe_t *pipe_);
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);
@@ -64,8 +63,6 @@ class dgram_t : public socket_base_t
     zmq::pipe_t *_pipe;
 
     zmq::pipe_t *_last_in;
-
-    blob_t _saved_credential;
 
     //  If true, more outgoing message parts are expected.
     bool _more_out;

--- a/src/dish.cpp
+++ b/src/dish.cpp
@@ -219,11 +219,6 @@ bool zmq::dish_t::xhas_in ()
     return true;
 }
 
-const zmq::blob_t &zmq::dish_t::get_credential () const
-{
-    return _fq.get_credential ();
-}
-
 void zmq::dish_t::send_subscriptions (pipe_t *pipe_)
 {
     for (subscriptions_t::iterator it = _subscriptions.begin (),

--- a/src/dish.hpp
+++ b/src/dish.hpp
@@ -59,7 +59,6 @@ class dish_t : public socket_base_t
     bool xhas_out ();
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
-    const blob_t &get_credential () const;
     void xread_activated (zmq::pipe_t *pipe_);
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xhiccuped (pipe_t *pipe_);

--- a/src/fq.cpp
+++ b/src/fq.cpp
@@ -64,7 +64,6 @@ void zmq::fq_t::pipe_terminated (pipe_t *pipe_)
     _pipes.erase (pipe_);
 
     if (_last_in == pipe_) {
-        _saved_credential.set_deep_copy (_last_in->get_credential ());
         _last_in = NULL;
     }
 }
@@ -148,9 +147,4 @@ bool zmq::fq_t::has_in ()
     }
 
     return false;
-}
-
-const zmq::blob_t &zmq::fq_t::get_credential () const
-{
-    return _last_in ? _last_in->get_credential () : _saved_credential;
 }

--- a/src/fq.hpp
+++ b/src/fq.hpp
@@ -55,7 +55,6 @@ class fq_t
     int recv (msg_t *msg_);
     int recvpipe (msg_t *msg_, pipe_t **pipe_);
     bool has_in ();
-    const blob_t &get_credential () const;
 
   private:
     //  Inbound pipes.
@@ -77,9 +76,6 @@ class fq_t
     //  If true, part of a multipart message was already received, but
     //  there are following parts still waiting in the current pipe.
     bool _more;
-
-    //  Holds credential after the last_active_pipe has terminated.
-    blob_t _saved_credential;
 
     fq_t (const fq_t &);
     const fq_t &operator= (const fq_t &);

--- a/src/gather.cpp
+++ b/src/gather.cpp
@@ -89,8 +89,3 @@ bool zmq::gather_t::xhas_in ()
 {
     return _fq.has_in ();
 }
-
-const zmq::blob_t &zmq::gather_t::get_credential () const
-{
-    return _fq.get_credential ();
-}

--- a/src/gather.hpp
+++ b/src/gather.hpp
@@ -52,7 +52,6 @@ class gather_t : public socket_base_t
                        bool locally_initiated_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
-    const blob_t &get_credential () const;
     void xread_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);
 

--- a/src/pair.cpp
+++ b/src/pair.cpp
@@ -68,7 +68,6 @@ void zmq::pair_t::xpipe_terminated (pipe_t *pipe_)
 {
     if (pipe_ == _pipe) {
         if (_last_in == _pipe) {
-            _saved_credential.set_deep_copy (_last_in->get_credential ());
             _last_in = NULL;
         }
         _pipe = NULL;
@@ -136,9 +135,4 @@ bool zmq::pair_t::xhas_out ()
         return false;
 
     return _pipe->check_write ();
-}
-
-const zmq::blob_t &zmq::pair_t::get_credential () const
-{
-    return _last_in ? _last_in->get_credential () : _saved_credential;
 }

--- a/src/pair.hpp
+++ b/src/pair.hpp
@@ -55,7 +55,6 @@ class pair_t : public socket_base_t
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
     bool xhas_out ();
-    const blob_t &get_credential () const;
     void xread_activated (zmq::pipe_t *pipe_);
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);
@@ -64,8 +63,6 @@ class pair_t : public socket_base_t
     zmq::pipe_t *_pipe;
 
     zmq::pipe_t *_last_in;
-
-    blob_t _saved_credential;
 
     pair_t (const pair_t &);
     const pair_t &operator= (const pair_t &);

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -143,11 +143,6 @@ const zmq::blob_t &zmq::pipe_t::get_routing_id () const
     return _router_socket_routing_id;
 }
 
-const zmq::blob_t &zmq::pipe_t::get_credential () const
-{
-    return _credential;
-}
-
 bool zmq::pipe_t::check_read ()
 {
     if (unlikely (!_in_active))
@@ -187,11 +182,8 @@ bool zmq::pipe_t::read (msg_t *msg_)
             return false;
         }
 
-        //  If this is a credential, save a copy and receive next message.
+        //  If this is a credential, ignore it and receive next message.
         if (unlikely (msg_->is_credential ())) {
-            const unsigned char *data =
-              static_cast<const unsigned char *> (msg_->data ());
-            _credential.set (data, msg_->size ());
             const int rc = msg_->close ();
             zmq_assert (rc == 0);
         } else

--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -92,8 +92,6 @@ class pipe_t : public object_t,
     void set_router_socket_routing_id (const blob_t &router_socket_routing_id_);
     const blob_t &get_routing_id () const;
 
-    const blob_t &get_credential () const;
-
     //  Returns true if there is at least one message to read in the pipe.
     bool check_read ();
 

--- a/src/pull.cpp
+++ b/src/pull.cpp
@@ -74,8 +74,3 @@ bool zmq::pull_t::xhas_in ()
 {
     return _fq.has_in ();
 }
-
-const zmq::blob_t &zmq::pull_t::get_credential () const
-{
-    return _fq.get_credential ();
-}

--- a/src/pull.hpp
+++ b/src/pull.hpp
@@ -54,7 +54,6 @@ class pull_t : public socket_base_t
                        bool locally_initiated_);
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
-    const blob_t &get_credential () const;
     void xread_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);
 

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -414,11 +414,6 @@ bool zmq::router_t::xhas_out ()
     return any_of_out_pipes (check_pipe_hwm);
 }
 
-const zmq::blob_t &zmq::router_t::get_credential () const
-{
-    return _fq.get_credential ();
-}
-
 int zmq::router_t::get_peer_state (const void *routing_id_,
                                    size_t routing_id_size_) const
 {

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -67,7 +67,6 @@ class router_t : public routing_socket_base_t
   protected:
     //  Rollback any message parts that were sent but not yet flushed.
     int rollback ();
-    const blob_t &get_credential () const;
 
   private:
     //  Receive peer id and update lookup map

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -179,8 +179,3 @@ bool zmq::server_t::xhas_out ()
     //  to be routed to.
     return true;
 }
-
-const zmq::blob_t &zmq::server_t::get_credential () const
-{
-    return _fq.get_credential ();
-}

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -63,9 +63,6 @@ class server_t : public socket_base_t
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xpipe_terminated (zmq::pipe_t *pipe_);
 
-  protected:
-    const blob_t &get_credential () const;
-
   private:
     //  Fair queueing object for inbound pipes.
     fq_t _fq;

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1453,13 +1453,6 @@ int zmq::socket_base_t::xrecv (msg_t *)
     return -1;
 }
 
-static const zmq::blob_t empty_blob;
-
-const zmq::blob_t &zmq::socket_base_t::get_credential () const
-{
-    return empty_blob;
-}
-
 void zmq::socket_base_t::xread_activated (pipe_t *)
 {
     zmq_assert (false);

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -167,11 +167,6 @@ class socket_base_t : public own_t,
     virtual bool xhas_in ();
     virtual int xrecv (zmq::msg_t *msg_);
 
-    //  Returns the credential for the peer from which we have received
-    //  the last message. If no message has been received yet,
-    //  the function returns empty credential.
-    virtual const blob_t &get_credential () const;
-
     //  i_pipe_events will be forwarded to these functions.
     virtual void xread_activated (pipe_t *pipe_);
     virtual void xwrite_activated (pipe_t *pipe_);

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -223,11 +223,6 @@ bool zmq::xsub_t::xhas_in ()
     }
 }
 
-const zmq::blob_t &zmq::xsub_t::get_credential () const
-{
-    return _fq.get_credential ();
-}
-
 bool zmq::xsub_t::match (msg_t *msg_)
 {
     bool matching = _subscriptions.check (

--- a/src/xsub.hpp
+++ b/src/xsub.hpp
@@ -57,7 +57,6 @@ class xsub_t : public socket_base_t
     bool xhas_out ();
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
-    const blob_t &get_credential () const;
     void xread_activated (zmq::pipe_t *pipe_);
     void xwrite_activated (zmq::pipe_t *pipe_);
     void xhiccuped (pipe_t *pipe_);


### PR DESCRIPTION
Solution: remove them

These methods were added by #819, and subsequently in new socket types, since they were required by socket_base, but they are never called. They also use some fields, which are not used (read) anywhere else, so they can be removed as well.