### PR TITLE
Update unittests/CMakeLists.txt: use ZeroMQ_SOURCE_DIR, ZeroMQ_BINARY_DIR

### DIFF
--- a/RELICENSE/WenbinHou.md
+++ b/RELICENSE/WenbinHou.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Wenbin Hou
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "Wenbin Hou", with
+commit author "Wenbin Hou <houwenbin@pku.edu.cn>", are copyright of Wenbin Hou.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Wenbin Hou
+2018/05/16

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -171,7 +171,7 @@ link_libraries(libzmq ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)
 else ()
 link_libraries(libzmq-static ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)
 endif ()
-include_directories("${CMAKE_SOURCE_DIR}/../include" "${CMAKE_BINARY_DIR}")
+include_directories("${ZeroMQ_SOURCE_DIR}/../include" "${ZeroMQ_BINARY_DIR}")
 
 foreach(test ${tests})
   # target_sources not supported before CMake 3.1
@@ -198,7 +198,7 @@ foreach(test ${tests})
   else()
     # per-test directories not generated on OS X / Darwin
     if (NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang.*")
-        link_directories(${test} PRIVATE "${CMAKE_SOURCE_DIR}/../lib")
+        link_directories(${test} PRIVATE "${ZeroMQ_SOURCE_DIR}/../lib")
     endif()
   endif()
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -22,8 +22,8 @@ if(WIN32)
     link_libraries(ws2_32.lib)
 endif()
 
-include_directories("${CMAKE_SOURCE_DIR}/include" "${CMAKE_SOURCE_DIR}/src" "${CMAKE_BINARY_DIR}")
-include_directories("${CMAKE_SOURCE_DIR}/external/unity")
+include_directories("${ZeroMQ_SOURCE_DIR}/include" "${ZeroMQ_SOURCE_DIR}/src" "${ZeroMQ_BINARY_DIR}")
+include_directories("${ZeroMQ_SOURCE_DIR}/external/unity")
 
 foreach(test ${unittests})
   # target_sources not supported before CMake 3.1
@@ -31,7 +31,7 @@ foreach(test ${unittests})
 
   # per-test directories not generated on OS X / Darwin
   if (NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang.*")
-      link_directories(${test} PRIVATE "${CMAKE_SOURCE_DIR}/../lib")     
+      link_directories(${test} PRIVATE "${ZeroMQ_SOURCE_DIR}/../lib")     
   endif()
   
   target_link_libraries(${test} libzmq-static ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)


### PR DESCRIPTION
# Problem
When placing libzmq in a subdirectory, and use cmake `add_subdirectory` command to build libzmq as a sub-project (static build, with ZMQ_BUILD_TESTS ON), some header files are not found.
This is due to usage of `CMAKE_SOURCE_DIR`, `CMAKE_BINARY_DIR` in **unittests/CMakeLists.txt**, which does not refers to libzmq source directory now.

# Solution:
Use `ZeroMQ_SOURCE_DIR`, `ZeroMQ_BINARY_DIR` instead of `CMAKE_SOURCE_DIR`, `CMAKE_BINARY_DIR` in **unittests/CMakeLists.txt**, which allows libzmq to become an "add_subdirectory" target (with static build).

Currently minimum required CMake version (in unittests/CMakeLists.txt: 2.8.1) is enough to support this. See [https://cmake.org/cmake/help/v2.8.1/cmake.html](https://cmake.org/cmake/help/v2.8.1/cmake.html)

> project: Set a name for the entire project.
> Sets the name of the project. Additionally this sets the variables \<projectName\>_BINARY_DIR and
> \<projectName\>_SOURCE_DIR to the respective values.
