### PR TITLE
Fix build failure on ARM due to bad variable name

### DIFF
--- a/src/atomic_counter.hpp
+++ b/src/atomic_counter.hpp
@@ -188,7 +188,7 @@ class atomic_counter_t
                            "+Qo"(_value)
                          : "Ir"(decrement_), "r"(&_value)
                          : "cc");
-        return old_value - decrement != 0;
+        return old_value - decrement_ != 0;
 #elif defined ZMQ_ATOMIC_COUNTER_MUTEX
         sync.lock ();
         _value -= decrement_;


### PR DESCRIPTION
### Problem: Build fails on ARM - Ubuntu 12.04
The variable `decrement` was changed to `decrement_` for consistency in naming style. 
(c581f43c9)

In -one- place, it had remained as `decrement`
and gives:

In file included from src/ctx.hpp:44:0,
from src/address.cpp:33:
src/atomic_counter.hpp: In member function 'bool zmq::atomic_counter_t::sub(zmq::atomic_counter_t::integer_t)':
src/atomic_counter.hpp:191:28: error: 'decrement' was not declared in this scope

Solution: Changing it to `decrement_` fixes the problem.

Fixes #3229