### PR TITLE
Revert "Problem: test_proxy not yet using unity"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -626,8 +626,7 @@ tests_test_issue_566_SOURCES = tests/test_issue_566.cpp
 tests_test_issue_566_LDADD = src/libzmq.la
 
 tests_test_proxy_SOURCES = tests/test_proxy.cpp
-tests_test_proxy_LDADD = src/libzmq.la ${UNITY_LIBS}
-tests_test_proxy_CPPFLAGS = ${UNITY_CPPFLAGS}
+tests_test_proxy_LDADD = src/libzmq.la
 
 tests_test_proxy_single_socket_SOURCES = tests/test_proxy_single_socket.cpp
 tests_test_proxy_single_socket_LDADD = src/libzmq.la


### PR DESCRIPTION
This reverts commit fd27324ec3daa50bebea381ce7fd4b505a6a53e6.

@bluca I didn't find the problem immediately, and don't have the time right now to investigate it further. I will revert this change for now, and give it a look again later on.