### PR TITLE
Added SO_REUSEPORT socket option for UDP recv ports

### DIFF
--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -199,6 +199,12 @@ void zmq::udp_engine_t::plug (io_thread_t *io_thread_, session_base_t *session_)
         errno_assert (rc == 0);
 #endif
 
+#ifdef SO_REUSEPORT
+        rc = setsockopt (_fd, SOL_SOCKET, SO_REUSEPORT,
+                         reinterpret_cast<char *> (&on), sizeof (on));
+        errno_assert (rc == 0);
+#endif
+
         const ip_addr_t *bind_addr = udp_addr->bind_addr ();
         ip_addr_t any = ip_addr_t::any (bind_addr->family ());
         const ip_addr_t *real_bind_addr;

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -199,19 +199,6 @@ void zmq::udp_engine_t::plug (io_thread_t *io_thread_, session_base_t *session_)
         errno_assert (rc == 0);
 #endif
 
-<<<<<<< HEAD
-=======
-#ifdef SO_REUSEPORT
-        rc = setsockopt (_fd, SOL_SOCKET, SO_REUSEPORT,
-                         reinterpret_cast<char *> (&on), sizeof (on));
-#ifdef ZMQ_HAVE_WINDOWS
-        wsa_assert (rc != SOCKET_ERROR);
-#else
-        errno_assert (rc == 0);
-#endif
-#endif
-
->>>>>>> 68d00a34aae3ce33bd37fdc4059a316e1237fbd6
         const ip_addr_t *bind_addr = udp_addr->bind_addr ();
         ip_addr_t any = ip_addr_t::any (bind_addr->family ());
         const ip_addr_t *real_bind_addr;


### PR DESCRIPTION
Problem: Binding UDP multicast ports more than once throws "Address already in use errors" [(referenced in this issue).](https://github.com/zeromq/libzmq/issues/3236)

Solution: Add SO_REUSEPORT socket option when binding UDP receive ports on platforms that support it.