### PR TITLE
Hwm tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ test_security_zap
 test_socket_null
 test_xpub_verbose
 test_mock_pub_sub
+test_proxy_hwm
 unittest_ip_resolver
 unittest_mtrie
 unittest_poller

--- a/Makefile.am
+++ b/Makefile.am
@@ -422,6 +422,7 @@ test_apps = \
 	tests/test_inproc_connect \
 	tests/test_issue_566 \
 	tests/test_proxy \
+	tests/test_proxy_hwm \
 	tests/test_proxy_single_socket \
 	tests/test_proxy_terminate \
 	tests/test_getsockopt_memset \
@@ -627,6 +628,10 @@ tests_test_issue_566_LDADD = src/libzmq.la
 
 tests_test_proxy_SOURCES = tests/test_proxy.cpp
 tests_test_proxy_LDADD = src/libzmq.la
+
+tests_test_proxy_hwm_SOURCES = tests/test_proxy_hwm.cpp
+tests_test_proxy_hwm_LDADD = src/libzmq.la ${UNITY_LIBS}
+tests_test_proxy_hwm_CPPFLAGS = ${UNITY_CPPFLAGS}
 
 tests_test_proxy_single_socket_SOURCES = tests/test_proxy_single_socket.cpp
 tests_test_proxy_single_socket_LDADD = src/libzmq.la

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -858,7 +858,7 @@ If this limit has been reached the socket shall enter an exceptional state and
 depending on the socket type, 0MQ shall take appropriate action such as
 blocking or dropping sent messages. Refer to the individual socket descriptions
 in linkzmq:zmq_socket[3] for details on the exact action taken for each socket
-type. 
+type.
 
 NOTE: 0MQ does not guarantee that the socket will accept as many as ZMQ_SNDHWM
 messages, and the actual limit may be as much as 90% lower depending on the

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -640,6 +640,10 @@ blocking or dropping sent messages. Refer to the individual socket descriptions
 in linkzmq:zmq_socket[3] for details on the exact action taken for each socket
 type.
 
+NOTE: 0MQ does not guarantee that the socket will be able to queue as many as ZMQ_RCVHWM
+messages, and the actual limit may be lower or higher, depending on socket transport.
+A notable example is for sockets using TCP transport; see linkzmq:zmq_tcp[7].
+
 [horizontal]
 Option value type:: int
 Option value unit:: messages
@@ -854,11 +858,13 @@ If this limit has been reached the socket shall enter an exceptional state and
 depending on the socket type, 0MQ shall take appropriate action such as
 blocking or dropping sent messages. Refer to the individual socket descriptions
 in linkzmq:zmq_socket[3] for details on the exact action taken for each socket
-type.
+type. 
 
 NOTE: 0MQ does not guarantee that the socket will accept as many as ZMQ_SNDHWM
 messages, and the actual limit may be as much as 90% lower depending on the
-flow of messages on the socket.
+flow of messages on the socket. The socket may even be able to accept more messages
+than the ZMQ_SNDHWM threshold; a notable example is for sockets using TCP transport;
+see linkzmq:zmq_tcp[7].
 
 [horizontal]
 Option value type:: int

--- a/doc/zmq_tcp.txt
+++ b/doc/zmq_tcp.txt
@@ -69,6 +69,30 @@ A 'peer address' may be specified by either of the following:
 Note: A description of the ZeroMQ Message Transport Protocol (ZMTP) which is 
 used by the TCP transport can be found at <http://rfc.zeromq.org/spec:15>
 
+
+HWM
+---
+
+For the TCP transport, the high water mark (HWM) mechanism works in conjunction
+with the TCP socket buffers handled at OS level.
+Depending on the OS and several other factors the size of such TCP buffers will
+be different. Moreover TCP buffers provided by the OS will accomodate a varying
+number of messages depending on the size of messages (unlike ZMQ HWM settings
+the TCP socket buffers are measured in bytes and not messages).
+
+This may result in apparently inexplicable behaviors: e.g., you may expect that
+setting ZMQ_SNDHWM to 100 on a socket using TCP transport will have the effect
+of blocking the transmission of the 101-th message if the receiver is slow.
+This is very unlikely when using TCP transport since OS TCP buffers will typically
+provide enough buffering to allow you sending much more than 100 messages.
+
+Of course if the receiver is slow, transmitting on a TCP ZMQ socket will eventually trigger
+the "mute state" of the socket; simply don't rely on the exact HWM value.
+
+Obviously the same considerations apply for the receive HWM (see ZMQ_RCVHWM).
+
+
+
 EXAMPLES
 --------
 .Assigning a local address to a socket

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ if(NOT WIN32)
           test_rebind_ipc
           test_reqrep_ipc
           test_proxy
+          test_proxy_hwm
           test_proxy_single_socket
           test_proxy_terminate
           test_getsockopt_memset

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -221,7 +221,9 @@ void test_defaults_1000 ()
 
     TEST_ASSERT_EQUAL_INT (1000, test_defaults (1000, 1000, "tcp://127.0.0.1:*"));
     TEST_ASSERT_EQUAL_INT (1000, test_defaults (1000, 1000, "inproc://a"));
+#ifndef ZMQ_HAVE_WINDOWS
     TEST_ASSERT_EQUAL_INT (1000, test_defaults (1000, 1000, "ipc://@tmp-tester"));
+#endif
 }
 
 void test_defaults_100 ()
@@ -231,7 +233,9 @@ void test_defaults_100 ()
 
     TEST_ASSERT_EQUAL_INT (100, test_defaults (100, 100, "tcp://127.0.0.1:*"));
     TEST_ASSERT_EQUAL_INT (100, test_defaults (100, 100, "inproc://a"));
+#ifndef ZMQ_HAVE_WINDOWS
     TEST_ASSERT_EQUAL_INT (100, test_defaults (100, 100, "ipc://@tmp-tester"));
+#endif
 }
 
 void test_blocking_2000 ()
@@ -241,7 +245,9 @@ void test_blocking_2000 ()
 
     TEST_ASSERT_EQUAL_INT (6000, test_blocking (2000, 6000, "tcp://127.0.0.1:*"));
     TEST_ASSERT_EQUAL_INT (6000, test_blocking (2000, 6000, "inproc://a"));
+#ifndef ZMQ_HAVE_WINDOWS
     TEST_ASSERT_EQUAL_INT (6000, test_blocking (2000, 6000, "ipc://@tmp-tester"));
+#endif
 }
 
 int main ()

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -46,11 +46,11 @@ int test_defaults (int send_hwm_, int msg_cnt_, const char* endpoint)
 {
     // Set up bind socket
     void *pub_socket = test_context_socket (ZMQ_PUB);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (pub_socket, ENDPOINT_0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (pub_socket, endpoint));
 
     // Set up connect socket
     void *sub_socket = test_context_socket (ZMQ_SUB);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub_socket, ENDPOINT_0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub_socket, endpoint));
 
     //set a hwm on publisher
     TEST_ASSERT_SUCCESS_ERRNO (

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -40,7 +40,7 @@ void tearDown ()
     teardown_test_context ();
 }
 
-int test_defaults (int send_hwm_, int msg_cnt_, const char* endpoint)
+int test_defaults (int send_hwm_, int msg_cnt_, const char *endpoint)
 {
     size_t len = MAX_SOCKET_STRING;
     char pub_endpoint[MAX_SOCKET_STRING];
@@ -61,7 +61,8 @@ int test_defaults (int send_hwm_, int msg_cnt_, const char* endpoint)
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (sub_socket, ZMQ_SUBSCRIBE, 0, 0));
 
-    msleep (SETTLE_TIME);    // give some time to background threads to perform PUB-SUB connection
+    msleep (
+      SETTLE_TIME); // give some time to background threads to perform PUB-SUB connection
 
     // Send until we reach "mute" state
     int send_count = 0;
@@ -99,7 +100,7 @@ int receive (void *socket_)
     return recv_count;
 }
 
-int test_blocking (int send_hwm_, int msg_cnt_, const char* endpoint)
+int test_blocking (int send_hwm_, int msg_cnt_, const char *endpoint)
 {
     size_t len = MAX_SOCKET_STRING;
     char pub_endpoint[MAX_SOCKET_STRING];
@@ -121,8 +122,8 @@ int test_blocking (int send_hwm_, int msg_cnt_, const char* endpoint)
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (pub_socket, ZMQ_XPUB_NODROP, &wait, sizeof (wait)));
     int timeout_ms = 10;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_setsockopt (sub_socket, ZMQ_RCVTIMEO, &timeout_ms, sizeof (timeout_ms)));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      sub_socket, ZMQ_RCVTIMEO, &timeout_ms, sizeof (timeout_ms)));
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (sub_socket, ZMQ_SUBSCRIBE, 0, 0));
 
@@ -142,7 +143,7 @@ int test_blocking (int send_hwm_, int msg_cnt_, const char* endpoint)
         }
     }
 
-    msleep (2*SETTLE_TIME);		// required for TCP transport
+    msleep (2 * SETTLE_TIME); // required for TCP transport
     recv_count += receive (sub_socket);
     TEST_ASSERT_EQUAL_INT (send_count, recv_count);
 
@@ -220,13 +221,15 @@ void test_reset_hwm ()
 void test_tcp ()
 {
     // send 1000 msg on hwm 1000, receive 1000, on TCP transport
-    TEST_ASSERT_EQUAL_INT (1000, test_defaults (1000, 1000, "tcp://127.0.0.1:*"));
+    TEST_ASSERT_EQUAL_INT (1000,
+                           test_defaults (1000, 1000, "tcp://127.0.0.1:*"));
 
     // send 100 msg on hwm 100, receive 100
     TEST_ASSERT_EQUAL_INT (100, test_defaults (100, 100, "tcp://127.0.0.1:*"));
 
     // send 6000 msg on hwm 2000, drops above hwm, only receive hwm:
-    TEST_ASSERT_EQUAL_INT (6000, test_blocking (2000, 6000, "tcp://127.0.0.1:*"));
+    TEST_ASSERT_EQUAL_INT (6000,
+                           test_blocking (2000, 6000, "tcp://127.0.0.1:*"));
 }
 
 void test_inproc ()

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -30,6 +30,8 @@
 #include "testutil.hpp"
 #include "testutil_unity.hpp"
 
+#define SOCKET_STRING_LEN (MAX_SOCKET_STRING * 4)
+
 void setUp ()
 {
     setup_test_context ();
@@ -42,8 +44,8 @@ void tearDown ()
 
 int test_defaults (int send_hwm_, int msg_cnt_, const char *endpoint)
 {
-    size_t len = MAX_SOCKET_STRING*4;
-    char pub_endpoint[MAX_SOCKET_STRING*4];
+    size_t len = SOCKET_STRING_LEN;
+    char pub_endpoint[SOCKET_STRING_LEN];
 
     // Set up and bind PUB socket
     void *pub_socket = test_context_socket (ZMQ_PUB);
@@ -102,8 +104,8 @@ int receive (void *socket_)
 
 int test_blocking (int send_hwm_, int msg_cnt_, const char *endpoint)
 {
-    size_t len = MAX_SOCKET_STRING*4;
-    char pub_endpoint[MAX_SOCKET_STRING*4];
+    size_t len = SOCKET_STRING_LEN;
+    char pub_endpoint[SOCKET_STRING_LEN];
 
     // Set up bind socket
     void *pub_socket = test_context_socket (ZMQ_PUB);
@@ -161,7 +163,7 @@ void test_reset_hwm ()
     const int first_count = 9999;
     const int second_count = 1100;
     int hwm = 11024;
-    char my_endpoint[MAX_SOCKET_STRING*4];
+    char my_endpoint[SOCKET_STRING_LEN];
 
     // Set up bind socket
     void *pub_socket = test_context_socket (ZMQ_PUB);

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -133,15 +133,15 @@ int test_blocking (int send_hwm_, int msg_cnt_, const char* endpoint)
         if (rc == 0) {
             ++send_count;
         } else if (-1 == rc) {
-            msleep (SETTLE_TIME/10);		// required for TCP transport
+            // if the PUB socket blocks due to HWM, errno should be EAGAIN:
             TEST_ASSERT_EQUAL_INT (EAGAIN, errno);
             recv_count += receive (sub_socket);
-            TEST_ASSERT_EQUAL_INT (send_count, recv_count);
         }
     }
 
     msleep (SETTLE_TIME);		// required for TCP transport
     recv_count += receive (sub_socket);
+    TEST_ASSERT_EQUAL_INT (send_count, recv_count);
 
     // Clean up
     test_context_socket_close (sub_socket);

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -66,7 +66,7 @@ int test_defaults (int send_hwm_, int msg_cnt_, const char* endpoint)
     // Send until we reach "mute" state
     int send_count = 0;
     while (send_count < msg_cnt_
-           && zmq_send (pub_socket, NULL, 0, ZMQ_DONTWAIT) == 0)
+           && zmq_send (pub_socket, "test message", 13, ZMQ_DONTWAIT) == 13)
         ++send_count;
 
     TEST_ASSERT_EQUAL_INT (send_hwm_, send_count);
@@ -74,7 +74,8 @@ int test_defaults (int send_hwm_, int msg_cnt_, const char* endpoint)
 
     // Now receive all sent messages
     int recv_count = 0;
-    while (0 == zmq_recv (sub_socket, NULL, 0, ZMQ_DONTWAIT)) {
+    char dummybuff[64];
+    while (13 == zmq_recv (sub_socket, &dummybuff, 64, ZMQ_DONTWAIT)) {
         ++recv_count;
     }
 

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -42,8 +42,8 @@ void tearDown ()
 
 int test_defaults (int send_hwm_, int msg_cnt_, const char *endpoint)
 {
-    size_t len = MAX_SOCKET_STRING;
-    char pub_endpoint[MAX_SOCKET_STRING];
+    size_t len = MAX_SOCKET_STRING*4;
+    char pub_endpoint[MAX_SOCKET_STRING*4];
 
     // Set up and bind PUB socket
     void *pub_socket = test_context_socket (ZMQ_PUB);
@@ -102,8 +102,8 @@ int receive (void *socket_)
 
 int test_blocking (int send_hwm_, int msg_cnt_, const char *endpoint)
 {
-    size_t len = MAX_SOCKET_STRING;
-    char pub_endpoint[MAX_SOCKET_STRING];
+    size_t len = MAX_SOCKET_STRING*4;
+    char pub_endpoint[MAX_SOCKET_STRING*4];
 
     // Set up bind socket
     void *pub_socket = test_context_socket (ZMQ_PUB);
@@ -161,7 +161,7 @@ void test_reset_hwm ()
     const int first_count = 9999;
     const int second_count = 1100;
     int hwm = 11024;
-    char my_endpoint[MAX_SOCKET_STRING];
+    char my_endpoint[MAX_SOCKET_STRING*4];
 
     // Set up bind socket
     void *pub_socket = test_context_socket (ZMQ_PUB);

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -92,7 +92,7 @@ int receive (void *socket_)
 {
     int recv_count = 0;
     // Now receive all sent messages
-    while (0 == zmq_recv (socket_, NULL, 0, ZMQ_DONTWAIT)) {
+    while (0 == zmq_recv (socket_, NULL, 0, 0)) {
         ++recv_count;
     }
 
@@ -120,6 +120,9 @@ int test_blocking (int send_hwm_, int msg_cnt_, const char* endpoint)
     int wait = 1;
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (pub_socket, ZMQ_XPUB_NODROP, &wait, sizeof (wait)));
+    int timeout_ms = 10;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (sub_socket, ZMQ_RCVTIMEO, &timeout_ms, sizeof (timeout_ms)));
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (sub_socket, ZMQ_SUBSCRIBE, 0, 0));
 
@@ -139,7 +142,7 @@ int test_blocking (int send_hwm_, int msg_cnt_, const char* endpoint)
         }
     }
 
-    msleep (SETTLE_TIME);		// required for TCP transport
+    msleep (2*SETTLE_TIME);		// required for TCP transport
     recv_count += receive (sub_socket);
     TEST_ASSERT_EQUAL_INT (send_count, recv_count);
 
@@ -237,9 +240,9 @@ void test_inproc ()
 
 void test_ipc ()
 {
-    TEST_ASSERT_EQUAL_INT (1000, test_defaults (1000, 1000, "ipc://@tmp-tester1"));
-    TEST_ASSERT_EQUAL_INT (100, test_defaults (100, 100, "ipc://@tmp-tester2"));
-    TEST_ASSERT_EQUAL_INT (6000, test_blocking (2000, 6000, "ipc://@tmp-tester3"));
+    TEST_ASSERT_EQUAL_INT (1000, test_defaults (1000, 1000, "ipc://*"));
+    TEST_ASSERT_EQUAL_INT (100, test_defaults (100, 100, "ipc://*"));
+    TEST_ASSERT_EQUAL_INT (6000, test_blocking (2000, 6000, "ipc://*"));
 }
 
 #endif

--- a/tests/test_proxy_hwm.cpp
+++ b/tests/test_proxy_hwm.cpp
@@ -1,0 +1,420 @@
+/*
+    Copyright (c) 2007-2017 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+
+#include <unity.h>
+
+
+// Asynchronous proxy test using ZMQ_XPUB_NODROP and HWM
+
+#define HWM					50
+#define NUM_MSGS			10000
+#define NUM_BYTES_PER_MSG	10
+#define UNIT_TEST_LOG(...)			do { printf(__VA_ARGS__); printf("\n"); } while(0)
+
+typedef struct
+{
+	void* context;
+	const char* frontend_endpoint;
+	const char* backend_endpoint;
+	const char* control_endpoint;
+
+	bool subscriber_received_all;
+} proxy_hwm_cfg_t;
+
+
+
+
+static void lower_hwm(void* skt)
+{
+	int send_hwm_ = HWM;
+	TEST_ASSERT_SUCCESS_ERRNO (
+	  zmq_setsockopt (skt, ZMQ_SNDHWM, &send_hwm_, sizeof (send_hwm_)));
+
+	TEST_ASSERT_SUCCESS_ERRNO (
+	  zmq_setsockopt (skt, ZMQ_RCVHWM, &send_hwm_, sizeof (send_hwm_)));
+}
+
+
+static
+void publisher_thread_main(void* pvoid)
+{
+	UNIT_TEST_LOG("publisher_thread_main started");
+	proxy_hwm_cfg_t* cfg = (proxy_hwm_cfg_t*)pvoid;
+
+	void* pubsocket = zmq_socket(cfg->context, ZMQ_PUB);
+	assert(pubsocket);
+
+	lower_hwm(pubsocket);
+
+	UNIT_TEST_LOG("publisher_thread_main connecting to endpoint %s", cfg->frontend_endpoint);
+	int rc = zmq_connect(pubsocket, cfg->frontend_endpoint);
+	assert (rc==0);
+
+	int optval = 1;
+	rc = zmq_setsockopt(pubsocket, ZMQ_XPUB_NODROP, &optval, sizeof(optval));
+	assert( rc == 0 );
+
+
+	//UNIT_TEST_LOG("publisher_thread_main waiting for the barrier");
+	//pthread_barrier_wait(&cfg->unit_test_barrier);
+	//UNIT_TEST_LOG("publisher_thread_main completed waiting for the barrier");
+
+	UNIT_TEST_LOG("publisher_thread_main waiting %dmsec to allow subscribers to REALLY connect", SETTLE_TIME);
+	msleep (SETTLE_TIME);
+	msleep (10*SETTLE_TIME);
+
+	uint64_t txfailed = 0;
+	for (uint64_t i = 0 ; i < NUM_MSGS ; ++i)
+	{
+		zmq_msg_t msg;
+		int rc = zmq_msg_init_size (&msg, NUM_BYTES_PER_MSG);
+		assert (rc == 0);
+
+		/* Fill in message content with 'AAAAAA' */
+		memset (zmq_msg_data (&msg), 'A', NUM_BYTES_PER_MSG);
+
+		/* Send the message to the socket */
+		rc = zmq_msg_send(&msg, pubsocket, 0);
+		//assert (rc == 0);
+		if (rc != -1)
+		{
+			UNIT_TEST_LOG(" ** publisher_thread_main sent successfully pkt #%zu, %d bytes sent, total failed %lu", i, rc, txfailed);
+		}
+		else
+		{
+			UNIT_TEST_LOG(" ** publisher_thread_main failed sending pkt #%zu with errno=%d", i, zmq_errno());
+			txfailed++;
+		}
+	}
+
+	// VERIFY EXPECTED RESULTS
+
+	UNIT_TEST_LOG("publisher_thread_main sent %lu packets successfully; %lu packets TX failed.",
+			NUM_MSGS-txfailed, txfailed );
+	assert( txfailed == 0 );
+
+
+	// CLEANUP
+
+	zmq_close( pubsocket );
+	UNIT_TEST_LOG("publisher_thread_main exiting");
+}
+
+static
+void subscriber_thread_main(void* pvoid)
+{
+	UNIT_TEST_LOG("subscriber_thread_main started");
+	proxy_hwm_cfg_t* cfg = (proxy_hwm_cfg_t*)pvoid;
+
+	void* subsocket = zmq_socket(cfg->context, ZMQ_SUB);
+	assert(subsocket);
+
+	lower_hwm(subsocket);
+
+	TEST_ASSERT_SUCCESS_ERRNO (
+	  zmq_setsockopt (subsocket, ZMQ_SUBSCRIBE, 0, 0));
+
+	UNIT_TEST_LOG("subscriber_thread_main connecting to endpoint %s", cfg->backend_endpoint);
+	TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (subsocket, cfg->backend_endpoint));
+
+
+	//UNIT_TEST_LOG("subscriber_thread_main waiting for the barrier");
+	//pthread_barrier_wait(&cfg->unit_test_barrier);
+	//UNIT_TEST_LOG("subscriber_thread_main completed waiting for the barrier");
+
+	// receive all sent messages
+	uint64_t rxfailed = 0, rxsuccess = 0;
+	bool success = true;
+	while (success)
+	{
+		zmq_msg_t msg;
+		int rc = zmq_msg_init(&msg);
+		assert (rc == 0);
+
+		rc = zmq_msg_recv(&msg, subsocket, 0);//ZMQ_DONTWAIT);
+		if (rc != -1)
+		{
+			UNIT_TEST_LOG(" ** received %lu pkts, total failed %lu", rxsuccess, rxfailed);
+			rxsuccess++;
+		}
+		else
+		{
+			UNIT_TEST_LOG(" ** failed receiving... total failed %lu", rxfailed);
+			rxfailed++;
+		}
+
+		sleep(1);
+	}
+
+
+	// VERIFY EXPECTED RESULTS
+
+	UNIT_TEST_LOG("subscriber_thread_main received %lu packets successfully; %lu packets RX failed.",
+			rxsuccess, rxfailed );
+	assert( rxfailed == 1 );
+
+
+	// INFORM THAT WE COMPLETED:
+
+	cfg->subscriber_received_all = true;
+
+
+	// CLEANUP
+
+	zmq_close(subsocket);
+
+	UNIT_TEST_LOG("subscriber_thread_main exiting");
+}
+
+uint64_t recv_stat (void *sock_, bool last_)
+{
+    uint64_t res;
+    zmq_msg_t stats_msg;
+
+    int rc = zmq_msg_init (&stats_msg);
+    assert (rc == 0);
+    rc = zmq_recvmsg (sock_, &stats_msg, 0);
+    assert (rc == sizeof (uint64_t));
+    memcpy (&res, zmq_msg_data (&stats_msg), zmq_msg_size (&stats_msg));
+    rc = zmq_msg_close (&stats_msg);
+    assert (rc == 0);
+
+    int more;
+    size_t moresz = sizeof more;
+    rc = zmq_getsockopt (sock_, ZMQ_RCVMORE, &more, &moresz);
+    assert (rc == 0);
+    assert ((last_ && !more) || (!last_ && more));
+
+    return res;
+}
+
+// Utility function to interrogate the proxy:
+
+typedef struct
+{
+    uint64_t msg_in;
+    uint64_t bytes_in;
+    uint64_t msg_out;
+    uint64_t bytes_out;
+} zmq_socket_stats_t;
+
+typedef struct
+{
+    zmq_socket_stats_t frontend;
+    zmq_socket_stats_t backend;
+} zmq_proxy_stats_t;
+
+void check_proxy_stats (void *control_proxy_)
+{
+    zmq_proxy_stats_t total_stats;
+    int rc;
+
+    rc = zmq_send (control_proxy_, "STATISTICS", 10, 0);
+    assert (rc == 10);
+
+    // first frame of the reply contains FRONTEND stats:
+    total_stats.frontend.msg_in = recv_stat (control_proxy_, false);
+    total_stats.frontend.bytes_in = recv_stat (control_proxy_, false);
+    total_stats.frontend.msg_out = recv_stat (control_proxy_, false);
+    total_stats.frontend.bytes_out = recv_stat (control_proxy_, false);
+
+    // second frame of the reply contains BACKEND stats:
+    total_stats.backend.msg_in = recv_stat (control_proxy_, false);
+    total_stats.backend.bytes_in = recv_stat (control_proxy_, false);
+    total_stats.backend.msg_out = recv_stat (control_proxy_, false);
+    total_stats.backend.bytes_out = recv_stat (control_proxy_, true);
+
+    // check stats
+
+    if (true) {//is_verbose) {
+        printf (
+          "frontend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
+          (unsigned long int) total_stats.frontend.msg_in,
+          (unsigned long int) total_stats.frontend.bytes_in,
+          (unsigned long int) total_stats.frontend.msg_out,
+          (unsigned long int) total_stats.frontend.bytes_out);
+        printf (
+          "backend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
+          (unsigned long int) total_stats.backend.msg_in,
+          (unsigned long int) total_stats.backend.bytes_in,
+          (unsigned long int) total_stats.backend.msg_out,
+          (unsigned long int) total_stats.backend.bytes_out);
+    }
+}
+
+static
+void proxy_stats_asker_thread_main(void* pvoid)
+{
+	UNIT_TEST_LOG("proxy_stats_asker_thread_main started");
+	proxy_hwm_cfg_t* cfg = (proxy_hwm_cfg_t*)pvoid;
+
+
+	// CONTROL REQ
+
+	void* control_req = zmq_socket(cfg->context, ZMQ_REQ);			// this one can be used to send command to the proxy
+	assert(control_req);
+
+	// connect CONTROL-REQ: a socket to which send commands
+	UNIT_TEST_LOG("proxy_stats_asker_thread_main connecting to endpoint %s", cfg->control_endpoint);
+	int rc = zmq_connect(control_req, cfg->control_endpoint);
+	assert( rc == 0 );
+
+	//UNIT_TEST_LOG("proxy_stats_asker_thread_main waiting for the barrier");
+	//pthread_barrier_wait(&cfg->unit_test_barrier);
+	//UNIT_TEST_LOG("proxy_stats_asker_thread_main completed waiting for the barrier");
+
+	// Start!
+
+	unsigned int nupdates = 0;
+	while (!cfg->subscriber_received_all)
+	{
+		//usleep(1000);
+		sleep(3);
+
+		check_proxy_stats(control_req);
+		nupdates++;
+		if ((nupdates%10000) == 0)
+		{
+			UNIT_TEST_LOG("proxy_stats_asker_thread_main completed update %d from proxy", nupdates);
+		}
+	}
+
+	UNIT_TEST_LOG("proxy_stats_asker_thread_main exiting");
+}
+
+static
+void proxy_thread_main(void* pvoid)
+{
+	UNIT_TEST_LOG("proxy_thread_main started");
+	proxy_hwm_cfg_t* cfg = (proxy_hwm_cfg_t*)pvoid;
+	int rc;
+
+
+	// FRONTEND SUB
+
+	void* frontend_xsub = zmq_socket(cfg->context, ZMQ_XSUB);		// the frontend is the one exposed to internal threads (INPROC)
+	assert(frontend_xsub);
+
+	lower_hwm(frontend_xsub);
+
+	// bind FRONTEND
+	rc = zmq_bind(frontend_xsub, cfg->frontend_endpoint);
+	assert( rc == 0 );
+
+
+
+	// BACKEND PUB
+
+	void* backend_xpub = zmq_socket(cfg->context, ZMQ_XPUB);			// the backend is the one exposed to the external world (TCP)
+	assert(backend_xpub);
+
+	int optval = 1;
+	rc = zmq_setsockopt(backend_xpub, ZMQ_XPUB_NODROP, &optval, sizeof(optval));
+	assert( rc == 0 );
+
+	lower_hwm(backend_xpub);
+
+	// bind BACKEND
+	rc = zmq_bind(backend_xpub, cfg->backend_endpoint);
+	assert( rc == 0 );
+
+
+	// CONTROL REP
+
+	void* control_rep = zmq_socket(cfg->context, ZMQ_REP);			// this one is used by the proxy to receive&reply to commands
+	assert(control_rep);
+
+	// bind CONTROL
+	rc = zmq_bind(control_rep, cfg->control_endpoint);
+	assert( rc == 0 );
+
+
+
+	// start proxying!
+
+	UNIT_TEST_LOG("proxy_thread_main starting proxy on frontend=%s, backend=%s, ctrl=%s",
+				cfg->frontend_endpoint, cfg->backend_endpoint, cfg->control_endpoint);
+
+	zmq_proxy_steerable(frontend_xsub,
+						backend_xpub,
+						NULL,
+						control_rep);
+
+	UNIT_TEST_LOG("proxy_thread_main exiting");
+}
+
+
+// The main thread simply starts several clients and a server, and then
+// waits for the server to finish.
+
+int main (void)
+{
+	setup_test_environment ();
+
+	void *context = zmq_ctx_new ();
+	assert (context);
+
+
+
+	// START ALL SECONDARY THREADS
+
+	proxy_hwm_cfg_t cfg;
+	cfg.context = context;
+	cfg.frontend_endpoint = "inproc://frontend";
+	cfg.backend_endpoint = ENDPOINT_0;//cfg.backend_endpoint = "tcp://127.0.0.1:8000";
+	cfg.control_endpoint = "inproc://ctrl";
+	cfg.subscriber_received_all = false;
+
+	void* proxy = zmq_threadstart(&proxy_thread_main, (void*) &cfg);
+	assert(proxy != 0);
+	void* server = zmq_threadstart(&publisher_thread_main, (void*) &cfg);
+	assert(server != 0);
+	void* client = zmq_threadstart(&subscriber_thread_main, (void*) &cfg);
+	assert(client != 0);
+	void* asker = zmq_threadstart(&proxy_stats_asker_thread_main, (void*) &cfg);
+	assert(asker != 0);
+
+
+	// CLEANUP
+
+	UNIT_TEST_LOG("main waiting for all threads to join");
+
+	zmq_threadclose (server);
+	zmq_threadclose (client);
+	zmq_threadclose (asker);
+	zmq_threadclose (proxy);
+
+	int rc = zmq_ctx_term (context);
+	assert (rc == 0);
+
+	return 0;
+}

--- a/tests/test_proxy_hwm.cpp
+++ b/tests/test_proxy_hwm.cpp
@@ -54,209 +54,207 @@
 //
 
 
-#define HWM							10
-#define NUM_BYTES_PER_MSG			50000
+#define HWM 10
+#define NUM_BYTES_PER_MSG 50000
 
-#if 0	// enable for debugging this test
-#define UNIT_TEST_LOG(...)			do { printf(__VA_ARGS__); printf("\n"); } while(0)
+#if 0 // enable for debugging this test
+#define UNIT_TEST_LOG(...)                                                     \
+    do {                                                                       \
+        printf (__VA_ARGS__);                                                  \
+        printf ("\n");                                                         \
+    } while (0)
 #else
-#define UNIT_TEST_LOG(...)			/* empty */
+#define UNIT_TEST_LOG(...) /* empty */
 #endif
 
 typedef struct
 {
-	void* context;
-	const char* frontend_endpoint;
-	const char* backend_endpoint;
-	const char* control_endpoint;
+    void *context;
+    const char *frontend_endpoint;
+    const char *backend_endpoint;
+    const char *control_endpoint;
 
-	bool subscriber_received_all;
+    bool subscriber_received_all;
 } proxy_hwm_cfg_t;
 
-static
-void lower_tcp_buff(void* sock_)
+static void lower_tcp_buff (void *sock_)
 {
-	int sndBuff;
-	size_t sndBuffSz = sizeof sndBuff;
-	int rc = zmq_getsockopt (sock_, ZMQ_SNDBUF, &sndBuff, &sndBuffSz);
-	assert (rc == 0);
-	UNIT_TEST_LOG("lower_tcp_buff current TCP buffer size = %d", sndBuff);
+    int sndBuff;
+    size_t sndBuffSz = sizeof sndBuff;
+    int rc = zmq_getsockopt (sock_, ZMQ_SNDBUF, &sndBuff, &sndBuffSz);
+    assert (rc == 0);
+    UNIT_TEST_LOG ("lower_tcp_buff current TCP buffer size = %d", sndBuff);
 
-	int newBuff = 1000;
-	TEST_ASSERT_SUCCESS_ERRNO (
-	  zmq_setsockopt (sock_, ZMQ_SNDBUF, &newBuff, sizeof (newBuff)));
+    int newBuff = 1000;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (sock_, ZMQ_SNDBUF, &newBuff, sizeof (newBuff)));
 
-	rc = zmq_getsockopt (sock_, ZMQ_SNDBUF, &sndBuff, &sndBuffSz);
-	assert (rc == 0);
-	UNIT_TEST_LOG("lower_tcp_buff new TCP buffer size = %d", sndBuff);
+    rc = zmq_getsockopt (sock_, ZMQ_SNDBUF, &sndBuff, &sndBuffSz);
+    assert (rc == 0);
+    UNIT_TEST_LOG ("lower_tcp_buff new TCP buffer size = %d", sndBuff);
 }
 
-static
-void lower_hwm(void* skt)
+static void lower_hwm (void *skt)
 {
-	int send_hwm_ = HWM;
-	TEST_ASSERT_SUCCESS_ERRNO (
-	  zmq_setsockopt (skt, ZMQ_SNDHWM, &send_hwm_, sizeof (send_hwm_)));
+    int send_hwm_ = HWM;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (skt, ZMQ_SNDHWM, &send_hwm_, sizeof (send_hwm_)));
 
-	TEST_ASSERT_SUCCESS_ERRNO (
-	  zmq_setsockopt (skt, ZMQ_RCVHWM, &send_hwm_, sizeof (send_hwm_)));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (skt, ZMQ_RCVHWM, &send_hwm_, sizeof (send_hwm_)));
 }
 
-static
-void publisher_thread_main(void* pvoid)
+static void publisher_thread_main (void *pvoid)
 {
-	UNIT_TEST_LOG("publisher_thread_main started");
-	proxy_hwm_cfg_t* cfg = (proxy_hwm_cfg_t*)pvoid;
+    UNIT_TEST_LOG ("publisher_thread_main started");
+    proxy_hwm_cfg_t *cfg = (proxy_hwm_cfg_t *) pvoid;
 
-	void* pubsocket = zmq_socket(cfg->context, ZMQ_PUB);
-	assert(pubsocket);
+    void *pubsocket = zmq_socket (cfg->context, ZMQ_PUB);
+    assert (pubsocket);
 
-	lower_hwm(pubsocket);
+    lower_hwm (pubsocket);
 
-	UNIT_TEST_LOG("publisher_thread_main connecting to endpoint %s", cfg->frontend_endpoint);
-	TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (pubsocket, cfg->frontend_endpoint));
+    UNIT_TEST_LOG ("publisher_thread_main connecting to endpoint %s",
+                   cfg->frontend_endpoint);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (pubsocket, cfg->frontend_endpoint));
 
-	int optval = 1;
-	TEST_ASSERT_SUCCESS_ERRNO (
-	  zmq_setsockopt (pubsocket, ZMQ_XPUB_NODROP, &optval, sizeof (optval)));
+    int optval = 1;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (pubsocket, ZMQ_XPUB_NODROP, &optval, sizeof (optval)));
 
-	UNIT_TEST_LOG("publisher_thread_main waiting %dmsec to allow subscribers to REALLY connect", SETTLE_TIME);
-	msleep (SETTLE_TIME);
+    UNIT_TEST_LOG ("publisher_thread_main waiting %dmsec to allow subscribers "
+                   "to REALLY connect",
+                   SETTLE_TIME);
+    msleep (SETTLE_TIME);
 
-	uint64_t send_count = 0;
-	while (true)
-	{
-		zmq_msg_t msg;
-		int rc = zmq_msg_init_size (&msg, NUM_BYTES_PER_MSG);
-		assert (rc == 0);
+    uint64_t send_count = 0;
+    while (true) {
+        zmq_msg_t msg;
+        int rc = zmq_msg_init_size (&msg, NUM_BYTES_PER_MSG);
+        assert (rc == 0);
 
-		/* Fill in message content with 'AAAAAA' */
-		memset (zmq_msg_data (&msg), 'A', NUM_BYTES_PER_MSG);
+        /* Fill in message content with 'AAAAAA' */
+        memset (zmq_msg_data (&msg), 'A', NUM_BYTES_PER_MSG);
 
-		/* Send the message to the socket */
-		rc = zmq_msg_send(&msg, pubsocket, ZMQ_DONTWAIT);
-		if (rc != -1)
-		{
-			UNIT_TEST_LOG(" ** publisher_thread_main sent successfully %d bytes sent, total sent %lu", rc, send_count);
-			send_count++;
-		}
-		else
-		{
-			UNIT_TEST_LOG(" ** publisher_thread_main failed sending pkt with errno=%d", zmq_errno());
-			break;
-		}
-	}
+        /* Send the message to the socket */
+        rc = zmq_msg_send (&msg, pubsocket, ZMQ_DONTWAIT);
+        if (rc != -1) {
+            UNIT_TEST_LOG (" ** publisher_thread_main sent successfully %d "
+                           "bytes sent, total sent %lu",
+                           rc, send_count);
+            send_count++;
+        } else {
+            UNIT_TEST_LOG (
+              " ** publisher_thread_main failed sending pkt with errno=%d",
+              zmq_errno ());
+            break;
+        }
+    }
 
-	// VERIFY EXPECTED RESULTS
+    // VERIFY EXPECTED RESULTS
 
-	UNIT_TEST_LOG("publisher_thread_main sent %lu packets successfully.", send_count);
-	TEST_ASSERT_EQUAL_INT( 2*HWM, send_count );
+    UNIT_TEST_LOG ("publisher_thread_main sent %lu packets successfully.",
+                   send_count);
+    TEST_ASSERT_EQUAL_INT (2 * HWM, send_count);
 
 
-	// CLEANUP
+    // CLEANUP
 
-	zmq_close( pubsocket );
-	UNIT_TEST_LOG("publisher_thread_main exiting");
+    zmq_close (pubsocket);
+    UNIT_TEST_LOG ("publisher_thread_main exiting");
 }
 
-static
-void subscriber_thread_main(void* pvoid)
+static void subscriber_thread_main (void *pvoid)
 {
-	UNIT_TEST_LOG("subscriber_thread_main started");
-	proxy_hwm_cfg_t* cfg = (proxy_hwm_cfg_t*)pvoid;
+    UNIT_TEST_LOG ("subscriber_thread_main started");
+    proxy_hwm_cfg_t *cfg = (proxy_hwm_cfg_t *) pvoid;
 
-	void* subsocket = zmq_socket(cfg->context, ZMQ_SUB);
-	assert(subsocket);
+    void *subsocket = zmq_socket (cfg->context, ZMQ_SUB);
+    assert (subsocket);
 
-	lower_hwm(subsocket);
+    lower_hwm (subsocket);
 
-	TEST_ASSERT_SUCCESS_ERRNO (
-	  zmq_setsockopt (subsocket, ZMQ_SUBSCRIBE, 0, 0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (subsocket, ZMQ_SUBSCRIBE, 0, 0));
 
-	UNIT_TEST_LOG("subscriber_thread_main connecting to endpoint %s", cfg->backend_endpoint);
-	TEST_ASSERT_SUCCESS_ERRNO (
-	  zmq_connect (subsocket, cfg->backend_endpoint));
+    UNIT_TEST_LOG ("subscriber_thread_main connecting to endpoint %s",
+                   cfg->backend_endpoint);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (subsocket, cfg->backend_endpoint));
 
-	lower_tcp_buff(subsocket);
+    lower_tcp_buff (subsocket);
 
-	// receive all sent messages
-	uint64_t rxsuccess = 0;
-	bool success = true;
-	while (success)
-	{
-		zmq_msg_t msg;
-		int rc = zmq_msg_init(&msg);
-		assert (rc == 0);
+    // receive all sent messages
+    uint64_t rxsuccess = 0;
+    bool success = true;
+    while (success) {
+        zmq_msg_t msg;
+        int rc = zmq_msg_init (&msg);
+        assert (rc == 0);
 
-		rc = zmq_msg_recv(&msg, subsocket, 0);
-		if (rc != -1)
-		{
-			UNIT_TEST_LOG(" ** received %lu pkts", rxsuccess);
-			rxsuccess++;
+        rc = zmq_msg_recv (&msg, subsocket, 0);
+        if (rc != -1) {
+            UNIT_TEST_LOG (" ** received %lu pkts", rxsuccess);
+            rxsuccess++;
 
-			// after receiving 1st message, set a finite timeout (default is infinite)
-			int timeout_ms = 100;
-			TEST_ASSERT_SUCCESS_ERRNO (
-			  zmq_setsockopt (subsocket, ZMQ_RCVTIMEO, &timeout_ms, sizeof(timeout_ms)));
-		}
-		else
-		{
-			UNIT_TEST_LOG(" ** failed receiving...  exiting");
-			break;
-		}
+            // after receiving 1st message, set a finite timeout (default is infinite)
+            int timeout_ms = 100;
+            TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+              subsocket, ZMQ_RCVTIMEO, &timeout_ms, sizeof (timeout_ms)));
+        } else {
+            UNIT_TEST_LOG (" ** failed receiving...  exiting");
+            break;
+        }
 
-		msleep(100);
-	}
+        msleep (100);
+    }
 
 
-	// VERIFY EXPECTED RESULTS
+    // VERIFY EXPECTED RESULTS
 
-	//UNIT_TEST_LOG("subscriber_thread_main received %lu packets successfully; %lu packets RX failed.",
-	//		rxsuccess, rxfailed );
-	//assert( rxsuccess == 1 );
-	TEST_ASSERT_EQUAL_INT( 2*HWM, rxsuccess );
-
-
-	// INFORM THAT WE COMPLETED:
-
-	cfg->subscriber_received_all = true;
+    //UNIT_TEST_LOG("subscriber_thread_main received %lu packets successfully; %lu packets RX failed.",
+    //		rxsuccess, rxfailed );
+    //assert( rxsuccess == 1 );
+    TEST_ASSERT_EQUAL_INT (2 * HWM, rxsuccess);
 
 
-	// CLEANUP
+    // INFORM THAT WE COMPLETED:
 
-	zmq_close(subsocket);
+    cfg->subscriber_received_all = true;
 
-	UNIT_TEST_LOG("subscriber_thread_main exiting");
+
+    // CLEANUP
+
+    zmq_close (subsocket);
+
+    UNIT_TEST_LOG ("subscriber_thread_main exiting");
 }
 
-bool recv_stat (void *sock_, bool last_, uint64_t* res)
+bool recv_stat (void *sock_, bool last_, uint64_t *res)
 {
-	zmq_msg_t stats_msg;
+    zmq_msg_t stats_msg;
 
-	int rc = zmq_msg_init (&stats_msg);
-	assert (rc == 0);
+    int rc = zmq_msg_init (&stats_msg);
+    assert (rc == 0);
 
-	rc = zmq_msg_recv (&stats_msg, sock_, 0); //ZMQ_DONTWAIT);
-	if (rc == -1 && errno == EAGAIN)
-	{
-		rc = zmq_msg_close (&stats_msg);
-		assert (rc == 0);
-		return false;				// cannot retrieve the stat
-	}
+    rc = zmq_msg_recv (&stats_msg, sock_, 0); //ZMQ_DONTWAIT);
+    if (rc == -1 && errno == EAGAIN) {
+        rc = zmq_msg_close (&stats_msg);
+        assert (rc == 0);
+        return false; // cannot retrieve the stat
+    }
 
-	assert (rc == sizeof (uint64_t));
-	memcpy (res, zmq_msg_data (&stats_msg), zmq_msg_size (&stats_msg));
+    assert (rc == sizeof (uint64_t));
+    memcpy (res, zmq_msg_data (&stats_msg), zmq_msg_size (&stats_msg));
 
-	rc = zmq_msg_close (&stats_msg);
-	assert (rc == 0);
+    rc = zmq_msg_close (&stats_msg);
+    assert (rc == 0);
 
-	int more;
-	size_t moresz = sizeof more;
-	rc = zmq_getsockopt (sock_, ZMQ_RCVMORE, &more, &moresz);
-	assert (rc == 0);
-	assert ((last_ && !more) || (!last_ && more));
+    int more;
+    size_t moresz = sizeof more;
+    rc = zmq_getsockopt (sock_, ZMQ_RCVMORE, &more, &moresz);
+    assert (rc == 0);
+    assert ((last_ && !more) || (!last_ && more));
 
-	return true;
+    return true;
 }
 
 // Utility function to interrogate the proxy:
@@ -277,183 +275,189 @@ typedef struct
 
 bool check_proxy_stats (void *control_proxy_)
 {
-	zmq_proxy_stats_t total_stats;
-	int rc;
+    zmq_proxy_stats_t total_stats;
+    int rc;
 
-	static unsigned int nupdates = 0, nsuccess = 0, nfailed = 0;
-	bool is_verbose = (((nupdates++)%1000) == 0);
+    static unsigned int nupdates = 0, nsuccess = 0, nfailed = 0;
+    bool is_verbose = (((nupdates++) % 1000) == 0);
 
-	if (is_verbose)
-		UNIT_TEST_LOG("asking update #%d from proxy (so far %d successful, %d failed):", nupdates, nsuccess, nfailed);
+    if (is_verbose)
+        UNIT_TEST_LOG (
+          "asking update #%d from proxy (so far %d successful, %d failed):",
+          nupdates, nsuccess, nfailed);
 
-	rc = zmq_send (control_proxy_, "STATISTICS", 10, ZMQ_DONTWAIT);
-	assert (rc == 10 ||
-			(rc == -1 && errno == EAGAIN));
-	if (rc == -1 && errno == EAGAIN)
-	{
-		nfailed++;
-		if (is_verbose) UNIT_TEST_LOG("    ...failed (TX)");
-		return false;
-	}
+    rc = zmq_send (control_proxy_, "STATISTICS", 10, ZMQ_DONTWAIT);
+    assert (rc == 10 || (rc == -1 && errno == EAGAIN));
+    if (rc == -1 && errno == EAGAIN) {
+        nfailed++;
+        if (is_verbose)
+            UNIT_TEST_LOG ("    ...failed (TX)");
+        return false;
+    }
 
-	// first frame of the reply contains FRONTEND stats:
-	if (!recv_stat( control_proxy_, false, &total_stats.frontend.msg_in ))
-	{
-		nfailed++;
-		if (is_verbose) UNIT_TEST_LOG("    ...failed (timedout)");
-		return false;
-	}
+    // first frame of the reply contains FRONTEND stats:
+    if (!recv_stat (control_proxy_, false, &total_stats.frontend.msg_in)) {
+        nfailed++;
+        if (is_verbose)
+            UNIT_TEST_LOG ("    ...failed (timedout)");
+        return false;
+    }
 
-	recv_stat( control_proxy_, false, &total_stats.frontend.bytes_in );
-	recv_stat( control_proxy_, false, &total_stats.frontend.msg_out );
-	recv_stat( control_proxy_, false, &total_stats.frontend.bytes_out );
+    recv_stat (control_proxy_, false, &total_stats.frontend.bytes_in);
+    recv_stat (control_proxy_, false, &total_stats.frontend.msg_out);
+    recv_stat (control_proxy_, false, &total_stats.frontend.bytes_out);
 
-	// second frame of the reply contains BACKEND stats:
-	recv_stat( control_proxy_, false, &total_stats.backend.msg_in );
-	recv_stat( control_proxy_, false, &total_stats.backend.bytes_in );
-	recv_stat( control_proxy_, false, &total_stats.backend.msg_out );
-	recv_stat( control_proxy_, true,  &total_stats.backend.bytes_out );
+    // second frame of the reply contains BACKEND stats:
+    recv_stat (control_proxy_, false, &total_stats.backend.msg_in);
+    recv_stat (control_proxy_, false, &total_stats.backend.bytes_in);
+    recv_stat (control_proxy_, false, &total_stats.backend.msg_out);
+    recv_stat (control_proxy_, true, &total_stats.backend.bytes_out);
 
-	// check stats
+    // check stats
 
-	if (is_verbose) {
-		UNIT_TEST_LOG (
-		  "frontend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
-		  (unsigned long int) total_stats.frontend.msg_in,
-		  (unsigned long int) total_stats.frontend.bytes_in,
-		  (unsigned long int) total_stats.frontend.msg_out,
-		  (unsigned long int) total_stats.frontend.bytes_out);
-		UNIT_TEST_LOG (
-		  "backend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
-		  (unsigned long int) total_stats.backend.msg_in,
-		  (unsigned long int) total_stats.backend.bytes_in,
-		  (unsigned long int) total_stats.backend.msg_out,
-		  (unsigned long int) total_stats.backend.bytes_out);
-	}
+    if (is_verbose) {
+        UNIT_TEST_LOG (
+          "frontend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
+          (unsigned long int) total_stats.frontend.msg_in,
+          (unsigned long int) total_stats.frontend.bytes_in,
+          (unsigned long int) total_stats.frontend.msg_out,
+          (unsigned long int) total_stats.frontend.bytes_out);
+        UNIT_TEST_LOG (
+          "backend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
+          (unsigned long int) total_stats.backend.msg_in,
+          (unsigned long int) total_stats.backend.bytes_in,
+          (unsigned long int) total_stats.backend.msg_out,
+          (unsigned long int) total_stats.backend.bytes_out);
+    }
 
-	nsuccess++;
-	return true;
+    nsuccess++;
+    return true;
 }
 
-static
-void proxy_stats_asker_thread_main(void* pvoid)
+static void proxy_stats_asker_thread_main (void *pvoid)
 {
-	UNIT_TEST_LOG("proxy_stats_asker_thread_main started");
-	proxy_hwm_cfg_t* cfg = (proxy_hwm_cfg_t*)pvoid;
+    UNIT_TEST_LOG ("proxy_stats_asker_thread_main started");
+    proxy_hwm_cfg_t *cfg = (proxy_hwm_cfg_t *) pvoid;
 
 
-	// CONTROL REQ
+    // CONTROL REQ
 
-	void* control_req = zmq_socket(cfg->context, ZMQ_REQ);			// this one can be used to send command to the proxy
-	assert(control_req);
+    void *control_req =
+      zmq_socket (cfg->context,
+                  ZMQ_REQ); // this one can be used to send command to the proxy
+    assert (control_req);
 
-	// connect CONTROL-REQ: a socket to which send commands
-	UNIT_TEST_LOG("proxy_stats_asker_thread_main connecting to endpoint %s", cfg->control_endpoint);
-	int rc = zmq_connect(control_req, cfg->control_endpoint);
-	assert( rc == 0 );
-
-
-	// IMPORTANT: by setting the tx/rx timeouts, we avoid getting blocked when interrogating a proxy which is
-	//            itself blocked in a zmq_msg_send() on its XPUB socket having ZMQ_XPUB_NODROP=1!
-
-	int optval = 10;
-	rc = zmq_setsockopt(control_req, ZMQ_SNDTIMEO, &optval, sizeof(optval));
-	assert( rc == 0 );
-	rc = zmq_setsockopt(control_req, ZMQ_RCVTIMEO, &optval, sizeof(optval));
-	assert( rc == 0 );
-
-	optval = 10;
-	rc = zmq_setsockopt(control_req, ZMQ_REQ_CORRELATE, &optval, sizeof(optval));
-	assert( rc == 0 );
-
-	rc = zmq_setsockopt(control_req, ZMQ_REQ_RELAXED, &optval, sizeof(optval));
-	assert( rc == 0 );
+    // connect CONTROL-REQ: a socket to which send commands
+    UNIT_TEST_LOG ("proxy_stats_asker_thread_main connecting to endpoint %s",
+                   cfg->control_endpoint);
+    int rc = zmq_connect (control_req, cfg->control_endpoint);
+    assert (rc == 0);
 
 
-	// Start!
+    // IMPORTANT: by setting the tx/rx timeouts, we avoid getting blocked when interrogating a proxy which is
+    //            itself blocked in a zmq_msg_send() on its XPUB socket having ZMQ_XPUB_NODROP=1!
 
-	while (!cfg->subscriber_received_all)
-	{
+    int optval = 10;
+    rc = zmq_setsockopt (control_req, ZMQ_SNDTIMEO, &optval, sizeof (optval));
+    assert (rc == 0);
+    rc = zmq_setsockopt (control_req, ZMQ_RCVTIMEO, &optval, sizeof (optval));
+    assert (rc == 0);
+
+    optval = 10;
+    rc =
+      zmq_setsockopt (control_req, ZMQ_REQ_CORRELATE, &optval, sizeof (optval));
+    assert (rc == 0);
+
+    rc =
+      zmq_setsockopt (control_req, ZMQ_REQ_RELAXED, &optval, sizeof (optval));
+    assert (rc == 0);
+
+
+    // Start!
+
+    while (!cfg->subscriber_received_all) {
 #ifdef ZMQ_BUILD_DRAFT_API
-		check_proxy_stats(control_req);
+        check_proxy_stats (control_req);
 #endif
-		usleep(1000);			// 1ms -> in best case we will get 1000updates/second
-	}
+        usleep (1000); // 1ms -> in best case we will get 1000updates/second
+    }
 
 
-	// Ask the proxy to exit: the subscriber has received all messages
+    // Ask the proxy to exit: the subscriber has received all messages
 
-	rc = zmq_send (control_req, "TERMINATE", 9, 0);
-	assert (rc == 9);
+    rc = zmq_send (control_req, "TERMINATE", 9, 0);
+    assert (rc == 9);
 
-	zmq_close( control_req );
+    zmq_close (control_req);
 
-	UNIT_TEST_LOG("proxy_stats_asker_thread_main exiting");
+    UNIT_TEST_LOG ("proxy_stats_asker_thread_main exiting");
 }
 
-static
-void proxy_thread_main(void* pvoid)
+static void proxy_thread_main (void *pvoid)
 {
-	UNIT_TEST_LOG("proxy_thread_main started");
-	proxy_hwm_cfg_t* cfg = (proxy_hwm_cfg_t*)pvoid;
-	int rc;
+    UNIT_TEST_LOG ("proxy_thread_main started");
+    proxy_hwm_cfg_t *cfg = (proxy_hwm_cfg_t *) pvoid;
+    int rc;
 
 
-	// FRONTEND SUB
+    // FRONTEND SUB
 
-	void* frontend_xsub = zmq_socket(cfg->context, ZMQ_XSUB);		// the frontend is the one exposed to internal threads (INPROC)
-	assert(frontend_xsub);
+    void *frontend_xsub = zmq_socket (
+      cfg->context,
+      ZMQ_XSUB); // the frontend is the one exposed to internal threads (INPROC)
+    assert (frontend_xsub);
 
-	lower_hwm(frontend_xsub);
+    lower_hwm (frontend_xsub);
 
-	// bind FRONTEND
-	rc = zmq_bind(frontend_xsub, cfg->frontend_endpoint);
-	assert( rc == 0 );
-
-
-
-	// BACKEND PUB
-
-	void* backend_xpub = zmq_socket(cfg->context, ZMQ_XPUB);			// the backend is the one exposed to the external world (TCP)
-	assert(backend_xpub);
-
-	int optval = 1;
-	rc = zmq_setsockopt(backend_xpub, ZMQ_XPUB_NODROP, &optval, sizeof(optval));
-	assert( rc == 0 );
-
-	lower_hwm(backend_xpub);
-
-	// bind BACKEND
-	rc = zmq_bind(backend_xpub, cfg->backend_endpoint);
-	assert( rc == 0 );
+    // bind FRONTEND
+    rc = zmq_bind (frontend_xsub, cfg->frontend_endpoint);
+    assert (rc == 0);
 
 
-	// CONTROL REP
+    // BACKEND PUB
 
-	void* control_rep = zmq_socket(cfg->context, ZMQ_REP);			// this one is used by the proxy to receive&reply to commands
-	assert(control_rep);
+    void *backend_xpub = zmq_socket (
+      cfg->context,
+      ZMQ_XPUB); // the backend is the one exposed to the external world (TCP)
+    assert (backend_xpub);
 
-	// bind CONTROL
-	rc = zmq_bind(control_rep, cfg->control_endpoint);
-	assert( rc == 0 );
+    int optval = 1;
+    rc =
+      zmq_setsockopt (backend_xpub, ZMQ_XPUB_NODROP, &optval, sizeof (optval));
+    assert (rc == 0);
+
+    lower_hwm (backend_xpub);
+
+    // bind BACKEND
+    rc = zmq_bind (backend_xpub, cfg->backend_endpoint);
+    assert (rc == 0);
 
 
+    // CONTROL REP
 
-	// start proxying!
+    void *control_rep = zmq_socket (
+      cfg->context,
+      ZMQ_REP); // this one is used by the proxy to receive&reply to commands
+    assert (control_rep);
 
-	UNIT_TEST_LOG("proxy_thread_main starting proxy on frontend=%s, backend=%s, ctrl=%s",
-				cfg->frontend_endpoint, cfg->backend_endpoint, cfg->control_endpoint);
+    // bind CONTROL
+    rc = zmq_bind (control_rep, cfg->control_endpoint);
+    assert (rc == 0);
 
-	zmq_proxy_steerable(frontend_xsub,
-						backend_xpub,
-						NULL,
-						control_rep);
 
-	zmq_close( frontend_xsub );
-	zmq_close( backend_xpub );
-	zmq_close( control_rep );
+    // start proxying!
 
-	UNIT_TEST_LOG("proxy_thread_main exiting");
+    UNIT_TEST_LOG (
+      "proxy_thread_main starting proxy on frontend=%s, backend=%s, ctrl=%s",
+      cfg->frontend_endpoint, cfg->backend_endpoint, cfg->control_endpoint);
+
+    zmq_proxy_steerable (frontend_xsub, backend_xpub, NULL, control_rep);
+
+    zmq_close (frontend_xsub);
+    zmq_close (backend_xpub);
+    zmq_close (control_rep);
+
+    UNIT_TEST_LOG ("proxy_thread_main exiting");
 }
 
 
@@ -462,43 +466,43 @@ void proxy_thread_main(void* pvoid)
 
 int main (void)
 {
-	setup_test_environment ();
+    setup_test_environment ();
 
-	void *context = zmq_ctx_new ();
-	assert (context);
-
-
-
-	// START ALL SECONDARY THREADS
-
-	proxy_hwm_cfg_t cfg;
-	cfg.context = context;
-	cfg.frontend_endpoint = "inproc://frontend";
-	cfg.backend_endpoint = "inproc://backend";
-	cfg.control_endpoint = "inproc://ctrl";
-	cfg.subscriber_received_all = false;
-
-	void* proxy = zmq_threadstart(&proxy_thread_main, (void*) &cfg);
-	assert(proxy != 0);
-	void* publisher = zmq_threadstart(&publisher_thread_main, (void*) &cfg);
-	assert(publisher != 0);
-	void* subscriber = zmq_threadstart(&subscriber_thread_main, (void*) &cfg);
-	assert(subscriber != 0);
-	void* asker = zmq_threadstart(&proxy_stats_asker_thread_main, (void*) &cfg);
-	assert(asker != 0);
+    void *context = zmq_ctx_new ();
+    assert (context);
 
 
-	// CLEANUP
+    // START ALL SECONDARY THREADS
 
-	UNIT_TEST_LOG("main waiting for all threads to join");
+    proxy_hwm_cfg_t cfg;
+    cfg.context = context;
+    cfg.frontend_endpoint = "inproc://frontend";
+    cfg.backend_endpoint = "inproc://backend";
+    cfg.control_endpoint = "inproc://ctrl";
+    cfg.subscriber_received_all = false;
 
-	zmq_threadclose (publisher);
-	zmq_threadclose (subscriber);
-	zmq_threadclose (asker);
-	zmq_threadclose (proxy);
+    void *proxy = zmq_threadstart (&proxy_thread_main, (void *) &cfg);
+    assert (proxy != 0);
+    void *publisher = zmq_threadstart (&publisher_thread_main, (void *) &cfg);
+    assert (publisher != 0);
+    void *subscriber = zmq_threadstart (&subscriber_thread_main, (void *) &cfg);
+    assert (subscriber != 0);
+    void *asker =
+      zmq_threadstart (&proxy_stats_asker_thread_main, (void *) &cfg);
+    assert (asker != 0);
 
-	int rc = zmq_ctx_term (context);
-	assert (rc == 0);
 
-	return 0;
+    // CLEANUP
+
+    UNIT_TEST_LOG ("main waiting for all threads to join");
+
+    zmq_threadclose (publisher);
+    zmq_threadclose (subscriber);
+    zmq_threadclose (asker);
+    zmq_threadclose (proxy);
+
+    int rc = zmq_ctx_term (context);
+    assert (rc == 0);
+
+    return 0;
 }

--- a/tests/test_proxy_hwm.cpp
+++ b/tests/test_proxy_hwm.cpp
@@ -201,6 +201,7 @@ static void subscriber_thread_main (void *pvoid)
               subsocket, ZMQ_RCVTIMEO, &timeout_ms, sizeof (timeout_ms)));
         } else {
             UNIT_TEST_LOG (" ** failed receiving...  exiting");
+            TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
             break;
         }
 

--- a/tests/test_proxy_hwm.cpp
+++ b/tests/test_proxy_hwm.cpp
@@ -183,7 +183,7 @@ static void subscriber_thread_main (void *pvoid)
             TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
               subsocket, ZMQ_RCVTIMEO, &timeout_ms, sizeof (timeout_ms)));
         } else {
-            //printf (" ** subscriber_thread_main failed receiving...  exiting");
+            TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
             break;
         }
 

--- a/tests/test_proxy_hwm.cpp
+++ b/tests/test_proxy_hwm.cpp
@@ -126,13 +126,12 @@ static void publisher_thread_main (void *pvoid)
         rc = zmq_msg_send (&msg, pubsocket, ZMQ_DONTWAIT);
         if (rc != -1) {
             //printf (" ** publisher_thread_main sent successfully %d bytes sent, total sent %lu",
-                           //rc, send_count);
+            //rc, send_count);
             send_count++;
         } else {
-            if (errno == EAGAIN)
-                TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+            TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
             //printf (" ** publisher_thread_main failed sending pkt with errno=%d",
-              	  	  //zmq_errno ());
+            //zmq_errno ());
             break;
         }
     }
@@ -140,8 +139,7 @@ static void publisher_thread_main (void *pvoid)
     // VERIFY EXPECTED RESULTS
 
     //printf ("publisher_thread_main sent %lu packets successfully; HWM = %d.", send_count, HWM);
-    TEST_ASSERT (4 * HWM == send_count ||
-    				2 * HWM == send_count);
+    TEST_ASSERT (4 * HWM == send_count || 2 * HWM == send_count);
 
 
     // CLEANUP
@@ -195,8 +193,7 @@ static void subscriber_thread_main (void *pvoid)
 
     // VERIFY EXPECTED RESULTS
 
-    TEST_ASSERT (4 * HWM == rxsuccess ||
-    				2 * HWM == rxsuccess);
+    TEST_ASSERT (4 * HWM == rxsuccess || 2 * HWM == rxsuccess);
 
     // INFORM THAT WE COMPLETED:
 
@@ -265,15 +262,15 @@ bool check_proxy_stats (void *control_proxy_)
     //bool is_verbose = (((nupdates++) % 1000) == 0);
 
     //if (is_verbose)
-        //printf ("asking update #%d from proxy (so far %d successful, %d failed):",
-          //nupdates, nsuccess, nfailed);
+    //printf ("asking update #%d from proxy (so far %d successful, %d failed):",
+    //nupdates, nsuccess, nfailed);
 
     rc = zmq_send (control_proxy_, "STATISTICS", 10, ZMQ_DONTWAIT);
     assert (rc == 10 || (rc == -1 && errno == EAGAIN));
     if (rc == -1 && errno == EAGAIN) {
         nfailed++;
         //if (is_verbose)
-            //printf ("    ...failed (TX)");
+        //printf ("    ...failed (TX)");
         return false;
     }
 
@@ -281,7 +278,7 @@ bool check_proxy_stats (void *control_proxy_)
     if (!recv_stat (control_proxy_, false, &total_stats.frontend.msg_in)) {
         nfailed++;
         //if (is_verbose)
-            //printf ("    ...failed (timedout)");
+        //printf ("    ...failed (timedout)");
         return false;
     }
 
@@ -296,7 +293,7 @@ bool check_proxy_stats (void *control_proxy_)
     recv_stat (control_proxy_, true, &total_stats.backend.bytes_out);
 
     // check stats
-/*
+    /*
     if (is_verbose) {
         //printf (
           "frontend: pkts_in=%lu bytes_in=%lu  pkts_out=%lu bytes_out=%lu\n",
@@ -429,7 +426,7 @@ static void proxy_thread_main (void *pvoid)
     // start proxying!
 
     //printf ( "proxy_thread_main starting proxy on frontend=%s, backend=%s, ctrl=%s",
-      //cfg->frontend_endpoint, cfg->backend_endpoint, cfg->control_endpoint);
+    //cfg->frontend_endpoint, cfg->backend_endpoint, cfg->control_endpoint);
 
     zmq_proxy_steerable (frontend_xsub, backend_xpub, NULL, control_rep);
 

--- a/tests/test_proxy_hwm.cpp
+++ b/tests/test_proxy_hwm.cpp
@@ -163,6 +163,7 @@ static void subscriber_thread_main (void *pvoid)
 
         rc = zmq_msg_recv (&msg, subsocket, 0);
         if (rc != -1) {
+            TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
             rxsuccess++;
 
             // after receiving 1st message, set a finite timeout (default is infinite)
@@ -170,7 +171,6 @@ static void subscriber_thread_main (void *pvoid)
             TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
               subsocket, ZMQ_RCVTIMEO, &timeout_ms, sizeof (timeout_ms)));
         } else {
-            TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
             break;
         }
 


### PR DESCRIPTION
Problem: correct HWM handling is checked only on INPROC transport
Problem: the ZMQ proxy control socket is unusable when the proxy reaches its XPUB HWM and lossy flag is set.

Solution: 
 - extend existing HWM unit test to test also TCP and IPC transports
 - add new unit test that shows that ZMQ proxy control socket is unusable when the proxy reaches its XPUB HWM and lossy flag is set and how to cope with that.

Note: this PR is still work-in-progress. In particular I need to think how to organize the new unit test on the proxy; currently it requires human inspection to understand what's going on.