### PR TITLE
CMake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -992,7 +992,7 @@ endif()
 if (MSVC)
   # Suppress linker warnings caused by #ifdef omission
   # of file content.
-  set( CMAKE_STATIC_LINKER_FLAGS /ignore:4221 )
+  set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
   set (PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
   set (PDB_NAME "libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}")
   function(enable_vs_guideline_checker target)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,553 +1,546 @@
 # CMake build script for ZeroMQ
+cmake_minimum_required(VERSION 2.8.12)
 
-cmake_minimum_required (VERSION 2.8.12)
-project (ZeroMQ)
+project(ZeroMQ)
 
-list (INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}")
-set (ZMQ_CMAKE_MODULES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/Modules)
-list (APPEND CMAKE_MODULE_PATH ${ZMQ_CMAKE_MODULES_DIR})
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}")
+set(ZMQ_CMAKE_MODULES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${ZMQ_CMAKE_MODULES_DIR})
 
 # Apply CMP0042: MACOSX_RPATH is enabled by default
-cmake_policy (SET CMP0042 NEW)
+cmake_policy(SET CMP0042 NEW)
 
 include(GNUInstallDirs)
-if (${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
+if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
   # Find more information: https://cmake.org/Wiki/CMake_RPATH_handling
 
   # Add an install rpath if it is not a system directory
-  list (FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
-  if ("${isSystemDir}" STREQUAL "-1")
-    set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-  endif ()
+  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+  if("${isSystemDir}" STREQUAL "-1")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+  endif()
 
   # Add linker search paths pointing to external dependencies
-  set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-endif ()
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
 
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=gnu++11" COMPILER_SUPPORTS_CXX11)
+check_cxx_compiler_flag("-std=gnu++11" COMPILER_SUPPORTS_CXX11)
 if(COMPILER_SUPPORTS_CXX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 endif()
 include(CheckCCompilerFlag)
-CHECK_C_COMPILER_FLAG("-std=gnu11" COMPILER_SUPPORTS_C11)
+check_c_compiler_flag("-std=gnu11" COMPILER_SUPPORTS_C11)
 if(COMPILER_SUPPORTS_C11)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
 endif()
 
-include (ZMQSupportMacros)
+include(ZMQSupportMacros)
 
 if(NOT MSVC)
-    # clang 6 has a warning that does not make sense on multi-platform code
-    CHECK_CXX_COMPILER_FLAG("-Wno-tautological-constant-compare" CXX_HAS_TAUT_WARNING)
-    if(CXX_HAS_TAUT_WARNING)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-constant-compare")
-    endif()
-    CHECK_C_COMPILER_FLAG("-Wno-tautological-constant-compare" CC_HAS_TAUT_WARNING)
-    if(CC_HAS_TAUT_WARNING)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-tautological-constant-compare")
-    endif()
+  # clang 6 has a warning that does not make sense on multi-platform code
+  check_cxx_compiler_flag("-Wno-tautological-constant-compare" CXX_HAS_TAUT_WARNING)
+  if(CXX_HAS_TAUT_WARNING)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-constant-compare")
+  endif()
+  check_c_compiler_flag("-Wno-tautological-constant-compare" CC_HAS_TAUT_WARNING)
+  if(CC_HAS_TAUT_WARNING)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-tautological-constant-compare")
+  endif()
 endif()
 
 # Will be used to add flags to pkg-config useful when apps want to statically link
-set (pkg_config_libs_private "")
+set(pkg_config_libs_private "")
 
-option (WITH_OPENPGM "Build with support for OpenPGM" OFF)
-option (WITH_VMCI "Build with support for VMware VMCI socket" OFF)
+option(WITH_OPENPGM "Build with support for OpenPGM" OFF)
+option(WITH_VMCI "Build with support for VMware VMCI socket" OFF)
 
-if (APPLE)
-    option (ZMQ_BUILD_FRAMEWORK "Build as OS X framework" OFF)
-endif ()
+if(APPLE)
+  option(ZMQ_BUILD_FRAMEWORK "Build as OS X framework" OFF)
+endif()
 
 # Select curve encryption library, defaults to tweetnacl
-# To use libsodium instead, use --with-libsodium (must be installed)
+# To use libsodium instead, use --with-libsodium(must be installed)
 # To disable curve, use --disable-curve
 
-option (WITH_LIBSODIUM "Use libsodium instead of built-in tweetnacl" OFF)
-option (ENABLE_CURVE "Enable CURVE security" ON)
+option(WITH_LIBSODIUM "Use libsodium instead of built-in tweetnacl" OFF)
+option(ENABLE_CURVE "Enable CURVE security" ON)
 
-if (NOT ENABLE_CURVE)
-    message (STATUS "CURVE security is disabled")
-
-elseif (WITH_LIBSODIUM)
-    find_package (Sodium)
-    if (SODIUM_FOUND)
-        message (STATUS "Using libsodium for CURVE security")
-        include_directories (${SODIUM_INCLUDE_DIRS})
-        set (ZMQ_USE_LIBSODIUM 1)
-        set (ZMQ_HAVE_CURVE 1)
-        set (pkg_config_libs_private "${pkg_config_libs_private} -lsodium")
-    else ()
-        message (FATAL_ERROR
-            "libsodium is not installed. Install it, then run CMake again")
-    endif ()
-
-else ()
-    message (STATUS "Using tweetnacl for CURVE security")
-    list (APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/src/tweetnacl.c)
-    set (ZMQ_USE_TWEETNACL 1)
-    set (ZMQ_HAVE_CURVE 1)
-endif ()
+if(NOT ENABLE_CURVE)
+  message(STATUS "CURVE security is disabled")
+elseif(WITH_LIBSODIUM)
+  find_package(Sodium)
+  if(SODIUM_FOUND)
+    message(STATUS "Using libsodium for CURVE security")
+    include_directories(${SODIUM_INCLUDE_DIRS})
+    set(ZMQ_USE_LIBSODIUM 1)
+    set(ZMQ_HAVE_CURVE 1)
+    set(pkg_config_libs_private "${pkg_config_libs_private} -lsodium")
+  else()
+    message(FATAL_ERROR
+      "libsodium is not installed. Install it, then run CMake again")
+  endif()
+else()
+  message(STATUS "Using tweetnacl for CURVE security")
+  list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/src/tweetnacl.c)
+  set(ZMQ_USE_TWEETNACL 1)
+  set(ZMQ_HAVE_CURVE 1)
+endif()
 
 set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
-if (EXISTS "${SOURCE_DIR}/.git")
-    OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" ON)
-else ()
-    OPTION (ENABLE_DRAFTS "Build and install draft classes and methods" OFF)
-endif ()
-IF (ENABLE_DRAFTS)
-    ADD_DEFINITIONS (-DZMQ_BUILD_DRAFT_API)
-    set (pkg_config_defines "-DZMQ_BUILD_DRAFT_API=1")
-ELSE (ENABLE_DRAFTS)
-    set (pkg_config_defines "")
-ENDIF (ENABLE_DRAFTS)
-
-option (WITH_MILITANT "Enable militant assertions" OFF)
-if (WITH_MILITANT)
-    add_definitions(-DZMQ_ACT_MILITANT)
+if(EXISTS "${SOURCE_DIR}/.git")
+  option(ENABLE_DRAFTS "Build and install draft classes and methods" ON)
+else()
+  option(ENABLE_DRAFTS "Build and install draft classes and methods" OFF)
+endif()
+if(ENABLE_DRAFTS)
+  add_definitions(-DZMQ_BUILD_DRAFT_API)
+  set(pkg_config_defines "-DZMQ_BUILD_DRAFT_API=1")
+else()
+  set(pkg_config_defines "")
 endif()
 
-set (API_POLLER "" CACHE STRING "Choose polling system for zmq_poll(er)_*. valid values are
-                            poll or select [default=poll unless POLLER=select]")
-
-set (POLLER "" CACHE STRING "Choose polling system for I/O threads. valid values are
-                            kqueue, epoll, devpoll, pollset, poll or select [default=autodetect]")
-
-include (CheckFunctionExists)
-include (CheckTypeSize)
-
-if (NOT MSVC)
-    if (POLLER STREQUAL "")
-        set (CMAKE_REQUIRED_INCLUDES sys/event.h)
-        check_function_exists (kqueue HAVE_KQUEUE)
-        set (CMAKE_REQUIRED_INCLUDES)
-        if (HAVE_KQUEUE)
-            set (POLLER "kqueue")
-        endif()
-    endif ()
-
-    if (POLLER STREQUAL "")
-        set (CMAKE_REQUIRED_INCLUDES sys/epoll.h)
-        check_function_exists (epoll_create HAVE_EPOLL)
-        set (CMAKE_REQUIRED_INCLUDES)
-        if (HAVE_EPOLL)
-            set (POLLER "epoll")
-            check_function_exists (epoll_create1 HAVE_EPOLL_CLOEXEC)
-            if (HAVE_EPOLL_CLOEXEC)
-                set (ZMQ_IOTHREAD_POLLER_USE_EPOLL_CLOEXEC 1)
-            endif ()
-        endif ()
-    endif ()
-
-    if (POLLER STREQUAL "")
-        set (CMAKE_REQUIRED_INCLUDES sys/devpoll.h)
-        check_type_size ("struct pollfd" DEVPOLL)
-        set (CMAKE_REQUIRED_INCLUDES)
-        if (HAVE_DEVPOLL)
-            set (POLLER "devpoll")
-        endif ()
-    endif ()
-
-    if (POLLER STREQUAL "")
-        set (CMAKE_REQUIRED_INCLUDES sys/pollset.h)
-        check_function_exists (pollset_create HAVE_POLLSET)
-        set (CMAKE_REQUIRED_INCLUDES)
-        if (HAVE_POLLSET)
-            set (POLLER "pollset")
-        endif()
-    endif ()
-
-    if (POLLER STREQUAL "")
-        set (CMAKE_REQUIRED_INCLUDES poll.h)
-        check_function_exists (poll HAVE_POLL)
-        set (CMAKE_REQUIRED_INCLUDES)
-        if (HAVE_POLL)
-            set (POLLER "poll")
-        endif ()
-    endif ()
+option(WITH_MILITANT "Enable militant assertions" OFF)
+if(WITH_MILITANT)
+  add_definitions(-DZMQ_ACT_MILITANT)
 endif()
 
-if (POLLER STREQUAL "")
-    if (WIN32)
-        set (CMAKE_REQUIRED_INCLUDES winsock2.h)
-        set (HAVE_SELECT 1)
-    else ()
-        set (CMAKE_REQUIRED_INCLUDES sys/select.h)
-        check_function_exists (select HAVE_SELECT)
-        set (CMAKE_REQUIRED_INCLUDES)
-    endif ()
-    if (HAVE_SELECT)
-        set (POLLER "select")
-    else ()
-        message (FATAL_ERROR
-            "Could not autodetect polling method")
-    endif ()
-endif ()
+set(API_POLLER "" CACHE STRING "Choose polling system for zmq_poll(er)_*. valid values are
+  poll or select [default=poll unless POLLER=select]")
 
-if (POLLER STREQUAL "kqueue"
- OR POLLER STREQUAL "epoll"
- OR POLLER STREQUAL "devpoll"
- OR POLLER STREQUAL "pollset"
- OR POLLER STREQUAL "poll"
- OR POLLER STREQUAL "select")
-    message (STATUS "Using polling method in I/O threads: ${POLLER}")
-    string (TOUPPER ${POLLER} UPPER_POLLER)
-    set (ZMQ_IOTHREAD_POLLER_USE_${UPPER_POLLER} 1)
-else ()
-    message (FATAL_ERROR "Invalid polling method")
-endif ()
+set(POLLER "" CACHE STRING "Choose polling system for I/O threads. valid values are
+  kqueue, epoll, devpoll, pollset, poll or select [default=autodetect]")
 
-if (POLLER STREQUAL "epoll" AND WIN32)
-    message (STATUS "Including wepoll")
-    list (APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/external/wepoll/wepoll.c ${CMAKE_CURRENT_SOURCE_DIR}/external/wepoll/wepoll.h)
+include(CheckFunctionExists)
+include(CheckTypeSize)
+
+if(NOT MSVC)
+  if(POLLER STREQUAL "")
+    set(CMAKE_REQUIRED_INCLUDES sys/event.h)
+    check_function_exists(kqueue HAVE_KQUEUE)
+    set(CMAKE_REQUIRED_INCLUDES)
+    if(HAVE_KQUEUE)
+      set(POLLER "kqueue")
+    endif()
+  endif()
+
+  if(POLLER STREQUAL "")
+    set(CMAKE_REQUIRED_INCLUDES sys/epoll.h)
+    check_function_exists(epoll_create HAVE_EPOLL)
+    set(CMAKE_REQUIRED_INCLUDES)
+    if(HAVE_EPOLL)
+      set(POLLER "epoll")
+      check_function_exists(epoll_create1 HAVE_EPOLL_CLOEXEC)
+      if(HAVE_EPOLL_CLOEXEC)
+        set(ZMQ_IOTHREAD_POLLER_USE_EPOLL_CLOEXEC 1)
+      endif()
+    endif()
+  endif()
+
+  if(POLLER STREQUAL "")
+    set(CMAKE_REQUIRED_INCLUDES sys/devpoll.h)
+    check_type_size("struct pollfd" DEVPOLL)
+    set(CMAKE_REQUIRED_INCLUDES)
+    if(HAVE_DEVPOLL)
+      set(POLLER "devpoll")
+    endif()
+  endif()
+
+  if(POLLER STREQUAL "")
+    set(CMAKE_REQUIRED_INCLUDES sys/pollset.h)
+    check_function_exists(pollset_create HAVE_POLLSET)
+    set(CMAKE_REQUIRED_INCLUDES)
+    if(HAVE_POLLSET)
+      set(POLLER "pollset")
+    endif()
+  endif()
+
+  if(POLLER STREQUAL "")
+    set(CMAKE_REQUIRED_INCLUDES poll.h)
+    check_function_exists(poll HAVE_POLL)
+    set(CMAKE_REQUIRED_INCLUDES)
+    if(HAVE_POLL)
+      set(POLLER "poll")
+    endif()
+  endif()
 endif()
 
-if (API_POLLER STREQUAL "")
-	if (POLLER STREQUAL "select")
-		set (API_POLLER "select")
-	else()
-		set (API_POLLER "poll")
-	endif()
+if(POLLER STREQUAL "")
+  if(WIN32)
+    set(CMAKE_REQUIRED_INCLUDES winsock2.h)
+    set(HAVE_SELECT 1)
+  else()
+    set(CMAKE_REQUIRED_INCLUDES sys/select.h)
+    check_function_exists(select HAVE_SELECT)
+    set(CMAKE_REQUIRED_INCLUDES)
+  endif()
+  if(HAVE_SELECT)
+    set(POLLER "select")
+  else()
+    message(FATAL_ERROR
+      "Could not autodetect polling method")
+  endif()
 endif()
 
-message (STATUS "Using polling method in zmq_poll(er)_* API: ${API_POLLER}")
-    string (TOUPPER ${API_POLLER} UPPER_API_POLLER)
-set (ZMQ_POLL_BASED_ON_${UPPER_API_POLLER} 1)
+if(POLLER STREQUAL "kqueue"
+  OR POLLER STREQUAL "epoll"
+  OR POLLER STREQUAL "devpoll"
+  OR POLLER STREQUAL "pollset"
+  OR POLLER STREQUAL "poll"
+  OR POLLER STREQUAL "select")
+  message(STATUS "Using polling method in I/O threads: ${POLLER}")
+  string(TOUPPER ${POLLER} UPPER_POLLER)
+  set(ZMQ_IOTHREAD_POLLER_USE_${UPPER_POLLER} 1)
+else()
+  message(FATAL_ERROR "Invalid polling method")
+endif()
 
-include (TestZMQVersion)
-if (NOT CMAKE_CROSSCOMPILING)
-  include (ZMQSourceRunChecks)
-endif ()
-include (CheckIncludeFiles)
-include (CheckLibraryExists)
-include (CheckCCompilerFlag)
-include (CheckCXXCompilerFlag)
-include (CheckCSourceCompiles)
-include (CheckCSourceRuns)
-include (CMakeDependentOption)
-include (CheckCXXSymbolExists)
-include (CheckSymbolExists)
+if(POLLER STREQUAL "epoll" AND WIN32)
+  message(STATUS "Including wepoll")
+  list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/external/wepoll/wepoll.c ${CMAKE_CURRENT_SOURCE_DIR}/external/wepoll/wepoll.h)
+endif()
 
-if (NOT CYGWIN)
-    # TODO cannot we simply do 'if (WIN32) set(ZMQ_HAVE_WINDOWS ON)' or similar?
-    check_include_files (windows.h ZMQ_HAVE_WINDOWS)
+if(API_POLLER STREQUAL "")
+  if(POLLER STREQUAL "select")
+    set(API_POLLER "select")
+  else()
+    set(API_POLLER "poll")
+  endif()
+endif()
+
+message(STATUS "Using polling method in zmq_poll(er)_* API: ${API_POLLER}")
+string(TOUPPER ${API_POLLER} UPPER_API_POLLER)
+set(ZMQ_POLL_BASED_ON_${UPPER_API_POLLER} 1)
+
+include(TestZMQVersion)
+if(NOT CMAKE_CROSSCOMPILING)
+  include(ZMQSourceRunChecks)
+endif()
+include(CheckIncludeFiles)
+include(CheckLibraryExists)
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+include(CheckCSourceCompiles)
+include(CheckCSourceRuns)
+include(CMakeDependentOption)
+include(CheckCXXSymbolExists)
+include(CheckSymbolExists)
+
+if(NOT CYGWIN)
+  # TODO cannot we simply do 'if(WIN32) set(ZMQ_HAVE_WINDOWS ON)' or similar?
+  check_include_files(windows.h ZMQ_HAVE_WINDOWS)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND CMAKE_SYSTEM_VERSION STREQUAL "10.0")
-  SET(ZMQ_HAVE_WINDOWS_UWP ON)
-  ADD_DEFINITIONS(-D_WIN32_WINNT=_WIN32_WINNT_WIN10)
+  set(ZMQ_HAVE_WINDOWS_UWP ON)
+  add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN10)
 endif()
-if (NOT MSVC)
-    check_include_files (ifaddrs.h ZMQ_HAVE_IFADDRS)
-    check_include_files (sys/uio.h ZMQ_HAVE_UIO)
-    check_include_files (sys/eventfd.h ZMQ_HAVE_EVENTFD)
-    if (ZMQ_HAVE_EVENTFD AND NOT CMAKE_CROSSCOMPILING)
-      zmq_check_efd_cloexec ()
-    endif ()
+if(NOT MSVC)
+  check_include_files(ifaddrs.h ZMQ_HAVE_IFADDRS)
+  check_include_files(sys/uio.h ZMQ_HAVE_UIO)
+  check_include_files(sys/eventfd.h ZMQ_HAVE_EVENTFD)
+  if(ZMQ_HAVE_EVENTFD AND NOT CMAKE_CROSSCOMPILING)
+    zmq_check_efd_cloexec()
+  endif()
 endif()
 
-if (ZMQ_HAVE_WINDOWS)
+if(ZMQ_HAVE_WINDOWS)
   # Cannot use check_library_exists because the symbol is always declared as char(*)(void)
   set(CMAKE_REQUIRED_LIBRARIES "ws2_32.lib")
-  check_symbol_exists (WSAStartup "winsock2.h" HAVE_WS2_32)
+  check_symbol_exists(WSAStartup "winsock2.h" HAVE_WS2_32)
 
   set(CMAKE_REQUIRED_LIBRARIES "rpcrt4.lib")
-  check_symbol_exists (UuidCreateSequential "rpc.h" HAVE_RPCRT4)
+  check_symbol_exists(UuidCreateSequential "rpc.h" HAVE_RPCRT4)
 
   set(CMAKE_REQUIRED_LIBRARIES "iphlpapi.lib")
-  check_symbol_exists (GetAdaptersAddresses "winsock2.h;iphlpapi.h" HAVE_IPHLAPI)
+  check_symbol_exists(GetAdaptersAddresses "winsock2.h;iphlpapi.h" HAVE_IPHLAPI)
 
   set(CMAKE_REQUIRED_LIBRARIES "")
   # TODO: This not the symbol we're looking for. What is the symbol?
-  check_library_exists (ws2 fopen "" HAVE_WS2)
+  check_library_exists(ws2 fopen "" HAVE_WS2)
 else()
-  check_cxx_symbol_exists (SO_PEERCRED sys/socket.h ZMQ_HAVE_SO_PEERCRED)
-  check_cxx_symbol_exists (LOCAL_PEERCRED sys/socket.h ZMQ_HAVE_LOCAL_PEERCRED)
+  check_cxx_symbol_exists(SO_PEERCRED sys/socket.h ZMQ_HAVE_SO_PEERCRED)
+  check_cxx_symbol_exists(LOCAL_PEERCRED sys/socket.h ZMQ_HAVE_LOCAL_PEERCRED)
 endif()
 
-find_library (RT_LIBRARY rt)
+find_library(RT_LIBRARY rt)
 
-find_package (Threads)
+find_package(Threads)
 
-
-if (WIN32 AND NOT CYGWIN)
-  if (NOT HAVE_WS2_32 AND NOT HAVE_WS2)
-    message (FATAL_ERROR "Cannot link to ws2_32 or ws2")
-  endif ()
-
-  if (NOT HAVE_RPCRT4)
-    message (FATAL_ERROR "Cannot link to rpcrt4")
-  endif ()
-
-  if (NOT HAVE_IPHLAPI)
-    message (FATAL_ERROR "Cannot link to iphlapi")
-  endif ()
-endif ()
-
-if (NOT MSVC)
-    set (CMAKE_REQUIRED_LIBRARIES rt)
-    check_function_exists (clock_gettime HAVE_CLOCK_GETTIME)
-    set (CMAKE_REQUIRED_LIBRARIES)
-
-    set (CMAKE_REQUIRED_INCLUDES unistd.h)
-    check_function_exists (fork HAVE_FORK)
-    set (CMAKE_REQUIRED_INCLUDES)
-
-    set (CMAKE_REQUIRED_INCLUDES sys/time.h)
-    check_function_exists (gethrtime HAVE_GETHRTIME)
-    set (CMAKE_REQUIRED_INCLUDES)
-
-    set (CMAKE_REQUIRED_INCLUDES stdlib.h)
-    check_function_exists (mkdtemp HAVE_MKDTEMP)
-    set (CMAKE_REQUIRED_INCLUDES)
-
-    set (CMAKE_REQUIRED_INCLUDES sys/socket.h)
-    check_function_exists (accept4 HAVE_ACCEPT4)
-    set (CMAKE_REQUIRED_INCLUDES)
-endif()
-
-add_definitions (-D_REENTRANT -D_THREAD_SAFE)
-add_definitions (-DZMQ_CUSTOM_PLATFORM_HPP)
-
-option (ENABLE_EVENTFD "Enable/disable eventfd" ZMQ_HAVE_EVENTFD)
-
-macro (zmq_check_cxx_flag_prepend flag)
-  check_cxx_compiler_flag ("${flag}" HAVE_FLAG_${flag})
-
-  if (HAVE_FLAG_${flag})
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-  endif ()
-endmacro ()
-
-OPTION (ENABLE_ANALYSIS "Build with static analysis (make take very long)" OFF)
-
-if (MSVC)
-  if (ENABLE_ANALYSIS)  
-    zmq_check_cxx_flag_prepend ("/W4")
-
-    zmq_check_cxx_flag_prepend ("/analyze")
-    
-    # C++11/14/17-specific, but maybe possible via conditional defines
-    zmq_check_cxx_flag_prepend ("/wd26440") # Function '...' can be declared 'noexcept' 
-    zmq_check_cxx_flag_prepend ("/wd26432") # If you define or delete any default operation in the type '...', define or delete them all
-    zmq_check_cxx_flag_prepend ("/wd26439") # This kind of function may not throw. Declare it 'noexcept' 
-    zmq_check_cxx_flag_prepend ("/wd26447") # The function is declared 'noexcept' but calls function '...' which may throw exceptions
-    zmq_check_cxx_flag_prepend ("/wd26433") # Function '...' should be marked with 'override'
-    zmq_check_cxx_flag_prepend ("/wd26409") # Avoid calling new and delete explicitly, use std::make_unique<T> instead
-    # Requires GSL
-    zmq_check_cxx_flag_prepend ("/wd26429") # Symbol '...' is never tested for nullness, it can be marked as not_null
-    zmq_check_cxx_flag_prepend ("/wd26446") # Prefer to use gsl::at()
-    zmq_check_cxx_flag_prepend ("/wd26481") # Don't use pointer arithmetic. Use span instead
-    zmq_check_cxx_flag_prepend ("/wd26472") # Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narow
-    zmq_check_cxx_flag_prepend ("/wd26448") # Consider using gsl::finally if final action is intended
-    zmq_check_cxx_flag_prepend ("/wd26400") # Do not assign the result of an allocation or a function call with an owner<T> return value to a raw pointer, use owner<T> instead    
-    zmq_check_cxx_flag_prepend ("/wd26485") # Expression '...': No array to pointer decay (bounds.3)
-  else()
-    zmq_check_cxx_flag_prepend ("/W3")
+if(WIN32 AND NOT CYGWIN)
+  if(NOT HAVE_WS2_32 AND NOT HAVE_WS2)
+    message(FATAL_ERROR "Cannot link to ws2_32 or ws2")
   endif()
 
-  if (MSVC_IDE)
-    set (MSVC_TOOLSET "-${CMAKE_VS_PLATFORM_TOOLSET}")
-  else ()
-    set (MSVC_TOOLSET "")
-  endif ()
-else ()
-  zmq_check_cxx_flag_prepend ("-Wall")
-endif ()
+  if(NOT HAVE_RPCRT4)
+    message(FATAL_ERROR "Cannot link to rpcrt4")
+  endif()
 
-if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  zmq_check_cxx_flag_prepend ("-Wextra")
-endif ()
-
-option (LIBZMQ_PEDANTIC "" ON)
-option (LIBZMQ_WERROR "" OFF)
-
-#   TODO: why is -Wno-long-long defined differently than in configure.ac?
-if (NOT MSVC)
-    zmq_check_cxx_flag_prepend ("-Wno-long-long")
-    zmq_check_cxx_flag_prepend ("-Wno-uninitialized")
-
-    if (LIBZMQ_PEDANTIC)
-      zmq_check_cxx_flag_prepend ("-pedantic")
-
-      if (${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
-        zmq_check_cxx_flag_prepend ("-strict-ansi")
-      endif ()
-
-      if (${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
-        zmq_check_cxx_flag_prepend ("-compat=5")
-      endif ()
-    endif ()
+  if(NOT HAVE_IPHLAPI)
+    message(FATAL_ERROR "Cannot link to iphlapi")
+  endif()
 endif()
 
-if (LIBZMQ_WERROR)
-    if(MSVC)
-        zmq_check_cxx_flag_prepend ("/WX")
-    else()
-        zmq_check_cxx_flag_prepend ("-Werror")
-        if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-            zmq_check_cxx_flag_prepend ("-errwarn=%all")
-        endif()
+if(NOT MSVC)
+  set(CMAKE_REQUIRED_LIBRARIES rt)
+  check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
+  set(CMAKE_REQUIRED_LIBRARIES)
+
+  set(CMAKE_REQUIRED_INCLUDES unistd.h)
+  check_function_exists(fork HAVE_FORK)
+  set(CMAKE_REQUIRED_INCLUDES)
+
+  set(CMAKE_REQUIRED_INCLUDES sys/time.h)
+  check_function_exists(gethrtime HAVE_GETHRTIME)
+  set(CMAKE_REQUIRED_INCLUDES)
+
+  set(CMAKE_REQUIRED_INCLUDES stdlib.h)
+  check_function_exists(mkdtemp HAVE_MKDTEMP)
+  set(CMAKE_REQUIRED_INCLUDES)
+
+  set(CMAKE_REQUIRED_INCLUDES sys/socket.h)
+  check_function_exists(accept4 HAVE_ACCEPT4)
+  set(CMAKE_REQUIRED_INCLUDES)
+endif()
+
+add_definitions(-D_REENTRANT -D_THREAD_SAFE)
+add_definitions(-DZMQ_CUSTOM_PLATFORM_HPP)
+
+option(ENABLE_EVENTFD "Enable/disable eventfd" ZMQ_HAVE_EVENTFD)
+
+macro(zmq_check_cxx_flag_prepend flag)
+  check_cxx_compiler_flag("${flag}" HAVE_FLAG_${flag})
+
+  if(HAVE_FLAG_${flag})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+  endif()
+endmacro()
+
+option(ENABLE_ANALYSIS "Build with static analysis(make take very long)" OFF)
+
+if(MSVC)
+  if(ENABLE_ANALYSIS)
+    zmq_check_cxx_flag_prepend("/W4")
+
+    zmq_check_cxx_flag_prepend("/analyze")
+
+    # C++11/14/17-specific, but maybe possible via conditional defines
+    zmq_check_cxx_flag_prepend("/wd26440") # Function '...' can be declared 'noexcept'
+    zmq_check_cxx_flag_prepend("/wd26432") # If you define or delete any default operation in the type '...', define or delete them all
+    zmq_check_cxx_flag_prepend("/wd26439") # This kind of function may not throw. Declare it 'noexcept'
+    zmq_check_cxx_flag_prepend("/wd26447") # The function is declared 'noexcept' but calls function '...' which may throw exceptions
+    zmq_check_cxx_flag_prepend("/wd26433") # Function '...' should be marked with 'override'
+    zmq_check_cxx_flag_prepend("/wd26409") # Avoid calling new and delete explicitly, use std::make_unique<T> instead
+    # Requires GSL
+    zmq_check_cxx_flag_prepend("/wd26429") # Symbol '...' is never tested for nullness, it can be marked as not_null
+    zmq_check_cxx_flag_prepend("/wd26446") # Prefer to use gsl::at()
+    zmq_check_cxx_flag_prepend("/wd26481") # Don't use pointer arithmetic. Use span instead
+    zmq_check_cxx_flag_prepend("/wd26472") # Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast or gsl::narow
+    zmq_check_cxx_flag_prepend("/wd26448") # Consider using gsl::finally if final action is intended
+    zmq_check_cxx_flag_prepend("/wd26400") # Do not assign the result of an allocation or a function call with an owner<T> return value to a raw pointer, use owner<T> instead
+    zmq_check_cxx_flag_prepend("/wd26485") # Expression '...': No array to pointer decay(bounds.3)
+  else()
+    zmq_check_cxx_flag_prepend("/W3")
+  endif()
+
+  if(MSVC_IDE)
+    set(MSVC_TOOLSET "-${CMAKE_VS_PLATFORM_TOOLSET}")
+  else()
+    set(MSVC_TOOLSET "")
+  endif()
+else()
+  zmq_check_cxx_flag_prepend("-Wall")
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  zmq_check_cxx_flag_prepend("-Wextra")
+endif()
+
+option(LIBZMQ_PEDANTIC "" ON)
+option(LIBZMQ_WERROR "" OFF)
+
+# TODO: why is -Wno-long-long defined differently than in configure.ac?
+if(NOT MSVC)
+  zmq_check_cxx_flag_prepend("-Wno-long-long")
+  zmq_check_cxx_flag_prepend("-Wno-uninitialized")
+
+  if(LIBZMQ_PEDANTIC)
+    zmq_check_cxx_flag_prepend("-pedantic")
+
+    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
+      zmq_check_cxx_flag_prepend("-strict-ansi")
     endif()
-endif ()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "^sparc")
-  zmq_check_cxx_flag_prepend ("-mcpu=v9")
-endif ()
+    if(${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
+      zmq_check_cxx_flag_prepend("-compat=5")
+    endif()
+  endif()
+endif()
 
-if (${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
-  zmq_check_cxx_flag_prepend ("-features=zla")
-endif ()
+if(LIBZMQ_WERROR)
+  if(MSVC)
+    zmq_check_cxx_flag_prepend("/WX")
+  else()
+    zmq_check_cxx_flag_prepend("-Werror")
+    if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      zmq_check_cxx_flag_prepend("-errwarn=%all")
+    endif()
+  endif()
+endif()
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^sparc")
+  zmq_check_cxx_flag_prepend("-mcpu=v9")
+endif()
 
-if (CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD")
-  message (STATUS "Checking whether atomic operations can be used")
-  check_c_source_compiles (
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
+  zmq_check_cxx_flag_prepend("-features=zla")
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+  message(STATUS "Checking whether atomic operations can be used")
+  check_c_source_compiles(
+  "\
+  #include <atomic.h> \
+  \
+  int main() \
+  { \
+    uint32_t value; \
+    atomic_cas_32(&value, 0, 0); \
+    return 0; \
+  } \
   "
-   #include <atomic.h>
+  HAVE_ATOMIC_H)
 
-    int main ()
-    {
-      uint32_t value;
-      atomic_cas_32 (&value, 0, 0);
-      return 0;
-    }
-    "
-    HAVE_ATOMIC_H)
+  if(NOT HAVE_ATOMIC_H)
+    set(ZMQ_FORCE_MUTEXES 1)
+  endif()
+endif()
 
-  if (NOT HAVE_ATOMIC_H)
-    set (ZMQ_FORCE_MUTEXES 1)
-  endif ()
-endif ()
-
-zmq_check_noexcept ()
+zmq_check_noexcept()
 
 #-----------------------------------------------------------------------------
-if (NOT CMAKE_CROSSCOMPILING AND NOT MSVC)
-  zmq_check_sock_cloexec ()
-  zmq_check_o_cloexec ()
-  zmq_check_so_bindtodevice ()
-  zmq_check_so_keepalive ()
-  zmq_check_tcp_keepcnt ()
-  zmq_check_tcp_keepidle ()
-  zmq_check_tcp_keepintvl ()
-  zmq_check_tcp_keepalive ()
-  zmq_check_tcp_tipc ()
-  zmq_check_pthread_setname ()
-  zmq_check_pthread_setaffinity ()
-  zmq_check_getrandom ()
-endif ()
+if(NOT CMAKE_CROSSCOMPILING AND NOT MSVC)
+  zmq_check_sock_cloexec()
+  zmq_check_o_cloexec()
+  zmq_check_so_bindtodevice()
+  zmq_check_so_keepalive()
+  zmq_check_tcp_keepcnt()
+  zmq_check_tcp_keepidle()
+  zmq_check_tcp_keepintvl()
+  zmq_check_tcp_keepalive()
+  zmq_check_tcp_tipc()
+  zmq_check_pthread_setname()
+  zmq_check_pthread_setaffinity()
+  zmq_check_getrandom()
+endif()
 
-if (    CMAKE_SYSTEM_NAME MATCHES "Linux"
-    OR CMAKE_SYSTEM_NAME MATCHES "GNU/kFreeBSD"
-    OR CMAKE_SYSTEM_NAME MATCHES "GNU/Hurd"
-    OR CYGWIN)
-  add_definitions (-D_GNU_SOURCE)
-elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-  add_definitions (-D__BSD_VISIBLE)
-elseif (CMAKE_SYSTEM_NAME MATCHES "NetBSD")
-  add_definitions (-D_NETBSD_SOURCE)
-elseif (CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
-  add_definitions (-D_OPENBSD_SOURCE)
-elseif (CMAKE_SYSTEM_NAME MATCHES "SunOS")
-  add_definitions (-D_PTHREADS)
-elseif (CMAKE_SYSTEM_NAME MATCHES "HP-UX")
-  add_definitions (-D_POSIX_C_SOURCE=200112L)
-  zmq_check_cxx_flag_prepend (-Ae)
-elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  add_definitions (-D_DARWIN_C_SOURCE)
-endif ()
+if(CMAKE_SYSTEM_NAME MATCHES "Linux"
+  OR CMAKE_SYSTEM_NAME MATCHES "GNU/kFreeBSD"
+  OR CMAKE_SYSTEM_NAME MATCHES "GNU/Hurd"
+  OR CYGWIN)
+  add_definitions(-D_GNU_SOURCE)
+elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+  add_definitions(-D__BSD_VISIBLE)
+elseif(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+  add_definitions(-D_NETBSD_SOURCE)
+elseif(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
+  add_definitions(-D_OPENBSD_SOURCE)
+elseif(CMAKE_SYSTEM_NAME MATCHES "SunOS")
+  add_definitions(-D_PTHREADS)
+elseif(CMAKE_SYSTEM_NAME MATCHES "HP-UX")
+  add_definitions(-D_POSIX_C_SOURCE=200112L)
+  zmq_check_cxx_flag_prepend(-Ae)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  add_definitions(-D_DARWIN_C_SOURCE)
+endif()
 
-find_package (AsciiDoc)
+find_package(AsciiDoc)
 
-cmake_dependent_option (WITH_DOC "Build Reference Guide documentation (requires DocBook)" ON
-                       "ASCIIDOC_FOUND;NOT WIN32" OFF)  # Do not build docs on Windows due to issues with symlinks
+cmake_dependent_option(WITH_DOC "Build Reference Guide documentation(requires DocBook)" ON
+  "ASCIIDOC_FOUND;NOT WIN32" OFF)  # Do not build docs on Windows due to issues with symlinks
 
-if (MSVC)
-  if (WITH_OPENPGM)
-    #   set (OPENPGM_ROOT "" CACHE PATH "Location of OpenPGM")
-    set (OPENPGM_VERSION_MAJOR 5)
-    set (OPENPGM_VERSION_MINOR 2)
-    set (OPENPGM_VERSION_MICRO 122)
-    if (CMAKE_CL_64)
-      find_path (OPENPGM_ROOT include/pgm/pgm.h
-                PATHS
-                "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
-                NO_DEFAULT_PATH
-               )
-      message (STATUS "OpenPGM x64 detected - ${OPENPGM_ROOT}")
-    else ()
-      find_path (OPENPGM_ROOT include/pgm/pgm.h
-                PATHS
-                "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
-                "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
-                NO_DEFAULT_PATH
-               )
-      message (STATUS "OpenPGM x86 detected - ${OPENPGM_ROOT}")
-    endif (CMAKE_CL_64)
-    set (OPENPGM_INCLUDE_DIRS ${OPENPGM_ROOT}/include)
-    set (OPENPGM_LIBRARY_DIRS ${OPENPGM_ROOT}/lib)
-    set (OPENPGM_LIBRARIES
+if(MSVC)
+  if(WITH_OPENPGM)
+    #set(OPENPGM_ROOT "" CACHE PATH "Location of OpenPGM")
+    set(OPENPGM_VERSION_MAJOR 5)
+    set(OPENPGM_VERSION_MINOR 2)
+    set(OPENPGM_VERSION_MICRO 122)
+    if(CMAKE_CL_64)
+      find_path(OPENPGM_ROOT include/pgm/pgm.h
+          PATHS
+          "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
+          NO_DEFAULT_PATH)
+      message(STATUS "OpenPGM x64 detected - ${OPENPGM_ROOT}")
+    else()
+      find_path(OPENPGM_ROOT include/pgm/pgm.h
+          PATHS
+          "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
+          "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Miru\\OpenPGM ${OPENPGM_VERSION_MAJOR}.${OPENPGM_VERSION_MINOR}.${OPENPGM_VERSION_MICRO}]"
+          NO_DEFAULT_PATH)
+      message(STATUS "OpenPGM x86 detected - ${OPENPGM_ROOT}")
+    endif()
+    set(OPENPGM_INCLUDE_DIRS ${OPENPGM_ROOT}/include)
+    set(OPENPGM_LIBRARY_DIRS ${OPENPGM_ROOT}/lib)
+    set(OPENPGM_LIBRARIES
       optimized libpgm${MSVC_TOOLSET}-mt-${OPENPGM_VERSION_MAJOR}_${OPENPGM_VERSION_MINOR}_${OPENPGM_VERSION_MICRO}.lib
       debug libpgm${MSVC_TOOLSET}-mt-gd-${OPENPGM_VERSION_MAJOR}_${OPENPGM_VERSION_MINOR}_${OPENPGM_VERSION_MICRO}.lib)
-  endif ()
-else ()
-  if (WITH_OPENPGM)
-    #  message (FATAL_ERROR "WITH_OPENPGM not implemented")
+  endif()
+else()
+  if(WITH_OPENPGM)
+    #  message(FATAL_ERROR "WITH_OPENPGM not implemented")
 
-    if (NOT OPENPGM_PKGCONFIG_NAME)
-      SET (OPENPGM_PKGCONFIG_NAME "openpgm-5.2")
-    endif(NOT OPENPGM_PKGCONFIG_NAME)
+    if(NOT OPENPGM_PKGCONFIG_NAME)
+      set(OPENPGM_PKGCONFIG_NAME "openpgm-5.2")
+    endif()
 
-    SET (OPENPGM_PKGCONFIG_NAME ${OPENPGM_PKGCONFIG_NAME} CACHE STRING
+    set(OPENPGM_PKGCONFIG_NAME ${OPENPGM_PKGCONFIG_NAME} CACHE STRING
       "Name pkg-config shall use to find openpgm libraries and include paths"
-      FORCE )
+      FORCE)
 
     find_package(PkgConfig)
-    pkg_check_modules (OPENPGM  ${OPENPGM_PKGCONFIG_NAME})
+    pkg_check_modules(OPENPGM  ${OPENPGM_PKGCONFIG_NAME})
 
-    if (OPENPGM_FOUND)
-        message (STATUS ${OPENPGM_PKGCONFIG_NAME}" found")
-    else ()
-        message (FATAL_ERROR
-            ${OPENPGM_PKGCONFIG_NAME}"  not found. openpgm is searchd via `pkg-config ${OPENPGM_PKGCONFIG_NAME}`. Consider providing a valid OPENPGM_PKGCONFIG_NAME")
-    endif ()
+    if(OPENPGM_FOUND)
+      message(STATUS ${OPENPGM_PKGCONFIG_NAME}" found")
+    else()
+      message(FATAL_ERROR
+        ${OPENPGM_PKGCONFIG_NAME}"  not found. openpgm is searchd via `pkg-config ${OPENPGM_PKGCONFIG_NAME}`. Consider providing a valid OPENPGM_PKGCONFIG_NAME")
+    endif()
 
     # DSO symbol visibility for openpgm
-    if (HAVE_FLAG_VISIBILITY_HIDDEN)
+    if(HAVE_FLAG_VISIBILITY_HIDDEN)
 
-    elseif (HAVE_FLAG_LDSCOPE_HIDDEN)
+    elseif(HAVE_FLAG_LDSCOPE_HIDDEN)
 
-    endif ()
-  endif ()
-endif ()
+    endif()
+  endif()
+endif()
 
 
 #-----------------------------------------------------------------------------
 # force off-tree build
 
-if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
-message (FATAL_ERROR "CMake generation is not allowed within the source directory!
-Remove the CMakeCache.txt file and try again from another folder, e.g.:
-
-   rm CMakeCache.txt
-   mkdir cmake-make
-   cd cmake-make
-   cmake ..
-")
-endif ()
+if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+  message(FATAL_ERROR "CMake generation is not allowed within the source directory! \
+    Remove the CMakeCache.txt file and try again from another folder, e.g.: \
+    \
+      rm CMakeCache.txt \
+      mkdir cmake-make \
+      cd cmake-make \
+      cmake ..")
+endif()
 
 #-----------------------------------------------------------------------------
 # default to Release build
 
-if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   # CMAKE_BUILD_TYPE is not used for multi-configuration generators like Visual Studio/XCode
   # which instead use CMAKE_CONFIGURATION_TYPES
-  set (CMAKE_BUILD_TYPE Release CACHE STRING
-      "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
-      FORCE)
-endif ()
+  set(CMAKE_BUILD_TYPE Release CACHE STRING
+    "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+    FORCE)
+endif()
 
 #-----------------------------------------------------------------------------
 # output directories
@@ -564,353 +557,355 @@ zmq_set_with_default(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${ZeroMQ_BINARY_DIR}/lib")
 #-----------------------------------------------------------------------------
 # platform specifics
 
-if (WIN32)
-    #   Socket limit is 16K (can be raised arbitrarily)
-    add_definitions (-DFD_SETSIZE=16384)
-    add_definitions (-D_CRT_SECURE_NO_WARNINGS)
-    add_definitions (-D_WINSOCK_DEPRECATED_NO_WARNINGS)
-endif ()
+if(WIN32)
+  # Socket limit is 16K(can be raised arbitrarily)
+  add_definitions(-DFD_SETSIZE=16384)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
+endif()
 
-if (MSVC)
+if(MSVC)
   # Parallel make.
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
 
   # Compile the static lib with debug information included
   # note: we assume here that the default flags contain some /Z flag
-  string (REGEX REPLACE "/Z." "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-  string (REGEX REPLACE "/Z." "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  string(REGEX REPLACE "/Z." "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  string(REGEX REPLACE "/Z." "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
   # Optimization flags.
   # http://msdn.microsoft.com/en-us/magazine/cc301698.aspx
-  if (NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GL")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
-    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LTCG")
-    set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /LTCG")
-  endif ()
-endif ()
+  if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GL")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LTCG")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /LTCG")
+  endif()
+endif()
 
 
 #-----------------------------------------------------------------------------
 # source files
 
-set (cxx-sources
-        precompiled.cpp
-        address.cpp
-        client.cpp
-        clock.cpp
-        ctx.cpp
-        curve_mechanism_base.cpp
-        curve_client.cpp
-        curve_server.cpp
-        dealer.cpp
-        devpoll.cpp
-        dgram.cpp
-        dist.cpp
-        epoll.cpp
-        err.cpp
-        fq.cpp
-        io_object.cpp
-        io_thread.cpp
-        ip.cpp
-        ipc_address.cpp
-        ipc_connecter.cpp
-        ipc_listener.cpp
-        kqueue.cpp
-        lb.cpp
-        mailbox.cpp
-        mailbox_safe.cpp
-        mechanism.cpp
-        mechanism_base.cpp
-        metadata.cpp
-        msg.cpp
-        mtrie.cpp
-        object.cpp
-        options.cpp
-        own.cpp
-        null_mechanism.cpp
-        pair.cpp
-        pgm_receiver.cpp
-        pgm_sender.cpp
-        pgm_socket.cpp
-        pipe.cpp
-        plain_client.cpp
-        plain_server.cpp
-        poll.cpp
-        poller_base.cpp
-        polling_util.cpp
-        pollset.cpp
-        proxy.cpp
-        pub.cpp
-        pull.cpp
-        push.cpp
-        random.cpp
-        raw_encoder.cpp
-        raw_decoder.cpp
-        reaper.cpp
-        rep.cpp
-        req.cpp
-        router.cpp
-        select.cpp
-        server.cpp
-        session_base.cpp
-        signaler.cpp
-        socket_base.cpp
-        socks.cpp
-        socks_connecter.cpp
-        stream.cpp
-        stream_engine.cpp
-        sub.cpp
-        tcp.cpp
-        tcp_address.cpp
-        tcp_connecter.cpp
-        tcp_listener.cpp
-        thread.cpp
-        trie.cpp
-        v1_decoder.cpp
-        v1_encoder.cpp
-        v2_decoder.cpp
-        v2_encoder.cpp
-        xpub.cpp
-        xsub.cpp
-        zmq.cpp
-        zmq_utils.cpp
-        decoder_allocators.cpp
-        socket_poller.cpp
-        timers.cpp
-        config.hpp
-        radio.cpp
-        dish.cpp
-        udp_engine.cpp
-        udp_address.cpp
-        scatter.cpp
-        gather.cpp
-	ip_resolver.cpp
-		zap_client.cpp
-		# at least for VS, the header files must also be listed
-		address.hpp
-		array.hpp
-		atomic_counter.hpp
-		atomic_ptr.hpp
-		blob.hpp
-		client.hpp
-		clock.hpp
-		command.hpp
-		condition_variable.hpp
-		config.hpp
-		ctx.hpp
-		curve_client.hpp
-		curve_client_tools.hpp
-		curve_mechanism_base.hpp
-		curve_server.hpp
-		dbuffer.hpp
-		dealer.hpp
-		decoder.hpp
-		decoder_allocators.hpp
-		devpoll.hpp
-		dgram.hpp
-		dish.hpp
-		dist.hpp
-		encoder.hpp
-		epoll.hpp
-		err.hpp
-		fd.hpp
-		fq.hpp
-		gather.hpp
-		generic_mtrie.hpp
-		generic_mtrie_impl.hpp
-		gssapi_client.hpp
-		gssapi_mechanism_base.hpp
-		gssapi_server.hpp
-		i_decoder.hpp
-		i_encoder.hpp
-		i_engine.hpp
-		i_mailbox.hpp
-		i_poll_events.hpp
-		io_object.hpp
-		io_thread.hpp
-		ip.hpp
-		ipc_address.hpp
-		ipc_connecter.hpp
-		ipc_listener.hpp
-		kqueue.hpp
-		lb.hpp
-		likely.hpp
-		macros.hpp
-		mailbox.hpp
-		mailbox_safe.hpp
-		mechanism.hpp
-		mechanism_base.hpp
-		metadata.hpp
-		msg.hpp
-		mtrie.hpp
-		mutex.hpp
-		norm_engine.hpp
-		null_mechanism.hpp
-		object.hpp
-		options.hpp
-		own.hpp
-		pair.hpp
-		pgm_receiver.hpp
-		pgm_sender.hpp
-		pgm_socket.hpp
-		pipe.hpp
-		plain_client.hpp
-		plain_common.hpp
-		plain_server.hpp
-		poll.hpp
-		poller.hpp
-		poller_base.hpp
-		polling_util.hpp
-		pollset.hpp
-		precompiled.hpp
-		proxy.hpp
-		pub.hpp
-		pull.hpp
-		push.hpp
-		radio.hpp
-		random.hpp
-		raw_decoder.hpp
-		raw_encoder.hpp
-		reaper.hpp
-		rep.hpp
-		req.hpp
-		router.hpp
-		scatter.hpp
-		select.hpp
-		server.hpp
-		session_base.hpp
-		signaler.hpp
-		socket_base.hpp
-		socket_poller.hpp
-		socks.hpp
-		socks_connecter.hpp
-		stdint.hpp
-		stream.hpp
-		stream_engine.hpp
-		sub.hpp
-		tcp.hpp
-		tcp_address.hpp
-		tcp_connecter.hpp
-		tcp_listener.hpp
-		thread.hpp
-		timers.hpp
-		tipc_address.hpp
-		tipc_connecter.hpp
-		tipc_listener.hpp
-		trie.hpp
-		udp_address.hpp
-		udp_engine.hpp
-		v1_decoder.hpp
-		v1_encoder.hpp
-		v2_decoder.hpp
-		v2_encoder.hpp
-		v2_protocol.hpp
-		vmci.hpp
-		vmci_address.hpp
-		vmci_connecter.hpp
-		vmci_listener.hpp
-		windows.hpp
-		wire.hpp
-		xpub.hpp
-		xsub.hpp
-		ypipe.hpp
-		ypipe_base.hpp
-		ypipe_conflate.hpp
-		yqueue.hpp
-		zap_client.hpp
-		)
+set(cxx-sources
+  precompiled.cpp
+  address.cpp
+  client.cpp
+  clock.cpp
+  ctx.cpp
+  curve_mechanism_base.cpp
+  curve_client.cpp
+  curve_server.cpp
+  dealer.cpp
+  devpoll.cpp
+  dgram.cpp
+  dist.cpp
+  epoll.cpp
+  err.cpp
+  fq.cpp
+  io_object.cpp
+  io_thread.cpp
+  ip.cpp
+  ipc_address.cpp
+  ipc_connecter.cpp
+  ipc_listener.cpp
+  kqueue.cpp
+  lb.cpp
+  mailbox.cpp
+  mailbox_safe.cpp
+  mechanism.cpp
+  mechanism_base.cpp
+  metadata.cpp
+  msg.cpp
+  mtrie.cpp
+  object.cpp
+  options.cpp
+  own.cpp
+  null_mechanism.cpp
+  pair.cpp
+  pgm_receiver.cpp
+  pgm_sender.cpp
+  pgm_socket.cpp
+  pipe.cpp
+  plain_client.cpp
+  plain_server.cpp
+  poll.cpp
+  poller_base.cpp
+  polling_util.cpp
+  pollset.cpp
+  proxy.cpp
+  pub.cpp
+  pull.cpp
+  push.cpp
+  random.cpp
+  raw_encoder.cpp
+  raw_decoder.cpp
+  reaper.cpp
+  rep.cpp
+  req.cpp
+  router.cpp
+  select.cpp
+  server.cpp
+  session_base.cpp
+  signaler.cpp
+  socket_base.cpp
+  socks.cpp
+  socks_connecter.cpp
+  stream.cpp
+  stream_engine.cpp
+  sub.cpp
+  tcp.cpp
+  tcp_address.cpp
+  tcp_connecter.cpp
+  tcp_listener.cpp
+  thread.cpp
+  trie.cpp
+  v1_decoder.cpp
+  v1_encoder.cpp
+  v2_decoder.cpp
+  v2_encoder.cpp
+  xpub.cpp
+  xsub.cpp
+  zmq.cpp
+  zmq_utils.cpp
+  decoder_allocators.cpp
+  socket_poller.cpp
+  timers.cpp
+  config.hpp
+  radio.cpp
+  dish.cpp
+  udp_engine.cpp
+  udp_address.cpp
+  scatter.cpp
+  gather.cpp
+  ip_resolver.cpp
+  zap_client.cpp
+  # at least for VS, the header files must also be listed
+  address.hpp
+  array.hpp
+  atomic_counter.hpp
+  atomic_ptr.hpp
+  blob.hpp
+  client.hpp
+  clock.hpp
+  command.hpp
+  condition_variable.hpp
+  config.hpp
+  ctx.hpp
+  curve_client.hpp
+  curve_client_tools.hpp
+  curve_mechanism_base.hpp
+  curve_server.hpp
+  dbuffer.hpp
+  dealer.hpp
+  decoder.hpp
+  decoder_allocators.hpp
+  devpoll.hpp
+  dgram.hpp
+  dish.hpp
+  dist.hpp
+  encoder.hpp
+  epoll.hpp
+  err.hpp
+  fd.hpp
+  fq.hpp
+  gather.hpp
+  generic_mtrie.hpp
+  generic_mtrie_impl.hpp
+  gssapi_client.hpp
+  gssapi_mechanism_base.hpp
+  gssapi_server.hpp
+  i_decoder.hpp
+  i_encoder.hpp
+  i_engine.hpp
+  i_mailbox.hpp
+  i_poll_events.hpp
+  io_object.hpp
+  io_thread.hpp
+  ip.hpp
+  ipc_address.hpp
+  ipc_connecter.hpp
+  ipc_listener.hpp
+  kqueue.hpp
+  lb.hpp
+  likely.hpp
+  macros.hpp
+  mailbox.hpp
+  mailbox_safe.hpp
+  mechanism.hpp
+  mechanism_base.hpp
+  metadata.hpp
+  msg.hpp
+  mtrie.hpp
+  mutex.hpp
+  norm_engine.hpp
+  null_mechanism.hpp
+  object.hpp
+  options.hpp
+  own.hpp
+  pair.hpp
+  pgm_receiver.hpp
+  pgm_sender.hpp
+  pgm_socket.hpp
+  pipe.hpp
+  plain_client.hpp
+  plain_common.hpp
+  plain_server.hpp
+  poll.hpp
+  poller.hpp
+  poller_base.hpp
+  polling_util.hpp
+  pollset.hpp
+  precompiled.hpp
+  proxy.hpp
+  pub.hpp
+  pull.hpp
+  push.hpp
+  radio.hpp
+  random.hpp
+  raw_decoder.hpp
+  raw_encoder.hpp
+  reaper.hpp
+  rep.hpp
+  req.hpp
+  router.hpp
+  scatter.hpp
+  select.hpp
+  server.hpp
+  session_base.hpp
+  signaler.hpp
+  socket_base.hpp
+  socket_poller.hpp
+  socks.hpp
+  socks_connecter.hpp
+  stdint.hpp
+  stream.hpp
+  stream_engine.hpp
+  sub.hpp
+  tcp.hpp
+  tcp_address.hpp
+  tcp_connecter.hpp
+  tcp_listener.hpp
+  thread.hpp
+  timers.hpp
+  tipc_address.hpp
+  tipc_connecter.hpp
+  tipc_listener.hpp
+  trie.hpp
+  udp_address.hpp
+  udp_engine.hpp
+  v1_decoder.hpp
+  v1_encoder.hpp
+  v2_decoder.hpp
+  v2_encoder.hpp
+  v2_protocol.hpp
+  vmci.hpp
+  vmci_address.hpp
+  vmci_connecter.hpp
+  vmci_listener.hpp
+  windows.hpp
+  wire.hpp
+  xpub.hpp
+  xsub.hpp
+  ypipe.hpp
+  ypipe_base.hpp
+  ypipe_conflate.hpp
+  yqueue.hpp
+  zap_client.hpp
+)
 
-if (MINGW)
+if(MINGW)
   # Generate the right type when using -m32 or -m64
-  macro (set_rc_arch rc_target)
-    set (CMAKE_RC_COMPILER_INIT windres)
-    enable_language (RC)
-    set (CMAKE_RC_COMPILE_OBJECT
-        "<CMAKE_RC_COMPILER> <FLAGS> -O coff --target=${rc_target} <DEFINES> -i <SOURCE> -o <OBJECT>")
-  endmacro ()
+  macro(set_rc_arch rc_target)
+    set(CMAKE_RC_COMPILER_INIT windres)
+    enable_language(RC)
+    set(CMAKE_RC_COMPILE_OBJECT
+      "<CMAKE_RC_COMPILER> <FLAGS> -O coff --target=${rc_target} <DEFINES> -i <SOURCE> -o <OBJECT>")
+  endmacro()
 
-  if (NOT CMAKE_SYSTEM_PROCESSOR)
-    set (CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
-  endif ()
+  if(NOT CMAKE_SYSTEM_PROCESSOR)
+    set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+  endif()
 
-  if (    CMAKE_SYSTEM_PROCESSOR MATCHES "i386"
-      OR CMAKE_SYSTEM_PROCESSOR MATCHES "i486"
-      OR CMAKE_SYSTEM_PROCESSOR MATCHES "i586"
-      OR CMAKE_SYSTEM_PROCESSOR MATCHES "i686"
-     # This also happens on x86_64 systems...what a worthless variable
-      OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86"
-      OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64"
-      OR CMAKE_SYSTEM_PROCESSOR MATCHES "amd64")
+  # Also happens on x86_64 systems...what a worthless variable
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "i386"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "i486"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "i586"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "i686"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "amd64")
 
-    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set_rc_arch ("pe-x86-64")
-    else ()
-      set_rc_arch ("pe-i386")
-    endif ()
-  endif ()
-endif ()
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      set_rc_arch("pe-x86-64")
+    else()
+      set_rc_arch("pe-i386")
+    endif()
+  endif()
+endif()
 
-set (public_headers include/zmq.h
-                    include/zmq_utils.h)
+set(public_headers
+  include/zmq.h
+  include/zmq_utils.h)
 
-set (readme-docs AUTHORS
-                COPYING
-                COPYING.LESSER
-                NEWS)
+set(readme-docs
+  AUTHORS
+  COPYING
+  COPYING.LESSER
+  NEWS)
 
 #-----------------------------------------------------------------------------
 # optional modules
 
-if (WITH_OPENPGM)
-  add_definitions (-DZMQ_HAVE_OPENPGM)
-  include_directories (${OPENPGM_INCLUDE_DIRS})
-  link_directories (${OPENPGM_LIBRARY_DIRS})
-  set (OPTIONAL_LIBRARIES ${OPENPGM_LIBRARIES})
-endif (WITH_OPENPGM)
+if(WITH_OPENPGM)
+  add_definitions(-DZMQ_HAVE_OPENPGM)
+  include_directories(${OPENPGM_INCLUDE_DIRS})
+  link_directories(${OPENPGM_LIBRARY_DIRS})
+  set(OPTIONAL_LIBRARIES ${OPENPGM_LIBRARIES})
+endif()
 
-if (WITH_VMCI)
-    add_definitions (-DZMQ_HAVE_VMCI)
-    include_directories (${VMCI_INCLUDE_DIRS})
-    list (APPEND cxx-sources vmci_address.cpp vmci_connecter.cpp vmci_listener.cpp vmci.cpp)
-endif (WITH_VMCI)
+if(WITH_VMCI)
+  add_definitions(-DZMQ_HAVE_VMCI)
+  include_directories(${VMCI_INCLUDE_DIRS})
+  list(APPEND cxx-sources vmci_address.cpp vmci_connecter.cpp vmci_listener.cpp vmci.cpp)
+endif()
 
-if (ZMQ_HAVE_TIPC)
-    add_definitions (-DZMQ_HAVE_TIPC)
-    list (APPEND cxx-sources tipc_address.cpp tipc_connecter.cpp tipc_listener.cpp)
-endif (ZMQ_HAVE_TIPC)
+if(ZMQ_HAVE_TIPC)
+  add_definitions(-DZMQ_HAVE_TIPC)
+  list(APPEND cxx-sources tipc_address.cpp tipc_connecter.cpp tipc_listener.cpp)
+endif()
 
 #-----------------------------------------------------------------------------
 # source generators
 
-foreach (source ${cxx-sources})
-  list (APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/src/${source})
-endforeach ()
+foreach(source ${cxx-sources})
+  list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/src/${source})
+endforeach()
 
-configure_file (${CMAKE_CURRENT_SOURCE_DIR}/src/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 
 #   Delete any src/platform.hpp left by configure
-file (REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/src/platform.hpp)
+file(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/src/platform.hpp)
 
-configure_file (${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/platform.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
-list (APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/platform.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
+list(APPEND sources ${CMAKE_CURRENT_BINARY_DIR}/platform.hpp)
 
-configure_file (${CMAKE_CURRENT_SOURCE_DIR}/src/libzmq.pc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc @ONLY)
-set (zmq-pkgconfig ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/libzmq.pc.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc @ONLY)
+set(zmq-pkgconfig ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc)
 
-if (NOT ZMQ_BUILD_FRAMEWORK)
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-endif ()
+if(NOT ZMQ_BUILD_FRAMEWORK)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libzmq.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()
 
-if (MSVC)
-  if (CMAKE_CL_64)
-    set (nsis-template ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/NSIS.template64.in)
-  else ()
-    set (nsis-template ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/NSIS.template32.in)
-  endif ()
+if(MSVC)
+  if(CMAKE_CL_64)
+    set(nsis-template ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/NSIS.template64.in)
+  else()
+    set(nsis-template ${CMAKE_CURRENT_SOURCE_DIR}/builds/cmake/NSIS.template32.in)
+  endif()
 
-  add_custom_command (
+  add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in
     COMMAND ${CMAKE_COMMAND}
     ARGS -E
@@ -918,17 +913,17 @@ if (MSVC)
     ${nsis-template}
     ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in
     DEPENDS ${nsis-template})
-endif ()
+endif()
 
-file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc)
-file (GLOB docs RELATIVE ${CMAKE_CURRENT_BINARY_DIR}/ "${CMAKE_CURRENT_SOURCE_DIR}/doc/*.txt")
-set (html-docs)
-foreach (txt ${docs})
-  string (REGEX REPLACE ".*/(.*)\\.txt" "\\1.html" html ${txt})
-  set (src ${txt})
-  set (dst doc/${html})
-  if (WITH_DOC)
-    add_custom_command (
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc)
+file(GLOB docs RELATIVE ${CMAKE_CURRENT_BINARY_DIR}/ "${CMAKE_CURRENT_SOURCE_DIR}/doc/*.txt")
+set(html-docs)
+foreach(txt ${docs})
+  string(REGEX REPLACE ".*/(.*)\\.txt" "\\1.html" html ${txt})
+  set(src ${txt})
+  set(dst doc/${html})
+  if(WITH_DOC)
+    add_custom_command(
       OUTPUT  ${dst}
       COMMAND ${ASCIIDOC_EXECUTABLE}
       -d manpage
@@ -940,38 +935,36 @@ foreach (txt ${docs})
       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${src}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Generating ${html}")
-    list (APPEND html-docs ${CMAKE_CURRENT_BINARY_DIR}/${dst})
-  endif ()
-endforeach ()
+    list(APPEND html-docs ${CMAKE_CURRENT_BINARY_DIR}/${dst})
+  endif()
+endforeach()
 
-if (ZMQ_BUILD_FRAMEWORK)
-  add_custom_command (
-    TARGET libzmq
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND}
-    ARGS -E make_directory "${CMAKE_LIBRARY_OUTPUT_PATH}/ZeroMQ.framework/Versions/${ZMQ_VERSION}/MacOS"
-    COMMENT "Perf tools")
-endif ()
+if(ZMQ_BUILD_FRAMEWORK)
+  add_custom_command(
+  TARGET libzmq
+  POST_BUILD
+  COMMAND ${CMAKE_COMMAND}
+  ARGS -E make_directory "${CMAKE_LIBRARY_OUTPUT_PATH}/ZeroMQ.framework/Versions/${ZMQ_VERSION}/MacOS"
+  COMMENT "Perf tools")
+endif()
 
-if (MSVC)
-    # default for all sources is to use precompiled headers
-    foreach(source ${sources})    
-        # C and C++ can not use the same precompiled header
-        if (${soruce} MATCHES ".cpp$" AND NOT ${source} STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/src/precompiled.cpp")
-            set_source_files_properties(${source}
-                PROPERTIES
-                COMPILE_FLAGS "/Yuprecompiled.hpp"
-                OBJECT_DEPENDS precompiled.hpp
-                )
-        endif()
-    endforeach()
-    # create precompiled header
-    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/precompiled.cpp
+if(MSVC)
+  # default for all sources is to use precompiled headers
+  foreach(source ${sources})
+    # C and C++ can not use the same precompiled header
+    if(${soruce} MATCHES ".cpp$" AND NOT ${source} STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/src/precompiled.cpp")
+      set_source_files_properties(${source}
         PROPERTIES
-        COMPILE_FLAGS "/Ycprecompiled.hpp"
-        OBJECT_OUTPUTS precompiled.hpp
-        )
-endif ()
+        COMPILE_FLAGS "/Yuprecompiled.hpp"
+        OBJECT_DEPENDS precompiled.hpp)
+    endif()
+  endforeach()
+  # create precompiled header
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/precompiled.cpp
+    PROPERTIES
+    COMPILE_FLAGS "/Ycprecompiled.hpp"
+    OBJECT_OUTPUTS precompiled.hpp)
+endif()
 
 
 #-----------------------------------------------------------------------------
@@ -981,32 +974,32 @@ option(BUILD_STATIC "Whether or not to build the static archive" ON)
 
 list(APPEND target_outputs "")
 
-if (BUILD_SHARED)
+if(BUILD_SHARED)
   list(APPEND target_outputs "libzmq")
 endif()
 
-if (BUILD_STATIC)
+if(BUILD_STATIC)
   list(APPEND target_outputs "libzmq-static")
 endif()
 
-if (MSVC)
+if(MSVC)
   # Suppress linker warnings caused by #ifdef omission
   # of file content.
   set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /ignore:4221")
-  set (PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
-  set (PDB_NAME "libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}")
+  set(PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
+  set(PDB_NAME "libzmq${MSVC_TOOLSET}-mt-gd-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}")
   function(enable_vs_guideline_checker target)
     set_target_properties(${target} PROPERTIES
-        VS_GLOBAL_EnableCppCoreCheck true
-        VS_GLOBAL_CodeAnalysisRuleSet CppCoreCheckRules.ruleset
-        VS_GLOBAL_RunCodeAnalysis true)
+      VS_GLOBAL_EnableCppCoreCheck true
+      VS_GLOBAL_CodeAnalysisRuleSet CppCoreCheckRules.ruleset
+      VS_GLOBAL_RunCodeAnalysis true)
   endfunction()
-  if (BUILD_SHARED)
-    add_library (libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+  if(BUILD_SHARED)
+    add_library(libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${CMAKE_CURRENT_BINARY_DIR}/NSIS.template.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
     if(ENABLE_ANALYSIS)
-        enable_vs_guideline_checker (libzmq)
+      enable_vs_guideline_checker(libzmq)
     endif()
-    set_target_properties (libzmq PROPERTIES
+    set_target_properties(libzmq PROPERTIES
       PUBLIC_HEADER "${public_headers}"
       RELEASE_POSTFIX "${MSVC_TOOLSET}-mt-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
       RELWITHDEBINFO_POSTFIX "${MSVC_TOOLSET}-mt-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
@@ -1017,9 +1010,9 @@ if (MSVC)
       OUTPUT_NAME "libzmq")
   endif()
 
-  if (BUILD_STATIC)
-    add_library (libzmq-static STATIC ${sources} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-    set_target_properties (libzmq-static PROPERTIES
+  if(BUILD_STATIC)
+    add_library(libzmq-static STATIC ${sources} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+    set_target_properties(libzmq-static PROPERTIES
       PUBLIC_HEADER "${public_headers}"
       RELEASE_POSTFIX "${MSVC_TOOLSET}-mt-s-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
       RELWITHDEBINFO_POSTFIX "${MSVC_TOOLSET}-mt-s-${ZMQ_VERSION_MAJOR}_${ZMQ_VERSION_MINOR}_${ZMQ_VERSION_PATCH}"
@@ -1028,377 +1021,376 @@ if (MSVC)
       COMPILE_FLAGS "/DZMQ_STATIC"
       OUTPUT_NAME "libzmq")
   endif()
-else ()
+else()
   # avoid building everything twice for shared + static
   # only on *nix, as Windows needs different preprocessor defines in static builds
-  if (NOT MINGW)
-    add_library (objects OBJECT ${sources})
+  if(NOT MINGW)
+    add_library(objects OBJECT ${sources})
     set_property(TARGET objects PROPERTY POSITION_INDEPENDENT_CODE ON)
-    target_include_directories (objects
+    target_include_directories(objects
       PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-        $<INSTALL_INTERFACE:include>
-    )
-  endif ()
-
-  if (BUILD_SHARED)
-    if (MINGW)
-      add_library (libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-    else ()
-      add_library (libzmq SHARED $<TARGET_OBJECTS:objects> ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-    endif ()
-    # NOTE: the SOVERSION and VERSION MUST be the same as the one generated by libtool! It is NOT the same as the version of the package.
-    set_target_properties (libzmq PROPERTIES
-                          COMPILE_DEFINITIONS "DLL_EXPORT"
-                          PUBLIC_HEADER "${public_headers}"
-                          VERSION "5.1.6"
-                          SOVERSION "5"
-                          OUTPUT_NAME "zmq"
-                          PREFIX "lib")
-    if (ZMQ_BUILD_FRAMEWORK)
-      set_target_properties (libzmq PROPERTIES
-                            FRAMEWORK TRUE
-                            MACOSX_FRAMEWORK_IDENTIFIER "org.zeromq.libzmq"
-                            MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${ZMQ_VERSION}
-                            MACOSX_FRAMEWORK_BUNDLE_VERSION ${ZMQ_VERSION})
-      set_source_files_properties (${html-docs} PROPERTIES
-                                  MACOSX_PACKAGE_LOCATION doc)
-      set_source_files_properties (${readme-docs} PROPERTIES
-                                  MACOSX_PACKAGE_LOCATION etc)
-      set_source_files_properties (${zmq-pkgconfig} PROPERTIES
-                                  MACOSX_PACKAGE_LOCATION lib/pkgconfig)
-    endif ()
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+      $<INSTALL_INTERFACE:include>)
   endif()
 
-  if (BUILD_STATIC)
-    if (MINGW)
-      add_library (libzmq-static STATIC ${sources} ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-    else ()
-      add_library (libzmq-static STATIC $<TARGET_OBJECTS:objects> ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-    endif ()
-    set_target_properties (libzmq-static PROPERTIES
+  if(BUILD_SHARED)
+    if(MINGW)
+      add_library(libzmq SHARED ${sources} ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+    else()
+      add_library(libzmq SHARED $<TARGET_OBJECTS:objects> ${public_headers} ${html-docs} ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+    endif()
+    # NOTE: the SOVERSION and VERSION MUST be the same as the one generated by libtool! It is NOT the same as the version of the package.
+    set_target_properties(libzmq PROPERTIES
+      COMPILE_DEFINITIONS "DLL_EXPORT"
+      PUBLIC_HEADER "${public_headers}"
+      VERSION "5.1.6"
+      SOVERSION "5"
+      OUTPUT_NAME "zmq"
+      PREFIX "lib")
+    if(ZMQ_BUILD_FRAMEWORK)
+      set_target_properties(libzmq PROPERTIES
+        FRAMEWORK TRUE
+        MACOSX_FRAMEWORK_IDENTIFIER "org.zeromq.libzmq"
+        MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${ZMQ_VERSION}
+        MACOSX_FRAMEWORK_BUNDLE_VERSION ${ZMQ_VERSION})
+      set_source_files_properties(${html-docs} PROPERTIES
+        MACOSX_PACKAGE_LOCATION doc)
+      set_source_files_properties(${readme-docs} PROPERTIES
+        MACOSX_PACKAGE_LOCATION etc)
+      set_source_files_properties(${zmq-pkgconfig} PROPERTIES
+        MACOSX_PACKAGE_LOCATION lib/pkgconfig)
+    endif()
+  endif()
+
+  if(BUILD_STATIC)
+    if(MINGW)
+      add_library(libzmq-static STATIC ${sources} ${public_headers} ${html-docs}
+        ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+    else()
+      add_library(libzmq-static STATIC $<TARGET_OBJECTS:objects> ${public_headers}
+        ${html-docs} ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+    endif()
+    set_target_properties(libzmq-static PROPERTIES
       PUBLIC_HEADER "${public_headers}"
       OUTPUT_NAME "zmq"
       PREFIX "lib")
   endif()
+endif()
 
-endif ()
-
-if (BUILD_STATIC)
+if(BUILD_STATIC)
   target_compile_definitions(libzmq-static
-    PUBLIC ZMQ_STATIC
-  )
-endif ()
+    PUBLIC ZMQ_STATIC)
+endif()
 
-foreach (target ${target_outputs})
-  target_include_directories (${target}
+foreach(target ${target_outputs})
+  target_include_directories(${target}
     PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-      $<INSTALL_INTERFACE:include>
-  )
+      $<INSTALL_INTERFACE:include>)
 endforeach()
 
-if (BUILD_SHARED)
-  target_link_libraries (libzmq ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+if(BUILD_SHARED)
+  target_link_libraries(libzmq ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-  if (SODIUM_FOUND)
-    target_link_libraries (libzmq ${SODIUM_LIBRARIES})
-	# On Solaris, libsodium depends on libssp
-    if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
-      target_link_libraries (libzmq ssp)
-    endif ()
-  endif ()
-
-  if (HAVE_WS2_32)
-    target_link_libraries (libzmq ws2_32)
-  elseif (HAVE_WS2)
-    target_link_libraries (libzmq ws2)
-  endif ()
-
-  if (HAVE_RPCRT4)
-    target_link_libraries (libzmq rpcrt4)
-  endif ()
-
-  if (HAVE_IPHLAPI)
-    target_link_libraries (libzmq iphlpapi)
-  endif ()
-
-  if (RT_LIBRARY)
-    target_link_libraries (libzmq -lrt)
-  endif ()
-endif ()
-
-if (BUILD_STATIC)
-  target_link_libraries (libzmq-static ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-
-  if (SODIUM_FOUND)
-    target_link_libraries (libzmq-static ${SODIUM_LIBRARIES})
+  if(SODIUM_FOUND)
+    target_link_libraries(libzmq ${SODIUM_LIBRARIES})
     # On Solaris, libsodium depends on libssp
-    if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
-      target_link_libraries (libzmq-static ssp)
-    endif ()
-  endif ()
+    if(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+      target_link_libraries(libzmq ssp)
+    endif()
+  endif()
 
-  if (HAVE_WS2_32)
-    target_link_libraries (libzmq-static ws2_32)
-  elseif (HAVE_WS2)
-    target_link_libraries (libzmq-static ws2)
-  endif ()
+  if(HAVE_WS2_32)
+    target_link_libraries(libzmq ws2_32)
+  elseif(HAVE_WS2)
+    target_link_libraries(libzmq ws2)
+  endif()
 
-  if (HAVE_RPCRT4)
-    target_link_libraries (libzmq-static rpcrt4)
-  endif ()
+  if(HAVE_RPCRT4)
+    target_link_libraries(libzmq rpcrt4)
+  endif()
 
-  if (HAVE_IPHLAPI)
-    target_link_libraries (libzmq-static iphlpapi)
-  endif ()
+  if(HAVE_IPHLAPI)
+    target_link_libraries(libzmq iphlpapi)
+  endif()
 
-  if (RT_LIBRARY)
-    target_link_libraries (libzmq-static -lrt)
-  endif ()
-endif ()
+  if(RT_LIBRARY)
+    target_link_libraries(libzmq -lrt)
+  endif()
+endif()
 
-if (BUILD_SHARED)
-  set (perf-tools local_lat
-                 remote_lat
-                 local_thr
-                 remote_thr
-                 inproc_lat
-                 inproc_thr)
+if(BUILD_STATIC)
+  target_link_libraries(libzmq-static ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-  if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug") # Why?
-    option (WITH_PERF_TOOL "Build with perf-tools" ON)
-  else ()
-    option (WITH_PERF_TOOL "Build with perf-tools" OFF)
-  endif ()
+  if(SODIUM_FOUND)
+    target_link_libraries(libzmq-static ${SODIUM_LIBRARIES})
+    # On Solaris, libsodium depends on libssp
+    if(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+      target_link_libraries(libzmq-static ssp)
+    endif()
+  endif()
 
-  if (WITH_PERF_TOOL)
-    foreach (perf-tool ${perf-tools})
-      add_executable (${perf-tool} perf/${perf-tool}.cpp)
-      target_link_libraries (${perf-tool} libzmq)
+  if(HAVE_WS2_32)
+    target_link_libraries(libzmq-static ws2_32)
+  elseif(HAVE_WS2)
+    target_link_libraries(libzmq-static ws2)
+  endif()
 
-      if (ZMQ_BUILD_FRAMEWORK)
+  if(HAVE_RPCRT4)
+    target_link_libraries(libzmq-static rpcrt4)
+  endif()
+
+  if(HAVE_IPHLAPI)
+    target_link_libraries(libzmq-static iphlpapi)
+  endif()
+
+  if(RT_LIBRARY)
+    target_link_libraries(libzmq-static -lrt)
+  endif()
+endif()
+
+if(BUILD_SHARED)
+  set(perf-tools
+    local_lat
+    remote_lat
+    local_thr
+    remote_thr
+    inproc_lat
+    inproc_thr)
+
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug") # Why?
+    option(WITH_PERF_TOOL "Build with perf-tools" ON)
+  else()
+    option(WITH_PERF_TOOL "Build with perf-tools" OFF)
+  endif()
+
+  if(WITH_PERF_TOOL)
+    foreach(perf-tool ${perf-tools})
+      add_executable(${perf-tool} perf/${perf-tool}.cpp)
+      target_link_libraries(${perf-tool} libzmq)
+
+      if(ZMQ_BUILD_FRAMEWORK)
         # Copy perf-tools binaries into Framework
-        add_custom_command (
+        add_custom_command(
           TARGET libzmq ${perf-tool}
           POST_BUILD
           COMMAND ${CMAKE_COMMAND}
           ARGS -E copy "$<TARGET_FILE:${perf-tool}>" "${LIBRARY_OUTPUT_PATH}/ZeroMQ.framework/Versions/${ZMQ_VERSION_STRING}/MacOS/${perf-tool}"
           VERBATIM
           COMMENT "Perf tools")
-      else ()
-        install (TARGETS ${perf-tool}
-                RUNTIME DESTINATION bin
-                COMPONENT PerfTools)
-      endif ()
-    endforeach ()
-  endif ()
-elseif (WITH_PERF_TOOL)
+      else()
+        install(TARGETS ${perf-tool}
+          RUNTIME DESTINATION bin
+          COMPONENT PerfTools)
+      endif()
+    endforeach()
+  endif()
+elseif(WITH_PERF_TOOL)
   message(FATAL_ERROR "Shared library disabled - perf-tools unavailable.")
-endif ()
+endif()
 
 #-----------------------------------------------------------------------------
 # tests
 
 option(BUILD_TESTS "Whether or not to build the tests" ON)
 
-set (ZMQ_BUILD_TESTS ${BUILD_TESTS} CACHE BOOL "Build the tests for ZeroMQ")
+set(ZMQ_BUILD_TESTS ${BUILD_TESTS} CACHE BOOL "Build the tests for ZeroMQ")
 
-if (ZMQ_BUILD_TESTS)
-  enable_testing () # Enable testing only works in root scope
-  ADD_SUBDIRECTORY (tests)
-  if (BUILD_STATIC)
-    add_subdirectory (unittests)
-  else ()
-    message (WARNING "Not building unit tests, since BUILD_STATIC is not enabled")
-  endif ()
-endif ()
+if(ZMQ_BUILD_TESTS)
+  enable_testing() # Enable testing only works in root scope
+  add_subdirectory(tests)
+  if(BUILD_STATIC)
+    add_subdirectory(unittests)
+  else()
+    message(WARNING "Not building unit tests, since BUILD_STATIC is not enabled")
+  endif()
+endif()
 
 #-----------------------------------------------------------------------------
 # installer
 
-if (MSVC AND (BUILD_SHARED OR BUILD_STATIC))
-  install (TARGETS ${target_outputs}
-          EXPORT ${PROJECT_NAME}-targets
-          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-          PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-          COMPONENT SDK)
-  if (MSVC_IDE)
-    install (FILES ${PDB_OUTPUT_DIRECTORY}/\${CMAKE_INSTALL_CONFIG_NAME}/${PDB_NAME}.pdb DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT SDK OPTIONAL)
+if(MSVC AND(BUILD_SHARED OR BUILD_STATIC))
+  install(TARGETS ${target_outputs}
+    EXPORT ${PROJECT_NAME}-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT SDK)
+  if(MSVC_IDE)
+    install(FILES ${PDB_OUTPUT_DIRECTORY}/\${CMAKE_INSTALL_CONFIG_NAME}/${PDB_NAME}.pdb DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT SDK OPTIONAL)
   else()
-    install (FILES ${PDB_OUTPUT_DIRECTORY}/${PDB_NAME}.pdb DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT SDK OPTIONAL)
+    install(FILES ${PDB_OUTPUT_DIRECTORY}/${PDB_NAME}.pdb DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT SDK OPTIONAL)
   endif()
-  if (BUILD_SHARED)
-    install (TARGETS libzmq
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            COMPONENT Runtime)
-  endif ()
-elseif (BUILD_SHARED OR BUILD_STATIC)
-  install (TARGETS ${target_outputs}
-          EXPORT ${PROJECT_NAME}-targets
-          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          FRAMEWORK DESTINATION "Library/Frameworks"
-          PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-endif ()
+  if(BUILD_SHARED)
+    install(TARGETS libzmq
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+      COMPONENT Runtime)
+  endif()
+elseif(BUILD_SHARED OR BUILD_STATIC)
+  install(TARGETS ${target_outputs}
+    EXPORT ${PROJECT_NAME}-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    FRAMEWORK DESTINATION "Library/Frameworks"
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
-# install (FILES ${public_headers}
-#          DESTINATION include
-#          COMPONENT SDK)
+# install(FILES ${public_headers}
+#   DESTINATION include
+#   COMPONENT SDK)
 
-#if (NOT ZMQ_BUILD_FRAMEWORK)
-#  file (GLOB private_headers "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp")
-#  install (FILES ${sources} ${private_headers} DESTINATION src/zmq
-#          COMPONENT SourceCode)
-#endif ()
+#if(NOT ZMQ_BUILD_FRAMEWORK)
+#  file(GLOB private_headers "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp")
+#  install(FILES ${sources} ${private_headers} DESTINATION src/zmq
+#    COMPONENT SourceCode)
+#endif()
 
-foreach (readme ${readme-docs})
-  configure_file (${CMAKE_CURRENT_SOURCE_DIR}/${readme} ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt)
+foreach(readme ${readme-docs})
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${readme} ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt)
 
-  if (NOT ZMQ_BUILD_FRAMEWORK)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION share/zmq)
-  endif ()
-endforeach ()
+  if(NOT ZMQ_BUILD_FRAMEWORK)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${readme}.txt DESTINATION share/zmq)
+  endif()
+endforeach()
 
-if (WITH_DOC)
-  if (NOT ZMQ_BUILD_FRAMEWORK)
-    install (FILES ${html-docs} DESTINATION doc/zmq COMPONENT RefGuide)
-  endif ()
-endif ()
+if(WITH_DOC)
+  if(NOT ZMQ_BUILD_FRAMEWORK)
+    install(FILES ${html-docs} DESTINATION doc/zmq COMPONENT RefGuide)
+  endif()
+endif()
 
 include(CMakePackageConfigHelpers)
 
-if (WIN32)
+if(WIN32)
   set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "CMake" CACHE STRING "install path for ZeroMQConfig.cmake")
 else()
   # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
   set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
 endif()
 
-if ((NOT CMAKE_VERSION VERSION_LESS 3.0) AND (BUILD_SHARED OR BUILD_STATIC))
+if((NOT CMAKE_VERSION VERSION_LESS 3.0) AND (BUILD_SHARED OR BUILD_STATIC))
   export(EXPORT ${PROJECT_NAME}-targets
-         FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
 endif()
 configure_package_config_file(builds/cmake/${PROJECT_NAME}Config.cmake.in
-                              "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-                              INSTALL_DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-                                 VERSION ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}
-                                 COMPATIBILITY AnyNewerVersion)
-if (BUILD_SHARED OR BUILD_STATIC)
+  VERSION ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}
+  COMPATIBILITY AnyNewerVersion)
+if(BUILD_SHARED OR BUILD_STATIC)
   install(EXPORT ${PROJECT_NAME}-targets
-          FILE ${PROJECT_NAME}Targets.cmake
-          DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
+    FILE ${PROJECT_NAME}Targets.cmake
+    DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-                ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-                DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION ${ZEROMQ_CMAKECONFIG_INSTALL_DIR})
 endif()
 
 option(ENABLE_CPACK "Enables cpack rules" ON)
-if (MSVC AND ENABLE_CPACK)
-  include (InstallRequiredSystemLibraries)
+if(MSVC AND ENABLE_CPACK)
+  include(InstallRequiredSystemLibraries)
 
-  if (CMAKE_CL_64)
-    set (arch_name "x64")
-  else ()
-    set (arch_name "x86")
-  endif ()
+  if(CMAKE_CL_64)
+    set(arch_name "x64")
+  else()
+    set(arch_name "x86")
+  endif()
 
-  set (CPACK_NSIS_DISPLAY_NAME "ZeroMQ ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH} (${arch_name})")
-  set (CPACK_PACKAGE_FILE_NAME "ZeroMQ-${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}-${arch_name}")
+  set(CPACK_NSIS_DISPLAY_NAME "ZeroMQ ${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}(${arch_name})")
+  set(CPACK_PACKAGE_FILE_NAME "ZeroMQ-${ZMQ_VERSION_MAJOR}.${ZMQ_VERSION_MINOR}.${ZMQ_VERSION_PATCH}-${arch_name}")
 
   # TODO: I think this part was intended to be used when running cpack
   # separately from cmake but I don't know how that works.
   #
-  # macro (add_crt_version version)
-  #   set (rel_dir "${CMAKE_CURRENT_BINARY_DIR}/build/${arch_name}/${version};ZeroMQ;ALL;/")
-  #   set (debug_dir "${CMAKE_CURRENT_BINARY_DIR}/debug/${arch_name}/${version};ZeroMQ;ALL;/")
-  #   if (EXISTS ${rel_dir})
-  #     list (APPEND CPACK_INSTALL_CMAKE_PROJECTS ${rel_dir})
-  #   endif ()
+  # macro(add_crt_version version)
+  #   set(rel_dir "${CMAKE_CURRENT_BINARY_DIR}/build/${arch_name}/${version};ZeroMQ;ALL;/")
+  #   set(debug_dir "${CMAKE_CURRENT_BINARY_DIR}/debug/${arch_name}/${version};ZeroMQ;ALL;/")
+  #   if(EXISTS ${rel_dir})
+  #     list(APPEND CPACK_INSTALL_CMAKE_PROJECTS ${rel_dir})
+  #   endif()
 
-  #   if (EXISTS ${debug_dir})
-  #     list (APPEND CPACK_INSTALL_CMAKE_PROJECTS ${rel_dir})
-  #   endmacro ()
-  # endmacro ()
+  #   if(EXISTS ${debug_dir})
+  #     list(APPEND CPACK_INSTALL_CMAKE_PROJECTS ${rel_dir})
+  #   endmacro()
+  # endmacro()
 
-  # add_crt_version (v110)
-  # add_crt_version (v100)
-  # add_crt_version (v90)
+  # add_crt_version(v110)
+  # add_crt_version(v100)
+  # add_crt_version(v90)
 
-  list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_BINARY_DIR})
-  set (CPACK_GENERATOR "NSIS")
-  set (CPACK_PACKAGE_NAME "ZeroMQ")
-  set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "ZeroMQ lightweight messaging kernel")
-  set (CPACK_PACKAGE_VENDOR "Miru")
-  set (CPACK_NSIS_CONTACT "Steven McCoy <Steven.McCoy@miru.hk>")
-  set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_BINARY_DIR}\\\\COPYING.txt")
-#  set (CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_BINARY_DIR}\\\\README.txt")
-#  set (CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_BINARY_DIR}\\\\WELCOME.txt")
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_BINARY_DIR})
+  set(CPACK_GENERATOR "NSIS")
+  set(CPACK_PACKAGE_NAME "ZeroMQ")
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ZeroMQ lightweight messaging kernel")
+  set(CPACK_PACKAGE_VENDOR "Miru")
+  set(CPACK_NSIS_CONTACT "Steven McCoy <Steven.McCoy@miru.hk>")
+  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_BINARY_DIR}\\\\COPYING.txt")
+  # set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_BINARY_DIR}\\\\README.txt")
+  # set(CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_BINARY_DIR}\\\\WELCOME.txt")
   # There is a bug in NSI that does not handle full unix paths properly. Make
-  # sure there is at least one set of four (4) backslashes.
-  set (CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\installer.ico")
-  set (CPACK_NSIS_MUI_UNIICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\installer.ico")
+  # sure there is at least one set of four(4) backslashes.
+  set(CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\installer.ico")
+  set(CPACK_NSIS_MUI_UNIICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\installer.ico")
 
-  set (CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\branding.bmp")
-  set (CPACK_NSIS_COMPRESSOR "/SOLID lzma")
-  set (CPACK_PACKAGE_VERSION ${ZMQ_VERSION})
-  set (CPACK_PACKAGE_VERSION_MAJOR ${ZMQ_VERSION_MAJOR})
-  set (CPACK_PACKAGE_VERSION_MINOR ${ZMQ_VERSION_MINOR})
-  set (CPACK_PACKAGE_VERSION_PATCH ${ZMQ_VERSION_PATCH})
-#  set (CPACK_PACKAGE_INSTALL_DIRECTORY "ZMQ Install Directory")
-#  set (CPACK_TEMPORARY_DIRECTORY "ZMQ Temporary CPack Directory")
+  set(CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}\\\\branding.bmp")
+  set(CPACK_NSIS_COMPRESSOR "/SOLID lzma")
+  set(CPACK_PACKAGE_VERSION ${ZMQ_VERSION})
+  set(CPACK_PACKAGE_VERSION_MAJOR ${ZMQ_VERSION_MAJOR})
+  set(CPACK_PACKAGE_VERSION_MINOR ${ZMQ_VERSION_MINOR})
+  set(CPACK_PACKAGE_VERSION_PATCH ${ZMQ_VERSION_PATCH})
+  # set(CPACK_PACKAGE_INSTALL_DIRECTORY "ZMQ Install Directory")
+  # set(CPACK_TEMPORARY_DIRECTORY "ZMQ Temporary CPack Directory")
 
-  include (CPack)
+  include(CPack)
 
-  cpack_add_component_group (Development
+  cpack_add_component_group(Development
     DISPLAY_NAME "ZeroMQ software development kit"
     EXPANDED)
-  cpack_add_component (PerfTools
+  cpack_add_component(PerfTools
     DISPLAY_NAME "ZeroMQ performance tools"
     INSTALL_TYPES FullInstall DevInstall)
-  cpack_add_component (SourceCode
+  cpack_add_component(SourceCode
     DISPLAY_NAME "ZeroMQ source code"
     DISABLED
     INSTALL_TYPES FullInstall)
-  cpack_add_component (SDK
+  cpack_add_component(SDK
     DISPLAY_NAME "ZeroMQ headers and libraries"
     INSTALL_TYPES FullInstall DevInstall
     GROUP Development)
-  if (WITH_DOC)
-    cpack_add_component (RefGuide
+  if(WITH_DOC)
+    cpack_add_component(RefGuide
       DISPLAY_NAME "ZeroMQ reference guide"
       INSTALL_TYPES FullInstall DevInstall
       GROUP Development)
-  endif ()
-  cpack_add_component (Runtime
+  endif()
+  cpack_add_component(Runtime
     DISPLAY_NAME "ZeroMQ runtime files"
     REQUIRED
     INSTALL_TYPES FullInstall DevInstall MinInstall)
-  cpack_add_install_type (FullInstall
+    cpack_add_install_type(FullInstall
     DISPLAY_NAME "Full install, including source code")
-  cpack_add_install_type (DevInstall
+    cpack_add_install_type(DevInstall
     DISPLAY_NAME "Developer install, headers and libraries")
-  cpack_add_install_type (MinInstall
+    cpack_add_install_type(MinInstall
     DISPLAY_NAME "Minimal install, runtime only")
-endif ()
+endif()
 
 # Export this for library to help build this as a sub-project
-set (ZEROMQ_LIBRARY libzmq CACHE STRING "ZeroMQ library")
+set(ZEROMQ_LIBRARY libzmq CACHE STRING "ZeroMQ library")
 
 # Workaround for MSVS10 to avoid the Dialog Hell
 # FIXME: This could be removed with future version of CMake.
-if (MSVC_VERSION EQUAL 1600)
-  set (ZMQ_SLN_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/ZeroMQ.sln")
-  if (EXISTS "${ZMQ_SLN_FILENAME}")
-    file (APPEND "${ZMQ_SLN_FILENAME}" "\n# This should be regenerated!\n")
-  endif ()
-endif ()
+if(MSVC_VERSION EQUAL 1600)
+  set(ZMQ_SLN_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/ZeroMQ.sln")
+  if(EXISTS "${ZMQ_SLN_FILENAME}")
+    file(APPEND "${ZMQ_SLN_FILENAME}" "\n# This should be regenerated!\n")
+  endif()
+endif()
 
 include(ClangFormat)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,115 +2,117 @@
 cmake_minimum_required(VERSION "2.8.1")
 
 # On Windows: solution file will be called tests.sln
-PROJECT(tests)
+project(tests)
 
 set(tests
-        test_ancillaries
-        test_system
-        test_pair_inproc
-        test_pair_tcp
-        test_reqrep_inproc
-        test_reqrep_tcp
-        test_hwm
-        test_hwm_pubsub
-        test_reqrep_device
-        test_sub_forward
-        test_invalid_rep
-        test_msg_flags
-        test_msg_ffn
-        test_connect_resolve
-        test_immediate
-        test_last_endpoint
-        test_term_endpoint
-        test_router_mandatory
-        test_probe_router
-        test_stream
-        test_stream_empty
-        test_stream_disconnect
-        test_disconnect_inproc
-        test_unbind_wildcard
-        test_ctx_options
-        test_ctx_destroy
-        test_security_null
-        test_security_plain
-        test_security_zap
-        test_iov
-        test_spec_req
-        test_spec_rep
-        test_spec_dealer
-        test_spec_router
-        test_spec_pushpull
-        test_req_correlate
-        test_req_relaxed
-        test_conflate
-        test_inproc_connect
-        test_issue_566
-        test_shutdown_stress
-        test_timeo
-        test_many_sockets
-        test_diffserv
-        test_connect_rid
-        test_xpub_nodrop
-        test_pub_invert_matching
-        test_setsockopt
-        test_sockopt_hwm
-        test_heartbeats
-        test_atomics
-        test_bind_src_address
-        test_capabilities
-        test_metadata
-        test_router_handover
-        test_srcfd
-        test_stream_timeout
-        test_xpub_manual
-        test_xpub_welcome_msg
-        test_xpub_verbose
-        test_base85
-        test_bind_after_connect_tcp
-        test_sodium
-        test_monitor
-		test_socket_null
-	test_reconnect_ivl
-        test_mock_pub_sub
+  test_ancillaries
+  test_system
+  test_pair_inproc
+  test_pair_tcp
+  test_reqrep_inproc
+  test_reqrep_tcp
+  test_hwm
+  test_hwm_pubsub
+  test_reqrep_device
+  test_sub_forward
+  test_invalid_rep
+  test_msg_flags
+  test_msg_ffn
+  test_connect_resolve
+  test_immediate
+  test_last_endpoint
+  test_term_endpoint
+  test_router_mandatory
+  test_probe_router
+  test_stream
+  test_stream_empty
+  test_stream_disconnect
+  test_disconnect_inproc
+  test_unbind_wildcard
+  test_ctx_options
+  test_ctx_destroy
+  test_security_null
+  test_security_plain
+  test_security_zap
+  test_iov
+  test_spec_req
+  test_spec_rep
+  test_spec_dealer
+  test_spec_router
+  test_spec_pushpull
+  test_req_correlate
+  test_req_relaxed
+  test_conflate
+  test_inproc_connect
+  test_issue_566
+  test_shutdown_stress
+  test_timeo
+  test_many_sockets
+  test_diffserv
+  test_connect_rid
+  test_xpub_nodrop
+  test_pub_invert_matching
+  test_setsockopt
+  test_sockopt_hwm
+  test_heartbeats
+  test_atomics
+  test_bind_src_address
+  test_capabilities
+  test_metadata
+  test_router_handover
+  test_srcfd
+  test_stream_timeout
+  test_xpub_manual
+  test_xpub_welcome_msg
+  test_xpub_verbose
+  test_base85
+  test_bind_after_connect_tcp
+  test_sodium
+  test_monitor
+  test_socket_null
+  test_reconnect_ivl
+  test_mock_pub_sub
 )
+
 if(ZMQ_HAVE_CURVE)
-  list(APPEND tests 
-          test_security_curve)
+  list(APPEND tests
+    test_security_curve)
 endif()
+
 if(NOT WIN32)
   list(APPEND tests
-          test_ipc_wildcard
-          test_pair_ipc
-          test_rebind_ipc
-          test_reqrep_ipc
-          test_proxy
-          test_proxy_single_socket
-          test_proxy_terminate
-          test_getsockopt_memset
-          test_filter_ipc
-          test_stream_exceeds_buffer
-          test_router_mandatory_hwm
-          test_use_fd
-          test_zmq_poll_fd
+    test_ipc_wildcard
+    test_pair_ipc
+    test_rebind_ipc
+    test_reqrep_ipc
+    test_proxy
+    test_proxy_single_socket
+    test_proxy_terminate
+    test_getsockopt_memset
+    test_filter_ipc
+    test_stream_exceeds_buffer
+    test_router_mandatory_hwm
+    test_use_fd
+    test_zmq_poll_fd
   )
   if(HAVE_FORK)
     list(APPEND tests test_fork)
   endif()
   if(CMAKE_SYSTEM_NAME MATCHES "Linux")
     list(APPEND tests
-          test_abstract_ipc
-    )
+      test_abstract_ipc
+      )
     if(ZMQ_HAVE_TIPC)
       list(APPEND tests
-            test_address_tipc
-            test_pair_tipc
-            test_reqrep_device_tipc
-            test_reqrep_tipc
-            test_router_mandatory_tipc
-            test_sub_forward_tipc
-            test_connect_delay_tipc
-            test_shutdown_stress_tipc
-            test_term_endpoint_tipc
+        test_address_tipc
+        test_pair_tipc
+        test_reqrep_device_tipc
+        test_reqrep_tipc
+        test_router_mandatory_tipc
+        test_sub_forward_tipc
+        test_connect_delay_tipc
+        test_shutdown_stress_tipc
+        test_term_endpoint_tipc
       )
     endif()
   endif()
@@ -118,92 +120,89 @@ endif()
 
 if(WITH_VMCI)
   list(APPEND tests
-          test_pair_vmci
-          test_reqrep_vmci
+    test_pair_vmci
+    test_reqrep_vmci
   )
 endif()
 
-
-IF (ENABLE_DRAFTS)
-    list(APPEND tests
-        test_poller
-        test_thread_safe
-        test_client_server
-        test_timers
-        test_radio_dish
-        test_scatter_gather
-        test_dgram
-        test_app_meta
-        test_router_notify
-    )
-ENDIF (ENABLE_DRAFTS)
+if(ENABLE_DRAFTS)
+  list(APPEND tests
+    test_poller
+    test_thread_safe
+    test_client_server
+    test_timers
+    test_radio_dish
+    test_scatter_gather
+    test_dgram
+    test_app_meta
+    test_router_notify
+  )
+endif()
 
 # add location of platform.hpp for Windows builds
 if(WIN32)
-    add_definitions(-DZMQ_CUSTOM_PLATFORM_HPP)
-    add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
-    # Same name on 64bit systems
-    link_libraries(ws2_32.lib)
+  add_definitions(-DZMQ_CUSTOM_PLATFORM_HPP)
+  add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
+  # Same name on 64bit systems
+  link_libraries(ws2_32.lib)
 endif()
 
-add_library (unity 
-    STATIC 
-    "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.c" 
-    "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.h" 
-    "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity_internals.h")
-set_target_properties (unity PROPERTIES
-                             PUBLIC_HEADER "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.h")
-target_compile_definitions (unity PUBLIC "UNITY_USE_COMMAND_LINE_ARGS" "UNITY_EXCLUDE_FLOAT")
-target_include_directories (unity PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../external/unity")
+add_library(unity STATIC
+  "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.c"
+  "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.h"
+  "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity_internals.h")
+set_target_properties(unity PROPERTIES
+  PUBLIC_HEADER "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.h")
+target_compile_definitions(unity PUBLIC "UNITY_USE_COMMAND_LINE_ARGS" "UNITY_EXCLUDE_FLOAT")
+target_include_directories(unity PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../external/unity")
 
-IF (MSVC_VERSION LESS 1700)
-    SET_SOURCE_FILES_PROPERTIES("${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.c" PROPERTIES LANGUAGE CXX)
-ENDIF()
+if(MSVC_VERSION LESS 1700)
+  set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.c" PROPERTIES LANGUAGE CXX)
+endif()
 
-IF (MSVC_VERSION LESS 1600)
-    target_compile_definitions (unity PUBLIC "UNITY_EXCLUDE_STDINT_H")
-ENDIF()
+if(MSVC_VERSION LESS 1600)
+  target_compile_definitions(unity PUBLIC "UNITY_EXCLUDE_STDINT_H")
+endif()
 
 # add library and include dirs for all targets
-if (BUILD_SHARED)
-link_libraries(libzmq ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)
-else ()
-link_libraries(libzmq-static ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)
-endif ()
+if(BUILD_SHARED)
+  link_libraries(libzmq ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)
+else()
+  link_libraries(libzmq-static ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)
+endif()
 include_directories("${ZeroMQ_SOURCE_DIR}/../include" "${ZeroMQ_BINARY_DIR}")
 
 foreach(test ${tests})
   # target_sources not supported before CMake 3.1
-  if (ZMQ_HAVE_CURVE AND ${test} MATCHES test_security_curve)
+  if(ZMQ_HAVE_CURVE AND ${test} MATCHES test_security_curve)
     add_executable(${test} ${test}.cpp
-        "../src/tweetnacl.c"
-        "../src/err.cpp"
-        "../src/random.cpp"
-        "../src/clock.cpp"
-        "testutil_security.hpp")
-  elseif (${test} MATCHES test_security_zap)
+      "../src/tweetnacl.c"
+      "../src/err.cpp"
+      "../src/random.cpp"
+      "../src/clock.cpp"
+      "testutil_security.hpp")
+  elseif(${test} MATCHES test_security_zap)
     add_executable(${test} ${test}.cpp
-        "testutil_security.hpp")
-  else ()
+      "testutil_security.hpp")
+  else()
     add_executable(${test} ${test}.cpp "testutil.hpp" "testutil_unity.hpp")
-  endif ()
+  endif()
   if(WIN32)
     # This is the output for Debug dynamic builds on Visual Studio 6.0
     # You should provide the correct directory, don't know how to do it automatically
     find_path(LIBZMQ_PATH "libzmq.lib" PATHS "../bin/Win32/Debug/v120/dynamic")
     if(NOT ${LIBZMQ_PATH} STREQUAL "LIBZMQ_PATH-NOTFOUND")
-        SET_TARGET_PROPERTIES( ${test} PROPERTIES LINK_FLAGS "/LIBPATH:${LIBZMQ_PATH}" )
+      set_target_properties(${test} PROPERTIES LINK_FLAGS "/LIBPATH:${LIBZMQ_PATH}")
     endif()
   else()
     # per-test directories not generated on OS X / Darwin
-    if (NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang.*")
-        link_directories(${test} PRIVATE "${ZeroMQ_SOURCE_DIR}/../lib")
+    if(NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang.*")
+      link_directories(${test} PRIVATE "${ZeroMQ_SOURCE_DIR}/../lib")
     endif()
   endif()
 
-
   if(RT_LIBRARY)
-    target_link_libraries(${test} ${RT_LIBRARY} )
+    target_link_libraries(${test} ${RT_LIBRARY})
   endif()
   if(WIN32)
     add_test(NAME ${test} WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH} COMMAND ${test})
@@ -242,7 +241,7 @@ file(GLOB ALL_TEST_SOURCES "test_*.cpp")
 foreach(TEST_SOURCE ${ALL_TEST_SOURCES})
   get_filename_component(TESTNAME "${TEST_SOURCE}" NAME_WE)
   string(REGEX MATCH "${TESTNAME}" MATCH_TESTNAME "${CURRENT_LIST_FILE_CONTENT}")
-  if (NOT MATCH_TESTNAME)
+  if(NOT MATCH_TESTNAME)
     message(AUTHOR_WARNING "Test '${TESTNAME}' is not known to CTest.")
   endif()
 endforeach()

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -9,17 +9,17 @@ set(unittests
   unittest_udp_address
 )
 
-#IF (ENABLE_DRAFTS)
-#    list(APPEND tests
-#    )
-#ENDIF (ENABLE_DRAFTS)
+#if(ENABLE_DRAFTS)
+#  list(APPEND tests
+#  )
+#endif(ENABLE_DRAFTS)
 
 # add location of platform.hpp for Windows builds
 if(WIN32)
-    add_definitions(-DZMQ_CUSTOM_PLATFORM_HPP)
-    add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
-    # Same name on 64bit systems
-    link_libraries(ws2_32.lib)
+  add_definitions(-DZMQ_CUSTOM_PLATFORM_HPP)
+  add_definitions(-D_WINSOCK_DEPRECATED_NO_WARNINGS)
+  # Same name on 64bit systems
+  link_libraries(ws2_32.lib)
 endif()
 
 include_directories("${ZeroMQ_SOURCE_DIR}/include" "${ZeroMQ_SOURCE_DIR}/src" "${ZeroMQ_BINARY_DIR}")
@@ -30,24 +30,24 @@ foreach(test ${unittests})
   add_executable(${test} ${test}.cpp "unittest_resolver_common.hpp")
 
   # per-test directories not generated on OS X / Darwin
-  if (NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang.*")
-      link_directories(${test} PRIVATE "${ZeroMQ_SOURCE_DIR}/../lib")     
+  if(NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang.*")
+    link_directories(${test} PRIVATE "${ZeroMQ_SOURCE_DIR}/../lib")
   endif()
-  
+
   target_link_libraries(${test} libzmq-static ${OPTIONAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} unity)
-  
+
   if(RT_LIBRARY)
     target_link_libraries(${test} ${RT_LIBRARY})
   endif()
-  
+
   if(WIN32)
     add_test(NAME ${test} WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH} COMMAND ${test})
   else()
     add_test(NAME ${test} COMMAND ${test})
   endif()
-  
+
   set_tests_properties(${test} PROPERTIES TIMEOUT 10)
-  
+
   # TODO prevent libzmq (non-static) being in the list of link libraries at all
   get_target_property(LIBS ${test} LINK_LIBRARIES)
   list(REMOVE_ITEM LIBS libzmq)
@@ -61,7 +61,7 @@ file(GLOB ALL_TEST_SOURCES "test_*.cpp")
 foreach(TEST_SOURCE ${ALL_TEST_SOURCES})
   get_filename_component(TESTNAME "${TEST_SOURCE}" NAME_WE)
   string(REGEX MATCH "${TESTNAME}" MATCH_TESTNAME "${CURRENT_LIST_FILE_CONTENT}")
-  if (NOT MATCH_TESTNAME)
+  if(NOT MATCH_TESTNAME)
     message(AUTHOR_WARNING "Test '${TESTNAME}' is not known to CTest.")
   endif()
 endforeach()


### PR DESCRIPTION
Problem: The `CMakeLists.txt` files give a very wildly grown impression

Solution: 
- Make files conform to [cmake-lint](https://github.com/richq/cmake-lint)
- While at it I fixed bad linker flags for `-G"Visual Studio 15 2017" -T"llvm"`

I can also implement changes according to [Effective Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1), if desired.