### PR TITLE
Problem: low-likelyhood memory leaks

### DIFF
--- a/src/curve_client.cpp
+++ b/src/curve_client.cpp
@@ -240,6 +240,7 @@ int zmq::curve_client_t::process_ready (const uint8_t *msg_data_,
         session->get_socket ()->event_handshake_failed_protocol (
           session->get_endpoint (), ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC);
         errno = EPROTO;
+        free(ready_plaintext);
         return -1;
     }
 

--- a/src/curve_client_tools.hpp
+++ b/src/curve_client_tools.hpp
@@ -189,8 +189,10 @@ struct curve_client_tools_t
                          initiate_nonce, cn_server_, cn_secret_);
         free (initiate_plaintext);
 
-        if (rc == -1)
+        if (rc == -1) {
+            free(initiate_box);
             return -1;
+        }
 
         uint8_t *initiate = static_cast<uint8_t *> (data_);
 

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -169,6 +169,7 @@ int zmq::msg_t::init_data (void *data_,
         _u.lmsg.content =
           static_cast<content_t *> (malloc (sizeof (content_t)));
         if (!_u.lmsg.content) {
+            ffn_(data_,hint_);
             errno = ENOMEM;
             return -1;
         }


### PR DESCRIPTION
There are three memory leaks:

* `curve_client_tools` is dealing with NaCL's inaccurate API.  That is, the encryption function can never fail but returns a success/error code anyway which is dutifully checked.  In that branch, which can never be taken, we should free the allocated buffer.

* `msg.cpp` has an unlikely issue where if one allocation attempt fails then a prior allocation won't be freed before to returning an error code.   It is possible I freed this memory incorrectly - look at this pessimistically.

* `curve_client` has the most interesting case where a server sending an invalid READY message can cause a leak in `process_ready()`.  The implication of this leak depends on the application.