### PR TITLE
Problem: test_connect_delay_tipc randomly fails

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1006,11 +1006,6 @@ XFAIL_TESTS += tests/test_ipc_wildcard \
 		tests/test_term_endpoint
 endif
 
-# TODO remove this again when resolving https://github.com/zeromq/libzmq/issues/3124
-if BUILD_TIPC
-XFAIL_TESTS += tests/test_connect_delay_tipc
-endif
-
 EXTRA_DIST = \
 	external/unity/license.txt \
 	external/unity/version.txt \


### PR DESCRIPTION
Solution: use a monitor to wait for a disconnect instead of a sleep,
and retry to send a message until it fails since the state machine
might be delayed due to the I/O thread being pre-empted on busy
systems.
Also set a receive timeout to avoid random hangs.

Fixes #3124