### PR TITLE
[ISSUE 2488] Updates the zmq_msg_send doc

### DIFF
--- a/RELICENSE/antonrd.md
+++ b/RELICENSE/antonrd.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Anton Dimitrov that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "antonrd", with
+commit author "Anton Dimitrov <dimitrov.anton@gmail.com>", are
+copyright of Anton Dimitrov.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Anton Dimitrov
+
+2018/10/01

--- a/doc/zmq_msg_send.txt
+++ b/doc/zmq_msg_send.txt
@@ -57,7 +57,8 @@ when sending each message part except the final one.
 RETURN VALUE
 ------------
 The _zmq_msg_send()_ function shall return number of bytes in the message
-if successful. Otherwise it shall return `-1` and set 'errno' to one of the
+if successful (if number of bytes is higher than 'MAX_INT', the function will 
+return 'MAX_INT'). Otherwise it shall return `-1` and set 'errno' to one of the 
 values defined below.
 
 

--- a/doc/zmq_msg_send.txt
+++ b/doc/zmq_msg_send.txt
@@ -57,8 +57,8 @@ when sending each message part except the final one.
 RETURN VALUE
 ------------
 The _zmq_msg_send()_ function shall return number of bytes in the message
-if successful (if number of bytes is higher than 'MAX_INT', the function will 
-return 'MAX_INT'). Otherwise it shall return `-1` and set 'errno' to one of the 
+if successful (if number of bytes is higher than 'MAX_INT', the function will
+return 'MAX_INT'). Otherwise it shall return `-1` and set 'errno' to one of the
 values defined below.
 
 


### PR DESCRIPTION
Specifies that the maximum possible return value in `zmq_msg_send` is `MAX_INT` and if more than this number of bytes are to be sent the function will not return the actual number of bytes. This is related to issue #2488. Just wanted to address an existing issue if that's ok.