### PR TITLE
Problem: Compilation with strict AARCH64 compilers is broken

### DIFF
--- a/RELICENSE/glemercier.md
+++ b/RELICENSE/glemercier.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Anton Dimitrov that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "glemercier", with
+commit author "Gregory Lemercier <greglemercier@free.fr>", are
+copyright of Gregory Lmercier.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Gregory Lemercier
+
+2018/10/07

--- a/src/v1_decoder.cpp
+++ b/src/v1_decoder.cpp
@@ -111,11 +111,13 @@ int zmq::v1_decoder_t::eight_byte_size_ready (unsigned char const *)
         return -1;
     }
 
+#ifndef __aarch64__
     //  Message size must fit within range of size_t data type.
     if (payload_length - 1 > std::numeric_limits<size_t>::max ()) {
         errno = EMSGSIZE;
         return -1;
     }
+#endif
 
     const size_t msg_size = static_cast<size_t> (payload_length - 1);
 


### PR DESCRIPTION
Problem: Compilation with strict AARCH64 compilers is broken

```
make[1]: Entering directory /opt/android/libzmq
  CXX      src/src_libzmq_la-v1_decoder.lo
src/v1_decoder.cpp:114:28: error: comparison 'unsigned long' > 18446744073709551615 is always false [-Werror,-Wtautological-constant-compare]
    if (payload_length - 1 > std::numeric_limits<size_t>::max ()) {
        ~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[1]: *** [src/src_libzmq_la-v1_decoder.lo] Error 1
make[1]: Leaving directory /opt/android/libzmq
make: *** [all-recursive] Error 1
```

Solution: ignore the condition when built with AARCH64 compilers. This test does not make sense on 64-bit architectures since 'size_t' and 'uint64_t' have the same size.