### PR TITLE
Problem: The flag that indicates the next expected message gets set even if the send fails

### DIFF
--- a/src/dgram.cpp
+++ b/src/dgram.cpp
@@ -106,18 +106,12 @@ int zmq::dgram_t::xsend (msg_t *msg_)
             errno = EINVAL;
             return -1;
         }
-
-        //  Expect one more message frame.
-        _more_out = true;
     } else {
         //  dgram messages are two part only, reject part if more is set
         if (msg_->flags () & msg_t::more) {
             errno = EINVAL;
             return -1;
         }
-
-        //  This is the last part of the message.
-        _more_out = false;
     }
 
     // Push the message into the pipe.
@@ -129,6 +123,9 @@ int zmq::dgram_t::xsend (msg_t *msg_)
     if (!(msg_->flags () & msg_t::more))
         _pipe->flush ();
 
+    // flip the more flag
+    _more_out = !_more_out;
+    
     //  Detach the message from the data buffer.
     int rc = msg_->init ();
     errno_assert (rc == 0);

--- a/src/dgram.cpp
+++ b/src/dgram.cpp
@@ -125,7 +125,7 @@ int zmq::dgram_t::xsend (msg_t *msg_)
 
     // flip the more flag
     _more_out = !_more_out;
-    
+ 
     //  Detach the message from the data buffer.
     int rc = msg_->init ();
     errno_assert (rc == 0);


### PR DESCRIPTION
In the dgram socket we have a flag that indicates the next expected message type to ensure that always a pair of "address" + "body" messages gets sent. The first one MUST have the sendmore flag, the second MUST NOT.

In case the message does not get sent because of HWM full, then the function returns EAGAIN as it should. But unfortunately the next expected message type-flag gets flipped as well. When the socket_base::send function now tries to resend the message, it became the _wrong_ message type... If you don't stop sending pairs of messages here (like me) then the next message that gets through will be of the wrong type, which in turn crashes the udp_engine function as described in #3268 

This PR fixes the flag behavior and in turn all of the described problems...