### PR TITLE
fix for android building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,7 +417,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD")
   endif()
 endif()
 
-zmq_check_noexcept()
+if(NOT ANDROID)
+    zmq_check_noexcept()
+endif()
 
 #-----------------------------------------------------------------------------
 if(NOT CMAKE_CROSSCOMPILING AND NOT MSVC)


### PR DESCRIPTION
# CMake validation for Android building issue

Problem: CMake stop configuration on:

`zmq_check_noexcept()`

Solution: I added validation on CMake for Android
