### PR TITLE
Relicense statement for Hpsaturn

### DIFF
--- a/RELICENSE/hpsaturn.md
+++ b/RELICENSE/hpsaturn.md
@@ -1,0 +1,9 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Antonio Vanegas that grants permission to relicense its copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "hpsaturn", with commit author "Antonio Vanegas", are copyright of Antonio Vanegas.
+This document hereby grants the libzmq project team to relicense libzmq, including all past, present and future contributions of the author listed above.
+
+Antonio Vanegas
+2018/10/27


### PR DESCRIPTION
# Permission to Relicense under MPLv2

This is a statement by Antonio Vanegas that grants permission to relicense its copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).

A portion of the commits made by the Github handle "hpsaturn", with commit author "Antonio Vanegas", are copyright of Antonio Vanegas.
This document hereby grants the libzmq project team to relicense libzmq, including all past, present and future contributions of the author listed above.

Antonio Vanegas
2018/10/27