### PR TITLE
Add support for UDP multicast ttl (ZMQ_MULTICAST_HOPS)

### DIFF
--- a/RELICENSE/kfish.md
+++ b/RELICENSE/kfish.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Conrad Parker that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "kfish", with
+commit author "Conrad Parker <conrad@metadecks.org>", are
+copyright of Conrad Parker.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Conrad Parker
+2018/10/30
+

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -149,6 +149,21 @@ void zmq::udp_engine_t::plug (io_thread_t *io_thread_, session_base_t *session_)
                 errno_assert (rc == 0);
 #endif
 
+                int hops = _options.multicast_hops;
+
+                if (hops > 0) {
+                    rc = setsockopt (_fd, level, IP_MULTICAST_TTL,
+                                     reinterpret_cast<char *> (&hops),
+                                     sizeof (hops));
+                } else {
+                    rc = 0;
+                }
+
+#ifdef ZMQ_HAVE_WINDOWS
+                wsa_assert (rc != SOCKET_ERROR);
+#else
+                errno_assert (rc == 0);
+#endif
                 if (out->family () == AF_INET6) {
                     int bind_if = udp_addr->bind_if ();
 


### PR DESCRIPTION
This adds support for setting the multicast TTL for UDP, allowing multicast traffic to be routed. This feature was already supported for PGM.