### PR TITLE
Problem: Use of pipe_t after free in zmq::socket_base_t::term_endpoint(). Issue #3245.

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -553,3 +553,13 @@ void zmq::pipe_t::send_hwms_to_peer (int inhwm_, int outhwm_)
 {
     send_pipe_hwm (_peer, inhwm_, outhwm_);
 }
+
+void zmq::pipe_t::set_endpoint_uri (const char *name_)
+{
+    _endpoint_uri = name_;
+}
+
+std::string &zmq::pipe_t::get_endpoint_uri ()
+{
+    return _endpoint_uri;
+}

--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -141,6 +141,9 @@ class pipe_t : public object_t,
     //  Returns true if HWM is not reached
     bool check_hwm () const;
 
+    void set_endpoint_uri (const char *name_);
+    std::string &get_endpoint_uri ();
+
   private:
     //  Type of the underlying lock-free pipe.
     typedef ypipe_base_t<msg_t> upipe_t;
@@ -243,6 +246,10 @@ class pipe_t : public object_t,
     static int compute_lwm (int hwm_);
 
     const bool _conflate;
+
+    // If the pipe belongs to socket's endpoint the endpoint's name is stored here.
+    // Otherwise this is empty.
+    std::string _endpoint_uri;
 
     //  Disable copying.
     pipe_t (const pipe_t &);


### PR DESCRIPTION
Solution: When pipe_t is freed (terminated) remove it from _endpoints member of zmq::socket_base_t. Resolves issue #3245.

In order to optimally search `_endpoints` multimap and find the pipe_t pointer to be removed (set to NULL), `std::string _endpoint_uri` is added into `zmq::pipe_t` class.
