### PR TITLE
Problem: stale issues linger on Github

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 365
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 56
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - Help%20Request
+  - Feature%20Request
+  - Problem%20reproduced
+  - Critical
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  activity for 365 days. It will be closed if no further activity occurs within
+  56 days. Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Solution: enable Stale Bot to automatically mark an issue as stale
after 365 days of inactivity and close it after further 56 days.

Issues marked with the following labels are excluded:

 - Help Request
 - Feature Request
 - Problem reproduced
 - Critical

This was proposed on the mailing list in September:

https://lists.zeromq.org/pipermail/zeromq-dev/2018-September/032719.html

@somdoron is this OK with you?