### PR TITLE
Problem: using FD_SETSIZE for optimized_fd_set_t is a pessimization

### DIFF
--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -266,7 +266,7 @@ int zmq::signaler_t::wait (int timeout_)
 
 #elif defined ZMQ_POLL_BASED_ON_SELECT
 
-    optimized_fd_set_t fds (FD_SETSIZE);
+    optimized_fd_set_t fds (1);
     FD_ZERO (fds.get ());
     FD_SET (_r, fds.get ());
     struct timeval timeout;


### PR DESCRIPTION
Solution: change it to the actual required number, 1

The fix to issue #2876, i.e. commit https://github.com/zeromq/libzmq/commit/7a9933f2e11a4cebd38f9aa942b56ccfd4629ebf, uses FD_SETSIZE (16384) for optimized_fd_set_t, although only a single descriptor is used in signaler::wait().

This fix avoids an unnecessary heap allocation of ~128KB.



