### PR TITLE
Problems: some tests still use hard-coded TCP ports, wrong usage of CPPFLAGS, missing NEWS, no way to force C++98 builds and CI for it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ test_reqrep_device_tipc
 test_reqrep_tipc
 test_router_handover
 test_router_mandatory_tipc
+test_router_notify
 test_shutdown_stress_tipc
 test_sub_forward_tipc
 test_term_endpoint_tipc
@@ -133,8 +134,7 @@ test_radio_dish
 test_udp
 test_scatter_gather
 test_socketopt_hwm
-test_use_fd_ipc
-test_use_fd_tcp
+test_use_fd
 test_pub_invert_matching
 test_dgram
 test_base85
@@ -144,6 +144,7 @@ test_zmq_poll_fd
 test_reconnect_ivl
 test_address_tipc
 test_app_meta
+test_security_gssapi
 test_security_zap
 test_socket_null
 test_xpub_verbose
@@ -166,12 +167,14 @@ remote_lat
 remote_thr
 inproc_lat
 inproc_thr
+benchmark_radix_tree
 !local_lat/
 !local_thr/
 !remote_lat/
 !remote_thr/
 !inproc_lat/
 !inproc_thr/
+!benchmark_radix_tree/
 doc/*.1
 doc/*.3
 doc/*.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,19 @@ matrix:
     os: linux
   - env: BUILD_TYPE=default POLLER=select
     os: linux
+  - env: CXX=clang++ BUILD_TYPE=default CURVE=libsodium GSSAPI=enabled PGM=enabled NORM=enabled FORCE_98=enabled
+    os: linux
+    compiler: clang
+    addons:
+      apt:
+        sources:
+        - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-stable/xUbuntu_14.04/ ./'
+          key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-stable/xUbuntu_14.04/Release.key'
+        packages:
+        - libkrb5-dev
+        - libnorm-dev
+        - libpgm-dev
+        - libsodium-dev
     
 sudo: false
 

--- a/NEWS
+++ b/NEWS
@@ -51,6 +51,10 @@
     on local listening sockets for UDP multicast sockets (ZMQ_RADIO).
   See doc/zmq_setsockopt.txt and doc/zmq_getsockopt.txt for details.
 
+* New perf tool, perf/benchmark_radix_tree, to measure the performance of the
+  different internal implementations of the trie algorithm used to track
+  subscriptions. Requires a compiler that supports C++11.
+
 * Many, many coding style, duplication and static analysis improvements.
 
 * Many, many improvements to the CMake build system, especially on Windows.

--- a/NEWS
+++ b/NEWS
@@ -55,6 +55,11 @@
   different internal implementations of the trie algorithm used to track
   subscriptions. Requires a compiler that supports C++11.
 
+* New autoconf flag "--enable-force-CXX98-compat" which will force -std=gnu++98
+  and, if the compiler supports them (clang++ at the moment), it will also add
+  -Wc++98-compat -Wc++98-compat-pedantic so that compatibility with C++98 can
+  be tested.
+
 * Many, many coding style, duplication and static analysis improvements.
 
 * Many, many improvements to the CMake build system, especially on Windows.

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -62,6 +62,10 @@ if [ $BUILD_TYPE == "default" ]; then
         CONFIG_OPTS+=("--enable-drafts=yes")
     fi
 
+    if [ -n "$FORCE_98" ] && [ "$FORCE_98" == "enabled" ]; then
+        CONFIG_OPTS+=("--enable-force-CXX98-compat=yes")
+    fi
+
     # Build and check this project
     (
         ./autogen.sh &&

--- a/configure.ac
+++ b/configure.ac
@@ -158,7 +158,8 @@ libzmq_on_gnu="no"
 libzmq_on_debian_kfreebsd="no"
 
 # Set some default features required by ZeroMQ code
-CPPFLAGS="-D_REENTRANT -D_THREAD_SAFE -Wno-long-long $CPPFLAGS"
+CPPFLAGS="-D_REENTRANT -D_THREAD_SAFE $CPPFLAGS"
+CXXFLAGS="-Wno-long-long $CXXFLAGS"
 
 # Will be used to add flags to pkg-config useful when apps want to statically link
 PKGCFG_LIBS_PRIVATE=""
@@ -188,7 +189,8 @@ case "${host_os}" in
         ;;
     *solaris*)
         # Define on Solaris to enable all library features
-        CPPFLAGS="-Wno-sign-compare -D_PTHREADS $CPPFLAGS"
+        CPPFLAGS="-D_PTHREADS $CPPFLAGS"
+        CXXFLAGS="-Wno-sign-compare $CXXFLAGS"
         AC_DEFINE(ZMQ_HAVE_SOLARIS, 1, [Have Solaris OS])
         AC_CHECK_LIB(socket, socket)
         AC_CHECK_LIB(nsl, gethostbyname)
@@ -602,14 +604,14 @@ AM_CONDITIONAL(HAVE_VMCI, test "x$have_vmci_ext" != "xno")
 AC_LANG_PUSH([C++])
 
 # Check how to enable -Wall
-LIBZMQ_LANG_WALL([CPPFLAGS="$libzmq_cv_[]_AC_LANG_ABBREV[]_wall_flag $CPPFLAGS"])
+LIBZMQ_LANG_WALL([CXXFLAGS="$libzmq_cv_[]_AC_LANG_ABBREV[]_wall_flag $CXXFLAGS"])
 
 if test "x$libzmq_werror" = "xyes" -a "x$libzmq_cv_[]_AC_LANG_ABBREV[]_sun_studio_compiler" != "xyes"; then
-    LIBZMQ_LANG_WERROR([CPPFLAGS="$libzmq_cv_[]_AC_LANG_ABBREV[]_werror_flag $CPPFLAGS"])
+    LIBZMQ_LANG_WERROR([CXXFLAGS="$libzmq_cv_[]_AC_LANG_ABBREV[]_werror_flag $CXXFLAGS"])
 fi
 
 if test "x$libzmq_pedantic" = "xyes"; then
-    LIBZMQ_LANG_STRICT([CPPFLAGS="$libzmq_cv_[]_AC_LANG_ABBREV[]_strict_flag $CPPFLAGS"])
+    LIBZMQ_LANG_STRICT([CXXFLAGS="$libzmq_cv_[]_AC_LANG_ABBREV[]_strict_flag $CXXFLAGS"])
 fi
 AC_LANG_POP([C++])
 

--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,6 @@ ZMQ_ORIG_CXXFLAGS="${CXXFLAGS:-none}"
 AC_PROG_CC
 AX_CHECK_COMPILE_FLAG([-std=gnu11], [CFLAGS+=" -std=gnu11"], [AC_PROG_CC_C99])
 AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX_11([ext], [optional])
 AX_CODE_COVERAGE
 AM_PROG_CC_C_O
 AC_PROG_SED
@@ -75,6 +74,17 @@ LIBZMQ_CONFIG_LIBTOOL
 AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL
 AX_VALGRIND_CHECK
+
+AC_ARG_ENABLE([force-CXX98-compat],
+    [AS_HELP_STRING([--enable-force-CXX98-compat], [force C++98 build [default=disabled]])])
+if test "x$enable_force_CXX98_compat" = "xyes"; then
+    AC_LANG_PUSH([C++])
+    AX_CHECK_COMPILE_FLAG([-std=gnu++98], [CXXFLAGS+=" -std=gnu++98"], [])
+    AX_CHECK_COMPILE_FLAG([-Wc++98-compat -Wc++98-compat-pedantic], [CXXFLAGS+=" -Wc++98-compat"], [])
+    AC_LANG_POP([C++])
+else
+    AX_CXX_COMPILE_STDCXX_11([ext], [optional])
+fi
 
 # Check whether to build a with debug symbols
 LIBZMQ_CHECK_ENABLE_DEBUG

--- a/tests/test_app_meta.cpp
+++ b/tests/test_app_meta.cpp
@@ -28,6 +28,7 @@
 */
 
 #include "testutil.hpp"
+#include "testutil_unity.hpp"
 #include <unity.h>
 
 
@@ -43,6 +44,7 @@ void test_app_meta_reqrep ()
     void *ctx;
     zmq_msg_t msg;
     void *rep_sock, *req_sock;
+    char connect_address[MAX_SOCKET_STRING];
     const char *req_hello = "X-hello:hello";
     const char *req_connection = "X-connection:primary";
     const char *req_z85 = "X-bin:009c6";
@@ -84,8 +86,8 @@ void test_app_meta_reqrep ()
         TEST_ASSERT_EQUAL_INT (-1, rc);
     }
 
-    rc = zmq_bind (rep_sock, "tcp://127.0.0.1:5555");
-    TEST_ASSERT_EQUAL_INT (0, rc);
+    test_bind (rep_sock, "tcp://127.0.0.1:*", connect_address,
+               sizeof (connect_address));
 
     l = 0;
     rc = zmq_setsockopt (req_sock, ZMQ_LINGER, &l, sizeof (l));
@@ -101,7 +103,7 @@ void test_app_meta_reqrep ()
     rc = zmq_setsockopt (req_sock, ZMQ_METADATA, req_z85, strlen (req_z85));
     TEST_ASSERT_EQUAL_INT (0, rc);
 
-    rc = zmq_connect (req_sock, "tcp://127.0.0.1:5555");
+    rc = zmq_connect (req_sock, connect_address);
     TEST_ASSERT_EQUAL_INT (0, rc);
 
     rc = zmq_msg_init_size (&msg, 1);

--- a/unittests/unittest_poller.cpp
+++ b/unittests/unittest_poller.cpp
@@ -59,6 +59,7 @@ struct test_events_t : zmq::i_poll_events
         fd (fd_),
         poller (poller_)
     {
+        (void)fd;
     }
 
     virtual void in_event ()


### PR DESCRIPTION
Solutions: fix them all