### PR TITLE
Problem: C4 process is not easily discoverable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ libzmq is distributed in the hope that it will be useful, but WITHOUT
 ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
 License for more details.
+
+## Contributing
+
+This project uses [C4(Collective Code Construction Contract)](https://rfc.zeromq.org/spec:42/C4/) process for contributions.

--- a/RELICENSE/crocket.md
+++ b/RELICENSE/crocket.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by crocket
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "crocket", with
+commit author "crocket <748856+crocket@users.noreply.github.com>", are copyright of crocket.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+crocket
+2018/11/10


### PR DESCRIPTION
Solution: Add 'Contributing' section to README.md

Do I need a relicensing grant? I vaguely remember that I consented to MPLv2 in a github issue, but I'm not totally sure.

It fixes https://github.com/zeromq/libzmq/issues/3302