### PR TITLE
Problems: no example for STATISTICS proxy command, no getters for some context options, new events zmq_stopwatch_intermediate proxy STATISTICS and context thread options are eligible to be made STABLE

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,12 @@
 * The following DRAFT APIs have been marked as STABLE and will not change
   anymore:
   - ZMQ_MSG_T_SIZE context option (see doc/zmq_ctx_get.txt)
+  - ZMQ_THREAD_AFFINITY_CPU_ADD and ZMQ_THREAD_AFFINITY_CPU_REMOVE (Posix only)
+    context options, to add/remove CPUs to the affinity set of the I/O threads.
+    See doc/zmq_ctx_set.txt and doc/zmq_ctx_get.txt for details.
+  - ZMQ_THREAD_NAME_PREFIX (Posix only) context option, to add a specific
+    integer prefix to the background threads names, to easily identify them.
+    See doc/zmq_ctx_set.txt and doc/zmq_ctx_get.txt for details.
   - ZMQ_GSSAPI_PRINCIPAL_NAMETYPE and ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE
     socket options, for the corresponding GSSAPI features. Additional
     definitions for principal name types:

--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,9 @@
     See doc/zmq_socket_monitor.txt for more details and error codes.
   - zmq_stopwatch_intermediate which returns the time elapsed without stopping
     the stopwatch.
+  - zmq_proxy_steerable command 'STATISTICS' to retrieve stats about the amount
+    of messages and bytes sent and received by the proxy.
+    See doc/zmq_proxy_steerable.txt for more information.
 
 * The build-time configuration option to select the poller has been split, and
   new API_POLLER (CMake) and --with-api-poller (autoconf) options will now

--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,8 @@
     - ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL: Protocol errors with peers or ZAP.
     - ZMQ_EVENT_HANDSHAKE_FAILED_AUTH: Failed authentication requests.
     See doc/zmq_socket_monitor.txt for more details and error codes.
+  - zmq_stopwatch_intermediate which returns the time elapsed without stopping
+    the stopwatch.
 
 * The build-time configuration option to select the poller has been split, and
   new API_POLLER (CMake) and --with-api-poller (autoconf) options will now

--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,12 @@
     NOTE: requires the program to be ran as root OR with CAP_NET_RAW
   - zmq_timers_* APIs. These functions can be used for cross-platforms timed
     callbacks. See doc/zmq_timers.txt for details.
+  - The following socket monitor events:
+    - ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL: unknown errors during handshake.
+    - ZMQ_EVENT_HANDSHAKE_SUCCEEDED: Handshake completed with authentication.
+    - ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL: Protocol errors with peers or ZAP.
+    - ZMQ_EVENT_HANDSHAKE_FAILED_AUTH: Failed authentication requests.
+    See doc/zmq_socket_monitor.txt for more details and error codes.
 
 * The build-time configuration option to select the poller has been split, and
   new API_POLLER (CMake) and --with-api-poller (autoconf) options will now

--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -64,6 +64,24 @@ zero if the "block forever on context termination" gambit was disabled by
 setting ZMQ_BLOCKY to false on all new contexts.
 
 
+ZMQ_THREAD_SCHED_POLICY: Get scheduling policy for I/O threads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_THREAD_SCHED_POLICY' argument returns the scheduling policy for
+internal context's thread pool.
+
+
+ZMQ_THREAD_PRIORITY: Get scheduling priority for I/O threads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_THREAD_PRIORITY' argument returns the scheduling priority for
+internal context's thread pool.
+
+
+ZMQ_THREAD_NAME_PREFIX: Get name prefix for I/O threads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_THREAD_NAME_PREFIX' argument gets the numeric prefix of each thread
+created for the internal context's thread pool.
+
+
 ZMQ_MSG_T_SIZE: Get the zmq_msg_t size at runtime
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_MSG_T_SIZE' argument returns the size of the zmq_msg_t structure at

--- a/doc/zmq_proxy_steerable.txt
+++ b/doc/zmq_proxy_steerable.txt
@@ -93,6 +93,21 @@ assert (zmq_send (control, "RESUME", 6, 0) == 0);
 
 // terminate the proxy
 assert (zmq_send (control, "TERMINATE", 9, 0) == 0);
+
+// check statistics
+assert (zmq_send (control, "STATISTICS", 10, 0) == 0);
+zmq_msg_t stats_msg;
+
+while (1) {
+    assert (zmq_msg_init (&stats_msg) == 0);
+    assert (zmq_recvmsg (control, &stats_msg, 0) == sizeof (uint64_t));
+    assert (rc == sizeof (uint64_t));
+    printf ("Stat: %lu\n", *(unsigned long int *)zmq_msg_data (&stats_msg));
+    if (!zmq_msg_get (&stats_msg, ZMQ_MORE))
+        break;
+    assert (zmq_msg_close (&stats_msg) == 0);
+}
+assert (zmq_msg_close (&stats_msg) == 0);
 ---
 
 

--- a/doc/zmq_socket_monitor.txt
+++ b/doc/zmq_socket_monitor.txt
@@ -99,20 +99,15 @@ ZMQ_EVENT_MONITOR_STOPPED
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Monitoring on this socket ended.
 
-DRAFT events - subject to change without notice
------------------------------------------------
-
 ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Unspecified error during handshake.
 The event value is an errno.
-NOTE: in DRAFT state, not yet available in stable releases.
 
 ZMQ_EVENT_HANDSHAKE_SUCCEEDED
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ZMTP security mechanism handshake succeeded.
 The event value is unspecified.
-NOTE: in DRAFT state, not yet available in stable releases.
 
 ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -141,14 +136,12 @@ ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID
 ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION
 ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE
 ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA
-NOTE: in DRAFT state, not yet available in stable releases.
 
 ZMQ_EVENT_HANDSHAKE_FAILED_AUTH
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ZMTP security mechanism handshake failed due to an authentication failure.
 The event value is the status code returned by the ZAP handler (i.e. 300, 
 400 or 500).
-NOTE: in DRAFT state, not yet available in stable releases.
 
 
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -216,6 +216,9 @@ ZMQ_EXPORT void zmq_version (int *major_, int *minor_, int *patch_);
 #define ZMQ_THREAD_SCHED_POLICY 4
 #define ZMQ_MAX_MSGSZ 5
 #define ZMQ_MSG_T_SIZE 6
+#define ZMQ_THREAD_AFFINITY_CPU_ADD 7
+#define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
+#define ZMQ_THREAD_NAME_PREFIX 9
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT 1
@@ -653,9 +656,6 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_ROUTER_NOTIFY 97
 
 /*  DRAFT Context options                                                     */
-#define ZMQ_THREAD_AFFINITY_CPU_ADD 7
-#define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
-#define ZMQ_THREAD_NAME_PREFIX 9
 #define ZMQ_ZERO_COPY_RECV 10
 
 /*  DRAFT Socket methods.                                                     */

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -437,6 +437,38 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
 #define ZMQ_EVENT_DISCONNECTED 0x0200
 #define ZMQ_EVENT_MONITOR_STOPPED 0x0400
 #define ZMQ_EVENT_ALL 0xFFFF
+/*  Unspecified system errors during handshake. Event value is an errno.      */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL 0x0800
+/*  Handshake complete successfully with successful authentication (if        *
+ *  enabled). Event value is unused.                                          */
+#define ZMQ_EVENT_HANDSHAKE_SUCCEEDED 0x1000
+/*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
+ *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL 0x2000
+/*  Failed authentication requests. Event value is the numeric ZAP status     *
+ *  code, i.e. 300, 400 or 500.                                               */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_AUTH 0x4000
+#define ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED 0x10000000
+#define ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND 0x10000001
+#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE 0x10000002
+#define ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE 0x10000003
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED 0x10000011
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE 0x10000012
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO 0x10000013
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE 0x10000014
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR 0x10000015
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY 0x10000016
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME 0x10000017
+#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA 0x10000018
+// the following two may be due to erroneous configuration of a peer
+#define ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC 0x11000001
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH 0x11000002
+#define ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED 0x20000000
+#define ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY 0x20000001
+#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID 0x20000002
+#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION 0x20000003
+#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE 0x20000004
+#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 
 ZMQ_EXPORT void *zmq_socket (void *, int type_);
 ZMQ_EXPORT int zmq_close (void *s_);
@@ -619,44 +651,6 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_METADATA 95
 #define ZMQ_MULTICAST_LOOP 96
 #define ZMQ_ROUTER_NOTIFY 97
-
-
-/*  DRAFT 0MQ socket events and monitoring                                    */
-/*  Unspecified system errors during handshake. Event value is an errno.      */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL 0x0800
-/*  Handshake complete successfully with successful authentication (if        *
- *  enabled). Event value is unused.                                          */
-#define ZMQ_EVENT_HANDSHAKE_SUCCEEDED 0x1000
-/*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
- *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL 0x2000
-/*  Failed authentication requests. Event value is the numeric ZAP status     *
- *  code, i.e. 300, 400 or 500.                                               */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_AUTH 0x4000
-
-#define ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED 0x10000000
-#define ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND 0x10000001
-#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE 0x10000002
-#define ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE 0x10000003
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED 0x10000011
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE 0x10000012
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO 0x10000013
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE 0x10000014
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR 0x10000015
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY 0x10000016
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME 0x10000017
-#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA 0x10000018
-
-// the following two may be due to erroneous configuration of a peer
-#define ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC 0x11000001
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH 0x11000002
-
-#define ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED 0x20000000
-#define ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY 0x20000001
-#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID 0x20000002
-#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION 0x20000003
-#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE 0x20000004
-#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_THREAD_AFFINITY_CPU_ADD 7

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -610,11 +610,9 @@ ZMQ_EXPORT int zmq_timers_execute (void *timers);
 /*  Starts the stopwatch. Returns the handle to the watch.                    */
 ZMQ_EXPORT void *zmq_stopwatch_start (void);
 
-#ifdef ZMQ_BUILD_DRAFT_API
 /*  Returns the number of microseconds elapsed since the stopwatch was        */
 /*  started, but does not stop or deallocate the stopwatch.                   */
 ZMQ_EXPORT unsigned long zmq_stopwatch_intermediate (void *watch_);
-#endif
 
 /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
 /*  the stopwatch was started, and deallocates that watch.                    */

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -271,8 +271,7 @@ int zmq::ctx_t::get (int option_)
     else if (option_ == ZMQ_ZERO_COPY_RECV) {
         rc = _zero_copy;
     } else {
-        errno = EINVAL;
-        rc = -1;
+        rc = thread_ctx_t::get (option_);
     }
     return rc;
 }
@@ -460,6 +459,25 @@ int zmq::thread_ctx_t::set (int option_, int optval_)
     } else if (option_ == ZMQ_THREAD_PRIORITY && optval_ >= 0) {
         scoped_lock_t locker (_opt_sync);
         _thread_priority = optval_;
+    } else {
+        errno = EINVAL;
+        rc = -1;
+    }
+    return rc;
+}
+
+int zmq::thread_ctx_t::get (int option_)
+{
+    int rc = 0;
+    if (option_ == ZMQ_THREAD_PRIORITY) {
+        scoped_lock_t locker (_opt_sync);
+        rc = _thread_priority;
+    } else if (option_ == ZMQ_THREAD_SCHED_POLICY) {
+        scoped_lock_t locker (_opt_sync);
+        rc = _thread_sched_policy;
+    } else if (option_ == ZMQ_THREAD_NAME_PREFIX) {
+        scoped_lock_t locker (_opt_sync);
+        rc = atoi (_thread_name_prefix.c_str ());
     } else {
         errno = EINVAL;
         rc = -1;

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -70,6 +70,7 @@ class thread_ctx_t
     void start_thread (thread_t &thread_, thread_fn *tfn_, void *arg_) const;
 
     int set (int option_, int optval_);
+    int get (int option_);
 
   protected:
     //  Synchronisation of access to context options.

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -425,20 +425,16 @@ int zmq::proxy (class socket_base_t *frontend_,
                     && memcmp (msg.data (), "TERMINATE", 9) == 0)
                     state = terminated;
                 else {
-#ifdef ZMQ_BUILD_DRAFT_API
                     if (msg.size () == 10
                         && memcmp (msg.data (), "STATISTICS", 10) == 0) {
                         rc = reply_stats (control_, &frontend_stats,
                                           &backend_stats);
                         CHECK_RC_EXIT_ON_FAILURE ();
                     } else {
-#endif
                         //  This is an API error, we assert
                         puts ("E: invalid command sent to proxy");
                         zmq_assert (false);
-#ifdef ZMQ_BUILD_DRAFT_API
                     }
-#endif
                 }
             }
             control_in = false;
@@ -604,7 +600,6 @@ int zmq::proxy (class socket_base_t *frontend_,
                      && memcmp (msg.data (), "TERMINATE", 9) == 0)
                 state = terminated;
             else {
-#ifdef ZMQ_BUILD_DRAFT_API
                 if (msg.size () == 10
                     && memcmp (msg.data (), "STATISTICS", 10) == 0) {
                     rc =
@@ -612,13 +607,10 @@ int zmq::proxy (class socket_base_t *frontend_,
                     if (unlikely (rc < 0))
                         return close_and_return (&msg, -1);
                 } else {
-#endif
                     //  This is an API error, we assert
                     puts ("E: invalid command sent to proxy");
                     zmq_assert (false);
-#ifdef ZMQ_BUILD_DRAFT_API
                 }
-#endif
             }
         }
         //  Process a request

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -950,9 +950,7 @@ void zmq::stream_engine_t::mechanism_ready ()
         alloc_assert (_metadata);
     }
 
-#ifdef ZMQ_BUILD_DRAFT_API
     _socket->event_handshake_succeeded (_endpoint, 0);
-#endif
 }
 
 int zmq::stream_engine_t::pull_msg_from_session (msg_t *msg_)
@@ -1068,7 +1066,6 @@ void zmq::stream_engine_t::error (error_reason_t reason_)
         _session->push_msg (&disconnect_notification);
     }
 
-#ifdef ZMQ_BUILD_DRAFT_API
     // protocol errors have been signaled already at the point where they occurred
     if (reason_ != protocol_error
         && (_mechanism == NULL
@@ -1076,7 +1073,7 @@ void zmq::stream_engine_t::error (error_reason_t reason_)
         int err = errno;
         _socket->event_handshake_failed_no_detail (_endpoint, err);
     }
-#endif
+
     _socket->event_disconnected (_endpoint, _s);
     _session->flush ();
     _session->engine_error (reason_);

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -37,10 +37,6 @@
 
 #ifndef ZMQ_BUILD_DRAFT_API
 
-/*  Returns the number of microseconds elapsed since the stopwatch was        */
-/*  started, but does not stop or deallocate the stopwatch.                   */
-unsigned long zmq_stopwatch_intermediate (void *watch_);
-
 /*  DRAFT Socket types.                                                       */
 #define ZMQ_SERVER 12
 #define ZMQ_CLIENT 13

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -58,9 +58,6 @@ unsigned long zmq_stopwatch_intermediate (void *watch_);
 #define ZMQ_ROUTER_NOTIFY 97
 
 /*  DRAFT Context options                                                     */
-#define ZMQ_THREAD_AFFINITY_CPU_ADD 7
-#define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
-#define ZMQ_THREAD_NAME_PREFIX 9
 #define ZMQ_ZERO_COPY_RECV 10
 
 /*  DRAFT Socket methods.                                                     */

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -57,43 +57,6 @@ unsigned long zmq_stopwatch_intermediate (void *watch_);
 #define ZMQ_MULTICAST_LOOP 96
 #define ZMQ_ROUTER_NOTIFY 97
 
-/*  DRAFT 0MQ socket events and monitoring                                    */
-/*  Unspecified system errors during handshake. Event value is an errno.      */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL 0x0800
-/*  Handshake complete successfully with successful authentication (if        *
- *  enabled). Event value is unused.                                          */
-#define ZMQ_EVENT_HANDSHAKE_SUCCEEDED 0x1000
-/*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
- *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL 0x2000
-/*  Failed authentication requests. Event value is the numeric ZAP status     *
- *  code, i.e. 300, 400 or 500.                                               */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_AUTH 0x4000
-
-#define ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED 0x10000000
-#define ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND 0x10000001
-#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE 0x10000002
-#define ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE 0x10000003
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED 0x10000011
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE 0x10000012
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO 0x10000013
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE 0x10000014
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR 0x10000015
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY 0x10000016
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME 0x10000017
-#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA 0x10000018
-
-// the following two may be due to erroneous configuration of a peer
-#define ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC 0x11000001
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH 0x11000002
-
-#define ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED 0x20000000
-#define ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY 0x20000001
-#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID 0x20000002
-#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION 0x20000003
-#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE 0x20000004
-#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
-
 /*  DRAFT Context options                                                     */
 #define ZMQ_THREAD_AFFINITY_CPU_ADD 7
 #define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -92,6 +92,8 @@ void test_ctx_thread_opts (void *ctx_)
     // as of ZMQ 4.2.3 this has an effect only on POSIX systems (nothing happens on Windows, but still it should return success):
     rc = zmq_ctx_set (ctx_, ZMQ_THREAD_SCHED_POLICY, TEST_POLICY);
     assert (rc == 0);
+    rc = zmq_ctx_get (ctx_, ZMQ_THREAD_SCHED_POLICY);
+    assert (rc == TEST_POLICY);
 
 
     // test priority:
@@ -110,6 +112,8 @@ void test_ctx_thread_opts (void *ctx_)
           ctx_, ZMQ_THREAD_PRIORITY,
           1 /* any positive value different than the default will be ok */);
         assert (rc == 0);
+        rc = zmq_ctx_get (ctx_, ZMQ_THREAD_PRIORITY);
+        assert (rc == 1);
     }
 
 
@@ -143,6 +147,8 @@ void test_ctx_thread_opts (void *ctx_)
 
     rc = zmq_ctx_set (ctx_, ZMQ_THREAD_NAME_PREFIX, 1234);
     assert (rc == 0);
+    rc = zmq_ctx_get (ctx_, ZMQ_THREAD_NAME_PREFIX);
+    assert (rc == 1234);
 #endif
 }
 

--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -86,17 +86,13 @@ int main (void)
     if (event == ZMQ_EVENT_CONNECT_DELAYED)
         event = get_monitor_event (client_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_CONNECTED);
-#ifdef ZMQ_BUILD_DRAFT_API
     expect_monitor_event (client_mon, ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
-#endif
     expect_monitor_event (client_mon, ZMQ_EVENT_MONITOR_STOPPED);
 
     //  This is the flow of server events
     expect_monitor_event (server_mon, ZMQ_EVENT_LISTENING);
     expect_monitor_event (server_mon, ZMQ_EVENT_ACCEPTED);
-#ifdef ZMQ_BUILD_DRAFT_API
     expect_monitor_event (server_mon, ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
-#endif
     event = get_monitor_event (server_mon, NULL, NULL);
     //  Sometimes the server sees the client closing before it gets closed.
     if (event != ZMQ_EVENT_DISCONNECTED) {

--- a/tests/test_proxy.cpp
+++ b/tests/test_proxy.cpp
@@ -472,11 +472,9 @@ int main (void)
     msleep (500); // Wait for all clients and workers to STOP
 
 
-#ifdef ZMQ_BUILD_DRAFT_API
     if (is_verbose)
         printf ("retrieving stats from the proxy\n");
     check_proxy_stats (control_proxy);
-#endif
 
     if (is_verbose)
         printf ("shutting down all clients and server workers\n");

--- a/tests/test_proxy_hwm.cpp
+++ b/tests/test_proxy_hwm.cpp
@@ -300,9 +300,7 @@ static void proxy_stats_asker_thread_main (void *pvoid)
     // Start!
 
     while (!zmq_atomic_counter_value (cfg->subscriber_received_all)) {
-#ifdef ZMQ_BUILD_DRAFT_API
         check_proxy_stats (control_req);
-#endif
         usleep (1000); // 1ms -> in best case we will get 1000updates/second
     }
 

--- a/tests/test_security_zap.cpp
+++ b/tests/test_security_zap.cpp
@@ -92,10 +92,8 @@ int expect_new_client_bounce_fail_and_count_monitor_events (
       client_mon_, expected_client_event_, expected_client_value_);
 
     int events_received = 0;
-#ifdef ZMQ_BUILD_DRAFT_API
     events_received = expect_monitor_event_multiple (
       server_mon_, expected_server_event_, expected_server_value_);
-#endif
 
     return events_received;
 }
@@ -139,13 +137,9 @@ void test_zap_unsuccessful_no_handler (void *ctx_,
         ctx_, my_endpoint_, server_, socket_config_, socket_config_data_,
         client_mon_, server_mon_, expected_event_, expected_err_);
 
-#ifdef ZMQ_BUILD_DRAFT_API
     //  there may be more than one ZAP request due to repeated attempts by the
     //  client
     assert (events_received > 0);
-#else
-    LIBZMQ_UNUSED (events_received);
-#endif
 }
 
 void test_zap_protocol_error (void *ctx_,
@@ -157,11 +151,7 @@ void test_zap_protocol_error (void *ctx_,
                               int expected_error_)
 {
     test_zap_unsuccessful (ctx_, my_endpoint_, server_, server_mon_,
-#ifdef ZMQ_BUILD_DRAFT_API
                            ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL, expected_error_,
-#else
-                           0, 0,
-#endif
                            socket_config_, socket_config_data_);
 }
 
@@ -173,22 +163,15 @@ void test_zap_unsuccessful_status_300 (void *ctx_,
                                        void *client_socket_config_data_)
 {
     void *client_mon;
-    test_zap_unsuccessful (ctx_, my_endpoint_, server_, server_mon_,
-#ifdef ZMQ_BUILD_DRAFT_API
-                           ZMQ_EVENT_HANDSHAKE_FAILED_AUTH, 300,
-#else
-                           0, 0,
-#endif
-                           client_socket_config_, client_socket_config_data_,
-                           &client_mon);
+    test_zap_unsuccessful (
+      ctx_, my_endpoint_, server_, server_mon_, ZMQ_EVENT_HANDSHAKE_FAILED_AUTH,
+      300, client_socket_config_, client_socket_config_data_, &client_mon);
 
-#ifdef ZMQ_BUILD_DRAFT_API
     // we can use a 0 timeout here, since the client socket is already closed
     assert_no_more_monitor_events_with_timeout (client_mon, 0);
 
     int rc = zmq_close (client_mon);
     assert (rc == 0);
-#endif
 }
 
 void test_zap_unsuccessful_status_500 (void *ctx_,
@@ -199,19 +182,9 @@ void test_zap_unsuccessful_status_500 (void *ctx_,
                                        void *client_socket_config_data_)
 {
     test_zap_unsuccessful (ctx_, my_endpoint_, server_, server_mon_,
-#ifdef ZMQ_BUILD_DRAFT_API
                            ZMQ_EVENT_HANDSHAKE_FAILED_AUTH, 500,
-#else
-                           0, 0,
-#endif
                            client_socket_config_, client_socket_config_data_,
-                           NULL,
-#ifdef ZMQ_BUILD_DRAFT_API
-                           ZMQ_EVENT_HANDSHAKE_FAILED_AUTH, 500
-#else
-                           0, 0
-#endif
-    );
+                           NULL, ZMQ_EVENT_HANDSHAKE_FAILED_AUTH, 500);
 }
 
 void test_zap_errors (socket_config_fn server_socket_config_,
@@ -236,12 +209,7 @@ void test_zap_errors (socket_config_fn server_socket_config_,
       server_socket_config_data_);
     test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
                              client_socket_config_, client_socket_config_data_,
-#ifdef ZMQ_BUILD_DRAFT_API
-                             ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION
-#else
-                             0
-#endif
-    );
+                             ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION);
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler);
 
@@ -253,12 +221,7 @@ void test_zap_errors (socket_config_fn server_socket_config_,
       server_socket_config_data_);
     test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
                              client_socket_config_, client_socket_config_data_,
-#ifdef ZMQ_BUILD_DRAFT_API
-                             ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID
-#else
-                             0
-#endif
-    );
+                             ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID);
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler);
 
@@ -270,12 +233,7 @@ void test_zap_errors (socket_config_fn server_socket_config_,
       server_socket_config_data_);
     test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
                              client_socket_config_, client_socket_config_data_,
-#ifdef ZMQ_BUILD_DRAFT_API
-                             ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE
-#else
-                             0
-#endif
-    );
+                             ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE);
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler);
 
@@ -287,12 +245,7 @@ void test_zap_errors (socket_config_fn server_socket_config_,
       server_socket_config_data_);
     test_zap_protocol_error (ctx, my_endpoint, server, server_mon,
                              client_socket_config_, client_socket_config_data_,
-#ifdef ZMQ_BUILD_DRAFT_API
-                             ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY
-#else
-                             0
-#endif
-    );
+                             ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY);
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler);
 
@@ -332,14 +285,10 @@ void test_zap_errors (socket_config_fn server_socket_config_,
       &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint, NULL,
       server_socket_config_,
       server_socket_config_data_ ? server_socket_config_data_ : &enforce);
-    test_zap_unsuccessful_no_handler (
-      ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-      ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, EFAULT,
-#else
-      0, 0,
-#endif
-      client_socket_config_, client_socket_config_data_);
+    test_zap_unsuccessful_no_handler (ctx, my_endpoint, server, server_mon,
+                                      ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
+                                      EFAULT, client_socket_config_,
+                                      client_socket_config_data_);
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler);
 #endif
@@ -349,14 +298,10 @@ void test_zap_errors (socket_config_fn server_socket_config_,
     setup_context_and_server_side (
       &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
       &zap_handler_disconnect, server_socket_config_);
-    test_zap_unsuccessful_no_handler (
-      ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-      ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, EPIPE,
-#else
-      0, 0,
-#endif
-      client_socket_config_, client_socket_config_data_);
+    test_zap_unsuccessful_no_handler (ctx, my_endpoint, server, server_mon,
+                                      ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
+                                      EPIPE, client_socket_config_,
+                                      client_socket_config_data_);
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler, true);
 
@@ -366,14 +311,10 @@ void test_zap_errors (socket_config_fn server_socket_config_,
     setup_context_and_server_side (
       &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
       &zap_handler_do_not_recv, server_socket_config_);
-    test_zap_unsuccessful_no_handler (
-      ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-      ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, EPIPE,
-#else
-      0, 0,
-#endif
-      client_socket_config_, client_socket_config_data_);
+    test_zap_unsuccessful_no_handler (ctx, my_endpoint, server, server_mon,
+                                      ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
+                                      EPIPE, client_socket_config_,
+                                      client_socket_config_data_);
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler);
 
@@ -383,14 +324,10 @@ void test_zap_errors (socket_config_fn server_socket_config_,
     setup_context_and_server_side (
       &ctx, &handler, &zap_thread, &server, &server_mon, my_endpoint,
       &zap_handler_do_not_send, server_socket_config_);
-    test_zap_unsuccessful_no_handler (
-      ctx, my_endpoint, server, server_mon,
-#ifdef ZMQ_BUILD_DRAFT_API
-      ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL, EPIPE,
-#else
-      0, 0,
-#endif
-      client_socket_config_, client_socket_config_data_);
+    test_zap_unsuccessful_no_handler (ctx, my_endpoint, server, server_mon,
+                                      ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL,
+                                      EPIPE, client_socket_config_,
+                                      client_socket_config_data_);
     shutdown_context_and_server_side (ctx, zap_thread, server, server_mon,
                                       handler);
 }

--- a/tests/test_timers.cpp
+++ b/tests/test_timers.cpp
@@ -156,21 +156,17 @@ void test_timers ()
     //  Timer should not have been invoked yet
     TEST_ASSERT_SUCCESS_ERRNO (zmq_timers_execute (timers));
 
-#ifdef ZMQ_BUILD_DRAFT_API
     if (zmq_stopwatch_intermediate (stopwatch) < full_timeout) {
         TEST_ASSERT_FALSE (timer_invoked);
     }
-#endif
 
     //  Wait half the time and check again
     long timeout = TEST_ASSERT_SUCCESS_ERRNO (zmq_timers_timeout (timers));
     msleep (timeout / 2);
     TEST_ASSERT_SUCCESS_ERRNO (zmq_timers_execute (timers));
-#ifdef ZMQ_BUILD_DRAFT_API
     if (zmq_stopwatch_intermediate (stopwatch) < full_timeout) {
         TEST_ASSERT_FALSE (timer_invoked);
     }
-#endif
 
     // Wait until the end
     TEST_ASSERT_SUCCESS_ERRNO (sleep_and_execute (timers));
@@ -181,11 +177,9 @@ void test_timers ()
     timeout = TEST_ASSERT_SUCCESS_ERRNO (zmq_timers_timeout (timers));
     msleep (timeout / 2);
     TEST_ASSERT_SUCCESS_ERRNO (zmq_timers_execute (timers));
-#ifdef ZMQ_BUILD_DRAFT_API
     if (zmq_stopwatch_intermediate (stopwatch) < 2 * full_timeout) {
         TEST_ASSERT_FALSE (timer_invoked);
     }
-#endif
 
     // Reset timer and wait half of the time left
     TEST_ASSERT_SUCCESS_ERRNO (zmq_timers_reset (timers, timer_id));

--- a/tests/testutil_security.hpp
+++ b/tests/testutil_security.hpp
@@ -409,8 +409,6 @@ void expect_monitor_event (void *monitor_, int expected_event_)
     }
 }
 
-#ifdef ZMQ_BUILD_DRAFT_API
-
 void print_unexpected_event (int event_,
                              int err_,
                              int expected_event_,
@@ -506,14 +504,11 @@ int expect_monitor_event_multiple (void *server_mon_,
         assert (event_count == 0);                                             \
     }
 
-#endif
-
 void setup_handshake_socket_monitor (void *ctx_,
                                      void *server_,
                                      void **server_mon_,
                                      const char *monitor_endpoint_)
 {
-#ifdef ZMQ_BUILD_DRAFT_API
     //  Monitor handshake events on the server
     int rc = zmq_socket_monitor (server_, monitor_endpoint_,
                                  ZMQ_EVENT_HANDSHAKE_SUCCEEDED
@@ -532,7 +527,6 @@ void setup_handshake_socket_monitor (void *ctx_,
     //  Connect it to the inproc endpoints so they'll get events
     rc = zmq_connect (*server_mon_, monitor_endpoint_);
     assert (rc == 0);
-#endif
 }
 
 void setup_context_and_server_side (
@@ -616,10 +610,8 @@ void shutdown_context_and_server_side (void *ctx_,
     int rc = zmq_close (zap_control_);
     assert (rc == 0);
 
-#ifdef ZMQ_BUILD_DRAFT_API
     rc = zmq_close (server_mon_);
     assert (rc == 0);
-#endif
     rc = zmq_close (server_);
     assert (rc == 0);
 
@@ -672,7 +664,6 @@ void expect_new_client_bounce_fail (void *ctx_,
       ctx_, my_endpoint_, socket_config_, socket_config_data_, client_mon_);
     expect_bounce_fail (server_, client);
 
-#ifdef ZMQ_BUILD_DRAFT_API
     if (expected_client_event_ != 0) {
         int events_received = 0;
         events_received = expect_monitor_event_multiple (
@@ -683,7 +674,6 @@ void expect_new_client_bounce_fail (void *ctx_,
         int rc = zmq_close (my_client_mon);
         assert (rc == 0);
     }
-#endif
 
     close_zero_linger (client);
 }


### PR DESCRIPTION
@sigiesec @f18m the following APIs are being declared STABLE and won't accept backward-incompatible changes anymore as they have been part of at least one release for at least 6 months without any changes:

- new handshake monitor events
- STATISTICS steerable proxy command
- zmq_stopwatch_intermediate
- ZMQ_THREAD_AFFINITY_CPU_ADD, ZMQ_THREAD_AFFINITY_CPU_REMOVE and ZMQ_THREAD_NAME_PREFIX context options

If you do _not_ want them to be declared STABLE and want to do more changes please let me know ASAP.