### PR TITLE
Android Things 1.06 with Termux changes

### DIFF
--- a/RELICENSE/jeffbrubaker.md
+++ b/RELICENSE/jeffbrubaker.md
@@ -1,0 +1,14 @@
+
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+This is a statement by Simon Giesecke that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+A portion of the commits made by the Github handle "sigiesec", with
+commit author "Simon Giesecke <simon.giesecke@btc-ag.com>", are
+copyright of Simon Giesecke.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+Jeff Brubaker
+2018/11/18

--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,6 @@ fi
 # Check whether to build a with debug symbols
 LIBZMQ_CHECK_ENABLE_DEBUG
 
-AC_CHECK_LIB([atomic],[__atomic_load_4],[LIBS="${LIBS} -latomic"]) 
 
 # Check whether to enable code coverage
 LIBZMQ_WITH_GCOV
@@ -196,7 +195,8 @@ case "${host_os}" in
         case "${host_os}" in
             *android*)
                 AC_DEFINE(ZMQ_HAVE_ANDROID, 1, [Have Android OS])
-                libzmq_on_android="yes"
+                AC_CHECK_LIB([atomic],[__atomic_load_4],[LIBS="${LIBS} -latomic"]) 
+		libzmq_on_android="yes"
             ;;
         esac
         ;;

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,8 @@ fi
 # Check whether to build a with debug symbols
 LIBZMQ_CHECK_ENABLE_DEBUG
 
+AC_CHECK_LIB([atomic],[__atomic_load_4],[LIBS="${LIBS} -latomic"]) 
+
 # Check whether to enable code coverage
 LIBZMQ_WITH_GCOV
 

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,7 @@ AC_RUN_IFELSE(
             memset(&topsrv, 0, sizeof(topsrv));
             topsrv.family = AF_TIPC;
             topsrv.addrtype = TIPC_ADDR_NAME;
+            topsrv.addr.name.domain = tipc_addr (10, 10, 10); 
             topsrv.addr.name.name.type = TIPC_TOP_SRV;
             topsrv.addr.name.name.instance = TIPC_TOP_SRV;
             fcntl(sd, F_SETFL, O_NONBLOCK);


### PR DESCRIPTION
Please consider the following changes to the configuration scripts. After making the changes below ( macro to check for libatomic and enhanced verification for tipc[I don't have a tipc unit to verify with but inserted the line that was causing an error on this configuration into configure.ac]) I was able to compile with termux under Android 1.06 and succesfully use test cases 

[still had to manually change configure script to use bash in this context but think that may normally be encapsulated in termux build scripts]
./configure --prefix=/data/data/com.termux/files/usr

This effort was necessitated to recompile libzmq from scratch in support of addressing this issue https://github.com/zeromq/pyzmq/issues/1240
