### PR TITLE
Consolidation of libatomic checks

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -681,7 +681,6 @@ int main (int, char **)
 
     if test "x$GCC_ATOMIC_BUILTINS_SUPPORTED" != x1; then
         save_LIBS=$LIBS
-        CXXFLAGS="$CXXFLAGS -Wno-atomic-alignment"
         LIBS="$LIBS -latomic"
         AC_LINK_IFELSE([AC_LANG_SOURCE([
         /* atomic intrinsics test */

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -680,7 +680,6 @@ int main (int, char **)
     [AC_MSG_RESULT(yes) ; GCC_ATOMIC_BUILTINS_SUPPORTED=1 libzmq_cv_has_atomic_instrisics="yes" ; $1])
 
     if test "x$GCC_ATOMIC_BUILTINS_SUPPORTED" != x1; then
-        save_CXXFLAGS=$CXXFLAGS
         save_LIBS=$LIBS
         CXXFLAGS="$CXXFLAGS -Wno-atomic-alignment"
         LIBS="$LIBS -latomic"
@@ -695,7 +694,6 @@ int main (int, char **)
         ])],
         [AC_MSG_RESULT(yes) ; libzmq_cv_has_atomic_instrisics="yes" ; $1],
         [AC_MSG_RESULT(no) ; libzmq_cv_has_atomic_instrisics="no" LIBS=$save_LIBS ; $2])
-        CXXFLAGS=$save_CXXFLAGS
     fi
 }])
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -680,7 +680,9 @@ int main (int, char **)
     [AC_MSG_RESULT(yes) ; GCC_ATOMIC_BUILTINS_SUPPORTED=1 libzmq_cv_has_atomic_instrisics="yes" ; $1])
 
     if test "x$GCC_ATOMIC_BUILTINS_SUPPORTED" != x1; then
-        save_LIBS=$LIBS
+        save_CFLAGS=$CFLAGS
+	save_LIBS=$LIBS
+	CFLAGS="$CFLAGS -Wno-atomic-alignment"
         LIBS="$LIBS -latomic"
         AC_LINK_IFELSE([AC_LANG_SOURCE([
         /* atomic intrinsics test */
@@ -693,6 +695,7 @@ int main (int, char **)
         ])],
         [AC_MSG_RESULT(yes) ; libzmq_cv_has_atomic_instrisics="yes" ; $1],
         [AC_MSG_RESULT(no) ; libzmq_cv_has_atomic_instrisics="no" LIBS=$save_LIBS ; $2])
+	CFLAGS=$save_CFLAGS
     fi
 }])
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -680,9 +680,9 @@ int main (int, char **)
     [AC_MSG_RESULT(yes) ; GCC_ATOMIC_BUILTINS_SUPPORTED=1 libzmq_cv_has_atomic_instrisics="yes" ; $1])
 
     if test "x$GCC_ATOMIC_BUILTINS_SUPPORTED" != x1; then
-        save_CFLAGS=$CFLAGS
+        save_CXXFLAGS=$CXXFLAGS
         save_LIBS=$LIBS
-        CFLAGS="$CFLAGS -Wno-atomic-alignment"
+        CXXFLAGS="$CXXFLAGS -Wno-atomic-alignment"
         LIBS="$LIBS -latomic"
         AC_LINK_IFELSE([AC_LANG_SOURCE([
         /* atomic intrinsics test */
@@ -695,7 +695,7 @@ int main (int, char **)
         ])],
         [AC_MSG_RESULT(yes) ; libzmq_cv_has_atomic_instrisics="yes" ; $1],
         [AC_MSG_RESULT(no) ; libzmq_cv_has_atomic_instrisics="no" LIBS=$save_LIBS ; $2])
-        CFLAGS=$save_CFLAGS
+        CXXFLAGS=$save_CXXFLAGS
     fi
 }])
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -681,8 +681,8 @@ int main (int, char **)
 
     if test "x$GCC_ATOMIC_BUILTINS_SUPPORTED" != x1; then
         save_CFLAGS=$CFLAGS
-	save_LIBS=$LIBS
-	CFLAGS="$CFLAGS -Wno-atomic-alignment"
+        save_LIBS=$LIBS
+        CFLAGS="$CFLAGS -Wno-atomic-alignment"
         LIBS="$LIBS -latomic"
         AC_LINK_IFELSE([AC_LANG_SOURCE([
         /* atomic intrinsics test */
@@ -695,7 +695,7 @@ int main (int, char **)
         ])],
         [AC_MSG_RESULT(yes) ; libzmq_cv_has_atomic_instrisics="yes" ; $1],
         [AC_MSG_RESULT(no) ; libzmq_cv_has_atomic_instrisics="no" LIBS=$save_LIBS ; $2])
-	CFLAGS=$save_CFLAGS
+        CFLAGS=$save_CFLAGS
     fi
 }])
 

--- a/configure.ac
+++ b/configure.ac
@@ -195,7 +195,6 @@ case "${host_os}" in
         case "${host_os}" in
             *android*)
                 AC_DEFINE(ZMQ_HAVE_ANDROID, 1, [Have Android OS])
-                AC_CHECK_LIB([atomic],[__atomic_load_4],[LIBS="${LIBS} -latomic"]) 
 		libzmq_on_android="yes"
             ;;
         esac

--- a/configure.ac
+++ b/configure.ac
@@ -637,6 +637,10 @@ AM_CONDITIONAL(ON_DEBIAN_KFREEBSD, test "x$libzmq_on_debian_kfreebsd" = "xyes")
 
 # Check for __atomic_Xxx compiler intrinsics
 AC_LANG_PUSH([C++])
+AX_CHECK_COMPILE_FLAG([-Wno-atomic-alignment],
+    [CXXFLAGS+=" -Wno-atomic-alignment"],
+    [],
+    [-Werror])
 LIBZMQ_CHECK_ATOMIC_INTRINSICS([
     AC_DEFINE([ZMQ_HAVE_ATOMIC_INTRINSICS],
               [1],


### PR DESCRIPTION
Per discussions, lets merge the two checks for atomic @bluca  @ffontaine 

This from my perspective accomplishes the goal of the test, which is to show the linker has to include "latomic"

On compilation the same error is produced. (CXXFLAGS is reset so the result below is produced) 

In file included from ./src/ctx.hpp:44:
./src/atomic_counter.hpp:110:21: error: misaligned or large atomic operation may incur significant performance penalty
      [-Werror,-Watomic-alignment]
        old_value = __atomic_fetch_add (&_value, increment_, __ATOMIC_ACQ_REL);"

Ultimately I removed the save CXX flags citing the bug report previously mentioned.
https://bugs.llvm.org/show_bug.cgi?id=38593

Out of curiosity, what is the basis for using an atomic add operation in C++? Is the built in + not atomic?