### PR TITLE
Problem: build fails on OpenBSD due to -Wl in LDFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -311,8 +311,7 @@ src_libzmq_la_LDFLAGS = \
 else
 src_libzmq_la_LDFLAGS = \
 	-version-info @LTVER@ \
-	@LIBZMQ_EXTRA_LDFLAGS@ \
-	-Wl
+	@LIBZMQ_EXTRA_LDFLAGS@
 endif
 endif
 endif


### PR DESCRIPTION
Solution: remove stray -Wl.

This fixes #3320 