### PR TITLE
Portable solution for library symbols visibility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -294,20 +294,17 @@ else
 if ON_LINUX
 src_libzmq_la_LDFLAGS = \
 	-version-info @LTVER@ \
-	@LIBZMQ_EXTRA_LDFLAGS@ \
-	-Wl,--version-script=$(srcdir)/src/libzmq.vers
+	@LIBZMQ_EXTRA_LDFLAGS@
 else
 if ON_GNU
 src_libzmq_la_LDFLAGS = \
 	-version-info @LTVER@ \
-	@LIBZMQ_EXTRA_LDFLAGS@ \
-	-Wl,--version-script=$(srcdir)/src/libzmq.vers
+	@LIBZMQ_EXTRA_LDFLAGS@
 else
 if ON_DEBIAN_KFREEBSD
 src_libzmq_la_LDFLAGS = \
 	-version-info @LTVER@ \
-	@LIBZMQ_EXTRA_LDFLAGS@ \
-	-Wl,--version-script=$(srcdir)/src/libzmq.vers
+	@LIBZMQ_EXTRA_LDFLAGS@
 else
 src_libzmq_la_LDFLAGS = \
 	-version-info @LTVER@ \
@@ -319,6 +316,8 @@ endif
 endif
 endif
 endif
+
+src_libzmq_la_LDFLAGS += -export-symbols-regex '^zmq_.*'
 
 src_libzmq_la_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS) $(LIBUNWIND_CFLAGS)
 src_libzmq_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(LIBUNWIND_CFLAGS)
@@ -1047,7 +1046,6 @@ EXTRA_DIST = \
 	version.sh	\
 	src/libzmq.pc.cmake.in \
 	ci_build.sh \
-	src/libzmq.vers \
 	src/version.rc.in \
 	tests/CMakeLists.txt \
 	unittests/CMakeLists.txt \

--- a/src/libzmq.vers
+++ b/src/libzmq.vers
@@ -1,4 +1,0 @@
-{
-  global: zmq_*;
-  local: *;
-};


### PR DESCRIPTION
Using symbol visibility tricks is a common practice to hide library internals from consumers.

Right now `-Wl,--version-script=...` is used on a few selected architectures to hide symbols not already handled by `-fvisibility=hidden`. This leads to clutter in configure.ac and an unmaintainable if/else/endif dance in Makefile.am.

libzmq uses libtool, which provides tools to address symbol visibility needs portably.  This merge request implements that and should improve the situation on all platforms not already using `-Wl,--version-script=...` (Windows, *BSD, Solaris, etc).  It has only been tested on OpenBSD, however.

This merge request does not remove now superfluous OS-specific code in Makefile.am and configure.ac.