### PR TITLE
Switching or desactivate wifi can crash Android application

### DIFF
--- a/RELICENSE/hgourvest.md
+++ b/RELICENSE/hgourvest.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+ This is a statement by Henri Gourvest that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+ A portion of the commits made by the Github handle "hgourvest", with
+commit author "Henri Gourvest <hgourvest@progdigy.com>", are
+copyright of Henri Gourvest.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+ Henri Gourvest
+2018/12/8

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -299,10 +299,15 @@ zmq::fd_t zmq::tcp_listener_t::accept ()
 #endif
 
     if (sock == retired_fd) {
-#ifdef ZMQ_HAVE_WINDOWS
+#if defined ZMQ_HAVE_WINDOWS
         const int last_error = WSAGetLastError ();
         wsa_assert (last_error == WSAEWOULDBLOCK || last_error == WSAECONNRESET
                     || last_error == WSAEMFILE || last_error == WSAENOBUFS);
+#elif defined ZMQ_HAVE_ANDROID
+        errno_assert (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR
+                      || errno == ECONNABORTED || errno == EPROTO
+                      || errno == ENOBUFS || errno == ENOMEM || errno == EMFILE
+                      || errno == ENFILE || errno == EINVAL);
 #else
         errno_assert (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR
                       || errno == ECONNABORTED || errno == EPROTO


### PR DESCRIPTION
Problem: Switching or desactivate wifi can lead to have EINVAL error code on Android
Solution: do not abort when this error happen