### PR TITLE
Prevent crashes related to zmq_msg_data, zmq_msg_size. Introduce zmq_msg_bytes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,6 +65,7 @@ Ilya Kulakov
 Ivo Danihelka
 Jacob Rideout
 Joe Thornber
+Joel Frederico
 Jon Dyte
 Kamil Shakirov
 Ken Steele

--- a/Makefile.am
+++ b/Makefile.am
@@ -387,6 +387,7 @@ test_apps = \
 	tests/test_reqrep_device \
 	tests/test_sub_forward \
 	tests/test_invalid_rep \
+	tests/test_msg_access \
 	tests/test_msg_flags \
 	tests/test_msg_ffn \
 	tests/test_connect_resolve \
@@ -504,6 +505,9 @@ tests_test_sub_forward_CPPFLAGS = ${UNITY_CPPFLAGS}
 
 tests_test_invalid_rep_SOURCES = tests/test_invalid_rep.cpp
 tests_test_invalid_rep_LDADD = src/libzmq.la
+
+tests_test_msg_access_SOURCES = tests/test_msg_access.cpp
+tests_test_msg_access_LDADD = src/libzmq.la
 
 tests_test_msg_flags_SOURCES = tests/test_msg_flags.cpp
 tests_test_msg_flags_LDADD = src/libzmq.la

--- a/RELICENSE/joelfrederico.md
+++ b/RELICENSE/joelfrederico.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Joel Frederico that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "joelfrederico",
+with commit author "Joel Frederico<joelfrederico@gmail.com>", are
+copyright of Joel Frederico.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Joel Frederico
+2018/12/11

--- a/builds/gyp/project-tests.gypi
+++ b/builds/gyp/project-tests.gypi
@@ -111,6 +111,16 @@
       ],
     },
     {
+      'target_name': 'test_msg_access',
+      'type': 'executable',
+      'sources': [
+        '../../tests/test_msg_access.cpp',
+        '../../tests/testutil.hpp'
+      ],
+      'dependencies': [
+        'libzmq'
+      ],
+    {
       'target_name': 'test_msg_flags',
       'type': 'executable',
       'sources': [

--- a/builds/gyp/project-tests.xml
+++ b/builds/gyp/project-tests.xml
@@ -9,6 +9,7 @@
     <test name = "test_reqrep_device" />
     <test name = "test_sub_forward" />
     <test name = "test_invalid_rep" />
+    <test name = "test_msg_access" />
     <test name = "test_msg_flags" />
     <test name = "test_msg_ffn" />
     <test name = "test_connect_resolve" />

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,8 +4,8 @@
 MAN3 = zmq_bind.3 zmq_unbind.3 zmq_connect.3 zmq_disconnect.3 zmq_close.3 \
     zmq_ctx_new.3 zmq_ctx_term.3 zmq_ctx_get.3 zmq_ctx_set.3 zmq_ctx_shutdown.3 \
     zmq_msg_init.3 zmq_msg_init_data.3 zmq_msg_init_size.3 \
-    zmq_msg_move.3 zmq_msg_copy.3 zmq_msg_size.3 zmq_msg_data.3 zmq_msg_close.3 \
-    zmq_msg_send.3 zmq_msg_recv.3 \
+    zmq_msg_move.3 zmq_msg_copy.3 zmq_msg_bytes.3 zmq_msg_size.3 zmq_msg_data.3 \
+    zmq_msg_close.3 zmq_msg_send.3 zmq_msg_recv.3 \
     zmq_msg_routing_id.3 zmq_msg_set_routing_id.3 \
     zmq_send.3 zmq_recv.3 zmq_send_const.3 \
     zmq_msg_get.3 zmq_msg_set.3 zmq_msg_more.3 zmq_msg_gets.3 \

--- a/doc/zmq.txt
+++ b/doc/zmq.txt
@@ -93,7 +93,7 @@ Release a message::
 
 Access message content::
     linkzmq:zmq_msg_data[3]
-    linkzmq:zmq_msg_size[3]
+    linkzmq:zmq_msg_bytes[3]
     linkzmq:zmq_msg_more[3]
 
 Work with message properties::

--- a/doc/zmq_msg_bytes.txt
+++ b/doc/zmq_msg_bytes.txt
@@ -1,21 +1,21 @@
-zmq_msg_size(3)
+zmq_msg_bytes(3)
 ===============
 
 
 NAME
 ----
-zmq_msg_size - retrieve message content size in bytes
+zmq_msg_bytes - retrieve message content size in bytes
 
 
 SYNOPSIS
 --------
-*size_t zmq_msg_size (zmq_msg_t '*msg');*
+*int zmq_msg_bytes (zmq_msg_t '*msg', size_t '*bytes');*
 
 
 DESCRIPTION
 -----------
-The _zmq_msg_size()_ function shall return the size in bytes of the content of
-the message object referenced by 'msg'.
+The _zmq_msg_bytes()_ function shall store the size in bytes of the content of
+the message object referenced by 'msg' in 'bytes'.
 
 CAUTION: Never access 'zmq_msg_t' members directly, instead always use the
 _zmq_msg_ family of functions.
@@ -23,11 +23,8 @@ _zmq_msg_ family of functions.
 
 RETURN VALUE
 ------------
-The _zmq_msg_size()_ function shall return the size of the message content in
-bytes if successful. Otherwise it shall return `0` and set 'errno' to one of
-the values defined below.
-
-NOTE: This API method is deprecated in favor of linkzmq:zmq_msg_bytes[3].
+The _zmq_msg_bytes()_ function shall return zero if successful. Otherwise
+it shall return `-1` and set 'errno' to one of the values defined below.
 
 
 ERRORS
@@ -38,7 +35,7 @@ Invalid message.
 
 SEE ALSO
 --------
-linkzmq:zmq_msg_bytes[3]
+linkzmq:zmq_msg_size[3]
 linkzmq:zmq_msg_data[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_init_size[3]

--- a/doc/zmq_msg_close.txt
+++ b/doc/zmq_msg_close.txt
@@ -46,7 +46,7 @@ linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_init_size[3]
 linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_data[3]
-linkzmq:zmq_msg_size[3]
+linkzmq:zmq_msg_bytes[3]
 linkzmq:zmq[7]
 
 

--- a/doc/zmq_msg_data.txt
+++ b/doc/zmq_msg_data.txt
@@ -34,7 +34,7 @@ No errors are defined.
 
 SEE ALSO
 --------
-linkzmq:zmq_msg_size[3]
+linkzmq:zmq_msg_bytes[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_init_size[3]
 linkzmq:zmq_msg_init_data[3]

--- a/doc/zmq_msg_init.txt
+++ b/doc/zmq_msg_init.txt
@@ -54,7 +54,7 @@ linkzmq:zmq_msg_init_size[3]
 linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq_msg_data[3]
-linkzmq:zmq_msg_size[3]
+linkzmq:zmq_msg_bytes[3]
 linkzmq:zmq[7]
 
 

--- a/doc/zmq_msg_init_data.txt
+++ b/doc/zmq_msg_init_data.txt
@@ -79,7 +79,7 @@ linkzmq:zmq_msg_init_size[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq_msg_data[3]
-linkzmq:zmq_msg_size[3]
+linkzmq:zmq_msg_bytes[3]
 linkzmq:zmq[7]
 
 

--- a/doc/zmq_msg_init_size.txt
+++ b/doc/zmq_msg_init_size.txt
@@ -48,7 +48,7 @@ linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq_msg_data[3]
-linkzmq:zmq_msg_size[3]
+linkzmq:zmq_msg_bytes[3]
 linkzmq:zmq[7]
 
 

--- a/doc/zmq_socket_monitor.txt
+++ b/doc/zmq_socket_monitor.txt
@@ -195,10 +195,11 @@ get_monitor_event (void *monitor, int *value, char **address)
 
     if (address) {
         uint8_t *data = (uint8_t *) zmq_msg_data (&msg);
-        size_t size = zmq_msg_size (&msg);
-        *address = (char *) malloc (size + 1);
-        memcpy (*address, data, size);
-        (*address)[size] = 0;
+        size_t bytes;
+        assert (zmq_msg_bytes (&msg, &bytes));
+        *address = (char *) malloc (bytes + 1);
+        memcpy (*address, data, bytes);
+        (*address)[bytes] = 0;
     }
     return event;
 }

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -274,6 +274,7 @@ ZMQ_EXPORT int zmq_msg_move (zmq_msg_t *dest_, zmq_msg_t *src_);
 ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest_, zmq_msg_t *src_);
 ZMQ_EXPORT void *zmq_msg_data (zmq_msg_t *msg_);
 ZMQ_EXPORT size_t zmq_msg_size (const zmq_msg_t *msg_);
+ZMQ_EXPORT size_t zmq_msg_bytes (const zmq_msg_t *msg_, size_t *bytes_);
 ZMQ_EXPORT int zmq_msg_more (const zmq_msg_t *msg_);
 ZMQ_EXPORT int zmq_msg_get (const zmq_msg_t *msg_, int property_);
 ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg_, int property_, int optval_);

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -113,6 +113,7 @@ class msg_t
     int copy (msg_t &src_);
     void *data ();
     size_t size () const;
+    int size (size_t *bytes_) const;
     unsigned char flags () const;
     void set_flags (unsigned char flags_);
     void reset_flags (unsigned char flags_);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -621,6 +621,11 @@ size_t zmq_msg_size (const zmq_msg_t *msg_)
     return ((zmq::msg_t *) msg_)->size ();
 }
 
+size_t zmq_msg_bytes (const zmq_msg_t *msg_, size_t *bytes_)
+{
+    return ((zmq::msg_t *) msg_)->size (bytes_);
+}
+
 int zmq_msg_more (const zmq_msg_t *msg_)
 {
     return zmq_msg_get (msg_, ZMQ_MORE);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
   test_reqrep_device
   test_sub_forward
   test_invalid_rep
+  test_msg_access
   test_msg_flags
   test_msg_ffn
   test_connect_resolve

--- a/tests/test_msg_access.cpp
+++ b/tests/test_msg_access.cpp
@@ -1,0 +1,65 @@
+/*
+    Copyright (c) 2007-2017 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+
+int main (void)
+{
+    setup_test_environment ();
+    //  Create the infrastructure
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    zmq_msg_t msg;
+
+    int status = zmq_msg_init (&msg);
+    assert (status == 0);
+
+    status = zmq_msg_close (&msg);
+    assert (status == 0);
+
+    // Test that accessing a closed message doesn't crash
+    size_t size = zmq_msg_size (&msg);
+    assert (size == 0);
+    assert (zmq_errno () == EFAULT);
+
+    size_t bytes = -1;
+    status = zmq_msg_bytes (&msg, &bytes);
+    assert (bytes == size_t (-1));
+    assert (zmq_errno () == EFAULT);
+
+    void *data = zmq_msg_data (&msg);
+    assert (data == NULL);
+    assert (zmq_errno () == EFAULT);
+
+    //  Deallocate the infrastructure.
+    int rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+    return 0;
+}

--- a/tests/test_msg_access.cpp
+++ b/tests/test_msg_access.cpp
@@ -46,7 +46,7 @@ int main (void)
 
     // Test that accessing a closed message doesn't crash
     size_t size = zmq_msg_size (&msg);
-    assert (size == 0);
+    assert (size == size_t (0));
     assert (zmq_errno () == EFAULT);
 
     size_t bytes = -1;


### PR DESCRIPTION
Solution:

- Change asserts to unlikely tests.
- `zmq_msg_data(...)` returns NULL on invalid `zmq_msg_t` and sets `errno` to `EFAULT`.
- `zmq_msg_size(...)` returns 0 on invalid `zmq_msg_t` and sets `errno` to `EFAULT`. Deprecated due to ambiguity of return result, legitimate messages may be size 0.
- Introduce error code oriented `int zmq_msg_bytes(zmq_msg_t *msg, size_t *bytes)`. `zmq_msg_bytes(...)` sets `size_t *bytes` to the size in bytes of the message. It returns zero on success and -1 on error. It sets `errno` to `EFAULT` on error. The only error condition is an invalid `zmq_msg_t`.
- Add tests and update docs.

See #3329.