### PR TITLE
TCP_NODELAY is set prior to connecting

### DIFF
--- a/RELICENSE/jacquesg.md
+++ b/RELICENSE/jacquesg.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Jacques Germishuys that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "jacquesg", with
+commit author "Jacques Germishuys <jacquesg@striata.com>", are
+copyright of Jacques Germishuys.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Jacques Germishuys
+2018/12/14
+

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -436,9 +436,6 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
     *w_ = open_socket (AF_INET, SOCK_STREAM, 0);
     wsa_assert (*w_ != INVALID_SOCKET);
 
-    //  Set TCP_NODELAY on writer socket.
-    tune_socket (*w_);
-
     if (sync != NULL) {
         //  Enter the critical section.
         DWORD dwrc = WaitForSingleObject (sync, INFINITE);
@@ -464,6 +461,9 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
     if (rc != SOCKET_ERROR)
         rc = connect (*w_, reinterpret_cast<struct sockaddr *> (&addr),
                       sizeof addr);
+
+    //  Set TCP_NODELAY on writer socket.
+    tune_socket (*w_);
 
     //  Accept connection from writer.
     if (rc != SOCKET_ERROR)


### PR DESCRIPTION
This is problematic on Windows.

Solution: Set TCP_NODELAY after connect()

Reference: https://mail.openvswitch.org/pipermail/ovs-dev/2014-October/290251.html