### PR TITLE
Problems: test failing on SPARC64 and hard-coded socket binds

### DIFF
--- a/tests/test_pair_ipc.cpp
+++ b/tests/test_pair_ipc.cpp
@@ -44,11 +44,16 @@ void tearDown ()
 
 void test_roundtrip ()
 {
+    char my_endpoint[256];
+    size_t len = sizeof (my_endpoint);
+
     void *sb = test_context_socket (ZMQ_PAIR);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb, "ipc:///tmp/test_pair_ipc"));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb, "ipc://*"));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, my_endpoint, &len));
 
     void *sc = test_context_socket (ZMQ_PAIR);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sc, "ipc:///tmp/test_pair_ipc"));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sc, my_endpoint));
 
     bounce (sb, sc);
 

--- a/tests/test_rebind_ipc.cpp
+++ b/tests/test_rebind_ipc.cpp
@@ -42,24 +42,27 @@ void tearDown ()
     teardown_test_context ();
 }
 
-static const char *SOCKET_ADDR = "ipc:///tmp/test_rebind_ipc";
-
 void test_rebind_ipc ()
 {
+    char my_endpoint[256];
+    size_t len = sizeof (my_endpoint);
+
     void *sb0 = test_context_socket (ZMQ_PUSH);
     void *sb1 = test_context_socket (ZMQ_PUSH);
 
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb0, SOCKET_ADDR));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb0, "ipc://*"));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_getsockopt (sb0, ZMQ_LAST_ENDPOINT, my_endpoint, &len));
 
     void *sc = test_context_socket (ZMQ_PULL);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sc, SOCKET_ADDR));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sc, my_endpoint));
 
     send_string_expect_success (sb0, "42", 0);
     recv_string_expect_success (sc, "42", 0);
 
     test_context_socket_close (sb0);
 
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb1, SOCKET_ADDR));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb1, my_endpoint));
 
     send_string_expect_success (sb1, "42", 0);
     recv_string_expect_success (sc, "42", 0);

--- a/tests/test_reconnect_ivl.cpp
+++ b/tests/test_reconnect_ivl.cpp
@@ -71,11 +71,15 @@ void test_reconnect_ivl_against_pair_socket (const char *my_endpoint_,
 #if !defined(ZMQ_HAVE_WINDOWS) && !defined(ZMQ_HAVE_GNU)
 void test_reconnect_ivl_ipc (void)
 {
-    const char *ipc_endpoint = "ipc:///tmp/test_reconnect_ivl";
-    void *sb = test_context_socket (ZMQ_PAIR);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb, ipc_endpoint));
+    char my_endpoint[256];
+    size_t len = sizeof (my_endpoint);
 
-    test_reconnect_ivl_against_pair_socket (ipc_endpoint, sb);
+    void *sb = test_context_socket (ZMQ_PAIR);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb, "ipc://*"));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, my_endpoint, &len));
+
+    test_reconnect_ivl_against_pair_socket (my_endpoint, sb);
     test_context_socket_close (sb);
 }
 #endif

--- a/tests/testutil_security.hpp
+++ b/tests/testutil_security.hpp
@@ -345,7 +345,7 @@ static int get_monitor_event_internal (void *monitor_,
     uint8_t *data = (uint8_t *) zmq_msg_data (&msg);
     uint16_t event = *(uint16_t *) (data);
     if (value_)
-        *value_ = *(uint32_t *) (data + 2);
+        memcpy (value_, data + 2, sizeof (uint32_t));
 
     //  Second frame in message contains event address
     zmq_msg_init (&msg);


### PR DESCRIPTION
Solutions: use memcpy to avoid unaligned pointer access (SIGBUS on sparc) and use randomised endpoints to avoid races and failures with multiple concurrent runs