### PR TITLE
Problem: GCC warnings about string overflows in tests

### DIFF
--- a/tests/test_inproc_connect.cpp
+++ b/tests/test_inproc_connect.cpp
@@ -160,7 +160,7 @@ void test_connect_before_bind_ctx_term ()
         // Connect first
         void *connect_socket = test_context_socket (ZMQ_ROUTER);
 
-        char ep[20];
+        char ep[32];
         sprintf (ep, "inproc://cbbrr%d", i);
         TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (connect_socket, ep));
 

--- a/tests/test_issue_566.cpp
+++ b/tests/test_issue_566.cpp
@@ -66,7 +66,8 @@ void test_issue_566 ()
         //  Create dealer with unique explicit routing id
         //  We assume the router learns this out-of-band
         void *dealer = zmq_socket (ctx2, ZMQ_DEALER);
-        char routing_id[10];
+        //  Leave space for NULL char from sprintf, gcc warning
+        char routing_id[11];
         sprintf (routing_id, "%09d", cycle);
         TEST_ASSERT_SUCCESS_ERRNO (
           zmq_setsockopt (dealer, ZMQ_ROUTING_ID, routing_id, 10));


### PR DESCRIPTION
Solution: mostly false positives, but fix them