### PR TITLE
Problem: ZMQ_SOCKET_LIMIT and ZMQ_THREAD_PRIORITY have the same value

### DIFF
--- a/doc/zmq_ctx_get.txt
+++ b/doc/zmq_ctx_get.txt
@@ -70,12 +70,6 @@ The 'ZMQ_THREAD_SCHED_POLICY' argument returns the scheduling policy for
 internal context's thread pool.
 
 
-ZMQ_THREAD_PRIORITY: Get scheduling priority for I/O threads
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The 'ZMQ_THREAD_PRIORITY' argument returns the scheduling priority for
-internal context's thread pool.
-
-
 ZMQ_THREAD_NAME_PREFIX: Get name prefix for I/O threads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_THREAD_NAME_PREFIX' argument gets the numeric prefix of each thread

--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -469,10 +469,7 @@ int zmq::thread_ctx_t::set (int option_, int optval_)
 int zmq::thread_ctx_t::get (int option_)
 {
     int rc = 0;
-    if (option_ == ZMQ_THREAD_PRIORITY) {
-        scoped_lock_t locker (_opt_sync);
-        rc = _thread_priority;
-    } else if (option_ == ZMQ_THREAD_SCHED_POLICY) {
+    if (option_ == ZMQ_THREAD_SCHED_POLICY) {
         scoped_lock_t locker (_opt_sync);
         rc = _thread_sched_policy;
     } else if (option_ == ZMQ_THREAD_NAME_PREFIX) {

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -112,8 +112,6 @@ void test_ctx_thread_opts (void *ctx_)
           ctx_, ZMQ_THREAD_PRIORITY,
           1 /* any positive value different than the default will be ok */);
         assert (rc == 0);
-        rc = zmq_ctx_get (ctx_, ZMQ_THREAD_PRIORITY);
-        assert (rc == 1);
     }
 
 


### PR DESCRIPTION
Solution: remove documents and tests for ZMQ_THREAD_PRIORITY getter. It
never worked and can never work as it has the same value as a get-only
option ZMQ_SOCKET_LIMIT. It cannot be changed without breaking ABI.
Note that the setter works fine as ZMQ_SOCKET_LIMIT is get-only.

Fixes #3362