### PR TITLE
Problems: test failures on PPC and GNU/hurd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,14 @@ include(CMakeDependentOption)
 include(CheckCXXSymbolExists)
 include(CheckSymbolExists)
 
+execute_process(COMMAND getconf LEVEL1_DCACHE_LINESIZE OUTPUT_VARIABLE CACHELINE_SIZE ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(CACHELINE_SIZE STREQUAL "" OR CACHELINE_SIZE EQUAL 0 OR CACHELINE_SIZE EQUAL -1)
+  set(ZMQ_CACHELINE_SIZE 64)
+else()
+  set(ZMQ_CACHELINE_SIZE ${CACHELINE_SIZE})
+endif()
+message(STATUS "Using ${ZMQ_CACHELINE_SIZE} bytes alignment for lock-free data structures")
+
 if(NOT CYGWIN)
   # TODO cannot we simply do 'if(WIN32) set(ZMQ_HAVE_WINDOWS ON)' or similar?
   check_include_files(windows.h ZMQ_HAVE_WINDOWS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1047,6 +1047,7 @@ endif
 if ON_GNU
 XFAIL_TESTS += tests/test_ipc_wildcard \
 		tests/test_reqrep_ipc \
+		tests/test_pair_ipc \
 		tests/test_term_endpoint
 endif
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1169,3 +1169,23 @@ AC_DEFUN([LIBZMQ_CHECK_POLLER], [{
         AC_MSG_ERROR([Invalid API poller '$api_poller' specified])
 	fi
 }])
+
+dnl ##############################################################################
+dnl # LIBZMQ_CHECK_CACHELINE                                                     #
+dnl # Check cacheline size for alignment purposes                                #
+dnl ##############################################################################
+AC_DEFUN([LIBZMQ_CHECK_CACHELINE], [{
+
+    zmq_cacheline_size=64
+    AC_CHECK_TOOL(libzmq_getconf, getconf)
+    if ! test "x$libzmq_getconf" = "x"; then
+        zmq_cacheline_size=$($libzmq_getconf LEVEL1_DCACHE_LINESIZE 2>/dev/null || echo 64)
+        if test "x$zmq_cacheline_size" = "x0" -o  "x$zmq_cacheline_size" = "x-1"; then
+            # getconf on some architectures does not know the size, try to fallback to
+            # the value the kernel knows on Linux
+            zmq_cacheline_size=$(cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size 2>/dev/null || echo 64)
+        fi
+    fi
+	AC_MSG_NOTICE([Using "$zmq_cacheline_size" bytes alignment for lock-free data structures])
+	AC_DEFINE_UNQUOTED(ZMQ_CACHELINE_SIZE, $zmq_cacheline_size, [Using "$zmq_cacheline_size" bytes alignment for lock-free data structures])
+}])

--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -11,6 +11,8 @@
 #cmakedefine ZMQ_POLL_BASED_ON_SELECT
 #cmakedefine ZMQ_POLL_BASED_ON_POLL
 
+#cmakedefine ZMQ_CACHELINE_SIZE @ZMQ_CACHELINE_SIZE@
+
 #cmakedefine ZMQ_FORCE_MUTEXES
 
 #cmakedefine HAVE_FORK

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ m4_include([m4/ax_cxx_compile_stdcxx_11.m4])
 m4_include([m4/ax_code_coverage.m4])
 m4_include([m4/ax_valgrind_check.m4])
 m4_include([m4/ax_check_vscript.m4])
+m4_include([m4/ax_func_posix_memalign.m4])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # This lets us use PACKAGE_VERSION in Makefiles
@@ -78,6 +79,7 @@ AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL
 AX_VALGRIND_CHECK
 AX_CHECK_VSCRIPT
+AX_FUNC_POSIX_MEMALIGN
 
 AC_ARG_ENABLE([force-CXX98-compat],
     [AS_HELP_STRING([--enable-force-CXX98-compat], [force C++98 build [default=disabled]])])
@@ -670,7 +672,7 @@ AC_LANG_POP([C++])
 
 # Checks for library functions.
 AC_TYPE_SIGNAL
-AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs fork posix_memalign mkdtemp accept4)
+AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs fork mkdtemp accept4)
 AC_CHECK_HEADERS([alloca.h])
 
 # pthread_setname is non-posix, and there are at least 4 different implementations

--- a/configure.ac
+++ b/configure.ac
@@ -376,6 +376,9 @@ LIBZMQ_CHECK_DOC_BUILD
 # Check polling system, set appropriate macro in src/platform.hpp
 LIBZMQ_CHECK_POLLER
 
+# Check cacheline size, set appropriate macro in src/platform.hpp
+LIBZMQ_CHECK_CACHELINE
+
 # Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS(\

--- a/m4/ax_func_posix_memalign.m4
+++ b/m4/ax_func_posix_memalign.m4
@@ -1,0 +1,50 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_func_posix_memalign.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_FUNC_POSIX_MEMALIGN
+#
+# DESCRIPTION
+#
+#   Some versions of posix_memalign (notably glibc 2.2.5) incorrectly apply
+#   their power-of-two check to the size argument, not the alignment
+#   argument. AX_FUNC_POSIX_MEMALIGN defines HAVE_POSIX_MEMALIGN if the
+#   power-of-two check is correctly applied to the alignment argument.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Scott Pakin <pakin@uiuc.edu>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 9
+
+AC_DEFUN([AX_FUNC_POSIX_MEMALIGN],
+[AC_CACHE_CHECK([for working posix_memalign],
+  [ax_cv_func_posix_memalign_works],
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <stdlib.h>
+
+int
+main ()
+{
+  void *buffer;
+
+  /* Some versions of glibc incorrectly perform the alignment check on
+   * the size word. */
+  exit (posix_memalign (&buffer, sizeof(void *), 123) != 0);
+}
+    ]])],
+    [ax_cv_func_posix_memalign_works=yes],
+    [ax_cv_func_posix_memalign_works=no],
+    [ax_cv_func_posix_memalign_works=no])])
+if test "$ax_cv_func_posix_memalign_works" = "yes" ; then
+  AC_DEFINE([HAVE_POSIX_MEMALIGN], [1],
+    [Define to 1 if `posix_memalign' works.])
+fi
+])

--- a/src/atomic_counter.hpp
+++ b/src/atomic_counter.hpp
@@ -35,11 +35,11 @@
 
 #if defined ZMQ_FORCE_MUTEXES
 #define ZMQ_ATOMIC_COUNTER_MUTEX
-#elif defined ZMQ_HAVE_ATOMIC_INTRINSICS
-#define ZMQ_ATOMIC_COUNTER_INTRINSIC
 #elif (defined __cplusplus && __cplusplus >= 201103L)                          \
   || (defined _MSC_VER && _MSC_VER >= 1900)
 #define ZMQ_ATOMIC_COUNTER_CXX11
+#elif defined ZMQ_HAVE_ATOMIC_INTRINSICS
+#define ZMQ_ATOMIC_COUNTER_INTRINSIC
 #elif (defined __i386__ || defined __x86_64__) && defined __GNUC__
 #define ZMQ_ATOMIC_COUNTER_X86
 #elif defined __ARM_ARCH_7A__ && defined __GNUC__

--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -34,11 +34,11 @@
 
 #if defined ZMQ_FORCE_MUTEXES
 #define ZMQ_ATOMIC_PTR_MUTEX
-#elif defined ZMQ_HAVE_ATOMIC_INTRINSICS
-#define ZMQ_ATOMIC_PTR_INTRINSIC
 #elif (defined __cplusplus && __cplusplus >= 201103L)                          \
   || (defined _MSC_VER && _MSC_VER >= 1900)
 #define ZMQ_ATOMIC_PTR_CXX11
+#elif defined ZMQ_HAVE_ATOMIC_INTRINSICS
+#define ZMQ_ATOMIC_PTR_INTRINSIC
 #elif (defined __i386__ || defined __x86_64__) && defined __GNUC__
 #define ZMQ_ATOMIC_PTR_X86
 #elif defined __ARM_ARCH_7A__ && defined __GNUC__

--- a/src/yqueue.hpp
+++ b/src/yqueue.hpp
@@ -55,8 +55,9 @@ namespace zmq
 // posix_memalign available. Default value is 64, this alignment will
 // prevent two queue chunks from occupying the same CPU cache line on
 // architectures where cache lines are <= 64 bytes (e.g. most things
-// except POWER).
-template <typename T, int N, size_t ALIGN = 64> class yqueue_t
+// except POWER). It is detected at build time to try to account for other
+// platforms like POWER and s390x.
+template <typename T, int N, size_t ALIGN = ZMQ_CACHELINE_SIZE> class yqueue_t
 #else
 template <typename T, int N> class yqueue_t
 #endif


### PR DESCRIPTION
Solutions: fix posix_memalign detection, improve cache alignment for yqueue, prefer CXX11 atomics to compiler intrinsics, add wildcard test to XFAIL