### PR TITLE
Problem: race condition breaks automated OBS release

### DIFF
--- a/ci_deploy.sh
+++ b/ci_deploy.sh
@@ -17,17 +17,16 @@ if [[ $BUILD_TYPE == "default" && $CURVE == "libsodium" && -z $DRAFT ]]; then
     cd -
 
     # Trigger source run on new tag on OBS.
-    # We have to create a temporary branch from the tag and delete it, as it is
+    # We have to keep a release branch on the lastest tag, as it is
     # not possible to edit files on OBS with secure tokens, and it is not
     # possible to dynamically fetch the latest git tag either.
     if [ -n "${GH_TOKEN}" -a -n "${OBS_STABLE_TOKEN}" -a -n "${OBS_DRAFT_TOKEN}" ]; then
         TAG_SHA=$(curl -s -H "Authorization: token ${GH_TOKEN}" -X GET https://api.github.com/repos/zeromq/libzmq/git/refs/tags/${TRAVIS_TAG} | grep -o -P '(?<=sha":\s).*(?=,)')
-        curl -H "Authorization: token ${GH_TOKEN}" -X POST --data "{\"ref\":\"refs/heads/tmp_obs_release_branch\",\"sha\":${TAG_SHA}}" https://api.github.com/repos/zeromq/libzmq/git/refs
+        curl -H "Authorization: token ${GH_TOKEN}" -X DELETE https://api.github.com/repos/zeromq/libzmq/git/refs/heads/latest_release
+        curl -H "Authorization: token ${GH_TOKEN}" -X POST --data "{\"ref\":\"refs/heads/latest_release\",\"sha\":${TAG_SHA}}" https://api.github.com/repos/zeromq/libzmq/git/refs
+        sleep 2 # try to avoid races if Github is slow
         curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
         curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
-        # give some time for the git clone to happen before deleting the temp branch
-        sleep 60
-        curl -H "Authorization: token ${GH_TOKEN}" -X DELETE https://api.github.com/repos/zeromq/libzmq/git/refs/heads/tmp_obs_release_branch
     fi
 else
     export LIBZMQ_DEPLOYMENT=""


### PR DESCRIPTION
Solution: instead of using a temporary release branch that gets
deleted after an arbitrary timer, which never matches the time OBS
actually takes to do a full git clone, keep the branch permanently
in place and simply move it forward to the latest tag on each
release.