### PR TITLE
Problem: tipc disconnect does not work anymore

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -979,7 +979,7 @@ int zmq::socket_base_t::connect (const char *endpoint_uri_)
     //  Save last endpoint URI
     paddr->to_string (_last_endpoint);
 
-    add_endpoint (make_unconnected_connect_endpoint_pair (_last_endpoint),
+    add_endpoint (make_unconnected_connect_endpoint_pair (endpoint_uri_),
                   static_cast<own_t *> (session), newpipe);
     return 0;
 }


### PR DESCRIPTION
Solution: change back the indentifier endpoint to the one passed by the
user rather than the resolved one, otherwise when the user passes the
same string to the disconnect call they do not match anymore