### PR TITLE
Problem: close always fails with wildcard bind, since directory is no…

### DIFF
--- a/tests/test_rebind_ipc.cpp
+++ b/tests/test_rebind_ipc.cpp
@@ -44,20 +44,8 @@ void tearDown ()
 
 void test_rebind_ipc ()
 {
-    char my_endpoint[32], random_file[16];
-    strcpy (random_file, "tmpXXXXXX");
-
-#ifdef HAVE_MKDTEMP
-    TEST_ASSERT_TRUE (mkdtemp (random_file));
-    strcat (random_file, "/ipc");
-#else
-    int fd = mkstemp (random_file);
-    TEST_ASSERT_TRUE (fd != -1);
-    close (fd);
-#endif
-
-    strcpy (my_endpoint, "ipc://");
-    strcat (my_endpoint, random_file);
+    char my_endpoint[32];
+    make_random_ipc_endpoint (my_endpoint);
 
     void *sb0 = test_context_socket (ZMQ_PUSH);
     void *sb1 = test_context_socket (ZMQ_PUSH);

--- a/tests/test_reconnect_ivl.cpp
+++ b/tests/test_reconnect_ivl.cpp
@@ -72,12 +72,10 @@ void test_reconnect_ivl_against_pair_socket (const char *my_endpoint_,
 void test_reconnect_ivl_ipc (void)
 {
     char my_endpoint[256];
-    size_t len = sizeof (my_endpoint);
+    make_random_ipc_endpoint (my_endpoint);
 
     void *sb = test_context_socket (ZMQ_PAIR);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb, "ipc://*"));
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, my_endpoint, &len));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (sb, my_endpoint));
 
     test_reconnect_ivl_against_pair_socket (my_endpoint, sb);
     test_context_socket_close (sb);

--- a/tests/testutil_unity.hpp
+++ b/tests/testutil_unity.hpp
@@ -326,3 +326,23 @@ void bind_loopback_ipv6 (void *socket_, char *my_endpoint_, size_t len_)
 {
     bind_loopback (socket_, true, my_endpoint_, len_);
 }
+
+// utility function to create a random IPC endpoint, similar to what a ipc://*
+// wildcard binding does, but in a way it can be reused for multiple binds
+void make_random_ipc_endpoint (char *out_endpoint_)
+{
+    char random_file[16];
+    strcpy (random_file, "tmpXXXXXX");
+
+#ifdef HAVE_MKDTEMP
+    TEST_ASSERT_TRUE (mkdtemp (random_file));
+    strcat (random_file, "/ipc");
+#else
+    int fd = mkstemp (random_file);
+    TEST_ASSERT_TRUE (fd != -1);
+    close (fd);
+#endif
+
+    strcpy (out_endpoint_, "ipc://");
+    strcat (out_endpoint_, random_file);
+}


### PR DESCRIPTION
…t empty

Solution: unlink the socket file first

Fixes #3387 
