### PR TITLE
Problem: test build fails on 32 bit systems

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -456,7 +456,7 @@ test_apps = \
 	tests/test_mock_pub_sub \
 	tests/test_socket_null
 
-UNITY_CPPFLAGS = -I$(top_srcdir)/external/unity -DUNITY_USE_COMMAND_LINE_ARGS -DUNITY_EXCLUDE_FLOAT
+UNITY_CPPFLAGS = -I$(top_srcdir)/external/unity -DUNITY_USE_COMMAND_LINE_ARGS -DUNITY_EXCLUDE_FLOAT -DUNITY_SUPPORT_64
 UNITY_LIBS = $(top_builddir)/external/unity/libunity.a
 noinst_LIBRARIES = external/unity/libunity.a
 external_unity_libunity_a_SOURCES = external/unity/unity.c \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,7 +154,7 @@ add_library(unity STATIC
   "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity_internals.h")
 set_target_properties(unity PROPERTIES
   PUBLIC_HEADER "${CMAKE_CURRENT_LIST_DIR}/../external/unity/unity.h")
-target_compile_definitions(unity PUBLIC "UNITY_USE_COMMAND_LINE_ARGS" "UNITY_EXCLUDE_FLOAT")
+target_compile_definitions(unity PUBLIC "UNITY_USE_COMMAND_LINE_ARGS" "UNITY_EXCLUDE_FLOAT" "UNITY_SUPPORT_64")
 target_include_directories(unity PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../external/unity")
 
 if(MSVC_VERSION LESS 1700)


### PR DESCRIPTION
Solution: define UNITY_SUPPORT_64 to force 64 bit support

@bluca this fixes the build for Win32, hope it does also for other 32 bit environments
