### PR TITLE
Problem: missing relicensing statement from bluca

### DIFF
--- a/RELICENSE/bluca.md
+++ b/RELICENSE/bluca.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Luca Boccassi (bluca)
+that grants permission to relicense his copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "bluca", with
+commit author "Luca Boccassi <luca.boccassi@gmail.com>" or
+"Luca Boccassi <bluca@debian.org>", are copyright of Luca Boccassi.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed
+above.
+
+Luca Boccassi
+2019/02/16


### PR DESCRIPTION
Solution: add it - I realised only now that I only submitted a
statement for the copyright owned by a previous employer, and not
my own.