### PR TITLE
Problem: missing relicense statement from Prarrot

### DIFF
--- a/RELICENSE/prarrot.md
+++ b/RELICENSE/prarrot.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Timothy Mossbarger
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "Prarrot", with
+commit author "Prarrot", are copyright of Timothy Mossbarger .
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Timothy Mossbarger
+18 Feb 2019


### PR DESCRIPTION
Solution: add the one received by email

Message-ID: <CAHPFjttticWbCuZ93r55gGRDBMxAgNn==4r70op4LnQNEJM23Q@mail.gmail.com>