### PR TITLE
Document that zmq_poller_new can return NULL.

### DIFF
--- a/RELICENSE/Eelis.md
+++ b/RELICENSE/Eelis.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Eelis van der Weegen that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "Eelis", with
+commit author "Eelis van der Weegen <eelis@eelis.net>", are
+copyright of Eelis van der Weegen.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Eelis van der Weegen
+2019/02/22

--- a/doc/zmq_poller.txt
+++ b/doc/zmq_poller.txt
@@ -172,7 +172,7 @@ be called from the same thread. Otherwise, behaviour is undefined.
 
 RETURN VALUE
 ------------
-_zmq_poller_new_ always returns a valid pointer to a poller.
+_zmq_poller_new_ returns a valid pointer to a poller, or NULL in case of a failure.
 
 All functions that return an int, return -1 in case of a failure. In that case,
 zmq_errno() can be used to query the type of the error as described below.


### PR DESCRIPTION
Fixes #3425.