### PR TITLE
Don't crash if memory allocation in socket_poller_t::rebuild fails.

### DIFF
--- a/doc/zmq_poller.txt
+++ b/doc/zmq_poller.txt
@@ -223,6 +223,8 @@ On _zmq_poller_add_fd_, _zmq_poller_modify_fd_ and _zmq_poller_remove_fd_:
 The _fd_ specified was the retired fd.
 
 On _zmq_poller_wait_ and _zmq_poller_wait_all_:
+*ENOMEM*::
+Necessary resources could not be allocated.
 *ETERM*::
 At least one of the registered objects is a 'socket' whose associated 0MQ 
 'context' was terminated.

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -101,7 +101,7 @@ class socket_poller_t
                         uint64_t &now_,
                         uint64_t &end_,
                         bool &first_pass_);
-    void rebuild ();
+    int rebuild ();
 
     //  Used to check whether the object is a socket_poller.
     uint32_t _tag;


### PR DESCRIPTION
Fixes #3427.