### PR TITLE
session_base: fix fd leak if ZMQ_ROUTER_HANDOVER is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ test_pair_tipc
 test_reqrep_device_tipc
 test_reqrep_tipc
 test_router_handover
+test_router_handover_leak
 test_router_mandatory_tipc
 test_router_notify
 test_shutdown_stress_tipc

--- a/AUTHORS
+++ b/AUTHORS
@@ -120,6 +120,7 @@ Toralf Wittner
 Tore Halvorsen
 Trevor Bernard
 Vitaly Mayatskikh
+Roman Penyaev
 
 Credits
 =======

--- a/Makefile.am
+++ b/Makefile.am
@@ -410,6 +410,7 @@ test_apps = \
 	tests/test_router_mandatory \
 	tests/test_router_mandatory_hwm \
 	tests/test_router_handover \
+	tests/test_router_handover_leak \
 	tests/test_probe_router \
 	tests/test_stream \
 	tests/test_stream_empty \
@@ -560,6 +561,10 @@ tests_test_router_mandatory_hwm_CPPFLAGS = ${UNITY_CPPFLAGS}
 tests_test_router_handover_SOURCES = tests/test_router_handover.cpp
 tests_test_router_handover_LDADD = src/libzmq.la ${UNITY_LIBS}
 tests_test_router_handover_CPPFLAGS = ${UNITY_CPPFLAGS}
+
+tests_test_router_handover_leak_SOURCES = tests/test_router_handover_leak.cpp
+tests_test_router_handover_leak_LDADD = src/libzmq.la ${UNITY_LIBS}
+tests_test_router_handover_leak_CPPFLAGS = ${UNITY_CPPFLAGS}
 
 tests_test_probe_router_SOURCES = tests/test_probe_router.cpp
 tests_test_probe_router_LDADD = src/libzmq.la ${UNITY_LIBS}

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -223,6 +223,7 @@ zmq::options_t::options_t () :
     recv_routing_id (false),
     raw_socket (false),
     raw_notify (true),
+    handover (false),
     tcp_keepalive (-1),
     tcp_keepalive_cnt (-1),
     tcp_keepalive_idle (-1),

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -156,6 +156,10 @@ struct options_t
     bool raw_socket;
     bool raw_notify; //  Provide connect notifications
 
+    // if true, router socket handovers the connection to the new client
+    // and disconnects the existing one.
+    bool handover;
+
     //  Address of SOCKS proxy
     std::string socks_proxy_address;
 

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -137,6 +137,7 @@ int zmq::router_t::xsetsockopt (int option_,
                 if (!options.connected) {
                     // We expect nothing is binded yet
                     _handover = (value != 0);
+                    options.handover = _handover;
                     return 0;
                 }
             }

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -134,8 +134,11 @@ int zmq::router_t::xsetsockopt (int option_,
 
         case ZMQ_ROUTER_HANDOVER:
             if (is_int && value >= 0) {
-                _handover = (value != 0);
-                return 0;
+                if (!options.connected) {
+                    // We expect nothing is binded yet
+                    _handover = (value != 0);
+                    return 0;
+                }
             }
             break;
 

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -263,7 +263,8 @@ void zmq::session_base_t::pipe_terminated (pipe_t *pipe_)
         // Remove the pipe from the detached pipes set
         _terminating_pipes.erase (pipe_);
 
-    if (!is_terminating () && options.raw_socket) {
+    if (!is_terminating () &&
+        (options.raw_socket || options.handover)) {
         if (_engine) {
             _engine->terminate ();
             _engine = NULL;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(tests
   test_capabilities
   test_metadata
   test_router_handover
+  test_router_handover_leak
   test_srcfd
   test_stream_timeout
   test_xpub_manual

--- a/tests/test_router_handover.cpp
+++ b/tests/test_router_handover.cpp
@@ -49,15 +49,15 @@ void test_with_handover ()
     char my_endpoint[MAX_SOCKET_STRING];
     void *router = test_context_socket (ZMQ_ROUTER);
 
+	// Enable the handover flag
+    int handover = 1;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (router, ZMQ_ROUTER_HANDOVER,
+                                               &handover, sizeof (handover)));
+
     TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (router, "tcp://127.0.0.1:*"));
 
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_getsockopt (router, ZMQ_LAST_ENDPOINT, my_endpoint, &len));
-
-    // Enable the handover flag
-    int handover = 1;
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (router, ZMQ_ROUTER_HANDOVER,
-                                               &handover, sizeof (handover)));
 
     //  Create dealer called "X" and connect it to our router
     void *dealer_one = test_context_socket (ZMQ_DEALER);

--- a/tests/test_router_handover_leak.cpp
+++ b/tests/test_router_handover_leak.cpp
@@ -1,0 +1,164 @@
+/*
+    Copyright (c) 2007-2019 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include "testutil.hpp"
+
+int main(int argc, char **argv)
+{
+	char my_endpoint[1024];
+	char buffer[255];
+	int flag, rc, i;
+	size_t len;
+
+	void *dealer_one, *dealer_two;
+	void *router;
+	void *ctx;
+
+	len = sizeof(my_endpoint);
+
+	ctx = zmq_ctx_new();
+	assert(ctx);
+
+	router = zmq_socket(ctx, ZMQ_ROUTER);
+	assert(router);
+
+	flag = 0;
+	rc = zmq_setsockopt(router, ZMQ_LINGER, &flag, sizeof(flag));
+	assert(rc == 0);
+
+	// Enable the handover flag
+	flag = 1;
+	rc = zmq_setsockopt(router, ZMQ_ROUTER_HANDOVER, &flag, sizeof(flag));
+	assert(rc == 0);
+
+	rc = zmq_bind(router, "tcp://127.0.0.1:5555");
+	assert(rc == 0);
+
+	rc = zmq_getsockopt(router, ZMQ_LAST_ENDPOINT, my_endpoint, &len);
+	assert(rc == 0);
+
+	//  Create dealer called "X" and connect it to our router
+	dealer_one = zmq_socket(ctx, ZMQ_DEALER);
+	assert(dealer_one);
+
+	flag = 0;
+	rc = zmq_setsockopt(dealer_one, ZMQ_LINGER, &flag, sizeof(flag));
+	assert(rc == 0);
+
+
+	rc = zmq_setsockopt(dealer_one, ZMQ_IDENTITY, "X", 1);
+	assert(rc == 0);
+
+	rc = zmq_connect(dealer_one, my_endpoint);
+	assert(rc == 0);
+
+	for (i = 0; i < 5000; i++) {
+		//  Get message from dealer to know when connection is ready
+		rc = zmq_send(dealer_one, "Hello", 5, 0);
+		assert(rc == 5);
+
+		rc = zmq_recv(router, buffer, sizeof(buffer), 0);
+		assert(rc == 1);
+		assert(memcmp(buffer, "X", 1) == 0);
+
+		rc = zmq_recv(router, buffer, sizeof(buffer), 0);
+		assert(rc == 5);
+		assert(memcmp(buffer, "Hello", 5) == 0);
+
+		// Now create a second dealer that uses the same routing id
+		dealer_two = zmq_socket(ctx, ZMQ_DEALER);
+		assert(dealer_two);
+
+		flag = 0;
+		rc = zmq_setsockopt(dealer_two, ZMQ_LINGER, &flag, sizeof(flag));
+		assert(rc == 0);
+
+		rc = zmq_setsockopt(dealer_two, ZMQ_IDENTITY, "X", 1);
+		assert(rc == 0);
+
+		rc = zmq_connect(dealer_two, my_endpoint);
+		assert(rc == 0);
+
+		//  Get message from dealer to know when connection is ready
+		rc = zmq_send(dealer_two, "Hello", 5, 0);
+		assert(rc == 5);
+
+		// Receive on router only first message
+		rc = zmq_recv(router, buffer, sizeof(buffer), 0);
+		assert(rc == 1);
+		assert(memcmp(buffer, "X", 1) == 0);
+
+		rc = zmq_recv(router, buffer, sizeof(buffer), 0);
+		assert(rc == 5);
+		assert(memcmp(buffer, "Hello", 5) == 0);
+
+		//
+		// Send from dealer which is inactive now, message should
+		// not be received, but on router side descriptor leaks !!!!!!
+		// see issue #3238
+		//
+		rc = zmq_send(dealer_one, "Hello", 5, 0);
+		assert(rc == 5);
+
+		// Roll to the active dealer
+		zmq_close(dealer_one);
+		dealer_one = dealer_two;
+
+		// Count number of opened descriptors each thousand
+#ifdef ZMQ_HAVE_LINUX
+		if (i && 0 == i % 1000) {
+			FILE *fp;
+
+			snprintf(buffer, sizeof(buffer), "ls -la /proc/%d/fd | wc -l",
+				 getpid());
+			fp = popen(buffer, "r");
+			assert(fp);
+
+			rc = fread(buffer, 1, sizeof(buffer)-1, fp);
+			assert(rc > 0 && rc < 10);
+			buffer[rc-1] = 0;
+
+			printf("Total fds: %s\n", buffer);
+			pclose(fp);
+		}
+#endif
+	}
+
+	// If we reach this line we have not crashed, so everything is fine
+	printf("OK\n");
+
+	return 0;
+}


### PR DESCRIPTION
This fixes the issue #3238
"decriptor leak on ZMQ_ROUTER if ZMQ_ROUTER_HANDOVER is set"

When ZMQ_ROUTER_HANDOVER is set router_t::identify_peer() closes
old pipe and uses the new one.  When old_pipe->terminate() is called
eventually session_base_t::pipe_terminated() is invoked, but the
following path:

  if (_pending && !_pipe && !_zap_pipe && _terminating_pipes.empty()) {
	  own_t::process_term(0);
  }

is never taken, because _pending == 0, thus session_base_t object leaks
and fd is never closed.

In order to free session_base_t correctly terminate() has to be called.

Signed-off-by: Roman Penyaev <r.peniaev@gmail.com>
