### PR TITLE
Restore /dev/poll support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ case of a released version.
 
 OS and version | Architecture | Compiler and version | Build system | Last report | Remarks
 -------------- | ------------ | -------------------- | ------------ | ----------- | -------
+Solaris 10 | x86, amd64, sparc | GCC 8.1.0 | CMake | 2019/03/18 |
 
 
 ### Supported platforms without known active users

--- a/src/devpoll.hpp
+++ b/src/devpoll.hpp
@@ -47,7 +47,7 @@ struct i_poll_events;
 
 //  Implements socket polling mechanism using the "/dev/poll" interface.
 
-class devpoll_t : public poller_base_t
+class devpoll_t : public worker_poller_base_t
 {
   public:
     typedef fd_t handle_t;
@@ -62,20 +62,13 @@ class devpoll_t : public poller_base_t
     void reset_pollin (handle_t handle_);
     void set_pollout (handle_t handle_);
     void reset_pollout (handle_t handle_);
-    void start ();
     void stop ();
 
     static int max_fds ();
 
   private:
-    //  Main worker thread routine.
-    static void worker_routine (void *arg_);
-
     //  Main event loop.
     void loop ();
-
-    // Reference to ZMQ context.
-    const thread_ctx_t &ctx;
 
     //  File descriptor referring to "/dev/poll" pseudo-device.
     fd_t devpoll_fd;
@@ -96,12 +89,6 @@ class devpoll_t : public poller_base_t
 
     //  Pollset manipulation function.
     void devpoll_ctl (fd_t fd_, short events_);
-
-    //  If true, thread is in the process of shutting down.
-    bool stopping;
-
-    //  Handle of the physical thread doing the I/O work.
-    thread_t worker;
 
     devpoll_t (const devpoll_t &);
     const devpoll_t &operator= (const devpoll_t &);

--- a/src/epoll.hpp
+++ b/src/epoll.hpp
@@ -103,9 +103,6 @@ class epoll_t : public worker_poller_base_t
     typedef std::vector<poll_entry_t *> retired_t;
     retired_t _retired;
 
-    //  Handle of the physical thread doing the I/O work.
-    thread_t _worker;
-
     epoll_t (const epoll_t &);
     const epoll_t &operator= (const epoll_t &);
 };


### PR DESCRIPTION
Restore support for ```/dev/poll``` on Solaris, remove one unused class variable from ```epoll_t```.