### PR TITLE
Problem: socket returned by ZMQ_FD cannot be used with CreateIoComple…

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -84,8 +84,9 @@ zmq::fd_t zmq::open_socket (int domain_, int type_, int protocol_)
 #if defined ZMQ_HAVE_WINDOWS && defined WSA_FLAG_NO_HANDLE_INHERIT
     // if supported, create socket with WSA_FLAG_NO_HANDLE_INHERIT, such that
     // the race condition in making it non-inheritable later is avoided
-    const fd_t s = WSASocket (domain_, type_, protocol_, NULL, 0,
-                              WSA_FLAG_NO_HANDLE_INHERIT);
+    const fd_t s =
+      WSASocket (domain_, type_, protocol_, NULL, 0,
+                 WSA_FLAG_OVERLAPPED || WSA_FLAG_NO_HANDLE_INHERIT);
 #else
     const fd_t s = socket (domain_, type_, protocol_);
 #endif


### PR DESCRIPTION
…tionPort

Solution: add WSA_FLAG_OVERLAPPED socket flag

Fixes #3269 