### PR TITLE
Relicensing grant from Ericsson

### DIFF
--- a/RELICENSE/ericsson.md
+++ b/RELICENSE/ericsson.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Ericsson
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "hugne", with
+commit author "Erik Hugne erik.hugne@ericsson.com", are copyright of Ericsson.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Jon Maloy <jon.maloy@ericsson.com>
+2019/03/27


### PR DESCRIPTION
Received via email on 2019/03/27, message-id:

BL0PR1501MB2003AF12CCA96A583B16D10F9A590@BL0PR1501MB2003.namprd15.prod.outlook.com