### PR TITLE
Some explicit endpoint type changes to support GCC 5

### DIFF
--- a/RELICENSE/SergheiNovac.md
+++ b/RELICENSE/SergheiNovac.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Serghei Novac
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "carbofos", with
+commit author "Serghei Novac <serghei.novac@epydoc.com>", are copyright of Serghei Novac.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Serghei Novac
+2019/03/05

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -683,13 +683,13 @@ int zmq::socket_base_t::bind (const char *endpoint_uri_)
         int rc = listener->set_local_address (address.c_str ());
         if (rc != 0) {
             LIBZMQ_DELETE (listener);
-            event_bind_failed (address, zmq_errno ());
+            event_bind_failed (make_unconnected_bind_endpoint_pair(address), zmq_errno ());
             return -1;
         }
 
         listener->get_local_address (_last_endpoint);
 
-        add_endpoint (_last_endpoint.c_str (), static_cast<own_t *> (listener),
+        add_endpoint (make_unconnected_bind_endpoint_pair (_last_endpoint), static_cast<own_t *> (listener),
                       NULL);
         options.connected = true;
         return 0;

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -353,9 +353,9 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_) const
         return -1;
     }
 
-        //  Check whether socket type and transport protocol match.
-        //  Specifically, multicast protocols can't be combined with
-        //  bi-directional messaging patterns (socket types).
+    //  Check whether socket type and transport protocol match.
+    //  Specifically, multicast protocols can't be combined with
+    //  bi-directional messaging patterns (socket types).
 #if defined ZMQ_HAVE_OPENPGM || defined ZMQ_HAVE_NORM
     if ((protocol_ == "pgm" || protocol_ == "epgm" || protocol_ == "norm")
         && options.type != ZMQ_PUB && options.type != ZMQ_SUB
@@ -683,14 +683,15 @@ int zmq::socket_base_t::bind (const char *endpoint_uri_)
         int rc = listener->set_local_address (address.c_str ());
         if (rc != 0) {
             LIBZMQ_DELETE (listener);
-            event_bind_failed (make_unconnected_bind_endpoint_pair(address), zmq_errno ());
+            event_bind_failed (make_unconnected_bind_endpoint_pair (address),
+                               zmq_errno ());
             return -1;
         }
 
         listener->get_local_address (_last_endpoint);
 
-        add_endpoint (make_unconnected_bind_endpoint_pair (_last_endpoint), static_cast<own_t *> (listener),
-                      NULL);
+        add_endpoint (make_unconnected_bind_endpoint_pair (_last_endpoint),
+                      static_cast<own_t *> (listener), NULL);
         options.connected = true;
         return 0;
     }
@@ -895,7 +896,7 @@ int zmq::socket_base_t::connect (const char *endpoint_uri_)
         }
     }
 
-        // TBD - Should we check address for ZMQ_HAVE_NORM???
+    // TBD - Should we check address for ZMQ_HAVE_NORM???
 
 #ifdef ZMQ_HAVE_OPENPGM
     if (protocol == "pgm" || protocol == "epgm") {

--- a/src/vmci_connecter.cpp
+++ b/src/vmci_connecter.cpp
@@ -136,8 +136,8 @@ void zmq::vmci_connecter_t::out_event ()
     }
 
     //  Create the engine object for this connection.
-    stream_engine_t *engine =
-      new (std::nothrow) stream_engine_t(fd, options, make_unconnected_bind_endpoint_pair(endpoint));
+    stream_engine_t *engine = new (std::nothrow) stream_engine_t (
+      fd, options, make_unconnected_bind_endpoint_pair (endpoint));
     alloc_assert (engine);
 
     //  Attach the engine to the corresponding session object.
@@ -146,7 +146,8 @@ void zmq::vmci_connecter_t::out_event ()
     //  Shut the connecter down.
     terminate ();
 
-    socket->event_connected (make_unconnected_bind_endpoint_pair(endpoint), fd);
+    socket->event_connected (make_unconnected_bind_endpoint_pair (endpoint),
+                             fd);
 }
 
 void zmq::vmci_connecter_t::timer_event (int id_)
@@ -181,7 +182,8 @@ void zmq::vmci_connecter_t::add_reconnect_timer ()
     if (options.reconnect_ivl != -1) {
         int rc_ivl = get_new_reconnect_ivl ();
         add_timer (rc_ivl, reconnect_timer_id);
-        socket->event_connect_retried (make_unconnected_bind_endpoint_pair(endpoint), rc_ivl);
+        socket->event_connect_retried (
+          make_unconnected_bind_endpoint_pair (endpoint), rc_ivl);
         timer_started = true;
     }
 }
@@ -247,7 +249,7 @@ void zmq::vmci_connecter_t::close ()
     const int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (make_unconnected_bind_endpoint_pair(endpoint), s);
+    socket->event_closed (make_unconnected_bind_endpoint_pair (endpoint), s);
     s = retired_fd;
 }
 

--- a/src/vmci_connecter.cpp
+++ b/src/vmci_connecter.cpp
@@ -137,7 +137,7 @@ void zmq::vmci_connecter_t::out_event ()
 
     //  Create the engine object for this connection.
     stream_engine_t *engine =
-      new (std::nothrow) stream_engine_t (fd, options, endpoint);
+      new (std::nothrow) stream_engine_t(fd, options, make_unconnected_bind_endpoint_pair(endpoint));
     alloc_assert (engine);
 
     //  Attach the engine to the corresponding session object.
@@ -146,7 +146,7 @@ void zmq::vmci_connecter_t::out_event ()
     //  Shut the connecter down.
     terminate ();
 
-    socket->event_connected (endpoint, fd);
+    socket->event_connected (make_unconnected_bind_endpoint_pair(endpoint), fd);
 }
 
 void zmq::vmci_connecter_t::timer_event (int id_)
@@ -181,7 +181,7 @@ void zmq::vmci_connecter_t::add_reconnect_timer ()
     if (options.reconnect_ivl != -1) {
         int rc_ivl = get_new_reconnect_ivl ();
         add_timer (rc_ivl, reconnect_timer_id);
-        socket->event_connect_retried (endpoint, rc_ivl);
+        socket->event_connect_retried (make_unconnected_bind_endpoint_pair(endpoint), rc_ivl);
         timer_started = true;
     }
 }
@@ -247,7 +247,7 @@ void zmq::vmci_connecter_t::close ()
     const int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (endpoint, s);
+    socket->event_closed (make_unconnected_bind_endpoint_pair(endpoint), s);
     s = retired_fd;
 }
 

--- a/src/vmci_listener.cpp
+++ b/src/vmci_listener.cpp
@@ -87,7 +87,8 @@ void zmq::vmci_listener_t::in_event ()
 
     //  If connection was reset by the peer in the meantime, just ignore it.
     if (fd == retired_fd) {
-        socket->event_accept_failed (make_unconnected_bind_endpoint_pair(endpoint), zmq_errno ());
+        socket->event_accept_failed (
+          make_unconnected_bind_endpoint_pair (endpoint), zmq_errno ());
         return;
     }
 
@@ -106,8 +107,8 @@ void zmq::vmci_listener_t::in_event ()
     }
 
     //  Create the engine object for this connection.
-    stream_engine_t *engine =
-      new (std::nothrow) stream_engine_t (fd, options, make_unconnected_bind_endpoint_pair(endpoint));
+    stream_engine_t *engine = new (std::nothrow) stream_engine_t (
+      fd, options, make_unconnected_bind_endpoint_pair (endpoint));
     alloc_assert (engine);
 
     //  Choose I/O thread to run connecter in. Given that we are already
@@ -122,7 +123,7 @@ void zmq::vmci_listener_t::in_event ()
     session->inc_seqnum ();
     launch_child (session);
     send_attach (session, engine, false);
-    socket->event_accepted (make_unconnected_bind_endpoint_pair(endpoint), fd);
+    socket->event_accepted (make_unconnected_bind_endpoint_pair (endpoint), fd);
 }
 
 int zmq::vmci_listener_t::get_local_address (std::string &addr_)
@@ -198,7 +199,7 @@ int zmq::vmci_listener_t::set_local_address (const char *addr_)
         goto error;
 #endif
 
-    socket->event_listening (make_unconnected_bind_endpoint_pair(endpoint), s);
+    socket->event_listening (make_unconnected_bind_endpoint_pair (endpoint), s);
     return 0;
 
 error:
@@ -218,7 +219,7 @@ void zmq::vmci_listener_t::close ()
     int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (make_unconnected_bind_endpoint_pair(endpoint), s);
+    socket->event_closed (make_unconnected_bind_endpoint_pair (endpoint), s);
     s = retired_fd;
 }
 

--- a/src/vmci_listener.cpp
+++ b/src/vmci_listener.cpp
@@ -87,7 +87,7 @@ void zmq::vmci_listener_t::in_event ()
 
     //  If connection was reset by the peer in the meantime, just ignore it.
     if (fd == retired_fd) {
-        socket->event_accept_failed (endpoint, zmq_errno ());
+        socket->event_accept_failed (make_unconnected_bind_endpoint_pair(endpoint), zmq_errno ());
         return;
     }
 
@@ -107,7 +107,7 @@ void zmq::vmci_listener_t::in_event ()
 
     //  Create the engine object for this connection.
     stream_engine_t *engine =
-      new (std::nothrow) stream_engine_t (fd, options, endpoint);
+      new (std::nothrow) stream_engine_t (fd, options, make_unconnected_bind_endpoint_pair(endpoint));
     alloc_assert (engine);
 
     //  Choose I/O thread to run connecter in. Given that we are already
@@ -122,7 +122,7 @@ void zmq::vmci_listener_t::in_event ()
     session->inc_seqnum ();
     launch_child (session);
     send_attach (session, engine, false);
-    socket->event_accepted (endpoint, fd);
+    socket->event_accepted (make_unconnected_bind_endpoint_pair(endpoint), fd);
 }
 
 int zmq::vmci_listener_t::get_local_address (std::string &addr_)
@@ -198,7 +198,7 @@ int zmq::vmci_listener_t::set_local_address (const char *addr_)
         goto error;
 #endif
 
-    socket->event_listening (endpoint, s);
+    socket->event_listening (make_unconnected_bind_endpoint_pair(endpoint), s);
     return 0;
 
 error:
@@ -218,7 +218,7 @@ void zmq::vmci_listener_t::close ()
     int rc = ::close (s);
     errno_assert (rc == 0);
 #endif
-    socket->event_closed (endpoint, s);
+    socket->event_closed (make_unconnected_bind_endpoint_pair(endpoint), s);
     s = retired_fd;
 }
 


### PR DESCRIPTION
# GCC 5 support

Problem: GCC 5 support was broken
Solution: Some explicit endpoint type changes were made and tested in GCC 5.5.0 and GCC 8.3.0