### PR TITLE
Problem: CI format check fails

### DIFF
--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -353,9 +353,9 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_) const
         return -1;
     }
 
-    //  Check whether socket type and transport protocol match.
-    //  Specifically, multicast protocols can't be combined with
-    //  bi-directional messaging patterns (socket types).
+        //  Check whether socket type and transport protocol match.
+        //  Specifically, multicast protocols can't be combined with
+        //  bi-directional messaging patterns (socket types).
 #if defined ZMQ_HAVE_OPENPGM || defined ZMQ_HAVE_NORM
     if ((protocol_ == "pgm" || protocol_ == "epgm" || protocol_ == "norm")
         && options.type != ZMQ_PUB && options.type != ZMQ_SUB
@@ -896,7 +896,7 @@ int zmq::socket_base_t::connect (const char *endpoint_uri_)
         }
     }
 
-    // TBD - Should we check address for ZMQ_HAVE_NORM???
+        // TBD - Should we check address for ZMQ_HAVE_NORM???
 
 #ifdef ZMQ_HAVE_OPENPGM
     if (protocol == "pgm" || protocol == "epgm") {


### PR DESCRIPTION
Solution: fix it

Yes it looks weird, but it's a known problem in clang-format