### PR TITLE
Request handling leaked memory.  Depending on the application's use o…

### DIFF
--- a/RELICENSE/tommd.md
+++ b/RELICENSE/tommd.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Thomas M. DuBuisson
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "tommd", with
+commit author "Thomas M. DuBuisson", are copyright of Thomas M. DuBuisson.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Thomas M. DuBuisson
+2019/04/11


### PR DESCRIPTION
Problem: xsend() can leak memory

Solution: free memory in case of error return from sendpipe().
