### PR TITLE
Zeromq 3479: fixed build for QNX 6.6 with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,8 +350,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND CMAKE_SYSTEM_VERSION STREQUAL "
 endif()
 if(NOT MSVC)
   check_include_files(ifaddrs.h ZMQ_HAVE_IFADDRS)
+  message("ZMQ_HAVE_IFADDRS: ${ZMQ_HAVE_IFADDRS}")
   check_include_files(sys/uio.h ZMQ_HAVE_UIO)
+  message("ZMQ_HAVE_UIO: ${ZMQ_HAVE_UIO}")
   check_include_files(sys/eventfd.h ZMQ_HAVE_EVENTFD)
+  message("ZMQ_HAVE_EVENTFD: ${ZMQ_HAVE_EVENTFD}")
   if(ZMQ_HAVE_EVENTFD AND NOT CMAKE_CROSSCOMPILING)
     zmq_check_efd_cloexec()
   endif()
@@ -373,7 +376,9 @@ if(ZMQ_HAVE_WINDOWS)
   check_library_exists(ws2 fopen "" HAVE_WS2)
 else()
   check_cxx_symbol_exists(SO_PEERCRED sys/socket.h ZMQ_HAVE_SO_PEERCRED)
+  message("ZMQ_HAVE_SO_PEERCRED: ${ZMQ_HAVE_SO_PEERCRED}")
   check_cxx_symbol_exists(LOCAL_PEERCRED sys/socket.h ZMQ_HAVE_LOCAL_PEERCRED)
+  message("ZMQ_HAVE_LOCAL_PEERCRED: ${ZMQ_HAVE_LOCAL_PEERCRED}")
 endif()
 
 find_library(RT_LIBRARY rt)
@@ -401,26 +406,33 @@ if(NOT MSVC)
   set(CMAKE_REQUIRED_LIBRARIES rt)
   check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
   set(CMAKE_REQUIRED_LIBRARIES)
+  message("HAVE_CLOCK_GETTIME: ${HAVE_CLOCK_GETTIME}")
 
   set(CMAKE_REQUIRED_INCLUDES unistd.h)
   check_function_exists(fork HAVE_FORK)
   set(CMAKE_REQUIRED_INCLUDES)
+  message("HAVE_FORK: ${HAVE_FORK}")
 
   set(CMAKE_REQUIRED_INCLUDES sys/time.h)
   check_function_exists(gethrtime HAVE_GETHRTIME)
   set(CMAKE_REQUIRED_INCLUDES)
+  message("HAVE_GETHRTIME: ${HAVE_GETHRTIME}")
 
   set(CMAKE_REQUIRED_INCLUDES stdlib.h)
   check_function_exists(mkdtemp HAVE_MKDTEMP)
   set(CMAKE_REQUIRED_INCLUDES)
+  message("HAVE_MKDTEMP: ${HAVE_MKDTEMP}")
 
   set(CMAKE_REQUIRED_INCLUDES sys/socket.h)
   check_function_exists(accept4 HAVE_ACCEPT4)
   set(CMAKE_REQUIRED_INCLUDES)
+  message("HAVE_ACCEPT4: ${HAVE_ACCEPT4}")
 
   set(CMAKE_REQUIRED_INCLUDES string.h)
   check_function_exists(strnlen HAVE_STRNLEN)
   set(CMAKE_REQUIRED_INCLUDES)
+  message("HAVE_STRNLEN: ${HAVE_STRNLEN}")
+
 endif()
 
 add_definitions(-D_REENTRANT -D_THREAD_SAFE)
@@ -516,7 +528,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "SunPro")
   zmq_check_cxx_flag_prepend("-features=zla")
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+if(CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD" OR CMAKE_SYSTEM_NAME MATCHES "QNX")
   message(STATUS "Checking whether atomic operations can be used")
   check_c_source_compiles(
   "\
@@ -530,7 +542,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "SunOS" OR CMAKE_SYSTEM_NAME MATCHES "NetBSD")
   } \
   "
   HAVE_ATOMIC_H)
-
+  message("HAVE_ATOMIC_H: ${HAVE_ATOMIC_H}")
   if(NOT HAVE_ATOMIC_H)
     set(ZMQ_FORCE_MUTEXES 1)
   endif()
@@ -1209,6 +1221,9 @@ else()
       add_library(libzmq-static STATIC $<TARGET_OBJECTS:objects> ${public_headers}
         ${html-docs} ${readme-docs} ${zmq-pkgconfig} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
     endif()
+    if(CMAKE_SYSTEM_NAME MATCHES "QNX")
+      target_link_libraries(libzmq-static m)
+    endif()
     set_target_properties(libzmq-static PROPERTIES
       PUBLIC_HEADER "${public_headers}"
       OUTPUT_NAME "zmq"
@@ -1286,6 +1301,10 @@ if(BUILD_STATIC)
 
   if(RT_LIBRARY)
     target_link_libraries(libzmq-static -lrt)
+  endif()
+
+  if(CMAKE_SYSTEM_NAME MATCHES "QNX")
+    add_definitions(-DUNITY_EXCLUDE_MATH_H)
   endif()
 endif()
 

--- a/RELICENSE/ipa.md
+++ b/RELICENSE/ipa.md
@@ -12,6 +12,6 @@ copyright oIwan Paoluccii.  This document hereby grants the libzmq
 project team to relicense libzmq, including all past, present and
 future contributions of the author listed above.
 
-Simon Giesecke
+Iwan Paolucci
 2019/04/18
 

--- a/RELICENSE/ipa.md
+++ b/RELICENSE/ipa.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Iwan Paolucci that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "ipa", with
+commit author "Iwan Paolucci <iwan.paolucci@gmail.com>", are
+copyright oIwan Paoluccii.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Simon Giesecke
+2019/04/18
+

--- a/builds/qnx/ToolchainQNX6.6_x86.cmake
+++ b/builds/qnx/ToolchainQNX6.6_x86.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_NAME QNX)
+
+set(arch gcc_ntox86)
+set(ntoarch x86)
+set(QNX_PROCESSOR x86)
+
+set(CMAKE_C_COMPILER qcc )
+set(CMAKE_C_COMPILER_TARGET ${arch})
+
+set(CMAKE_CXX_COMPILER QCC -lang-c++ -g)
+set(CMAKE_CXX_COMPILER_TARGET ${arch})
+
+set(CMAKE_ASM_COMPILER qcc -V${arch})
+set(CMAKE_ASM_DEFINE_FLAG "-Wa,--defsym,")
+
+set(CMAKE_RANLIB $ENV{QNX_HOST}/usr/bin/nto${ntoarch}-ranlib
+	    CACHE PATH "QNX ranlib Program" FORCE)
+    set(CMAKE_AR $ENV{QNX_HOST}/usr/bin/nto${ntoarch}-ar
+	        CACHE PATH "QNX qr Program" FORCE)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -238,10 +238,16 @@ foreach(test ${tests})
       link_directories(${test} PRIVATE "${ZeroMQ_SOURCE_DIR}/../lib")
     endif()
   endif()
-
+  
   if(RT_LIBRARY)
     target_link_libraries(${test} ${RT_LIBRARY})
   endif()
+
+  if(CMAKE_SYSTEM_NAME MATCHES "QNX")
+    target_link_libraries(${test} socket)
+    target_link_libraries(${test} m)
+  endif()
+
   if(WIN32)
     add_test(NAME ${test} WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH} COMMAND ${test})
   else()

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -41,6 +41,11 @@ foreach(test ${unittests})
     target_link_libraries(${test} ${RT_LIBRARY})
   endif()
 
+  if(CMAKE_SYSTEM_NAME MATCHES "QNX")
+    target_link_libraries(${test} socket)
+    target_link_libraries(${test} m)
+  endif()
+
   if(WIN32)
     add_test(NAME ${test} WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH} COMMAND ${test})
   else()


### PR DESCRIPTION
Solution to #3479 : 
- libm and libsocket have to be linked explicitely
- QNX crosscompiler needs a toolchain file to crosscompile to qnx 

# Pull Request Notice

With these modifications libzmq-static could be built. The shared libraries are still not working.

The following CMake command was used to 
```
cmake -G "Eclipse CDT4 - Unix Makefiles" -DCMAKE_BUILD_TYPE=debug,release -DCMAKE_TOOLCHAIN_FILE="../builds/qnx/ToolchainQNX6.6_x86.cmake" -DBUILD_SHARED=OFF -DPOLLER=poll ..
cmake --build .
```

The unit tests ran without errors on QNX 6.6
[test_output.txt](https://github.com/zeromq/libzmq/files/3094200/test_output.txt)

