### PR TITLE
Add <ios> include to fix uClibc++ compilation

### DIFF
--- a/RELICENSE/neheb.md
+++ b/RELICENSE/neheb.md
@@ -1,0 +1,14 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Rosen Penev
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "flub", with
+commit author "Rosen Penev <rosenp@gmail.com>", are copyright of
+Rosen Penev .
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Rosen Penev
+2019/04/19

--- a/src/blob.hpp
+++ b/src/blob.hpp
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <algorithm>
+#include <ios>
 
 #if __cplusplus >= 201103L || defined(_MSC_VER) && _MSC_VER > 1700
 #define ZMQ_HAS_MOVE_SEMANTICS


### PR DESCRIPTION
Under uClibc++, streamoff is defined in <ios>. This header is needed to fix compilation.