### PR TITLE
 Problem: Cannot get thread safe socket fd 

### DIFF
--- a/RELICENSE/jean-airoldie.md
+++ b/RELICENSE/jean-airoldie.md
@@ -1,0 +1,7 @@
+Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Jean Airoldie that grants permission to relicense its copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other Open Source Initiative approved license chosen by the current ZeroMQ BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "jean-airoldie", with commit author "jean-airoldie <25088801+jean-airoldie@users.noreply.github.com>", are copyright of Jean Airoldie. This document hereby grants the libzmq project team to relicense libzmq, including all past, present and future contributions of the author listed above.
+
+Jean Airoldie 2019/04/27

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -709,6 +709,7 @@ ZMQ_EXPORT int zmq_poller_wait_all (void *poller,
                                     zmq_poller_event_t *events,
                                     int n_events,
                                     long timeout);
+ZMQ_EXPORT int zmq_poller_fd (void *poller);
 
 #if defined _WIN32
 ZMQ_EXPORT int

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -86,6 +86,17 @@ bool zmq::socket_poller_t::check_tag ()
     return _tag == 0xCAFEBABE;
 }
 
+int zmq::socket_poller_t::signaler_fd ()
+{
+    if (_signaler) {
+        return _signaler->get_fd ();
+    } else {
+        // Only thread-safe socket types are guaranteed to have a signaler.
+        errno = EINVAL;
+        return -1;
+    }
+}
+
 int zmq::socket_poller_t::add (socket_base_t *socket_,
                                void *user_data_,
                                short events_)

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -75,6 +75,8 @@ class socket_poller_t
     int add_fd (fd_t fd_, void *user_data_, short events_);
     int modify_fd (fd_t fd_, short events_);
     int remove_fd (fd_t fd_);
+    // Returns the signaler's fd if there is one, otherwise errors.
+    int signaler_fd ();
 
     int wait (event_t *event_, int n_events_, long timeout_);
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1278,6 +1278,11 @@ int zmq_poller_wait_all (void *poller_,
     return rc;
 }
 
+int zmq_poller_fd (void *poller_)
+{
+    return static_cast<zmq::socket_poller_t *> (poller_)->signaler_fd ();
+}
+
 //  Peer-specific state
 
 int zmq_socket_get_peer_state (void *s_,

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -105,6 +105,7 @@ int zmq_poller_wait_all (void *poller_,
                          zmq_poller_event_t *events_,
                          int n_events_,
                          long timeout_);
+int zmq_poller_fd (void *poller_);
 
 #if defined _WIN32
 int zmq_poller_add_fd (void *poller_,


### PR DESCRIPTION
This is based on [somdoron's comment](https://github.com/zeromq/libzmq/issues/2941#issuecomment-366983640).

This partially fixes #2941 by adding a way to retrieve the fd from the zmq::socket_poller_t signaler, if it exists. This allows integration of thread-safe socket types into event loops by creating a poller instance for each thread safe socket and polling the poller's fd.