### PR TITLE
Problem: zmq_socket_monitor example did not include HANDSHAKE_SUCCEEDED event causing assert failure

### DIFF
--- a/RELICENSE/normano.md
+++ b/RELICENSE/normano.md
@@ -12,4 +12,4 @@ This document hereby grants the libzmq project team to relicense libzmq,
 including all past, present and future contributions of the author listed above.
 
 This is a statement by Norman Ovenseri
-2019/05/21
+2019/05/01

--- a/RELICENSE/normano.md
+++ b/RELICENSE/normano.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Norman Ovenseri
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "normano", with
+commit author "normano", are copyright of Norman Ovenseri.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+This is a statement by Norman Ovenseri
+2019/05/21

--- a/doc/zmq_socket_monitor.txt
+++ b/doc/zmq_socket_monitor.txt
@@ -116,9 +116,9 @@ The event value is unspecified.
 
 ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ZMTP security mechanism handshake failed due to some mechanism protocol 
-error, either between the ZMTP mechanism peers, or between the mechanism 
-server and the ZAP handler. This indicates a configuration or implementation 
+The ZMTP security mechanism handshake failed due to some mechanism protocol
+error, either between the ZMTP mechanism peers, or between the mechanism
+server and the ZAP handler. This indicates a configuration or implementation
 error in either peer resp. the ZAP handler.
 The event value is one of the ZMQ_PROTOCOL_ERROR_* values:
 ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED
@@ -145,7 +145,7 @@ ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA
 ZMQ_EVENT_HANDSHAKE_FAILED_AUTH
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ZMTP security mechanism handshake failed due to an authentication failure.
-The event value is the status code returned by the ZAP handler (i.e. 300, 
+The event value is the status code returned by the ZAP handler (i.e. 300,
 400 or 500).
 
 
@@ -259,6 +259,8 @@ int main (void)
         event = get_monitor_event (client_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_CONNECTED);
     event = get_monitor_event (client_mon, NULL, NULL);
+    assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
+    event = get_monitor_event (client_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_MONITOR_STOPPED);
 
     //  This is the flow of server events
@@ -266,6 +268,8 @@ int main (void)
     assert (event == ZMQ_EVENT_LISTENING);
     event = get_monitor_event (server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_ACCEPTED);
+    event = get_monitor_event (server_mon, NULL, NULL);
+    assert (event == ZMQ_EVENT_HANDSHAKE_SUCCEEDED);
     event = get_monitor_event (server_mon, NULL, NULL);
     assert (event == ZMQ_EVENT_CLOSED);
     event = get_monitor_event (server_mon, NULL, NULL);


### PR DESCRIPTION
Solution: Added HANDSHAKE_SUCCEEDED Before MONITOR_STOPPED event on client and before CLOSED event on server.
