### PR TITLE
Fix a typo in root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1102,7 +1102,7 @@ if(MSVC)
   # default for all sources is to use precompiled headers
   foreach(source ${sources})
     # C and C++ can not use the same precompiled header
-    if(${soruce} MATCHES ".cpp$" AND NOT ${source} STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/src/precompiled.cpp")
+    if(${source} MATCHES ".cpp$" AND NOT ${source} STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/src/precompiled.cpp")
       set_source_files_properties(${source}
         PROPERTIES
         COMPILE_FLAGS "/Yuprecompiled.hpp"

--- a/RELICENSE/moretromain.md
+++ b/RELICENSE/moretromain.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Romain Moret that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "moretromain", with
+commit author "Romain Moret <moretromain@gmail.com>", are
+copyright of Romain Moret.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Romain Moret
+2019/05/06


### PR DESCRIPTION
Problem: a small typo in the root CMakeLists.txt for PCH handling in MSVC
Solution: replace wrong variable "soruce" with the expected one "source"