### PR TITLE
Problem: syntax error on Windows related to socket descriptor type

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -685,14 +685,16 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 
 #define ZMQ_HAVE_POLLER
 
+#if defined _WIN32
+typedef SOCKET zmq_fd_t;
+#else
+typedef int zmq_fd_t;
+#endif
+
 typedef struct zmq_poller_event_t
 {
     void *socket;
-#if defined _WIN32
-    SOCKET fd;
-#else
-    int fd;
-#endif
+    zmq_fd_t fd;
     void *user_data;
     short events;
 } zmq_poller_event_t;
@@ -709,19 +711,12 @@ ZMQ_EXPORT int zmq_poller_wait_all (void *poller,
                                     zmq_poller_event_t *events,
                                     int n_events,
                                     long timeout);
-ZMQ_EXPORT int zmq_poller_fd (void *poller);
+ZMQ_EXPORT zmq_fd_t zmq_poller_fd (void *poller);
 
-#if defined _WIN32
 ZMQ_EXPORT int
-zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, SOCKET fd, short events);
-ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, SOCKET fd);
-#else
-ZMQ_EXPORT int
-zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
-ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
-#endif
+zmq_poller_add_fd (void *poller, zmq_fd_t fd, void *user_data, short events);
+ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, zmq_fd_t fd, short events);
+ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, zmq_fd_t fd);
 
 ZMQ_EXPORT int zmq_socket_get_peer_state (void *socket,
                                           const void *routing_id,

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -86,7 +86,7 @@ bool zmq::socket_poller_t::check_tag ()
     return _tag == 0xCAFEBABE;
 }
 
-int zmq::socket_poller_t::signaler_fd ()
+zmq::fd_t zmq::socket_poller_t::signaler_fd ()
 {
     if (_signaler) {
         return _signaler->get_fd ();

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -76,7 +76,7 @@ class socket_poller_t
     int modify_fd (fd_t fd_, short events_);
     int remove_fd (fd_t fd_);
     // Returns the signaler's fd if there is one, otherwise errors.
-    int signaler_fd ();
+    fd_t signaler_fd ();
 
     int wait (event_t *event_, int n_events_, long timeout_);
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1278,7 +1278,7 @@ int zmq_poller_wait_all (void *poller_,
     return rc;
 }
 
-int zmq_poller_fd (void *poller_)
+zmq_fd_t zmq_poller_fd (void *poller_)
 {
     if (!poller_
         || !(static_cast<zmq::socket_poller_t *> (poller_)->check_tag ())) {

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -80,14 +80,16 @@ const char *zmq_msg_group (zmq_msg_t *msg_);
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
 /******************************************************************************/
 
+#if defined _WIN32
+typedef SOCKET zmq_fd_t;
+#else
+typedef int zmq_fd_t;
+#endif
+
 typedef struct zmq_poller_event_t
 {
     void *socket;
-#if defined _WIN32
-    SOCKET fd;
-#else
-    int fd;
-#endif
+    zmq_fd_t fd;
     void *user_data;
     short events;
 } zmq_poller_event_t;
@@ -105,20 +107,14 @@ int zmq_poller_wait_all (void *poller_,
                          zmq_poller_event_t *events_,
                          int n_events_,
                          long timeout_);
-int zmq_poller_fd (void *poller_);
+zmq_fd_t zmq_poller_fd (void *poller_);
 
-#if defined _WIN32
 int zmq_poller_add_fd (void *poller_,
-                       SOCKET fd_,
+                       zmq_fd_t fd_,
                        void *user_data_,
                        short events_);
-int zmq_poller_modify_fd (void *poller_, SOCKET fd_, short events_);
-int zmq_poller_remove_fd (void *poller_, SOCKET fd_);
-#else
-int zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
-int zmq_poller_modify_fd (void *poller, int fd, short events);
-int zmq_poller_remove_fd (void *poller, int fd);
-#endif
+int zmq_poller_modify_fd (void *poller_, zmq_fd_t fd_, short events_);
+int zmq_poller_remove_fd (void *poller_, zmq_fd_t fd_);
 
 int zmq_socket_get_peer_state (void *socket_,
                                const void *routing_id_,


### PR DESCRIPTION
Solution: use proper fd_t type, and also define and use a zmq_fd_t in the API
