### PR TITLE
Problem: signature of zmq_poller_fd does is incompatible with regular…

### DIFF
--- a/doc/zmq_poller.txt
+++ b/doc/zmq_poller.txt
@@ -29,7 +29,7 @@ SYNOPSIS
                           int 'n_events',
                           long 'timeout');*
 
-*int zmq_poller_fd (void *'poller');*
+*int zmq_poller_fd (void *'poller', zmq_fd_t *'fd');*
 
 DESCRIPTION
 -----------
@@ -129,7 +129,8 @@ The client does therefore not need to initialize the contents of the events
 array before a call to _zmq_poller_wait_all_. It is unspecified whether the
 the remaining elements of 'events' are written to by _zmq_poller_wait_all_.
 
-_zmq_poller_fd_ returns the file descriptor associated with the zmq_poller.
+_zmq_poller_fd_ queries the file descriptor associated with the zmq_poller,
+and stores it in the address pointer to by 'fd'.
 The zmq_poller is only guaranteed to have a file descriptor if
 at least one thread-safe socket is currently registered.
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -711,7 +711,7 @@ ZMQ_EXPORT int zmq_poller_wait_all (void *poller,
                                     zmq_poller_event_t *events,
                                     int n_events,
                                     long timeout);
-ZMQ_EXPORT zmq_fd_t zmq_poller_fd (void *poller);
+ZMQ_EXPORT int zmq_poller_fd (void *poller, zmq_fd_t *fd);
 
 ZMQ_EXPORT int
 zmq_poller_add_fd (void *poller, zmq_fd_t fd, void *user_data, short events);

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -86,10 +86,11 @@ bool zmq::socket_poller_t::check_tag ()
     return _tag == 0xCAFEBABE;
 }
 
-zmq::fd_t zmq::socket_poller_t::signaler_fd ()
+int zmq::socket_poller_t::signaler_fd (fd_t *fd_)
 {
     if (_signaler) {
-        return _signaler->get_fd ();
+        *fd_ = _signaler->get_fd ();
+        return 0;
     } else {
         // Only thread-safe socket types are guaranteed to have a signaler.
         errno = EINVAL;

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -76,7 +76,7 @@ class socket_poller_t
     int modify_fd (fd_t fd_, short events_);
     int remove_fd (fd_t fd_);
     // Returns the signaler's fd if there is one, otherwise errors.
-    fd_t signaler_fd ();
+    int signaler_fd (fd_t *fd_);
 
     int wait (event_t *event_, int n_events_, long timeout_);
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1278,14 +1278,14 @@ int zmq_poller_wait_all (void *poller_,
     return rc;
 }
 
-zmq_fd_t zmq_poller_fd (void *poller_)
+int zmq_poller_fd (void *poller_, zmq_fd_t *fd_)
 {
     if (!poller_
         || !(static_cast<zmq::socket_poller_t *> (poller_)->check_tag ())) {
         errno = EFAULT;
         return -1;
     } else {
-        return static_cast<zmq::socket_poller_t *> (poller_)->signaler_fd ();
+        return static_cast<zmq::socket_poller_t *> (poller_)->signaler_fd (fd_);
     }
 }
 

--- a/tests/test_poller.cpp
+++ b/tests/test_poller.cpp
@@ -198,7 +198,8 @@ void test_null_poller_pointers_wait_all_indirect ()
 void test_null_poller_pointer_poller_fd ()
 {
     void *null_poller = NULL;
-    TEST_ASSERT_FAILURE_ERRNO (EFAULT, zmq_poller_fd (&null_poller));
+    zmq_fd_t fd;
+    TEST_ASSERT_FAILURE_ERRNO (EFAULT, zmq_poller_fd (&null_poller, &fd));
 }
 
 void test_null_socket_pointers ()
@@ -273,7 +274,8 @@ void test_call_poller_fd_no_signaler ()
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_poller_add (poller, socket, NULL, ZMQ_POLLIN));
 
-    TEST_ASSERT_FAILURE_ERRNO (EINVAL, zmq_poller_fd (poller));
+    zmq_fd_t fd;
+    TEST_ASSERT_FAILURE_ERRNO (EINVAL, zmq_poller_fd (poller, &fd));
 
     TEST_ASSERT_SUCCESS_ERRNO (zmq_poller_destroy (&poller));
 
@@ -290,7 +292,8 @@ void test_call_poller_fd ()
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_poller_add (poller, socket, NULL, ZMQ_POLLIN));
 
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_poller_fd (poller));
+    zmq_fd_t fd;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_poller_fd (poller, &fd));
 
     TEST_ASSERT_SUCCESS_ERRNO (zmq_poller_destroy (&poller));
 


### PR DESCRIPTION
… error handling

Solution: change return type to int (again) and return fd via an output parameter
