### PR TITLE
Problem: Socket monitoring only allows ZMQ_PAIR

### DIFF
--- a/doc/zmq_socket_monitor_versioned.txt
+++ b/doc/zmq_socket_monitor_versioned.txt
@@ -11,6 +11,8 @@ zmq_socket_monitor_versioned - monitor socket events
 SYNOPSIS
 --------
 *int zmq_socket_monitor_versioned (void '*socket', char '*endpoint', uint64_t 'events', int 'event_version');*
+*int zmq_socket_monitor_versioned_typed (
+    void '*socket', char '*endpoint', uint64_t 'events', int 'event_version', int 'type');*
 
 *int zmq_socket_monitor_pipes_stats (void '*socket');*
 
@@ -55,6 +57,17 @@ connection uses a bound or connected local endpoint.
 
 Note that the format of the second and further frames, and also the number of
 frames, may be different for events added in the future.
+
+The _zmq_socket_monitor_versioned_typed()_ is a generalisation of
+_zmq_socket_monitor_versioned_ that supports more monitoring socket types.
+The 'type' argument is used to specify the type of the monitoring socket.
+Supported types are 'ZMQ_PAIR' (which is the equivalent of
+_zmq_socket_monitor_versioned_), 'ZMQ_PUB' and 'ZMQ_PUSH'. Note that consumers
+of the events will have to be compatible with the socket type, for instance a
+monitoring socket of type 'ZMQ_PUB' will require consumers of type 'ZMQ_SUB'.
+In the case that the monitoring socket type is of 'ZMQ_PUB', the multipart
+message topic is the event number, thus consumers should subscribe to the
+events they want to receive.
 
 The _zmq_socket_monitor_pipes_stats()_ method triggers an event of type
 ZMQ_EVENT_PIPES_STATS for each connected peer of the monitored socket.
@@ -213,6 +226,20 @@ sockets are required to use the inproc:// transport.
 
 *EINVAL*::
 The monitor 'endpoint' supplied does not exist.
+
+
+ERRORS - _zmq_socket_monitor_typed()_
+-------------------------------
+*ETERM*::
+The 0MQ 'context' associated with the specified 'socket' was terminated.
+
+*EPROTONOSUPPORT*::
+The transport protocol of the monitor 'endpoint' is not supported. Monitor
+sockets are required to use the inproc:// transport.
+
+*EINVAL*::
+The monitor 'endpoint' supplied does not exist or the specified socket 'type'
+is not supported.
 
 
 ERRORS - _zmq_socket_monitor_pipes_stats()_

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -735,6 +735,8 @@ ZMQ_EXPORT int zmq_socket_monitor_versioned (void *s_,
                                              const char *addr_,
                                              uint64_t events_,
                                              int event_version_);
+ZMQ_EXPORT int zmq_socket_monitor_versioned_typed (
+  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_);
 ZMQ_EXPORT int zmq_socket_monitor_pipes_stats (void *s);
 
 #endif // ZMQ_BUILD_DRAFT_API

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -119,7 +119,10 @@ class socket_base_t : public own_t,
     void lock ();
     void unlock ();
 
-    int monitor (const char *endpoint_, uint64_t events_, int event_version_);
+    int monitor (const char *endpoint_,
+                 uint64_t events_,
+                 int event_version_,
+                 int type_);
 
     void event_connected (const endpoint_uri_pair_t &endpoint_uri_pair_,
                           zmq::fd_t fd_);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -275,12 +275,22 @@ int zmq_socket_monitor_versioned (void *s_,
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
         return -1;
-    return s->monitor (addr_, events_, event_version_);
+    return s->monitor (addr_, events_, event_version_, ZMQ_PAIR);
 }
 
 int zmq_socket_monitor (void *s_, const char *addr_, int events_)
 {
     return zmq_socket_monitor_versioned (s_, addr_, events_, 1);
+}
+
+int zmq_socket_monitor_versioned_typed (
+  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_)
+{
+    zmq::socket_base_t *s = as_socket_base_t (s_);
+    if (!s)
+        return -1;
+
+    return s->monitor (addr_, events_, event_version_, type_);
 }
 
 int zmq_join (void *s_, const char *group_)

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -133,6 +133,8 @@ int zmq_socket_monitor_versioned (void *s_,
                                   const char *addr_,
                                   uint64_t events_,
                                   int event_version_);
+int zmq_socket_monitor_versioned_typed (
+  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_);
 int zmq_socket_monitor_pipes_stats (void *s_);
 
 #endif // ZMQ_BUILD_DRAFT_API


### PR DESCRIPTION
Solution: Allow ZMQ_PUB and ZMQ_PUSH sockets types for the monitoring.
This way someone could create a ZMQ_PULL socket connected to multiple monitoring
sockets at the same time. Or event better, create a ZMQ_PUB monitor socket with `ZMQ_EVENT_ALL` specified and then let the subscribers decide what events they want to receive.

This is especially helpful if someone wants to dedicate only one thread to globally log events.