### PR TITLE
Fix issues with SOCKS5 proxy connection

### DIFF
--- a/RELICENSE/guillon.md
+++ b/RELICENSE/guillon.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Christophe Guillon
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "guillon", with
+commit author "Christophe Guillon <christophe.guillon.perso@gmail.com>", are copyright of Christophe Guillon .
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Christophe Guillon
+2019/06/10


### PR DESCRIPTION
Two issues where introduced by commit 12c4b55a:
- the proxy connection was done to the target address instead of
the proxy address
- on error the proxy connection status was not reset to unplugged
