### PR TITLE
Problem: disconnect & unbind doc is misleading

### DIFF
--- a/doc/zmq_disconnect.txt
+++ b/doc/zmq_disconnect.txt
@@ -4,7 +4,7 @@ zmq_disconnect(3)
 
 NAME
 ----
-zmq_disconnect - Disconnect a socket
+zmq_disconnect - Disconnect a socket from an endpoint
 
 
 SYNOPSIS
@@ -16,11 +16,22 @@ DESCRIPTION
 -----------
 The _zmq_disconnect()_ function shall disconnect a socket specified
 by the 'socket' argument from the endpoint specified by the 'endpoint'
-argument. Any outstanding messages physically received from the network but not
-yet received by the application with _zmq_recv()_ shall be discarded. The
-behaviour for discarding messages sent by the application with _zmq_send()_ but
-not yet physically transferred to the network depends on the value of the
-_ZMQ_LINGER_ socket option for the specified 'socket'.
+argument. Note the actual disconnect system call might occur at a later time.
+
+Upon disconnection the will also stop receiving messages originating from
+this endpoint. Moreover, the socket will no longuer be able
+to queue outgoing messages to this endpoint. The outgoing message queue
+associated with the endpoint will be discarded. However, if the socket's linger
+period is non-zero, libzmq will still attempt to transmit these discarded messages,
+until the linger period expires.
+
+Addionally, if the disconnected endpoint was previously connected to
+(as opposed to bound), the incoming message queue associated with the
+endpoint will be discarded. This means that after unbinding an endpoint
+using `disconnect`, it is possible to received messages originating
+from that same endpoint if they were already present in the incoming message
+queue before unbinding. However, this is not the case when disconnecting
+from a connected endpoint.
 
 The 'endpoint' argument is as described in linkzmq:zmq_connect[3]
 
@@ -28,6 +39,12 @@ NOTE: The default setting of _ZMQ_LINGER_ does not discard unsent messages;
 this behaviour may cause the application to block when calling _zmq_ctx_term()_.
 For details refer to linkzmq:zmq_setsockopt[3] and linkzmq:zmq_ctx_term[3].
 
+Unbinding wild-card address from a socket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When a wild-card `*` 'endpoint' (described in linkzmq:zmq_tcp[7],
+linkzmq:zmq_ipc[7] and linkzmq:zmq_vmci[7]) was used in _zmq_bind()_, the caller
+should use the real 'endpoint' obtained from the ZMQ_LAST_ENDPOINT socket option
+to unbind this 'endpoint' from a socket.
 
 RETURN VALUE
 ------------
@@ -43,7 +60,7 @@ The 0MQ 'context' associated with the specified 'socket' was terminated.
 *ENOTSOCK*::
 The provided 'socket' was invalid.
 *ENOENT*::
-The provided endpoint is not connected.
+The provided endpoint is not in use by the socket.
 
 
 EXAMPLE
@@ -61,6 +78,36 @@ rc = zmq_disconnect (socket, "tcp://server001:5555");
 assert (rc == 0);
 ----
 
+.Unbind a subscriber socket from a TCP transport
+----
+/* Create a ZMQ_SUB socket */
+void *socket = zmq_socket (context, ZMQ_SUB);
+assert (socket);
+/* Connect it to the host server001, port 5555 using a TCP transport */
+rc = zmq_bind (socket, "tcp://127.0.0.1:5555");
+assert (rc == 0);
+/* Disconnect from the previously connected endpoint */
+rc = zmq_disconnect(socket, "tcp://127.0.0.1:5555");
+assert (rc == 0);
+----
+
+.Unbind wild-card `*` binded socket
+----
+/* Create a ZMQ_SUB socket */
+void *socket = zmq_socket (context, ZMQ_SUB);
+assert (socket);
+/* Bind it to the system-assigned ephemeral port using a TCP transport */
+rc = zmq_bind (socket, "tcp://127.0.0.1:*");
+assert (rc == 0);
+/* Obtain real endpoint */
+const size_t buf_size = 32;
+char buf[buf_size];
+rc = zmq_getsockopt (socket, ZMQ_LAST_ENDPOINT, buf, (size_t *)&buf_size);
+assert (rc == 0);
+/* Unbind socket by real endpoint */
+rc = zmq_disconnect (socket, buf);
+assert (rc == 0);
+----
 
 SEE ALSO
 --------

--- a/doc/zmq_unbind.txt
+++ b/doc/zmq_unbind.txt
@@ -4,7 +4,7 @@ zmq_unbind(3)
 
 NAME
 ----
-zmq_unbind - Stop accepting connections on a socket
+zmq_unbind - Another name for zmq_disconnect
 
 
 SYNOPSIS
@@ -14,68 +14,8 @@ int zmq_unbind (void '*socket', const char '*endpoint');
 
 DESCRIPTION
 -----------
-The _zmq_unbind()_ function shall unbind a socket specified
-by the 'socket' argument from the endpoint specified by the 'endpoint'
-argument. 
-
-The 'endpoint' argument is as described in linkzmq:zmq_bind[3]
-
-Unbinding wild-card address from a socket
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When wild-card `*` 'endpoint' (described in linkzmq:zmq_tcp[7],
-linkzmq:zmq_ipc[7] and linkzmq:zmq_vmci[7]) was used in _zmq_bind()_, the caller should use
-real 'endpoint' obtained from the ZMQ_LAST_ENDPOINT socket option
-to unbind this 'endpoint' from a socket.
-
-RETURN VALUE
-------------
-The _zmq_unbind()_ function shall return zero if successful. Otherwise it
-shall return `-1` and set 'errno' to one of the values defined below.
-
-ERRORS
-------
-*EINVAL*::
-The endpoint supplied is invalid.
-*ETERM*::
-The 0MQ 'context' associated with the specified 'socket' was terminated.
-*ENOTSOCK*::
-The provided 'socket' was invalid.
-*ENOENT*::
-The endpoint supplied was not previously bound.
-
-
-EXAMPLES
---------
-.Unbind a subscriber socket from a TCP transport
-----
-/* Create a ZMQ_SUB socket */
-void *socket = zmq_socket (context, ZMQ_SUB);
-assert (socket);
-/* Connect it to the host server001, port 5555 using a TCP transport */
-rc = zmq_bind (socket, "tcp://127.0.0.1:5555");
-assert (rc == 0);
-/* Disconnect from the previously connected endpoint */
-rc = zmq_unbind (socket, "tcp://127.0.0.1:5555");
-assert (rc == 0);
-----
-
-.Unbind wild-card `*` binded socket
-----
-/* Create a ZMQ_SUB socket */
-void *socket = zmq_socket (context, ZMQ_SUB);
-assert (socket);
-/* Bind it to the system-assigned ephemeral port using a TCP transport */
-rc = zmq_bind (socket, "tcp://127.0.0.1:*");
-assert (rc == 0);
-/* Obtain real endpoint */
-const size_t buf_size = 32;
-char buf[buf_size];
-rc = zmq_getsockopt (socket, ZMQ_LAST_ENDPOINT, buf, (size_t *)&buf_size);
-assert (rc == 0);
-/* Unbind socket by real endpoint */
-rc = zmq_unbind (socket, buf);
-assert (rc == 0);
-----
+The _zmq_unbind()_ has the same exact behavior as _zmq_disconnect()_.
+Refer to linkzmq:zmq_disconnect[3].
 
 SEE ALSO
 --------


### PR DESCRIPTION
This closes #3529.

I also made it explicit that `zmq_disconnect` is the preferred option.

This documentation is inferred from my usage of the `Server` and `Client` socket. However, I am unsure if it can be generalized to all socket types.