### PR TITLE
Free memory when curve_client sends invalid ready message.

### DIFF
--- a/src/curve_client.cpp
+++ b/src/curve_client.cpp
@@ -240,6 +240,7 @@ int zmq::curve_client_t::process_ready (const uint8_t *msg_data_,
         session->get_socket ()->event_handshake_failed_protocol (
           session->get_endpoint (), ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC);
         errno = EPROTO;
+        free (ready_plaintext);
         return -1;
     }
 


### PR DESCRIPTION
Problem: Malicious clients can cause arbitrary amounts of memory to leak (well, fixed amout an arbitrary number of times).

Solution: Free memory in the error case.
