### PR TITLE
acinclude.m4, configure.ac: use default cacheline size in case of cross-compiling

### DIFF
--- a/RELICENSE/mdionisio.md
+++ b/RELICENSE/mdionisio.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Thomas M. DuBuisson
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "mdionisio", with
+commit author "Michele Dionisio", are copyright of Michele Dionisio.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Michele Dionisio
+2019/07/09

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1176,17 +1176,22 @@ dnl # Check cacheline size for alignment purposes                               
 dnl ##############################################################################
 AC_DEFUN([LIBZMQ_CHECK_CACHELINE], [{
 
-    zmq_cacheline_size=64
-    AC_CHECK_TOOL(libzmq_getconf, getconf)
-    if ! test "x$libzmq_getconf" = "x"; then
-        zmq_cacheline_size=$($libzmq_getconf LEVEL1_DCACHE_LINESIZE 2>/dev/null || echo 64)
-        if test "x$zmq_cacheline_size" = "x0" -o  "x$zmq_cacheline_size" = "x-1"; then
-            # getconf on some architectures does not know the size, try to fallback to
-            # the value the kernel knows on Linux
-            zmq_cacheline_size=$(cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size 2>/dev/null || echo 64)
+    if test $cross_compiling = yes ; then
+        zmq_cacheline_size=64
+        AC_MSG_NOTICE([Using default "$zmq_cacheline_size" bytes alignment for lock-free data structures because crosscompiling])
+    else
+        zmq_cacheline_size=64
+        AC_CHECK_TOOL(libzmq_getconf, getconf)
+        if ! test "x$libzmq_getconf" = "x"; then
+            zmq_cacheline_size=$($libzmq_getconf LEVEL1_DCACHE_LINESIZE 2>/dev/null || echo 64)
+            if test "x$zmq_cacheline_size" = "x0" -o  "x$zmq_cacheline_size" = "x-1"; then
+                # getconf on some architectures does not know the size, try to fallback to
+                # the value the kernel knows on Linux
+                zmq_cacheline_size=$(cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size 2>/dev/null || echo 64)
+            fi
         fi
+        AC_MSG_NOTICE([Using "$zmq_cacheline_size" bytes alignment for lock-free data structures])
     fi
-	AC_MSG_NOTICE([Using "$zmq_cacheline_size" bytes alignment for lock-free data structures])
 	AC_DEFINE_UNQUOTED(ZMQ_CACHELINE_SIZE, $zmq_cacheline_size, [Using "$zmq_cacheline_size" bytes alignment for lock-free data structures])
 }])
 


### PR DESCRIPTION
when cross-compiling with autotools it is not possible to use machine variable for cacheline size