### PR TITLE
Static analysis warnings

### DIFF
--- a/builds/abi-compliance-checker/ci_build.sh
+++ b/builds/abi-compliance-checker/ci_build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -x
+set -e
 
 cd ../../
 

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -396,8 +396,8 @@ void zmq::udp_engine_t::out_event ()
     if (rc == 0) {
         msg_t body_msg;
         rc = _session->pull_msg (&body_msg);
-        //  TODO rc is not checked here. We seem to assume rc == 0. An
-        //  assertion should be added.
+        //  If there's a group, there should also be a body
+        errno_assert (rc == 0);
 
         const size_t group_size = group_msg.size ();
         const size_t body_size = body_msg.size ();
@@ -412,7 +412,7 @@ void zmq::udp_engine_t::out_event ()
                 rc = group_msg.close ();
                 errno_assert (rc == 0);
 
-                body_msg.close ();
+                rc = body_msg.close ();
                 errno_assert (rc == 0);
 
                 return;

--- a/tests/testutil_monitoring.cpp
+++ b/tests/testutil_monitoring.cpp
@@ -339,9 +339,9 @@ void expect_monitor_event_v2 (void *monitor_,
     }
     if (expected_remote_address_
         && 0 != strcmp (remote_address, expected_remote_address_)) {
-        pos += snprintf (pos, sizeof buf - (pos - buf),
-                         "Expected remote address %s, but received %s\n",
-                         expected_remote_address_, remote_address);
+        snprintf (pos, sizeof buf - (pos - buf),
+                  "Expected remote address %s, but received %s\n",
+                  expected_remote_address_, remote_address);
     }
     free (local_address);
     free (remote_address);


### PR DESCRIPTION
@TomMD it seems the tool doesn't see when variables are used for array sizes, these are false positives:

1. DEAD_STORE
    - At [src/tcp_address.cpp(121,5)](https://github.com/zeromq/libzmq/blob/90ff30c086bc299d619346a04d9eb5a02e96636e/src/tcp_address.cpp#L121)
    - The value written to &max_port_str_length (type unsigned long const ) is never used.
1. DEAD_STORE
    - At [src/tcp_address.cpp(288,5)](https://github.com/zeromq/libzmq/blob/90ff30c086bc299d619346a04d9eb5a02e96636e/src/tcp_address.cpp#L288)
    - The value written to &max_mask_len (type unsigned long const ) is never used.

These are also false positives, the struct is initialized by the systemcall:

1. UNINITIALIZED_VALUE
    - At [src/stream_engine.cpp(79,13)](https://github.com/zeromq/libzmq/blob/90ff30c086bc299d619346a04d9eb5a02e96636e/src/stream_engine.cpp#L79)
    - The value read from cred.gid was never initialized.
1. UNINITIALIZED_VALUE
    - At [src/stream_engine.cpp(79,13)](https://github.com/zeromq/libzmq/blob/90ff30c086bc299d619346a04d9eb5a02e96636e/src/stream_engine.cpp#L79)
    - The value read from cred.pid was never initialized.
1. UNINITIALIZED_VALUE
    - At [src/stream_engine.cpp(79,13)](https://github.com/zeromq/libzmq/blob/90ff30c086bc299d619346a04d9eb5a02e96636e/src/stream_engine.cpp#L79)
    - The value read from cred.uid was never initialized.

These are also false positives:

1. UNINITIALIZED_VALUE
    - At [src/tweetnacl.c(138,15)](https://github.com/zeromq/libzmq/blob/90ff30c086bc299d619346a04d9eb5a02e96636e/src/tweetnacl.c#L138)
    - The value read from w[_] was never initialized.
1. UNINITIALIZED_VALUE
    - At [src/tweetnacl.c(149,7)](https://github.com/zeromq/libzmq/blob/90ff30c086bc299d619346a04d9eb5a02e96636e/src/tweetnacl.c#L149)
    - The value read from x[_] was never initialized.
1. UNINITIALIZED_VALUE
    - At [src/tweetnacl.c(575,18)](https://github.com/zeromq/libzmq/blob/90ff30c086bc299d619346a04d9eb5a02e96636e/src/tweetnacl.c#L575)
    - The value read from a[_] was never initialized.