### PR TITLE
Problem: build on centos6/ubuntu12 still broken

### DIFF
--- a/src/stdint.hpp
+++ b/src/stdint.hpp
@@ -69,8 +69,6 @@ typedef unsigned __int64 uint64_t;
 
 #else
 
-//  To define SIZE_MAX with older compilers
-#define __STDC_LIMIT_MACROS
 #include <stdint.h>
 
 #endif

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -29,6 +29,9 @@
 
 // TODO remove this workaround for handling libsodium/tweetnacl
 
+//  To define SIZE_MAX with older compilers
+#define __STDC_LIMIT_MACROS
+
 #if defined ZMQ_CUSTOM_PLATFORM_HPP
 #include "platform.hpp"
 #else


### PR DESCRIPTION
Solution: move the definition of __STDC_LIMIT_MACROS somewhere the test actually uses
