### PR TITLE
CMake: Install debug libraries for debug msvc builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1439,6 +1439,11 @@ endif()
 
 option(ENABLE_CPACK "Enables cpack rules" ON)
 if(MSVC AND ENABLE_CPACK)
+  if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    set(CMAKE_INSTALL_DEBUG_LIBRARIES_ONLY TRUE)
+    set(CMAKE_INSTALL_DEBUG_LIBRARIES TRUE)
+    set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)
+  endif()
   include(InstallRequiredSystemLibraries)
 
   if(CMAKE_CL_64)

--- a/RELICENSE/inuik.md
+++ b/RELICENSE/inuik.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Rishi Theivendan (inuik)
+that grants permission to relicense his copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "inuik", with
+commit author "Rishi Theivendran <29522253+inuik@users.noreply.github.com>" or
+"Rishi Theivendran <rishi.theivendran@rohde-schwarz.com>", are copyright of Rishi Theivendran.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed
+above.
+
+Rishi Theivendran
+2019/07/18


### PR DESCRIPTION
Problem: When installing msvc debug builds via CMake, the corresponding system debug libraries (dll) like msvcp140d.dll, vcruntime140d.dll ... are not copied to the install path instead only the release versions are copied. This is not a problem if Visual Studio is installed on the target machine, otherwise one has to copy these system libraries manually.

Solution: Configure CMake module InstallRequiredSystemLibraries to install debug libraries in case of debug builds.

