### PR TITLE
 Problem: stream_engine use after free

### DIFF
--- a/RELICENSE/mancasg.md
+++ b/RELICENSE/mancasg.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Mancaș George
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "mancasg", with
+commit author "Mancaș George <mancas.f.george@gmail.com>", are copyright of Mancaș George .
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Mancaș George
+2019/07/24

--- a/src/stream_engine_base.cpp
+++ b/src/stream_engine_base.cpp
@@ -522,7 +522,7 @@ const zmq::endpoint_uri_pair_t &zmq::stream_engine_base_t::get_endpoint () const
 
 void zmq::stream_engine_base_t::mechanism_ready ()
 {
-    if (_options.heartbeat_interval > 0) {
+    if (_options.heartbeat_interval > 0 && !_has_heartbeat_timer) {
         add_timer (_options.heartbeat_interval, heartbeat_ivl_timer_id);
         _has_heartbeat_timer = true;
     }


### PR DESCRIPTION
Solution: Don't allow concurrent heartbeat timers