### PR TITLE
Problem:  include/zmq.h is not so much broken as inconsistent in

### DIFF
--- a/RELICENSE/latchmoor-services-carcich.md
+++ b/RELICENSE/latchmoor-services-carcich.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Latchmoor Services, LLC
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "drbitboy", with
+commit author "Brian Carcich <drbitboy@gmail.com>", are copyright of Latchmoor
+Services, LLC.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Latchmoor Services, LLC
+2019/07/26

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -493,6 +493,15 @@ zmq_send_const (void *s_, const void *buf_, size_t len_, int flags_);
 ZMQ_EXPORT int zmq_recv (void *s_, void *buf_, size_t len_, int flags_);
 ZMQ_EXPORT int zmq_socket_monitor (void *s_, const char *addr_, int events_);
 
+/******************************************************************************/
+/*  Hide socket fd type; this was before zmq_poller_event_t typedef below     */
+/******************************************************************************/
+
+#if defined _WIN32
+typedef SOCKET zmq_fd_t;
+#else
+typedef int zmq_fd_t;
+#endif
 
 /******************************************************************************/
 /*  Deprecated I/O multiplexing. Prefer using zmq_poller API                  */
@@ -506,11 +515,7 @@ ZMQ_EXPORT int zmq_socket_monitor (void *s_, const char *addr_, int events_);
 typedef struct zmq_pollitem_t
 {
     void *socket;
-#if defined _WIN32
-    SOCKET fd;
-#else
-    int fd;
-#endif
+    zmq_fd_t fd;
     short events;
     short revents;
 } zmq_pollitem_t;
@@ -690,12 +695,6 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 /******************************************************************************/
 
 #define ZMQ_HAVE_POLLER
-
-#if defined _WIN32
-typedef SOCKET zmq_fd_t;
-#else
-typedef int zmq_fd_t;
-#endif
 
 typedef struct zmq_poller_event_t
 {


### PR DESCRIPTION
          how it declares the file descriptor (fd) of a socket
          in struct zmq_pollitem_t vs. struct zmq_poller_event_t

Solution:  Make include/zmq.h consistent in this matter