### PR TITLE
 Fix build on SL6.9. Fix #3603. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ endif()
 check_c_compiler_flag("-std=gnu11" COMPILER_SUPPORTS_C11)
 if(COMPILER_SUPPORTS_C11)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
+else()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 endif()
 
 if(NOT MSVC)

--- a/RELICENSE/bl0x.md
+++ b/RELICENSE/bl0x.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Bastian Löher that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "bl0x", with
+commit author "Bastian Löher <me@l-dot.de>", are
+copyright of Bastian Löher.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Bastian Löher
+2019/08/01


### PR DESCRIPTION
Problem: Build of bundled unity would not succeed on Scientific Linux 6.9 because of insufficient compiler flags.

Solution: Add -std=gnu99 flag in case -std=gnu11 is no supported.