### PR TITLE
[DragonFlyBSD] fix for IPv4 mapping not supported

### DIFF
--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -75,8 +75,13 @@
   #define ZMQ_HAVE_MINGW32
 #endif
 
-#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)
+#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
   #define ZMQ_HAVE_FREEBSD
+#endif
+
+#if defined(__DragonFly__)
+  #define ZMQ_HAVE_FREEBSD
+  #define ZMQ_HAVE_DRAGONFLY
 #endif
 
 #if defined __hpux

--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,7 @@ case "${host_os}" in
         ;;
     *dragonfly*)
         CPPFLAGS="-D__BSD_VISIBLE $CPPFLAGS"
+        AC_DEFINE(ZMQ_HAVE_FREEBSD, 1, [Have DragonFly OS])
         AC_DEFINE(ZMQ_HAVE_DRAGONFLY, 1, [Have DragonFly OS])
         ;;
     *darwin*)

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -129,7 +129,7 @@ void zmq::enable_ipv4_mapping (fd_t s_)
 {
     LIBZMQ_UNUSED (s_);
 
-#if defined IPV6_V6ONLY && !defined ZMQ_HAVE_OPENBSD
+#if defined IPV6_V6ONLY && !defined ZMQ_HAVE_OPENBSD && !defined ZMQ_HAVE_DRAGONFLY
 #ifdef ZMQ_HAVE_WINDOWS
     DWORD flag = 0;
 #else


### PR DESCRIPTION
On DragonFly the zmq::enable_ipv4_mapping in ip.cpp fais with a not supported error
So handle this case the same as for OpenBSD

Also update configure files to set the correct definitions for DragonFly OS

This includes all patches from the dports/net/libzmq/dragonfly patches directory