### PR TITLE
problem: sudo:false has been deprecated by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ matrix:
   - env: BUILD_TYPE=default CURVE=tweetnacl IPv6=ON
     os: linux
     dist: precise
-    sudo: false
   - env: BUILD_TYPE=coverage CURVE=tweetnacl DRAFT=enabled
     os: linux
     addons:
@@ -73,7 +72,6 @@ matrix:
         - xmlto
   - env: BUILD_TYPE=default CURVE=libsodium DRAFT=enabled GSSAPI=enabled PGM=enabled NORM=enabled TIPC=enabled
     os: linux
-    sudo: required
     addons:
       apt:
         sources:
@@ -134,7 +132,6 @@ matrix:
         - abi-dumper
         - abi-compliance-checker
     
-sudo: false
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "android" ] ; then brew update; brew install binutils ; fi

--- a/RELICENSE/fanquake.md
+++ b/RELICENSE/fanquake.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Michael Ford that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "fanquake", with
+commit author "Michael Ford <fanquake@gmail.com>", are
+copyright of Michael Ford.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Michael Ford
+2019/08/10
+


### PR DESCRIPTION
solution: remove `sudo:false` usage from `travis.yml`

Travis has deprecated the usage of `sudo:false` in `travis.yml`.
See this blog post for more details: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
Also: https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure