### PR TITLE
[CMake] Add ENABLE_PRECOMPILED option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1080,7 +1080,8 @@ if(ZMQ_BUILD_FRAMEWORK)
   COMMENT "Perf tools")
 endif()
 
-if(MSVC)
+option(ENABLE_PRECOMPILED "Enable precompiled headers, if possible" ON)
+if(MSVC AND ENABLE_PRECOMPILED)
   # default for all sources is to use precompiled headers
   foreach(source ${sources})
     # C and C++ can not use the same precompiled header


### PR DESCRIPTION
Problem: Builds fails with `ninja: error: build.ninja:995: multiple rules generate precompiled.hpp [-w dupbuild=err]` (Ninja is extremely strict with build rules).

Solution: Add a flag `ENABLE_PRECOMPILED` to disable precompiled headers for MSVC. Defaults to `On` to avoid changes in behavior for other users.

License was singed in #3247 