### PR TITLE
Problem: appveyor binary archives do not contain import libraries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -216,10 +216,12 @@ after_build:
             # -Dsonar.cxx.compiler.reportPath=build.log 
             # -Dsonar.cxx.compiler.charset=UTF-8 
             # -Dsonar.cxx.compiler.regex=^(?<filename>.*)\\((?<line>[0-9]+)\\):\\x20warning\\x20(?<id>C\\d\\d\\d\\d):(?<message>.*)$
+# TODO this should be done differently, using the INSTALL cmake target, the current handling depends on the details of the CMakeLists.txt
   - cmd: cd %LIBZMQ_BUILDDIR%\bin\%Configuration%"
   - cmd: if "%WITH_LIBSODIUM%"=="ON" copy "%SODIUM_LIBRARY_DIR%\libsodium.dll" .
   - cmd: copy "%LIBZMQ_SRCDIR%\include\zmq.h" .
-  - cmd: 7z a -y -bd -mx=9 libzmq.zip *.exe *.dll *.pdb *.h
+  - cmd: copy ..\..\lib\%Configuration%\libzmq*.lib .
+  - cmd: 7z a -y -bd -mx=9 libzmq.zip *.exe *.dll *.pdb *.h *.lib
   - ps: Push-AppveyorArtifact "libzmq.zip" -Filename "libzmq-${env:ARTIFACT_NAME}-${env:ZMQ_VERSION_MAJOR}_${env:ZMQ_VERSION_MINOR}_${env:ZMQ_VERSION_PATCH}.zip"
 
 test_script:


### PR DESCRIPTION
Solution: include all *.lib files

Fixes #3635