### PR TITLE
UDP engine aborts on networking-related errors from socket syscalls (2) #2862

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -237,6 +237,8 @@ int zmq::bind_to_device (fd_t s_, const std::string &bound_device_)
     if (rc != 0) {
         assert_success_or_recoverable (s_, rc);
         return -1;
+    } else {
+        return 0;
     }
 #else
     LIBZMQ_UNUSED (s_);

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -702,12 +702,12 @@ void zmq::assert_success_or_recoverable (zmq::fd_t s_, int rc_)
 #ifdef ZMQ_HAVE_WINDOWS
     zmq_assert (rc == 0);
     if (err != 0) {
-        wsa_assert (
-          err == WSAECONNREFUSED || err == WSAECONNRESET
-          || err == WSAECONNABORTED || err == WSAEINTR || err == WSAETIMEDOUT
-          || err == WSAEHOSTUNREACH || err == WSAENETUNREACH
-          || err == WSAENETDOWN || err == WSAENETRESET || err == WSAEINVAL
-          || err == WSAEADDRINUSE || err == WSAEACCES || err == WSAEWOULDBLOCK);
+        wsa_assert (err == WSAECONNREFUSED || err == WSAECONNRESET
+                    || err == WSAECONNABORTED || err == WSAEINTR
+                    || err == WSAETIMEDOUT || err == WSAEHOSTUNREACH
+                    || err == WSAENETUNREACH || err == WSAENETDOWN
+                    || err == WSAENETRESET || err == WSAEACCES
+                    || err == WSAEINVAL || err == WSAEADDRINUSE);
     }
 #else
     //  Following code should handle both Berkeley-derived socket
@@ -716,12 +716,11 @@ void zmq::assert_success_or_recoverable (zmq::fd_t s_, int rc_)
         err = errno;
     if (err != 0) {
         errno = err;
-        errno_assert (
-          errno == ECONNREFUSED || errno == ECONNRESET || errno == ECONNABORTED
-          || errno == EINTR || errno == ETIMEDOUT || errno == EHOSTUNREACH
-          || errno == ENETUNREACH || errno == ENETDOWN || errno == ENETRESET
-          || errno == EINVAL || errno == EADDRINUSE || errno == EACCES
-          || errno == EWOULDBLOCK || errno == EAGAIN || errno == EPIPE);
+        errno_assert (errno == ECONNREFUSED || errno == ECONNRESET
+                      || errno == ECONNABORTED || errno == EINTR
+                      || errno == ETIMEDOUT || errno == EHOSTUNREACH
+                      || errno == ENETUNREACH || errno == ENETDOWN
+                      || errno == ENETRESET || errno == EINVAL);
     }
 #endif
 }

--- a/src/ip.hpp
+++ b/src/ip.hpp
@@ -72,9 +72,10 @@ int make_fdpair (fd_t *r_, fd_t *w_);
 // Asserts on any failure.
 void make_socket_noninheritable (fd_t sock_);
 
-//  Asserts that an internal error did not occur.  Does not assert
-//  on network errors such as reset or aborted connections.
-void assert_socket_tuning_error (fd_t s_, int rc_);
+//  Asserts that:
+//  - an internal 0MQ error did not occur,
+//  - and, if a socket error occured, it can be recovered from.
+void assert_success_or_recoverable (fd_t s_, int rc_);
 }
 
 #endif

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -62,7 +62,7 @@ int zmq::tune_tcp_socket (fd_t s_)
     int nodelay = 1;
     int rc = setsockopt (s_, IPPROTO_TCP, TCP_NODELAY,
                          reinterpret_cast<char *> (&nodelay), sizeof (int));
-    assert_socket_tuning_error (s_, rc);
+    assert_success_or_recoverable (s_, rc);
     if (rc != 0)
         return rc;
 
@@ -81,7 +81,7 @@ int zmq::set_tcp_send_buffer (fd_t sockfd_, int bufsize_)
     const int rc =
       setsockopt (sockfd_, SOL_SOCKET, SO_SNDBUF,
                   reinterpret_cast<char *> (&bufsize_), sizeof bufsize_);
-    assert_socket_tuning_error (sockfd_, rc);
+    assert_success_or_recoverable (sockfd_, rc);
     return rc;
 }
 
@@ -90,7 +90,7 @@ int zmq::set_tcp_receive_buffer (fd_t sockfd_, int bufsize_)
     const int rc =
       setsockopt (sockfd_, SOL_SOCKET, SO_RCVBUF,
                   reinterpret_cast<char *> (&bufsize_), sizeof bufsize_);
-    assert_socket_tuning_error (sockfd_, rc);
+    assert_success_or_recoverable (sockfd_, rc);
     return rc;
 }
 
@@ -133,7 +133,7 @@ int zmq::tune_tcp_keepalives (fd_t s_,
         int rc =
           setsockopt (s_, SOL_SOCKET, SO_KEEPALIVE,
                       reinterpret_cast<char *> (&keepalive_), sizeof (int));
-        assert_socket_tuning_error (s_, rc);
+        assert_success_or_recoverable (s_, rc);
         if (rc != 0)
             return rc;
 
@@ -141,7 +141,7 @@ int zmq::tune_tcp_keepalives (fd_t s_,
         if (keepalive_cnt_ != -1) {
             int rc = setsockopt (s_, IPPROTO_TCP, TCP_KEEPCNT, &keepalive_cnt_,
                                  sizeof (int));
-            assert_socket_tuning_error (s_, rc);
+            assert_success_or_recoverable (s_, rc);
             if (rc != 0)
                 return rc;
         }
@@ -160,7 +160,7 @@ int zmq::tune_tcp_keepalives (fd_t s_,
         if (keepalive_idle_ != -1) {
             int rc = setsockopt (s_, IPPROTO_TCP, TCP_KEEPALIVE,
                                  &keepalive_idle_, sizeof (int));
-            assert_socket_tuning_error (s_, rc);
+            assert_success_or_recoverable (s_, rc);
             if (rc != 0)
                 return rc;
         }
@@ -171,7 +171,7 @@ int zmq::tune_tcp_keepalives (fd_t s_,
         if (keepalive_intvl_ != -1) {
             int rc = setsockopt (s_, IPPROTO_TCP, TCP_KEEPINTVL,
                                  &keepalive_intvl_, sizeof (int));
-            assert_socket_tuning_error (s_, rc);
+            assert_success_or_recoverable (s_, rc);
             if (rc != 0)
                 return rc;
         }

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -71,7 +71,7 @@ int zmq::tune_tcp_socket (fd_t s_)
     int nodelack = 1;
     rc = setsockopt (s_, IPPROTO_TCP, TCP_NODELACK, (char *) &nodelack,
                      sizeof (int));
-    assert_socket_tuning_error (s_, rc);
+    assert_success_or_recoverable (s_, rc);
 #endif
     return rc;
 }
@@ -123,7 +123,7 @@ int zmq::tune_tcp_keepalives (fd_t s_,
         int rc = WSAIoctl (s_, SIO_KEEPALIVE_VALS, &keepalive_opts,
                            sizeof (keepalive_opts), NULL, 0,
                            &num_bytes_returned, NULL, NULL);
-        assert_socket_tuning_error (s_, rc);
+        assert_success_or_recoverable (s_, rc);
         if (rc == SOCKET_ERROR)
             return rc;
     }
@@ -151,7 +151,7 @@ int zmq::tune_tcp_keepalives (fd_t s_,
         if (keepalive_idle_ != -1) {
             int rc = setsockopt (s_, IPPROTO_TCP, TCP_KEEPIDLE,
                                  &keepalive_idle_, sizeof (int));
-            assert_socket_tuning_error (s_, rc);
+            assert_success_or_recoverable (s_, rc);
             if (rc != 0)
                 return rc;
         }
@@ -196,13 +196,13 @@ int zmq::tune_tcp_maxrt (fd_t sockfd_, int timeout_)
     int rc =
       setsockopt (sockfd_, IPPROTO_TCP, TCP_MAXRT,
                   reinterpret_cast<char *> (&timeout_), sizeof (timeout_));
-    assert_socket_tuning_error (sockfd_, rc);
+    assert_success_or_recoverable (sockfd_, rc);
     return rc;
 // FIXME: should be ZMQ_HAVE_TCP_USER_TIMEOUT
 #elif defined(TCP_USER_TIMEOUT)
     int rc = setsockopt (sockfd_, IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout_,
                          sizeof (timeout_));
-    assert_socket_tuning_error (sockfd_, rc);
+    assert_success_or_recoverable (sockfd_, rc);
     return rc;
 #else
     return 0;

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -491,14 +491,14 @@ void zmq::udp_engine_t::out_event ()
         rc = sendto (_fd, _out_buffer, size, 0, _out_address, _out_address_len);
 #endif
         if (rc < 0) {
-            assert_success_or_recoverable (_fd, rc);
 #ifdef ZMQ_HAVE_WINDOWS
-            const int last_error = WSAGetLastError ();
-            if (last_error != WSAEWOULDBLOCK) {
+            if (WSAGetLastError () != WSAEWOULDBLOCK) {
+                assert_success_or_recoverable (_fd, rc);
                 error (connection_error);
             }
 #else
             if (rc != EWOULDBLOCK) {
+                assert_success_or_recoverable (_fd, rc);
                 error (connection_error);
             }
 #endif
@@ -537,14 +537,14 @@ void zmq::udp_engine_t::in_event ()
                 reinterpret_cast<sockaddr *> (&in_address), &in_addrlen);
 
     if (nbytes < 0) {
-        assert_success_or_recoverable (_fd, nbytes);
 #ifdef ZMQ_HAVE_WINDOWS
-        const int last_error = WSAGetLastError ();
-        if (last_error != WSAEWOULDBLOCK) {
+        if (WSAGetLastError () != WSAEWOULDBLOCK) {
+            assert_success_or_recoverable (_fd, nbytes);
             error (connection_error);
         }
 #else
         if (nbytes != EWOULDBLOCK) {
+            assert_success_or_recoverable (_fd, nbytes);
             error (connection_error);
         }
 #endif


### PR DESCRIPTION
Follow-up for UDP send/receive. Also updated `plug` function to terminate session only when `setsockopt` failed, and request reconnection otherwise. Still haven't looked into how socket monitoring events work, so error handling happens silently.

Note that I added EAGAIN/EWOULDBLOCK and EPIPE in the list of "recoverable" errors.