### PR TITLE
RELICENSE: add relicense agreement from msune

### DIFF
--- a/RELICENSE/msune.md
+++ b/RELICENSE/msune.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Marc Suñé Clos (msune)
+that grants permission to relicense his copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "msune", with
+commit author "Marc Sune <marcdevel@gmail.com>" or
+"Marc Sune <marc@voltanet.io>", are copyright of Marc Suñé.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed
+above.
+
+Marc Suñé Clos
+2019/08/31


### PR DESCRIPTION
Add RELICENSE document for msune contributions, both for:

* marcdevel at gmail dot com
* marc at voltanet io