### PR TITLE
[WIP, RFC] Problem: Relevant events on sockets are discarded

### DIFF
--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -202,7 +202,10 @@ class msg_t
         //  Leave message for radio_dish
         type_leave = 107,
 
-        type_max = 107
+        // Notification message.
+        type_notif = 108,
+
+        type_max = 108
     };
 
     //  Note that fields shared between different message types are not


### PR DESCRIPTION
Solution: Introduce notification message using `msg_t` to forward these relevant events to the user.

See #3658.

# RFC
The following is a informal rfc so that I can better understand what is involved in such changes.

# Definitions used in this doc
* `server` = a socket which acts as a bound endpoint
* `client` = a socket which connects to a `server`

# Frontend changes

## Add `zmq_connect_peer` function.
This `zmq_connect_peer` function is functionally the same as `zmq_connect`, except
it returns a `routing_id` used to refer to the connection with the peer. This `routing_id` will be
used by notifications to refer to this peer. A `routing_id` of `0` means an
error occured.

## Add `ZMQ_FILTER_NOTIF` sockopt
The `ZMQ_FILTER_NOTIF` sockopt is used to configure what event notifications
should be received by the user. This socket takes a `uint64_t` bitmask,
which defaults to 0 (no notifications). See `NotifType` for
the list of possible events.

## Add `zmq_msg_notif` function.
This `zmq_msg_notif` function can be used to retreive the `NotifType` of
a message. A returned value of `-1` means that the message is not a notification.

## NotifType
These are the possible notifications events. Note that each of these is a bitflag.
* `ZMQ_NOTIF_CONNECTED` means a connection of a `client` was established with
    a remote `server`. The `routing_id` of the message is used to refer to
    the specific `server`.
* `ZMQ_NOTIF_DISCONNECTED` means a connection of a `client` with a remote
    `server` was closed. The `routing_id` of the message is used to refer to
    the specific `server`.
* `ZMQ_NOTIF_CONNECTION_ACCEPTED` means a `server` accepted a connection from a
    remote `client`. The `routing_id` of the message is used to refer to the specific `client`.
* `ZMQ_NOTIF_CONNECTION_CLOSED` means a connection accepted by the `server` from
    a remote `client` was closed. The `routing_id` of the message is used to
    refer to the specific `client`.
* `ZMQ_NOTIF_JOINED` means a remote `DISH` connected to a `RADIO` joined a `group`.
    The `group` of the message is used to refer the specific grouped that was joined.
* `ZMQ_NOTIF_LEAVED` means a remote `DISH` connected to a `RADIO` leaved a `group`.
    The `group` of the message is used to refer the specific grouped that was leaved.
* `ZMQ_NOTIF_HANDSHAKE_FAILED` means a ZAP handshake of a `client` with a
    remote `server` failed. The `routing_id` of the message is used to refer
    to the specific `server`. The `group` of the message is a `HandshakeFailureDetails`.
    See `HandshakeFailureDetails` for details.

## HandshakeFailureDetails
A handshake failure details is used to give details on the type of handshake failure.

```c
enum HandshakeFailureType {
    no_details = 0,
    protocol = 1,
    auth = 2,
};

struct HandshakeFailureDetails {
    HanshakeFailureType type;
    // if HandshakeFailureType::no_details, then code is an errno.
    // if HandshakeFailureType::protocol, then code is a ZMQ_PROTOCOL_ERROR_*
    // if HandshakeFailureType::auth, then code is a ZAP status code (i.e. 300, 400, 500).
    int code;
}
```
# Implementation

## zmq_connect_peer
???. Basically a socket would need to assigne a `routing_id` to each connection, but I don't know how that would be implemented.

## zmq_msg_notif
Check if the msg_type is `type_notif` then return the `NotifType` stored in the union. Else return -1 with EINVAL.

## ZMQ_NOTIF_FILTER sockopt
Add a notif_filter field to the socket options that will be used as a mask, similarly to how `zmq_socket_monitor` is implemented.

## notification msg format
Create a new msg_type::type_notif as well as a new message union. The message union has to contain a `NotifType`, a `group` and a `routing_id`.

## notification queue
??? Unsure how that would be implemented.

## notification mechanism
This would be very similar to how zmq_monitor is currently implemented. In each location where a relevant event occurs:
* Check the `notif_filter` bitflag so see if the notification is activated
* If it is, create a notification msg_t and set the appropriate field depending on the `NotifType`
* Queue the message to the notification queue.

## notification retrieval mechanism
When calling `recv` on a socket, check the notification queue first. If it contains a notification,
return it, otherwise operate as normal.

## Unresolved questions
* Should there be a notification for when a `server` denies a connection (handshake failure)?
* How should zmq_connect_peer be implemented?
* How should the notification queue be implemented?
* Should this mechanism be limited to DRAFT socket types?