### PR TITLE
Safer regex replace, keeping options like "/Zc:twoPhase-" intact

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,8 +671,8 @@ if(MSVC)
 
   # Compile the static lib with debug information included
   # note: we assume here that the default flags contain some /Z flag
-  string(REGEX REPLACE "/Z." "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-  string(REGEX REPLACE "/Z." "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  string(REGEX REPLACE "/Z.[^:]" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  string(REGEX REPLACE "/Z.[^:]" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
   # Optimization flags.
   # http://msdn.microsoft.com/en-us/magazine/cc301698.aspx

--- a/RELICENSE/straubar.md
+++ b/RELICENSE/straubar.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Alexander Straub
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "straubar", with
+commit author "Alexander Straub <alexander.straub@visus.uni-stuttgart.de>", are copyright of Alexander Straub.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Alexander Straub
+2019/09/04


### PR DESCRIPTION
In our project, we include libzmq via the FetchContent mechanism and add it using add_subdirectory. In the already set CMAKE_CXX_FLAGS_DEBUG and CMAKE_CXX_FLAGS_RELWITHDEBINFO, we have multiple flags set, such as /Zc:twoPhase-. By applying the regex replace, this was converted to /Z7:twoPhase-, which caused the compilation to fail. The now proposed regex replace is a bit safer, as it does not touch flags containing a ":".