### PR TITLE
Bugfix/dont include winsock2

### DIFF
--- a/RELICENSE/TobiSchluter.md
+++ b/RELICENSE/TobiSchluter.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Tobias Schlüter
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "TobiSchluter", with
+commit author "TobiSchluter", are copyright of Tobias Schlüter .
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Tobias Schlüter
+2019/09/13

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -71,7 +71,6 @@ extern "C" {
 #error You need at least Windows XP target
 #endif
 #endif
-#include <winsock2.h>
 #endif
 
 /*  Handle DSO symbol visibility                                             */
@@ -498,7 +497,12 @@ ZMQ_EXPORT int zmq_socket_monitor (void *s_, const char *addr_, int events_);
 /******************************************************************************/
 
 #if defined _WIN32
-typedef SOCKET zmq_fd_t;
+// Windows uses a pointer-sized unsigned integer to store the socket fd.
+#if defined _WIN64
+typedef unsigned __int64 zmq_fd_t;
+#else
+typedef unsigned int zmq_fd_t;
+#endif
 #else
 typedef int zmq_fd_t;
 #endif


### PR DESCRIPTION
Including winsock2.h in zmq.h leads to ordering issues because different versions of headers or inclusions with intermediate defines can lead to collisions. In particular, inclusion of winsock2.h after windows.h can be troublesome. Since windows.h is a system header whereas zmq.h is a library header, the common pattern where system headers are included before additional library headers is thus broken.

This patch fixes it: the inclusion of winsock2.h in zmq.h is only needed for the definition of `SOCKET`, which is a pointer-wide integer, i.e. `unsigned int` (on 32bit) or `unsigned __uint64` (on 64bit). Replace `SOCKET` with this, remove inclusion.

Tested by running ctests on 32bit and 64bit builds on Visual Studio 2019.