### PR TITLE
Allow "configure --disable-maintainer-mode"

### DIFF
--- a/RELICENSE/dimpase.md
+++ b/RELICENSE/dimpase.md
@@ -1,0 +1,14 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Dmitrii (Dima) Pasechnik
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "dimpase", with
+commit author "Dima Pasechnik dimpase@gmail.com", are copyright of Dmitrii Pasechnik.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Dmitrii Pasechnik  2019/09/18

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,8 @@ AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS([src/platform.hpp])
 AM_INIT_AUTOMAKE(foreign subdir-objects tar-ustar dist-zip)
+# Allow "configure --disable-maintainer-mode" to disable timestamp checking 
+AM_MAINTAINER_MODE([enable])
 
 m4_pattern_allow([AC_PROG_CC_C99])
 m4_include([m4/ax_check_compile_flag.m4])


### PR DESCRIPTION
Allow "configure --disable-maintainer-mode" to disable timestamp checking.
This is useful for one-off builds, in particular on e.g. clusters, where slightly skew clocks force aclocal and friends to kick in for no good reason.