### PR TITLE
Fix behavior of ZMQ_CONFLATE on PUB sockets

### DIFF
--- a/src/dbuffer.hpp
+++ b/src/dbuffer.hpp
@@ -78,12 +78,12 @@ template <> class dbuffer_t<msg_t>
         msg_t &xvalue = const_cast<msg_t &> (value_);
 
         zmq_assert (xvalue.check ());
-        _back->move (xvalue); // cannot just overwrite, might leak
+        *_back = value_;
 
         zmq_assert (_back->check ());
 
         if (_sync.try_lock ()) {
-            std::swap (_back, _front);
+            _front->move (*_back);
             _has_msg = true;
 
             _sync.unlock ();


### PR DESCRIPTION
This commit actually solves two problems that originated in `dbuffer::write`:
- only one subscriber could receive messages: since the pending message was moved to the back buffer, it was closed and further writes of the same message to other conflate pipes were writes of an empty message.
- leaking messages when one subscriber is not responsive: the front buffer being not closed because of this, swapping the front buffer with the back buffer does not release its enclosed pending message. `msg_t::move` is more indicated in that case.

As such, provides a fix for #3323.