### PR TITLE
Add IBM i build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ OS and version | Architecture | Compiler and version | Build system | Last repor
 -------------- | ------------ | -------------------- | ------------ | ----------- | -------
 Solaris 10 | x86, amd64, sparc | GCC 8.1.0 | CMake | 2019/03/18 |
 DragonFly BSD | amd64 | gcc 8.3 | autotools | 2018/08/07 git-72854e63 |
+IBM i | ppc64 | gcc 6.3 | autotools | 2019/10/02 git-25320a3 |
 
 
 ### Supported platforms without known active users

--- a/RELICENSE/ThePrez.md
+++ b/RELICENSE/ThePrez.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Jesse Gorzinski
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "ThePrez", with
+commit author "ThePrez &lt;jgorzinski@gmail.com&gt;", are copyright of Jesse Gorzinski.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Jesse Gorzinski
+2019/10/02

--- a/configure.ac
+++ b/configure.ac
@@ -285,7 +285,7 @@ case "${host_os}" in
         AC_DEFINE(ZMQ_HAVE_QNXNTO, 1, [Have QNX Neutrino OS])
         AC_CHECK_LIB(socket, socket)
         ;;
-    *aix*)
+    *aix*|*os400*)
         AC_DEFINE(ZMQ_HAVE_AIX, 1, [Have AIX OS])
         ;;
     *hpux*)


### PR DESCRIPTION
IBM i uses zeromq in a runtime called PASE (self-identifies as 'os400' due to historical complexities), which is a variant of AIX. 