### PR TITLE
Problem: test_wss_transport doesn't compile without DRAFT

### DIFF
--- a/tests/test_wss_transport.cpp
+++ b/tests/test_wss_transport.cpp
@@ -33,6 +33,7 @@
 
 SETUP_TEARDOWN_TESTCONTEXT
 
+#ifdef ZMQ_WSS_CERT_PEM
 const char *key =
   "-----BEGIN PRIVATE KEY-----\n"
   "MIIJRAIBADANBgkqhkiG9w0BAQEFAASCCS4wggkqAgEAAoICAQCrXKFPWrRqbdNo\n"
@@ -148,3 +149,10 @@ int main ()
     RUN_TEST (test_roundtrip);
     return UNITY_END ();
 }
+#else
+int main ()
+{
+    printf ("WSS unavailable, skipping test\n");
+    return 77;
+}
+#endif


### PR DESCRIPTION
Solution: skip it