### PR TITLE
Fix linking to libzmq.a statically on CentOS 7

### DIFF
--- a/RELICENSE/yan12125.md
+++ b/RELICENSE/yan12125.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Chih-Hsuan Yen
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "yan12125", with
+commit author "Chih-Hsuan Yen <yan12125@gmail.com>", are copyright of Chih-Hsuan Yen.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Chih-Hsuan Yen
+2019/10/12

--- a/src/libzmq.pc.in
+++ b/src/libzmq.pc.in
@@ -7,6 +7,6 @@ Name: libzmq
 Description: 0MQ c++ library
 Version: @VERSION@
 Libs: -L${libdir} -lzmq
-Libs.private: -lstdc++ @pkg_config_libs_private@
+Libs.private: -lstdc++ -lm @pkg_config_libs_private@
 Requires.private: @pkg_config_names_private@
 Cflags: -I${includedir} @pkg_config_defines@


### PR DESCRIPTION
* Problem: pkg-config file cannot be used for static linking on CentOS 7

Solution: add -lm to Libs.private of libzmq.pc so that the std::ceil
usage in src/decoder_allocators.cpp is satisfied during static linking
on CentOS 7.

See https://github.com/zeromq/libzmq/issues/3710 for a reproducer.

* Add relicense note for @yan12125

Based on RELICENSE/templates/relicense-template-mplv2.txt. MPLv2 is
definitely fine, but I'm not sure if I'm OK with other licenses.

Both commits are signed with my PGP key. The public key can be found at https://keybase.io/yan12125/pgp_keys.asc.