### PR TITLE
Revert "Problem: pkg-config file cannot be used for static linking on…

### DIFF
--- a/src/libzmq.pc.in
+++ b/src/libzmq.pc.in
@@ -7,6 +7,6 @@ Name: libzmq
 Description: 0MQ c++ library
 Version: @VERSION@
 Libs: -L${libdir} -lzmq
-Libs.private: -lstdc++ -lm @pkg_config_libs_private@
+Libs.private: -lstdc++ @pkg_config_libs_private@
 Requires.private: @pkg_config_names_private@
 Cflags: -I${includedir} @pkg_config_defines@


### PR DESCRIPTION
… CentOS 7"

This reverts commit 765c24740d6d2a1e3256ee90dc126d05917ca15d.

libm is not required any after commit f07f47b1e3f78f781ca58a3008491cb7a740c0f3