### PR TITLE
Problem: libzmq-dev not installable with libczmq-dev on Ubuntu 16.04

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,7 +10,7 @@ Build-Depends: debhelper (>= 9),
  libsodium-dev,
  libunwind-dev | libunwind8-dev | libunwind7-dev,
  libnss3-dev,
- libgnutls28-dev,
+ libgnutls28-dev | libgnutls-dev,
  pkg-config,
  asciidoc-base | asciidoc, xmlto,
 Standards-Version: 3.9.8
@@ -41,7 +41,7 @@ Depends: libzmq5 (= ${binary:Version}), ${misc:Depends},
  libsodium-dev,
  libunwind-dev | libunwind8-dev | libunwind7-dev,
  libnss3-dev,
- libgnutls28-dev,
+ libgnutls28-dev | libgnutls-dev,
 Conflicts: libzmq-dev, libzmq5-dev
 Replaces: libzmq5-dev
 Provides: libzmq5-dev

--- a/packaging/debian/zeromq.dsc.obs
+++ b/packaging/debian/zeromq.dsc.obs
@@ -6,7 +6,7 @@ Version: 4.3.3
 Maintainer: libzmq Developers <zeromq-dev@lists.zeromq.org>
 Homepage: http://www.zeromq.org/
 Standards-Version: 3.9.8
-Build-Depends: debhelper (>= 9), dh-autoreconf, libkrb5-dev, libpgm-dev, libnorm-dev, libsodium-dev, libunwind-dev | libunwind8-dev | libunwind7-dev, libnss3-dev, libgnutls28-dev, pkg-config, asciidoc-base | asciidoc, xmlto
+Build-Depends: debhelper (>= 9), dh-autoreconf, libkrb5-dev, libpgm-dev, libnorm-dev, libsodium-dev, libunwind-dev | libunwind8-dev | libunwind7-dev, libnss3-dev, libgnutls28-dev | libgnutls-dev, pkg-config, asciidoc-base | asciidoc, xmlto
 Package-List:
  libzmq3-dev deb libdevel optional arch=any
  libzmq5 deb libs optional arch=any


### PR DESCRIPTION
Solution: add alternative dependency as libgnutls-dev | libgnutls28-dev,
so that the resolver can break the tie, as libcurl4-nss-dev depends on
libgnutls-dev which conflicts with libgnutls28-dev