### PR TITLE
Problem: WSAEventSelect checks for FD_OOB, but select does not

### DIFF
--- a/src/select.cpp
+++ b/src/select.cpp
@@ -376,16 +376,13 @@ void zmq::select_t::loop ()
                         rc =
                           WSAEventSelect (fd, wsa_events.events[3],
                                           FD_READ | FD_ACCEPT | FD_CLOSE
-                                            | FD_WRITE | FD_CONNECT | FD_OOB);
+                                            | FD_WRITE | FD_CONNECT);
                     else if (FD_ISSET (fd, &family_entry.fds_set.read))
                         rc = WSAEventSelect (fd, wsa_events.events[0],
-                                             FD_READ | FD_ACCEPT | FD_CLOSE
-                                               | FD_OOB);
+                                             FD_READ | FD_ACCEPT | FD_CLOSE);
                     else if (FD_ISSET (fd, &family_entry.fds_set.write))
                         rc = WSAEventSelect (fd, wsa_events.events[1],
-                                             FD_WRITE | FD_CONNECT | FD_OOB);
-                    else if (FD_ISSET (fd, &family_entry.fds_set.error))
-                        rc = WSAEventSelect (fd, wsa_events.events[2], FD_OOB);
+                                             FD_WRITE | FD_CONNECT);
                     else
                         rc = 0;
 


### PR DESCRIPTION
WSAEventSelect is used on Windows (when select is the polling method)
only if waiting for more than one socket family, excluding IPv4/6.
It is then passed FD_OOB, which means it can be woken by OOB messages,
but select later on never checks for it.
Remove FD_OOB as it's not actually used for anything.