### PR TITLE
Remove the superfluous build requirement of libsodium-devel

### DIFF
--- a/RELICENSE/viciious.md
+++ b/RELICENSE/viciious.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Victor Luchits
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "viciious", with
+commit author "Victor Luchits", are copyright of Victor Luchits.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Victor Luchits
+2019/11/12

--- a/packaging/redhat/zeromq.spec
+++ b/packaging/redhat/zeromq.spec
@@ -19,7 +19,7 @@ URL:           http://www.zeromq.org/
 Source:        http://download.zeromq.org/%{name}-%{version}.tar.gz
 Prefix:        %{_prefix}
 Buildroot:     %{_tmppath}/%{name}-%{version}-%{release}-root
-BuildRequires:  autoconf automake libtool libsodium-devel glib2-devel
+BuildRequires:  autoconf automake libtool glib2-devel
 %if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
 BuildRequires:  e2fsprogs-devel
 BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)


### PR DESCRIPTION
The following lines in the .spec file ensure that the necessary packages are present on the system in case the rpm is being built with libsodium support enabled:

```
%bcond_with libsodium
%if %{with libsodium}
BuildRequires:  libsodium-devel
%define SODIUM yes
%else
%define SODIUM no
%endif
```

```
%{?_with_libsodium:BuildRequires: libsodium-devel}
%{?_with_libsodium:Requires: libsodium}
```

Unconditionally requiring libsodium-devel makes it impossible to build the spec file with default arguments if the aforementioned package is not installed. This merge request amends that.