### PR TITLE
Change XSUB -> XPUB message processing.

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1154,6 +1154,22 @@ Default value:: NULL
 Applicable socket types:: ZMQ_XPUB
 
 
+ZMQ_ONLY_FIRST_SUBSCRIBE: Process only fist subscribe/unsubscribe in a multipart message
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If set, only the first part of the multipart message is processed as
+a subscribe/unsubscribe message. The rest are forwarded as user data
+regardless of message contents.
+
+It not set (default), subscribe/unsubscribe messages in a multipart message
+are processed as such regardless of their number and order.
+
+[horizontal]
+Option value type:: int
+Option value unit:: boolean
+Default value:: 0 (false)
+Applicable socket types:: ZMQ_XSUB, ZMQ_XPUB
+
+
 ZMQ_ZAP_DOMAIN: Set RFC 27 authentication domain
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sets the domain for ZAP (ZMQ RFC 27) authentication. A ZAP domain must be 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -675,6 +675,7 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_WSS_TRUST_PEM 105
 #define ZMQ_WSS_HOSTNAME 106
 #define ZMQ_WSS_TRUST_SYSTEM 107
+#define ZMQ_ONLY_FIRST_SUBSCRIBE 108
 
 
 /*  DRAFT Context options                                                     */

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -96,6 +96,15 @@ class xpub_t : public socket_base_t
     //  True if we are in the middle of receiving a multi-part message.
     bool _more_recv;
 
+    //  If true, subscribe and cancel messages are processed for the rest
+    //  of multipart message.
+    bool _process_subscribe;
+
+    //  This option is enabled with ZMQ_ONLY_FIRST_SUBSCRIBE.
+    //  If true, messages following subscribe/unsubscribe in a multipart
+    //  message are treated as user data regardless of the first byte.
+    bool _only_first_subscribe;
+
     //  Drop messages if HWM reached, otherwise return with EAGAIN
     bool _lossy;
 

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -38,7 +38,9 @@ zmq::xsub_t::xsub_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
     socket_base_t (parent_, tid_, sid_),
     _has_message (false),
     _more_send (false),
-    _more_recv (false)
+    _more_recv (false),
+    _process_subscribe (false),
+    _only_first_subscribe (false)
 {
     options.type = ZMQ_XSUB;
 
@@ -95,17 +97,38 @@ void zmq::xsub_t::xhiccuped (pipe_t *pipe_)
     pipe_->flush ();
 }
 
+int zmq::xsub_t::xsetsockopt (int option_,
+                              const void *optval_,
+                              size_t optvallen_)
+{
+    if (option_ == ZMQ_ONLY_FIRST_SUBSCRIBE) {
+        if (optvallen_ != sizeof (int)
+            || *static_cast<const int *> (optval_) < 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        _only_first_subscribe = (*static_cast<const int *> (optval_) != 0);
+        return 0;
+    } else {
+        errno = EINVAL;
+        return -1;
+    }
+}
+
 int zmq::xsub_t::xsend (msg_t *msg_)
 {
     size_t size = msg_->size ();
     unsigned char *data = static_cast<unsigned char *> (msg_->data ());
 
-    bool send_more = _more_send;
+    bool first_part = !_more_send;
     _more_send = (msg_->flags () & msg_t::more) != 0;
 
-    if (send_more)
+    if (first_part) {
+        _process_subscribe = !_only_first_subscribe;
+    } else if (!_process_subscribe) {
         //  User message sent upstream to XPUB socket
         return _dist.send_to_all (msg_);
+    }
 
     if (msg_->is_subscribe () || (size > 0 && *data == 1)) {
         //  Process subscribe message
@@ -121,6 +144,7 @@ int zmq::xsub_t::xsend (msg_t *msg_)
             size = size - 1;
         }
         _subscriptions.add (data, size);
+        _process_subscribe = true;
         return _dist.send_to_all (msg_);
     }
     if (msg_->is_cancel () || (size > 0 && *data == 0)) {
@@ -132,6 +156,7 @@ int zmq::xsub_t::xsend (msg_t *msg_)
             data = data + 1;
             size = size - 1;
         }
+        _process_subscribe = true;
         if (_subscriptions.rm (data, size))
             return _dist.send_to_all (msg_);
     } else

--- a/src/xsub.hpp
+++ b/src/xsub.hpp
@@ -57,6 +57,7 @@ class xsub_t : public socket_base_t
     void xattach_pipe (zmq::pipe_t *pipe_,
                        bool subscribe_to_all_,
                        bool locally_initiated_);
+    int xsetsockopt (int option_, const void *optval_, size_t optvallen_);
     int xsend (zmq::msg_t *msg_);
     bool xhas_out ();
     int xrecv (zmq::msg_t *msg_);
@@ -100,6 +101,15 @@ class xsub_t : public socket_base_t
     //  If true, part of a multipart message was already received, but
     //  there are following parts still waiting.
     bool _more_recv;
+
+    //  If true, subscribe and cancel messages are processed for the rest
+    //  of multipart message.
+    bool _process_subscribe;
+
+    //  This option is enabled with ZMQ_ONLY_FIRST_SUBSCRIBE.
+    //  If true, messages following subscribe/unsubscribe in a multipart
+    //  message are treated as user data regardless of the first byte.
+    bool _only_first_subscribe;
 
     xsub_t (const xsub_t &);
     const xsub_t &operator= (const xsub_t &);

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -57,6 +57,8 @@
 #define ZMQ_SOCKS_PASSWORD 100
 #define ZMQ_IN_BATCH_SIZE 101
 #define ZMQ_OUT_BATCH_SIZE 102
+#define ZMQ_ONLY_FIRST_SUBSCRIBE 108
+
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10


### PR DESCRIPTION
Now if the first frame in a multipart message is not subscribe/unsubscribe,
the rest of the parts are also considered to be not subscribe/unsubscribe.