### PR TITLE
Make use of = default and = delete if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,9 @@ matrix:
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "android" ] ; then brew update; brew install binutils ; fi
 - if [ $TRAVIS_OS_NAME == "osx" -a $CURVE == "libsodium" ] ; then brew update; brew install libsodium ; fi
+# To allow sonar to process history information, unshallow clone first.
 - if [ -n "$CLANG_TIDY" ] ; then
+    git fetch --unshallow ;
     curl -L https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip -o build-wrapper-linux-x86.zip ;
     unzip build-wrapper-linux-x86.zip ;
     export SONARCLOUD_BUILD_WRAPPER_PATH="$(pwd)/build-wrapper-linux-x86/" ;

--- a/src/array.hpp
+++ b/src/array.hpp
@@ -33,6 +33,8 @@
 #include <vector>
 #include <algorithm>
 
+#include "macros.hpp"
+
 namespace zmq
 {
 //  Implementation of fast arrays with O(1) access, insertion and
@@ -55,7 +57,7 @@ template <int ID = 0> class array_item_t
 
     //  The destructor doesn't have to be virtual. It is made virtual
     //  just to keep ICC and code checking tools from complaining.
-    inline virtual ~array_item_t () {}
+    inline virtual ~array_item_t () ZMQ_DEFAULT;
 
     inline void set_array_index (int index_) { _array_index = index_; }
 
@@ -64,8 +66,7 @@ template <int ID = 0> class array_item_t
   private:
     int _array_index;
 
-    array_item_t (const array_item_t &);
-    const array_item_t &operator= (const array_item_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (array_item_t)
 };
 
 
@@ -77,7 +78,7 @@ template <typename T, int ID = 0> class array_t
   public:
     typedef typename std::vector<T *>::size_type size_type;
 
-    inline array_t () {}
+    inline array_t () ZMQ_DEFAULT;
 
     inline size_type size () { return _items.size (); }
 
@@ -125,8 +126,7 @@ template <typename T, int ID = 0> class array_t
     typedef std::vector<T *> items_t;
     items_t _items;
 
-    array_t (const array_t &);
-    const array_t &operator= (const array_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (array_t)
 };
 }
 

--- a/src/array.hpp
+++ b/src/array.hpp
@@ -79,8 +79,6 @@ template <typename T, int ID = 0> class array_t
 
     inline array_t () {}
 
-    inline ~array_t () {}
-
     inline size_type size () { return _items.size (); }
 
     inline bool empty () { return _items.empty (); }

--- a/src/atomic_counter.hpp
+++ b/src/atomic_counter.hpp
@@ -214,8 +214,7 @@ class atomic_counter_t
 #endif
 
 #if !defined ZMQ_ATOMIC_COUNTER_CXX11
-    atomic_counter_t (const atomic_counter_t &);
-    const atomic_counter_t &operator= (const atomic_counter_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (atomic_counter_t)
 #endif
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)                             \
   || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \

--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -232,8 +232,7 @@ template <typename T> class atomic_ptr_t
 #endif
 
 #if !defined ZMQ_ATOMIC_PTR_CXX11
-    atomic_ptr_t (const atomic_ptr_t &);
-    const atomic_ptr_t &operator= (const atomic_ptr_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (atomic_ptr_t)
 #endif
 };
 

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -66,8 +66,7 @@ class client_t : public socket_base_t
     fq_t _fq;
     lb_t _lb;
 
-    client_t (const client_t &);
-    const client_t &operator= (const client_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (client_t)
 };
 }
 

--- a/src/clock.hpp
+++ b/src/clock.hpp
@@ -30,6 +30,7 @@
 #ifndef __ZMQ_CLOCK_HPP_INCLUDED__
 #define __ZMQ_CLOCK_HPP_INCLUDED__
 
+#include "macros.hpp"
 #include "stdint.hpp"
 
 #if defined ZMQ_HAVE_OSX
@@ -72,8 +73,7 @@ class clock_t
     //  Physical time corresponding to the TSC above (in milliseconds).
     uint64_t _last_time;
 
-    clock_t (const clock_t &);
-    const clock_t &operator= (const clock_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (clock_t)
 };
 }
 

--- a/src/condition_variable.hpp
+++ b/src/condition_variable.hpp
@@ -44,8 +44,6 @@ class condition_variable_t
   public:
     inline condition_variable_t () { zmq_assert (false); }
 
-    inline ~condition_variable_t () {}
-
     inline int wait (mutex_t *mutex_, int timeout_)
     {
         zmq_assert (false);
@@ -54,10 +52,7 @@ class condition_variable_t
 
     inline void broadcast () { zmq_assert (false); }
 
-  private:
-    //  Disable copy construction and assignment.
-    condition_variable_t (const condition_variable_t &);
-    void operator= (const condition_variable_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (condition_variable_t)
 };
 }
 
@@ -71,8 +66,6 @@ class condition_variable_t
 {
   public:
     inline condition_variable_t () { InitializeConditionVariable (&_cv); }
-
-    inline ~condition_variable_t () {}
 
     inline int wait (mutex_t *mutex_, int timeout_)
     {
@@ -95,9 +88,7 @@ class condition_variable_t
   private:
     CONDITION_VARIABLE _cv;
 
-    //  Disable copy construction and assignment.
-    condition_variable_t (const condition_variable_t &);
-    void operator= (const condition_variable_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (condition_variable_t)
 };
 }
 
@@ -110,9 +101,7 @@ namespace zmq
 class condition_variable_t
 {
   public:
-    inline condition_variable_t () {}
-
-    inline ~condition_variable_t () {}
+    inline condition_variable_t () ZMQ_DEFAULT;
 
     inline int wait (mutex_t *mutex_, int timeout_)
     {
@@ -139,9 +128,7 @@ class condition_variable_t
   private:
     std::condition_variable_any _cv;
 
-    //  Disable copy construction and assignment.
-    condition_variable_t (const condition_variable_t &);
-    void operator= (const condition_variable_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (condition_variable_t)
 };
 }
 
@@ -154,7 +141,7 @@ namespace zmq
 class condition_variable_t
 {
   public:
-    inline condition_variable_t () {}
+    inline condition_variable_t () ZMQ_DEFAULT;
 
     inline ~condition_variable_t ()
     {
@@ -224,9 +211,7 @@ class condition_variable_t
     mutex_t _listenersMutex;
     std::vector<SEM_ID> _listeners;
 
-    // Disable copy construction and assignment.
-    condition_variable_t (const condition_variable_t &);
-    const condition_variable_t &operator= (const condition_variable_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (condition_variable_t)
 };
 }
 
@@ -318,9 +303,7 @@ class condition_variable_t
   private:
     pthread_cond_t _cond;
 
-    // Disable copy construction and assignment.
-    condition_variable_t (const condition_variable_t &);
-    const condition_variable_t &operator= (const condition_variable_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (condition_variable_t)
 };
 }
 

--- a/src/ctx.hpp
+++ b/src/ctx.hpp
@@ -241,8 +241,7 @@ class ctx_t : public thread_ctx_t
     // Should we use zero copy message decoding in this context?
     bool _zero_copy;
 
-    ctx_t (const ctx_t &);
-    const ctx_t &operator= (const ctx_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ctx_t)
 
 #ifdef HAVE_FORK
     // the process that created this context. Used to detect forking.

--- a/src/dbuffer.hpp
+++ b/src/dbuffer.hpp
@@ -132,9 +132,7 @@ template <> class dbuffer_t<msg_t>
     mutex_t _sync;
     bool _has_msg;
 
-    //  Disable copying of dbuffer.
-    dbuffer_t (const dbuffer_t &);
-    const dbuffer_t &operator= (const dbuffer_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (dbuffer_t)
 };
 }
 

--- a/src/dealer.hpp
+++ b/src/dealer.hpp
@@ -76,8 +76,7 @@ class dealer_t : public socket_base_t
     // if true, send an empty message to every connected router peer
     bool _probe_router;
 
-    dealer_t (const dealer_t &);
-    const dealer_t &operator= (const dealer_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (dealer_t)
 };
 }
 

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -186,8 +186,7 @@ class decoder_base_t : public i_decoder
     A _allocator;
     unsigned char *_buf;
 
-    decoder_base_t (const decoder_base_t &);
-    const decoder_base_t &operator= (const decoder_base_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (decoder_base_t)
 };
 }
 

--- a/src/decoder_allocators.hpp
+++ b/src/decoder_allocators.hpp
@@ -64,8 +64,7 @@ class c_single_allocator
     std::size_t _buf_size;
     unsigned char *_buf;
 
-    c_single_allocator (c_single_allocator const &);
-    c_single_allocator &operator= (c_single_allocator const &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (c_single_allocator)
 };
 
 // This allocator allocates a reference counted buffer which is used by v2_decoder_t

--- a/src/devpoll.hpp
+++ b/src/devpoll.hpp
@@ -90,8 +90,7 @@ class devpoll_t : public worker_poller_base_t
     //  Pollset manipulation function.
     void devpoll_ctl (fd_t fd_, short events_);
 
-    devpoll_t (const devpoll_t &);
-    const devpoll_t &operator= (const devpoll_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (devpoll_t)
 };
 
 typedef devpoll_t poller_t;

--- a/src/dgram.hpp
+++ b/src/dgram.hpp
@@ -67,8 +67,7 @@ class dgram_t : public socket_base_t
     //  If true, more outgoing message parts are expected.
     bool _more_out;
 
-    dgram_t (const dgram_t &);
-    const dgram_t &operator= (const dgram_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (dgram_t)
 };
 }
 

--- a/src/dish.hpp
+++ b/src/dish.hpp
@@ -87,8 +87,7 @@ class dish_t : public socket_base_t
     bool _has_message;
     msg_t _message;
 
-    dish_t (const dish_t &);
-    const dish_t &operator= (const dish_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (dish_t)
 };
 
 class dish_session_t : public session_base_t
@@ -115,8 +114,7 @@ class dish_session_t : public session_base_t
 
     msg_t _group_msg;
 
-    dish_session_t (const dish_session_t &);
-    const dish_session_t &operator= (const dish_session_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (dish_session_t)
 };
 }
 

--- a/src/dist.hpp
+++ b/src/dist.hpp
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "array.hpp"
+#include "macros.hpp"
 
 namespace zmq
 {
@@ -107,8 +108,7 @@ class dist_t
     //  True if last we are in the middle of a multipart message.
     bool _more;
 
-    dist_t (const dist_t &);
-    const dist_t &operator= (const dist_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (dist_t)
 };
 }
 

--- a/src/encoder.hpp
+++ b/src/encoder.hpp
@@ -171,10 +171,9 @@ template <typename T> class encoder_base_t : public i_encoder
     const size_t _buf_size;
     unsigned char *const _buf;
 
-    encoder_base_t (const encoder_base_t &);
-    void operator= (const encoder_base_t &);
-
     msg_t *_in_progress;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (encoder_base_t)
 };
 }
 

--- a/src/epoll.hpp
+++ b/src/epoll.hpp
@@ -103,8 +103,7 @@ class epoll_t : public worker_poller_base_t
     typedef std::vector<poll_entry_t *> retired_t;
     retired_t _retired;
 
-    epoll_t (const epoll_t &);
-    const epoll_t &operator= (const epoll_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (epoll_t)
 };
 
 typedef epoll_t poller_t;

--- a/src/fq.hpp
+++ b/src/fq.hpp
@@ -77,8 +77,7 @@ class fq_t
     //  there are following parts still waiting in the current pipe.
     bool _more;
 
-    fq_t (const fq_t &);
-    const fq_t &operator= (const fq_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (fq_t)
 };
 }
 

--- a/src/gather.hpp
+++ b/src/gather.hpp
@@ -59,8 +59,7 @@ class gather_t : public socket_base_t
     //  Fair queueing object for inbound pipes.
     fq_t _fq;
 
-    gather_t (const gather_t &);
-    const gather_t &operator= (const gather_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (gather_t)
 };
 }
 

--- a/src/generic_mtrie.hpp
+++ b/src/generic_mtrie.hpp
@@ -33,6 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stddef.h>
 #include <set>
 
+#include "macros.hpp"
 #include "stdint.hpp"
 
 namespace zmq
@@ -118,9 +119,7 @@ template <typename T> class generic_mtrie_t
         class generic_mtrie_t<value_t> **table;
     } _next;
 
-    generic_mtrie_t (const generic_mtrie_t<value_t> &);
-    const generic_mtrie_t<value_t> &
-    operator= (const generic_mtrie_t<value_t> &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (generic_mtrie_t)
 };
 }
 

--- a/src/i_decoder.hpp
+++ b/src/i_decoder.hpp
@@ -30,6 +30,7 @@
 #ifndef __ZMQ_I_DECODER_HPP_INCLUDED__
 #define __ZMQ_I_DECODER_HPP_INCLUDED__
 
+#include "macros.hpp"
 #include "stdint.hpp"
 
 namespace zmq
@@ -41,7 +42,7 @@ class msg_t;
 class i_decoder
 {
   public:
-    virtual ~i_decoder () {}
+    virtual ~i_decoder () ZMQ_DEFAULT;
 
     virtual void get_buffer (unsigned char **data_, size_t *size_) = 0;
 

--- a/src/i_encoder.hpp
+++ b/src/i_encoder.hpp
@@ -30,6 +30,7 @@
 #ifndef __ZMQ_I_ENCODER_HPP_INCLUDED__
 #define __ZMQ_I_ENCODER_HPP_INCLUDED__
 
+#include "macros.hpp"
 #include "stdint.hpp"
 
 namespace zmq
@@ -41,7 +42,7 @@ class msg_t;
 
 struct i_encoder
 {
-    virtual ~i_encoder () {}
+    virtual ~i_encoder () ZMQ_DEFAULT;
 
     //  The function returns a batch of binary data. The data
     //  are filled to a supplied buffer. If no buffer is supplied (data_

--- a/src/i_engine.hpp
+++ b/src/i_engine.hpp
@@ -31,6 +31,7 @@
 #define __ZMQ_I_ENGINE_HPP_INCLUDED__
 
 #include "endpoint.hpp"
+#include "macros.hpp"
 
 namespace zmq
 {
@@ -47,7 +48,7 @@ struct i_engine
         timeout_error
     };
 
-    virtual ~i_engine () {}
+    virtual ~i_engine () ZMQ_DEFAULT;
 
     //  Plug the engine to the session.
     virtual void plug (zmq::io_thread_t *io_thread_,

--- a/src/i_mailbox.hpp
+++ b/src/i_mailbox.hpp
@@ -30,6 +30,7 @@
 #ifndef __ZMQ_I_MAILBOX_HPP_INCLUDED__
 #define __ZMQ_I_MAILBOX_HPP_INCLUDED__
 
+#include "macros.hpp"
 #include "stdint.hpp"
 
 namespace zmq
@@ -39,7 +40,7 @@ namespace zmq
 class i_mailbox
 {
   public:
-    virtual ~i_mailbox () {}
+    virtual ~i_mailbox () ZMQ_DEFAULT;
 
     virtual void send (const command_t &cmd_) = 0;
     virtual int recv (command_t *cmd_, int timeout_) = 0;

--- a/src/i_poll_events.hpp
+++ b/src/i_poll_events.hpp
@@ -30,6 +30,8 @@
 #ifndef __ZMQ_I_POLL_EVENTS_HPP_INCLUDED__
 #define __ZMQ_I_POLL_EVENTS_HPP_INCLUDED__
 
+#include "macros.hpp"
+
 namespace zmq
 {
 // Virtual interface to be exposed by object that want to be notified
@@ -37,7 +39,7 @@ namespace zmq
 
 struct i_poll_events
 {
-    virtual ~i_poll_events () {}
+    virtual ~i_poll_events () ZMQ_DEFAULT;
 
     // Called by I/O thread when file descriptor is ready for reading.
     virtual void in_event () = 0;

--- a/src/io_object.hpp
+++ b/src/io_object.hpp
@@ -76,8 +76,7 @@ class io_object_t : public i_poll_events
   private:
     poller_t *_poller;
 
-    io_object_t (const io_object_t &);
-    const io_object_t &operator= (const io_object_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (io_object_t)
 };
 }
 

--- a/src/io_thread.hpp
+++ b/src/io_thread.hpp
@@ -85,8 +85,7 @@ class io_thread_t : public object_t, public i_poll_events
     //  I/O multiplexing is performed using a poller object.
     poller_t *_poller;
 
-    io_thread_t (const io_thread_t &);
-    const io_thread_t &operator= (const io_thread_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (io_thread_t)
 };
 }
 

--- a/src/ipc_address.hpp
+++ b/src/ipc_address.hpp
@@ -30,9 +30,9 @@
 #ifndef __ZMQ_IPC_ADDRESS_HPP_INCLUDED__
 #define __ZMQ_IPC_ADDRESS_HPP_INCLUDED__
 
-#include <string>
-
 #if defined ZMQ_HAVE_IPC
+
+#include <string>
 
 #if defined _MSC_VER
 #include <afunix.h>
@@ -40,6 +40,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #endif
+
+#include "macros.hpp"
 
 namespace zmq
 {
@@ -63,8 +65,7 @@ class ipc_address_t
     struct sockaddr_un _address;
     socklen_t _addrlen;
 
-    ipc_address_t (const ipc_address_t &);
-    const ipc_address_t &operator= (const ipc_address_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ipc_address_t)
 };
 }
 

--- a/src/ipc_connecter.hpp
+++ b/src/ipc_connecter.hpp
@@ -64,8 +64,7 @@ class ipc_connecter_t : public stream_connecter_base_t
     //  retired_fd if the connection was unsuccessful.
     fd_t connect ();
 
-    ipc_connecter_t (const ipc_connecter_t &);
-    const ipc_connecter_t &operator= (const ipc_connecter_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ipc_connecter_t)
 };
 }
 

--- a/src/ipc_listener.hpp
+++ b/src/ipc_listener.hpp
@@ -79,8 +79,7 @@ class ipc_listener_t : public stream_listener_base_t
     //  Name of the file associated with the UNIX domain address.
     std::string _filename;
 
-    ipc_listener_t (const ipc_listener_t &);
-    const ipc_listener_t &operator= (const ipc_listener_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ipc_listener_t)
 };
 }
 

--- a/src/kqueue.hpp
+++ b/src/kqueue.hpp
@@ -93,8 +93,7 @@ class kqueue_t : public worker_poller_base_t
     typedef std::vector<poll_entry_t *> retired_t;
     retired_t retired;
 
-    kqueue_t (const kqueue_t &);
-    const kqueue_t &operator= (const kqueue_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (kqueue_t)
 
 #ifdef HAVE_FORK
     // the process that created this context. Used to detect forking.

--- a/src/lb.hpp
+++ b/src/lb.hpp
@@ -78,8 +78,7 @@ class lb_t
     //  True if we are dropping current message.
     bool _dropping;
 
-    lb_t (const lb_t &);
-    const lb_t &operator= (const lb_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (lb_t)
 };
 }
 

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -19,3 +19,29 @@
 #define ZMQ_NOEXCEPT
 #endif
 #endif
+
+#if !defined ZMQ_DEFAULT
+#if defined ZMQ_HAVE_NOEXCEPT
+#define ZMQ_DEFAULT = default;
+#else
+#define ZMQ_DEFAULT                                                            \
+    {                                                                          \
+    }
+#endif
+#endif
+
+#if !defined ZMQ_NON_COPYABLE_NOR_MOVABLE
+#if defined ZMQ_HAVE_NOEXCEPT
+#define ZMQ_NON_COPYABLE_NOR_MOVABLE(classname)                                \
+  public:                                                                      \
+    classname (const classname &) = delete;                                    \
+    classname &operator= (const classname &) = delete;                         \
+    classname (classname &&) = delete;                                         \
+    classname &operator= (classname &&) = delete;
+#else
+#define ZMQ_NON_COPYABLE_NOR_MOVABLE(classname)                                \
+  private:                                                                     \
+    classname (const classname &);                                             \
+    classname &operator= (const classname &);
+#endif
+#endif

--- a/src/mailbox.hpp
+++ b/src/mailbox.hpp
@@ -79,9 +79,7 @@ class mailbox_t : public i_mailbox
     //  read commands from it.
     bool _active;
 
-    //  Disable copying of mailbox_t object.
-    mailbox_t (const mailbox_t &);
-    const mailbox_t &operator= (const mailbox_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (mailbox_t)
 };
 }
 

--- a/src/mailbox_safe.hpp
+++ b/src/mailbox_safe.hpp
@@ -81,9 +81,7 @@ class mailbox_safe_t : public i_mailbox
 
     std::vector<zmq::signaler_t *> _signalers;
 
-    //  Disable copying of mailbox_t object.
-    mailbox_safe_t (const mailbox_safe_t &);
-    const mailbox_safe_t &operator= (const mailbox_safe_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (mailbox_safe_t)
 };
 }
 

--- a/src/metadata.hpp
+++ b/src/metadata.hpp
@@ -55,14 +55,13 @@ class metadata_t
     bool drop_ref ();
 
   private:
-    metadata_t (const metadata_t &);
-    metadata_t &operator= (const metadata_t &);
-
     //  Reference counter.
     atomic_counter_t _ref_cnt;
 
     //  Dictionary holding metadata.
     const dict_t _dict;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (metadata_t)
 };
 }
 

--- a/src/mutex.hpp
+++ b/src/mutex.hpp
@@ -31,6 +31,7 @@
 #define __ZMQ_MUTEX_HPP_INCLUDED__
 
 #include "err.hpp"
+#include "macros.hpp"
 
 //  Mutex class encapsulates OS mutex in a platform-independent way.
 
@@ -61,9 +62,7 @@ class mutex_t
   private:
     CRITICAL_SECTION _cs;
 
-    //  Disable copy construction and assignment.
-    mutex_t (const mutex_t &);
-    void operator= (const mutex_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (mutex_t)
 };
 }
 
@@ -100,9 +99,7 @@ class mutex_t
   private:
     SEM_ID _semId;
 
-    // Disable copy construction and assignment.
-    mutex_t (const mutex_t &);
-    const mutex_t &operator= (const mutex_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (mutex_t)
 };
 }
 
@@ -164,9 +161,7 @@ class mutex_t
     pthread_mutex_t _mutex;
     pthread_mutexattr_t _attr;
 
-    // Disable copy construction and assignment.
-    mutex_t (const mutex_t &);
-    const mutex_t &operator= (const mutex_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (mutex_t)
 };
 }
 
@@ -184,9 +179,7 @@ struct scoped_lock_t
   private:
     mutex_t &_mutex;
 
-    // Disable copy construction and assignment.
-    scoped_lock_t (const scoped_lock_t &);
-    const scoped_lock_t &operator= (const scoped_lock_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (scoped_lock_t)
 };
 
 
@@ -207,9 +200,7 @@ struct scoped_optional_lock_t
   private:
     mutex_t *_mutex;
 
-    // Disable copy construction and assignment.
-    scoped_optional_lock_t (const scoped_lock_t &);
-    const scoped_optional_lock_t &operator= (const scoped_lock_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (scoped_optional_lock_t)
 };
 }
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -31,8 +31,10 @@
 #define __ZMQ_OBJECT_HPP_INCLUDED__
 
 #include <string>
-#include "stdint.hpp"
+
 #include "endpoint.hpp"
+#include "macros.hpp"
+#include "stdint.hpp"
 
 namespace zmq
 {
@@ -157,8 +159,7 @@ class object_t
 
     void send_command (command_t &cmd_);
 
-    object_t (const object_t &);
-    const object_t &operator= (const object_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (object_t)
 };
 }
 

--- a/src/own.hpp
+++ b/src/own.hpp
@@ -140,8 +140,7 @@ class own_t : public object_t
     //  Number of events we have to get before we can destroy the object.
     int _term_acks;
 
-    own_t (const own_t &);
-    const own_t &operator= (const own_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (own_t)
 };
 }
 

--- a/src/pair.hpp
+++ b/src/pair.hpp
@@ -64,8 +64,7 @@ class pair_t : public socket_base_t
 
     zmq::pipe_t *_last_in;
 
-    pair_t (const pair_t &);
-    const pair_t &operator= (const pair_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (pair_t)
 };
 }
 

--- a/src/pgm_receiver.hpp
+++ b/src/pgm_receiver.hpp
@@ -135,8 +135,7 @@ class pgm_receiver_t : public io_object_t, public i_engine
     //  Poll handle associated with engine PGM waiting pipe.
     handle_t pipe_handle;
 
-    pgm_receiver_t (const pgm_receiver_t &);
-    const pgm_receiver_t &operator= (const pgm_receiver_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (pgm_receiver_t)
 };
 }
 

--- a/src/pgm_sender.hpp
+++ b/src/pgm_sender.hpp
@@ -115,8 +115,7 @@ class pgm_sender_t : public io_object_t, public i_engine
     //  If zero, there are no data to be sent.
     size_t write_size;
 
-    pgm_sender_t (const pgm_sender_t &);
-    const pgm_sender_t &operator= (const pgm_sender_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (pgm_sender_t)
 };
 }
 #endif

--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -59,7 +59,7 @@ int pipepair (zmq::object_t *parents_[2],
 
 struct i_pipe_events
 {
-    virtual ~i_pipe_events () {}
+    virtual ~i_pipe_events () ZMQ_DEFAULT;
 
     virtual void read_activated (zmq::pipe_t *pipe_) = 0;
     virtual void write_activated (zmq::pipe_t *pipe_) = 0;
@@ -256,9 +256,7 @@ class pipe_t : public object_t,
     // The endpoints of this pipe.
     endpoint_uri_pair_t _endpoint_pair;
 
-    //  Disable copying.
-    pipe_t (const pipe_t &);
-    const pipe_t &operator= (const pipe_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (pipe_t)
 };
 
 void send_routing_id (pipe_t *pipe_, const options_t &options_);

--- a/src/poll.hpp
+++ b/src/poll.hpp
@@ -99,8 +99,7 @@ class poll_t : public worker_poller_base_t
     //  If true, there's at least one retired event source.
     bool retired;
 
-    poll_t (const poll_t &);
-    const poll_t &operator= (const poll_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (poll_t)
 };
 
 typedef poll_t poller_t;

--- a/src/poller_base.hpp
+++ b/src/poller_base.hpp
@@ -155,8 +155,7 @@ class poller_base_t
     //  registered.
     atomic_counter_t _load;
 
-    poller_base_t (const poller_base_t &);
-    const poller_base_t &operator= (const poller_base_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (poller_base_t)
 };
 
 //  Base class for a poller with a single worker thread.

--- a/src/polling_util.hpp
+++ b/src/polling_util.hpp
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <vector>
 
+#include "macros.hpp"
 #include "stdint.hpp"
 #include "platform.hpp"
 #include "err.hpp"
@@ -62,11 +63,10 @@ template <typename T, size_t S> class fast_vector_t
     }
 
   private:
-    fast_vector_t (const fast_vector_t &);
-    fast_vector_t &operator= (const fast_vector_t &);
-
     T _static_buf[S];
     T *_buf;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (fast_vector_t)
 };
 
 template <typename T, size_t S> class resizable_fast_vector_t
@@ -96,11 +96,10 @@ template <typename T, size_t S> class resizable_fast_vector_t
     ~resizable_fast_vector_t () { delete _dynamic_buf; }
 
   private:
-    resizable_fast_vector_t (const resizable_fast_vector_t &);
-    resizable_fast_vector_t &operator= (const resizable_fast_vector_t &);
-
     T _static_buf[S];
     std::vector<T> *_dynamic_buf;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (resizable_fast_vector_t)
 };
 
 #if defined ZMQ_POLL_BASED_ON_POLL

--- a/src/pollset.hpp
+++ b/src/pollset.hpp
@@ -105,8 +105,7 @@ class pollset_t : public poller_base_t
     //  Handle of the physical thread doing the I/O work.
     thread_t worker;
 
-    pollset_t (const pollset_t &);
-    const pollset_t &operator= (const pollset_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (pollset_t)
 };
 
 typedef pollset_t poller_t;

--- a/src/pub.hpp
+++ b/src/pub.hpp
@@ -52,9 +52,7 @@ class pub_t : public xpub_t
     int xrecv (zmq::msg_t *msg_);
     bool xhas_in ();
 
-  private:
-    pub_t (const pub_t &);
-    const pub_t &operator= (const pub_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (pub_t)
 };
 }
 

--- a/src/pull.hpp
+++ b/src/pull.hpp
@@ -61,8 +61,7 @@ class pull_t : public socket_base_t
     //  Fair queueing object for inbound pipes.
     fq_t _fq;
 
-    pull_t (const pull_t &);
-    const pull_t &operator= (const pull_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (pull_t)
 };
 }
 

--- a/src/push.hpp
+++ b/src/push.hpp
@@ -61,8 +61,7 @@ class push_t : public socket_base_t
     //  Load balancer managing the outbound pipes.
     lb_t _lb;
 
-    push_t (const push_t &);
-    const push_t &operator= (const push_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (push_t)
 };
 }
 

--- a/src/radio.hpp
+++ b/src/radio.hpp
@@ -79,8 +79,7 @@ class radio_t : public socket_base_t
     //  Drop messages if HWM reached, otherwise return with EAGAIN
     bool _lossy;
 
-    radio_t (const radio_t &);
-    const radio_t &operator= (const radio_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (radio_t)
 };
 
 class radio_session_t : public session_base_t
@@ -107,8 +106,7 @@ class radio_session_t : public session_base_t
 
     msg_t _pending_msg;
 
-    radio_session_t (const radio_session_t &);
-    const radio_session_t &operator= (const radio_session_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (radio_session_t)
 };
 }
 

--- a/src/raw_decoder.hpp
+++ b/src/raw_decoder.hpp
@@ -61,8 +61,7 @@ class raw_decoder_t : public i_decoder
 
     shared_message_memory_allocator _allocator;
 
-    raw_decoder_t (const raw_decoder_t &);
-    void operator= (const raw_decoder_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (raw_decoder_t)
 };
 }
 

--- a/src/raw_encoder.hpp
+++ b/src/raw_encoder.hpp
@@ -49,8 +49,7 @@ class raw_encoder_t : public encoder_base_t<raw_encoder_t>
   private:
     void raw_message_ready ();
 
-    raw_encoder_t (const raw_encoder_t &);
-    const raw_encoder_t &operator= (const raw_encoder_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (raw_encoder_t)
 };
 }
 

--- a/src/raw_engine.hpp
+++ b/src/raw_engine.hpp
@@ -70,8 +70,7 @@ class raw_engine_t : public stream_engine_base_t
   private:
     int push_raw_msg_to_session (msg_t *msg_);
 
-    raw_engine_t (const raw_engine_t &);
-    const raw_engine_t &operator= (const raw_engine_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (raw_engine_t)
 };
 }
 

--- a/src/reaper.hpp
+++ b/src/reaper.hpp
@@ -77,13 +77,12 @@ class reaper_t : public object_t, public i_poll_events
     //  If true, we were already asked to terminate.
     bool _terminating;
 
-    reaper_t (const reaper_t &);
-    const reaper_t &operator= (const reaper_t &);
-
 #ifdef HAVE_FORK
     // the process that created this context. Used to detect forking.
     pid_t _pid;
 #endif
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (reaper_t)
 };
 }
 

--- a/src/rep.hpp
+++ b/src/rep.hpp
@@ -60,8 +60,7 @@ class rep_t : public router_t
     //  of the request is the backtrace stack.
     bool _request_begins;
 
-    rep_t (const rep_t &);
-    const rep_t &operator= (const rep_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (rep_t)
 };
 }
 

--- a/src/req.hpp
+++ b/src/req.hpp
@@ -83,8 +83,7 @@ class req_t : public dealer_t
     //  still pending.
     bool _strict;
 
-    req_t (const req_t &);
-    const req_t &operator= (const req_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (req_t)
 };
 
 class req_session_t : public session_base_t
@@ -109,8 +108,7 @@ class req_session_t : public session_base_t
         body
     } _state;
 
-    req_session_t (const req_session_t &);
-    const req_session_t &operator= (const req_session_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (req_session_t)
 };
 }
 

--- a/src/router.hpp
+++ b/src/router.hpp
@@ -123,8 +123,7 @@ class router_t : public routing_socket_base_t
     // will be terminated.
     bool _handover;
 
-    router_t (const router_t &);
-    const router_t &operator= (const router_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (router_t)
 };
 }
 

--- a/src/scatter.hpp
+++ b/src/scatter.hpp
@@ -61,8 +61,7 @@ class scatter_t : public socket_base_t
     //  Load balancer managing the outbound pipes.
     lb_t _lb;
 
-    scatter_t (const scatter_t &);
-    const scatter_t &operator= (const scatter_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (scatter_t)
 };
 }
 

--- a/src/secure_allocator.hpp
+++ b/src/secure_allocator.hpp
@@ -48,7 +48,8 @@ template <class T> struct secure_allocator_t
 {
     typedef T value_type;
 
-    secure_allocator_t () {}
+    secure_allocator_t () ZMQ_DEFAULT;
+
     template <class U>
     secure_allocator_t (const secure_allocator_t<U> &) ZMQ_NOEXCEPT
     {

--- a/src/select.hpp
+++ b/src/select.hpp
@@ -160,8 +160,7 @@ class select_t : public worker_poller_base_t
     static fd_entries_t::iterator
     find_fd_entry_by_handle (fd_entries_t &fd_entries_, handle_t handle_);
 
-    select_t (const select_t &);
-    const select_t &operator= (const select_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (select_t)
 };
 
 typedef select_t poller_t;

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -81,8 +81,7 @@ class server_t : public socket_base_t
     //  algorithm. This value is the next ID to use (if not used already).
     uint32_t _next_routing_id;
 
-    server_t (const server_t &);
-    const server_t &operator= (const server_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (server_t)
 };
 }
 

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -196,8 +196,7 @@ class session_base_t : public own_t, public io_object_t, public i_pipe_events
     //  in order to maintain the value at the creation time
     char *_wss_hostname;
 
-    session_base_t (const session_base_t &);
-    const session_base_t &operator= (const session_base_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (session_base_t)
 };
 }
 

--- a/src/signaler.hpp
+++ b/src/signaler.hpp
@@ -35,6 +35,7 @@
 #endif
 
 #include "fd.hpp"
+#include "macros.hpp"
 
 namespace zmq
 {
@@ -72,10 +73,6 @@ class signaler_t
     fd_t _w;
     fd_t _r;
 
-    //  Disable copying of signaler_t object.
-    signaler_t (const signaler_t &);
-    const signaler_t &operator= (const signaler_t &);
-
 #ifdef HAVE_FORK
     // the process that created this context. Used to detect forking.
     pid_t pid;
@@ -83,6 +80,8 @@ class signaler_t
     // and forked().
     void close_internal ();
 #endif
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (signaler_t)
 };
 }
 

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -341,8 +341,7 @@ class socket_base_t : public own_t,
     // Mutex to synchronize access to the monitor Pair socket
     mutex_t _monitor_sync;
 
-    socket_base_t (const socket_base_t &);
-    const socket_base_t &operator= (const socket_base_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (socket_base_t)
 };
 
 class routing_socket_base_t : public socket_base_t

--- a/src/socket_poller.hpp
+++ b/src/socket_poller.hpp
@@ -144,8 +144,7 @@ class socket_poller_t
     zmq::fd_t _max_fd;
 #endif
 
-    socket_poller_t (const socket_poller_t &);
-    const socket_poller_t &operator= (const socket_poller_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (socket_poller_t)
 };
 }
 

--- a/src/socks_connecter.hpp
+++ b/src/socks_connecter.hpp
@@ -128,8 +128,7 @@ class socks_connecter_t : public stream_connecter_base_t
 
     int _status;
 
-    socks_connecter_t (const socks_connecter_t &);
-    const socks_connecter_t &operator= (const socks_connecter_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (socks_connecter_t)
 };
 }
 

--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -87,8 +87,7 @@ class stream_t : public routing_socket_base_t
     //  algorithm. This value is the next ID to use (if not used already).
     uint32_t _next_integral_routing_id;
 
-    stream_t (const stream_t &);
-    const stream_t &operator= (const stream_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (stream_t)
 };
 }
 

--- a/src/stream_connecter_base.hpp
+++ b/src/stream_connecter_base.hpp
@@ -117,8 +117,7 @@ class stream_connecter_base_t : public own_t, public io_object_t
     //  Current reconnect ivl, updated for backoff strategy
     int _current_reconnect_ivl;
 
-    stream_connecter_base_t (const stream_connecter_base_t &);
-    const stream_connecter_base_t &operator= (const stream_connecter_base_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (stream_connecter_base_t)
 };
 }
 

--- a/src/stream_engine_base.hpp
+++ b/src/stream_engine_base.hpp
@@ -191,8 +191,7 @@ class stream_engine_base_t : public io_object_t, public i_engine
     // Socket
     zmq::socket_base_t *_socket;
 
-    stream_engine_base_t (const stream_engine_base_t &);
-    const stream_engine_base_t &operator= (const stream_engine_base_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (stream_engine_base_t)
 };
 }
 

--- a/src/stream_listener_base.hpp
+++ b/src/stream_listener_base.hpp
@@ -81,9 +81,7 @@ class stream_listener_base_t : public own_t, public io_object_t
     // String representation of endpoint to bind to
     std::string _endpoint;
 
-  private:
-    stream_listener_base_t (const stream_listener_base_t &);
-    const stream_listener_base_t &operator= (const stream_listener_base_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (stream_listener_base_t)
 };
 }
 

--- a/src/sub.hpp
+++ b/src/sub.hpp
@@ -50,9 +50,7 @@ class sub_t : public xsub_t
     int xsend (zmq::msg_t *msg_);
     bool xhas_out ();
 
-  private:
-    sub_t (const sub_t &);
-    const sub_t &operator= (const sub_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (sub_t)
 };
 }
 

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -296,8 +296,8 @@ bool zmq::tcp_connecter_t::tune_socket (const fd_t fd_)
 {
     const int rc = tune_tcp_socket (fd_)
                    | tune_tcp_keepalives (
-                       fd_, options.tcp_keepalive, options.tcp_keepalive_cnt,
-                       options.tcp_keepalive_idle, options.tcp_keepalive_intvl)
+                     fd_, options.tcp_keepalive, options.tcp_keepalive_cnt,
+                     options.tcp_keepalive_idle, options.tcp_keepalive_intvl)
                    | tune_tcp_maxrt (fd_, options.tcp_maxrt);
     return rc == 0;
 }

--- a/src/tcp_connecter.hpp
+++ b/src/tcp_connecter.hpp
@@ -83,8 +83,7 @@ class tcp_connecter_t : public stream_connecter_base_t
     //  True iff a timer has been started.
     bool _connect_timer_started;
 
-    tcp_connecter_t (const tcp_connecter_t &);
-    const tcp_connecter_t &operator= (const tcp_connecter_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (tcp_connecter_t)
 };
 }
 

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -81,8 +81,8 @@ void zmq::tcp_listener_t::in_event ()
     int rc = tune_tcp_socket (fd);
     rc = rc
          | tune_tcp_keepalives (
-             fd, options.tcp_keepalive, options.tcp_keepalive_cnt,
-             options.tcp_keepalive_idle, options.tcp_keepalive_intvl);
+           fd, options.tcp_keepalive, options.tcp_keepalive_cnt,
+           options.tcp_keepalive_idle, options.tcp_keepalive_intvl);
     rc = rc | tune_tcp_maxrt (fd, options.tcp_maxrt);
     if (rc != 0) {
         _socket->event_accept_failed (

--- a/src/tcp_listener.hpp
+++ b/src/tcp_listener.hpp
@@ -64,8 +64,7 @@ class tcp_listener_t : public stream_listener_base_t
     //  Address to listen on.
     tcp_address_t _address;
 
-    tcp_listener_t (const tcp_listener_t &);
-    const tcp_listener_t &operator= (const tcp_listener_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (tcp_listener_t)
 };
 }
 

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -129,8 +129,7 @@ class thread_t
     int _thread_sched_policy;
     std::set<int> _thread_affinity_cpus;
 
-    thread_t (const thread_t &);
-    const thread_t &operator= (const thread_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (thread_t)
 };
 }
 

--- a/src/timers.hpp
+++ b/src/timers.hpp
@@ -99,10 +99,9 @@ class timers_t
     typedef std::set<int> cancelled_timers_t;
     cancelled_timers_t _cancelled_timers;
 
-    timers_t (const timers_t &);
-    const timers_t &operator= (const timers_t &);
-
     struct match_by_id;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (timers_t)
 };
 }
 

--- a/src/tipc_connecter.hpp
+++ b/src/tipc_connecter.hpp
@@ -66,8 +66,7 @@ class tipc_connecter_t : public stream_connecter_base_t
     //  EAGAIN errno if async connect was launched.
     int open ();
 
-    tipc_connecter_t (const tipc_connecter_t &);
-    const tipc_connecter_t &operator= (const tipc_connecter_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (tipc_connecter_t)
 };
 }
 

--- a/src/tipc_listener.hpp
+++ b/src/tipc_listener.hpp
@@ -67,8 +67,7 @@ class tipc_listener_t : public stream_listener_base_t
     // Address to listen on
     tipc_address_t _address;
 
-    tipc_listener_t (const tipc_listener_t &);
-    const tipc_listener_t &operator= (const tipc_listener_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (tipc_listener_t)
 };
 }
 

--- a/src/trie.hpp
+++ b/src/trie.hpp
@@ -32,6 +32,7 @@
 
 #include <stddef.h>
 
+#include "macros.hpp"
 #include "stdint.hpp"
 
 namespace zmq
@@ -77,8 +78,7 @@ class trie_t
         class trie_t **table;
     } _next;
 
-    trie_t (const trie_t &);
-    const trie_t &operator= (const trie_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (trie_t)
 };
 }
 

--- a/src/v1_decoder.hpp
+++ b/src/v1_decoder.hpp
@@ -55,8 +55,7 @@ class v1_decoder_t : public decoder_base_t<v1_decoder_t>
 
     const int64_t _max_msg_size;
 
-    v1_decoder_t (const v1_decoder_t &);
-    void operator= (const v1_decoder_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (v1_decoder_t)
 };
 }
 

--- a/src/v1_encoder.hpp
+++ b/src/v1_encoder.hpp
@@ -48,8 +48,7 @@ class v1_encoder_t : public encoder_base_t<v1_encoder_t>
 
     unsigned char _tmpbuf[10];
 
-    v1_encoder_t (const v1_encoder_t &);
-    const v1_encoder_t &operator= (const v1_encoder_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (v1_encoder_t)
 };
 }
 

--- a/src/v2_decoder.hpp
+++ b/src/v2_decoder.hpp
@@ -63,8 +63,7 @@ class v2_decoder_t
     const bool _zero_copy;
     const int64_t _max_msg_size;
 
-    v2_decoder_t (const v2_decoder_t &);
-    void operator= (const v2_decoder_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (v2_decoder_t)
 };
 }
 

--- a/src/v2_encoder.hpp
+++ b/src/v2_encoder.hpp
@@ -48,8 +48,7 @@ class v2_encoder_t : public encoder_base_t<v2_encoder_t>
 
     unsigned char _tmp_buf[9];
 
-    v2_encoder_t (const v2_encoder_t &);
-    const v2_encoder_t &operator= (const v2_encoder_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (v2_encoder_t)
 };
 }
 

--- a/src/vmci_address.hpp
+++ b/src/vmci_address.hpp
@@ -61,8 +61,8 @@ class vmci_address_t
     ctx_t *parent;
 
     vmci_address_t ();
-    vmci_address_t (const vmci_address_t &);
-    const vmci_address_t &operator= (const vmci_address_t &);
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (vmci_address_t)
 };
 }
 

--- a/src/vmci_connecter.hpp
+++ b/src/vmci_connecter.hpp
@@ -128,8 +128,7 @@ class vmci_connecter_t : public own_t, public io_object_t
     // Socket
     zmq::socket_base_t *socket;
 
-    vmci_connecter_t (const vmci_connecter_t &);
-    const vmci_connecter_t &operator= (const vmci_connecter_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (vmci_connecter_t)
 };
 }
 

--- a/src/vmci_listener.hpp
+++ b/src/vmci_listener.hpp
@@ -89,8 +89,7 @@ class vmci_listener_t : public own_t, public io_object_t
     // String representation of endpoint to bind to
     std::string endpoint;
 
-    vmci_listener_t (const vmci_listener_t &);
-    const vmci_listener_t &operator= (const vmci_listener_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (vmci_listener_t)
 };
 }
 

--- a/src/ws_connecter.hpp
+++ b/src/ws_connecter.hpp
@@ -88,11 +88,10 @@ class ws_connecter_t : public stream_connecter_base_t
     //  True iff a timer has been started.
     bool _connect_timer_started;
 
-    ws_connecter_t (const ws_connecter_t &);
-    const ws_connecter_t &operator= (const ws_connecter_t &);
-
     bool _wss;
     const char *_hostname;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ws_connecter_t)
 };
 }
 

--- a/src/ws_decoder.hpp
+++ b/src/ws_decoder.hpp
@@ -74,8 +74,7 @@ class ws_decoder_t
     zmq::ws_protocol_t::opcode_t _opcode;
     unsigned char _mask[4];
 
-    ws_decoder_t (const ws_decoder_t &);
-    void operator= (const ws_decoder_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ws_decoder_t)
 };
 }
 

--- a/src/ws_encoder.hpp
+++ b/src/ws_encoder.hpp
@@ -51,8 +51,7 @@ class ws_encoder_t : public encoder_base_t<ws_encoder_t>
     unsigned char _mask[4];
     msg_t _masked_msg;
 
-    ws_encoder_t (const ws_encoder_t &);
-    const ws_encoder_t &operator= (const ws_encoder_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ws_encoder_t)
 };
 }
 

--- a/src/ws_listener.hpp
+++ b/src/ws_listener.hpp
@@ -72,13 +72,12 @@ class ws_listener_t : public stream_listener_base_t
     //  Address to listen on.
     ws_address_t _address;
 
-    ws_listener_t (const ws_listener_t &);
-    const ws_listener_t &operator= (const ws_listener_t &);
-
     bool _wss;
 #if ZMQ_HAVE_WSS
     gnutls_certificate_credentials_t _tls_cred;
 #endif
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ws_listener_t)
 };
 }
 

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -132,8 +132,7 @@ class xpub_t : public socket_base_t
     std::deque<metadata_t *> _pending_metadata;
     std::deque<unsigned char> _pending_flags;
 
-    xpub_t (const xpub_t &);
-    const xpub_t &operator= (const xpub_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (xpub_t)
 };
 }
 

--- a/src/xsub.hpp
+++ b/src/xsub.hpp
@@ -111,8 +111,7 @@ class xsub_t : public socket_base_t
     //  message are treated as user data regardless of the first byte.
     bool _only_first_subscribe;
 
-    xsub_t (const xsub_t &);
-    const xsub_t &operator= (const xsub_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (xsub_t)
 };
 }
 

--- a/src/ypipe.hpp
+++ b/src/ypipe.hpp
@@ -58,10 +58,6 @@ template <typename T, int N> class ypipe_t : public ypipe_base_t<T>
         _c.set (&_queue.back ());
     }
 
-    //  The destructor doesn't have to be virtual. It is made virtual
-    //  just to keep ICC and code checking tools from complaining.
-    inline virtual ~ypipe_t () {}
-
     //  Following function (write) deliberately copies uninitialised data
     //  when used with zmq_msg. Initialising the VSM body for
     //  non-VSM messages won't be good for performance.
@@ -202,9 +198,7 @@ template <typename T, int N> class ypipe_t : public ypipe_base_t<T>
     //  atomic operations.
     atomic_ptr_t<T> _c;
 
-    //  Disable copying of ypipe object.
-    ypipe_t (const ypipe_t &);
-    const ypipe_t &operator= (const ypipe_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ypipe_t)
 };
 }
 

--- a/src/ypipe_base.hpp
+++ b/src/ypipe_base.hpp
@@ -31,6 +31,7 @@
 #ifndef __ZMQ_YPIPE_BASE_HPP_INCLUDED__
 #define __ZMQ_YPIPE_BASE_HPP_INCLUDED__
 
+#include "macros.hpp"
 
 namespace zmq
 {
@@ -41,7 +42,7 @@ namespace zmq
 template <typename T> class ypipe_base_t
 {
   public:
-    virtual ~ypipe_base_t () {}
+    virtual ~ypipe_base_t () ZMQ_DEFAULT;
     virtual void write (const T &value_, bool incomplete_) = 0;
     virtual bool unwrite (T *value_) = 0;
     virtual bool flush () = 0;

--- a/src/ypipe_conflate.hpp
+++ b/src/ypipe_conflate.hpp
@@ -49,10 +49,6 @@ template <typename T> class ypipe_conflate_t : public ypipe_base_t<T>
     //  Initialises the pipe.
     inline ypipe_conflate_t () : reader_awake (false) {}
 
-    //  The destructor doesn't have to be virtual. It is made virtual
-    //  just to keep ICC and code checking tools from complaining.
-    inline virtual ~ypipe_conflate_t () {}
-
     //  Following function (write) deliberately copies uninitialised data
     //  when used with zmq_msg. Initialising the VSM body for
     //  non-VSM messages won't be good for performance.
@@ -110,9 +106,7 @@ template <typename T> class ypipe_conflate_t : public ypipe_base_t<T>
     dbuffer_t<T> dbuffer;
     bool reader_awake;
 
-    //  Disable copying of ypipe object.
-    ypipe_conflate_t (const ypipe_conflate_t &);
-    const ypipe_conflate_t &operator= (const ypipe_conflate_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (ypipe_conflate_t)
 };
 }
 

--- a/src/yqueue.hpp
+++ b/src/yqueue.hpp
@@ -207,9 +207,7 @@ template <typename T, int N> class yqueue_t
     //  us from having to call malloc/free.
     atomic_ptr_t<chunk_t> _spare_chunk;
 
-    //  Disable copying of yqueue.
-    yqueue_t (const yqueue_t &);
-    const yqueue_t &operator= (const yqueue_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (yqueue_t)
 };
 }
 

--- a/src/zmtp_engine.hpp
+++ b/src/zmtp_engine.hpp
@@ -125,8 +125,7 @@ class zmtp_engine_t : public stream_engine_base_t
 
     int _heartbeat_timeout;
 
-    zmtp_engine_t (const zmtp_engine_t &);
-    const zmtp_engine_t &operator= (const zmtp_engine_t &);
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (zmtp_engine_t)
 };
 }
 


### PR DESCRIPTION
This helps to better integrate with other C++11 features relying on detection of copyability/movability and trivial construction/destruction, and enable improved static analysis.