### PR TITLE
mingw: add missing namespace

### DIFF
--- a/RELICENSE/kanonet.md
+++ b/RELICENSE/kanonet.md
@@ -1,0 +1,8 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Christoph Kahl that grants permission to relicense its copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other Open Source Initiative approved license chosen by the current ZeroMQ BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "kanonet", with commit author "Christoph Kahl", are copyright of Christoph Kahl. This document hereby grants the libzmq project team to relicense libzmq, including all past, present and future contributions of the author listed above.
+
+Christoph Kahl  
+2020/01/09

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -382,7 +382,7 @@ static int make_fdpair_tcpip (zmq::fd_t *r_, zmq::fd_t *w_)
         wchar_t mutex_name[MAX_PATH];
 #ifdef __MINGW32__
         _snwprintf (mutex_name, MAX_PATH, L"Global\\zmq-signaler-port-%d",
-                    signaler_port);
+                    zmq::signaler_port);
 #else
         swprintf (mutex_name, MAX_PATH, L"Global\\zmq-signaler-port-%d",
                   zmq::signaler_port);


### PR DESCRIPTION
Hi,
this fixes compiling the lib under msys2-mingw.
Tests need further commits to be able to get compiled.