### PR TITLE
acinclude.m4: add -latomic to PKGCFG_LIBS_PRIVATE

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -691,7 +691,7 @@ int main (int, char **)
             return t;
         }
         ])],
-        [AC_MSG_RESULT(yes) ; libzmq_cv_has_atomic_instrisics="yes" ; $1],
+        [AC_MSG_RESULT(yes) ; libzmq_cv_has_atomic_instrisics="yes" PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -latomic" ; $1],
         [AC_MSG_RESULT(no) ; libzmq_cv_has_atomic_instrisics="no" LIBS=$save_LIBS ; $2])
     fi
 }])


### PR DESCRIPTION
Add -latomic to PKGCFG_LIBS_PRIVATE so applications linking statically
with libzmq (such czmq) will know that they have to link with -latomic
and the following build failure will be avoided:

```
  CCLD     src/czmq_selftest
/home/buildroot/autobuild/run/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/sparc-buildroot-linux-uclibc/7.4.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: /home/buildroot/autobuild/run/instance-3/output-1/host/sparc-buildroot-linux-uclibc/sysroot/usr/lib/libzmq.a(src_libzmq_la-ctx.o): in function `zmq::ctx_t::create_socket(int)':
ctx.cpp:(.text+0x1710): undefined reference to `__atomic_fetch_add_4'

```
Fixes:
 - http://autobuild.buildroot.org/results/4a12f1ede260cd956a0b5ccb4eec6ca8b44cb04f

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>