### PR TITLE
Documentation fix regarding thread-safety of zmq_poll/zmq_poller.txt.

### DIFF
--- a/RELICENSE/std-any-emplace.md
+++ b/RELICENSE/std-any-emplace.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other share-alike OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by the Github user "std-any-emplace"
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+share-alike Open Source Initiative approved license chosen by the current 
+ZeroMQ BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "std-any-emplace", with
+commit author "std-any-emplace", are copyright of the Github user "std-any-emplace".
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+"std-any-emplace"
+2020/01/19

--- a/doc/zmq_poll.txt
+++ b/doc/zmq_poll.txt
@@ -80,6 +80,16 @@ NOTE: The _zmq_poll()_ function may be implemented or emulated using operating
 system interfaces other than _poll()_, and as such may be subject to the limits
 of those interfaces in ways not defined in this documentation.
 
+THREAD SAFETY
+-------------
+The *zmq_pollitem_t* array must only be used by the thread which 
+will/is calling _zmq_poll_.
+
+If a socket is contained in multiple *zmq_pollitem_t* arrays, each owned by a
+different thread, the socket itself needs to be thead-safe (Server, Client, ...).
+Otherwise, behaviour is undefined.
+
+
 RETURN VALUE
 ------------
 Upon successful completion, the _zmq_poll()_ function shall return the number

--- a/doc/zmq_poller.txt
+++ b/doc/zmq_poller.txt
@@ -56,8 +56,11 @@ In addition, _user_data_ may be specified, which is not used by the poller, but
 passed back to the caller when an event was signalled in a call to
 _zmq_poller_wait_ or _zmq_poller_wait_all_. _user_data_ may be NULL. If it is
 not NULL, it must be a valid pointer. Otherwise, behaviour is undefined.
-_zmq_poller_add_ may not be called multiple times for the same socket
-(unless _zmq_poller_remove_ has been called for that socket).
+You must only add a socket to a single poller instance once (unless 
+_zmq_poller_remove_ has been called for that socket before). You may
+add a socket to multiple poller instances, if the socket itself
+is explicitly thread-safe (Server, Client, ...). If the socket is not,
+you may invoke undefined behavior.
 
 _zmq_poller_modify_ modifies the subscribed events for a socket. It is
 legal to specify no events (i.e. 0) to disable events temporarily, and
@@ -182,6 +185,10 @@ THREAD SAFETY
 -------------
 Like most other 0MQ objects, a poller is not thread-safe. All operations must
 be called from the same thread. Otherwise, behaviour is undefined.
+
+In addition to that, if you want to add a socket to multiple existing poller
+instances, the socket itself needs to be thread-safe (Server, Client, ...).
+Otherwise, behaviour is undefined. 
 
 RETURN VALUE
 ------------


### PR DESCRIPTION
See https://github.com/zeromq/libzmq/issues/3778.