### PR TITLE
Problem: sockets can be created after calling zmq_ctx_shutdown

### DIFF
--- a/doc/zmq_ctx_shutdown.txt
+++ b/doc/zmq_ctx_shutdown.txt
@@ -19,7 +19,9 @@ The _zmq_ctx_shutdown()_ function shall shutdown the 0MQ context 'context'.
 Context shutdown will cause any blocking operations currently in progress on 
 sockets open within 'context' to return immediately with an error code of ETERM.
 With the exception of _zmq_close()_, any further operations on sockets open within
-'context' shall fail with an error code of ETERM.
+'context' shall fail with an error code of ETERM. No further sockets can be created
+using _zmq_socket()_ on a context for which _zmq_ctx_shutdown()_ has been called,
+it will return and set errno to ETERM.
 
 This function is optional, client code is still required to call the linkzmq:zmq_ctx_term[3]
 function to free all resources allocated by zeromq.

--- a/doc/zmq_socket.txt
+++ b/doc/zmq_socket.txt
@@ -556,7 +556,7 @@ The provided 'context' is invalid.
 *EMFILE*::
 The limit on the total number of open 0MQ sockets has been reached.
 *ETERM*::
-The context specified was terminated.
+The context specified was shutdown or terminated.
 
 EXAMPLE
 -------


### PR DESCRIPTION
Solution: fix handling of _starting and _terminate flags

Add tests for this situation.

Clarify documentation of zmq_ctx_shutdown and zmq_socket.

Fixes #3792