### PR TITLE
Problem: intermittent timeouts on test_heartbeats

### DIFF
--- a/tests/test_heartbeats.cpp
+++ b/tests/test_heartbeats.cpp
@@ -50,7 +50,7 @@ SETUP_TEARDOWN_TESTCONTEXT
 
 static int get_monitor_event (void *monitor_)
 {
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < 10; i++) {
         //  First frame in message contains event number and value
         zmq_msg_t msg;
         TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&msg));
@@ -417,7 +417,9 @@ void test_setsockopt_heartbeat_ttl_near_zero ()
 
 int main (void)
 {
-    setup_test_environment ();
+    //  The test cases are very long-running. The default timeout of 60 seconds
+    //  is not always enough.
+    setup_test_environment (90);
 
     UNITY_BEGIN ();
 

--- a/tests/testutil.cpp
+++ b/tests/testutil.cpp
@@ -215,7 +215,7 @@ void close_zero_linger (void *socket_)
     TEST_ASSERT_SUCCESS_ERRNO (zmq_close (socket_));
 }
 
-void setup_test_environment ()
+void setup_test_environment (int timeout_seconds_)
 {
 #if defined _WIN32
 #if defined _MSC_VER
@@ -228,10 +228,8 @@ void setup_test_environment ()
     // abort test after 121 seconds
     alarm (121);
 #else
-#if !defined ZMQ_DISABLE_TEST_TIMEOUT
-    // abort test after 60 seconds
-    alarm (60);
-#endif
+    // abort test after timeout_seconds_ seconds
+    alarm (timeout_seconds_);
 #endif
 #endif
 #if defined __MVS__

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -144,7 +144,11 @@ void s_recv_seq (void *socket_, ...);
 //  Sets a zero linger period on a socket and closes it.
 void close_zero_linger (void *socket_);
 
-void setup_test_environment (void);
+//  Setups the test environment. Must be called at the beginning of each test
+//  executable. On POSIX systems, it sets an alarm to the specified number of
+//  seconds, after which the test will be killed. Set to 0 to disable this
+//  timeout.
+void setup_test_environment (int timeout_seconds_ = 60);
 
 //  Provide portable millisecond sleep
 //  http://www.cplusplus.com/forum/unices/60161/


### PR DESCRIPTION
Solution: increase number of retries when reading monitor event