### PR TITLE
Fix intermittent test_monitor and test_security_zap timeouts/deadlocks for now

### DIFF
--- a/tests/test_monitor.cpp
+++ b/tests/test_monitor.cpp
@@ -116,6 +116,12 @@ void test_monitor_basic ()
     if (event != ZMQ_EVENT_DISCONNECTED) {
         TEST_ASSERT_EQUAL_INT (ZMQ_EVENT_MONITOR_STOPPED, event);
     }
+    //  TODO: When not waiting until the monitor stopped, the I/O thread runs
+    //  into some deadlock. This must be fixed, but until it is fixed, we wait
+    //  here in order to have more reliable test execution.
+    while (event != ZMQ_EVENT_MONITOR_STOPPED) {
+        event = get_monitor_event (server_mon, NULL, NULL);
+    }
 
     //  Close down the sockets
     //  TODO why does this use zero_linger?
@@ -254,6 +260,12 @@ void test_monitor_versioned_basic (bind_function_t bind_function_,
     }
     if (event != ZMQ_EVENT_DISCONNECTED) {
         TEST_ASSERT_EQUAL_INT (ZMQ_EVENT_MONITOR_STOPPED, event);
+    }
+    //  TODO: When not waiting until the monitor stopped, the I/O thread runs
+    //  into some deadlock. This must be fixed, but until it is fixed, we wait
+    //  here in order to have more reliable test execution.
+    while (event != ZMQ_EVENT_MONITOR_STOPPED) {
+        event = get_monitor_event_v2 (server_mon, NULL, NULL, NULL);
     }
     free (client_local_address);
     free (client_remote_address);

--- a/tests/testutil_security.cpp
+++ b/tests/testutil_security.cpp
@@ -346,6 +346,7 @@ void shutdown_context_and_server_side (void *zap_thread_,
           zmq_unbind (zap_control_, "inproc://handler-control"));
     }
     test_context_socket_close (zap_control_);
+    zmq_socket_monitor (server_, NULL, 0);
     test_context_socket_close (server_mon_);
     test_context_socket_close (server_);
 


### PR DESCRIPTION
@bluca @somdoron Adding the additional loop in `test_monitor_versioned_basic` seems to fix the intermittent failures. We might add this to the test, but I think that it shouldn't really be required for a user to always wait for ZMQ_EVENT_MONITOR_STOPPED. I can show you tomorrow what happens in the bad case without this addition.