### PR TITLE
support compiling with IBM XL 16.1 w/ clang front end

### DIFF
--- a/RELICENSE/cwsmith.md
+++ b/RELICENSE/cwsmith.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Cameron Smith
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "cwsmith", with
+commit author "Cameron Smith <smithc11@rpi.edu>", are copyright of Cameron Smith.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Cameron Smith
+2020/02/05

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -59,6 +59,8 @@ const char *errno_to_string (int errno_);
 #if defined __clang__
 #if __has_feature(attribute_analyzer_noreturn)
 void zmq_abort (const char *errmsg_) __attribute__ ((analyzer_noreturn));
+#else
+void zmq_abort (const char *errmsg_);
 #endif
 #elif defined __MSCVER__
 __declspec(noreturn) void zmq_abort (const char *errmsg_);


### PR DESCRIPTION
Compiling libzmq 4.3.2 (via spack) with the IBM XL 16.1.1 results in the following errors:

```
  CXX      src/src_libzmq_la-address.lo                                                                         
In file included from src/address.cpp:33:                                                                                                                                                                                       
In file included from ./src/ctx.hpp:38:                                                                                                                                                                                         
In file included from ./src/mailbox.hpp:39:                                                                                                                                                                                     
In file included from ./src/ypipe.hpp:34:                                                                                                                                                                                       
./src/yqueue.hpp:70:9: error: no member named 'zmq_abort' in namespace 'zmq'                                    
        alloc_assert (_begin_chunk);                                                                                                                                                                                            
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                             
./src/err.hpp:177:18: note: expanded from macro 'alloc_assert'                                                                                                                                                                  
            zmq::zmq_abort ("FATAL ERROR: OUT OF MEMORY");                     \                                                                                                                                                
            ~~~~~^                                                                                                                                                                                                              
In file included from src/address.cpp:33:                                                                       
In file included from ./src/ctx.hpp:38:                                                                         
In file included from ./src/mailbox.hpp:39:                                                                     
In file included from ./src/ypipe.hpp:34:                                                                       
./src/yqueue.hpp:118:13: error: no member named 'zmq_abort' in namespace 'zmq'                                  
            alloc_assert (_end_chunk->next);                                                                    
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                     
./src/err.hpp:177:18: note: expanded from macro 'alloc_assert'                                                                                                                                                                  
            zmq::zmq_abort ("FATAL ERROR: OUT OF MEMORY");                     \                                
            ~~~~~^                                                                   
```

This PR resolves the error by defining the `zmq_abort` function for clang based compilers that do not provide the `attribute_analyzer_noreturn` feature.

This was tested on the [RPI AiMOS IBM AC922 system](https://secure.cci.rpi.edu/wiki/index.php?title=DCS_Supercomputer).