### PR TITLE
Fix unused-variable warning in perf/proxy_thr.cpp

### DIFF
--- a/RELICENSE/lstacul.md
+++ b/RELICENSE/lstacul.md
@@ -1,0 +1,14 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Laurent Stacul
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "stac47", with
+commit author "Laurent Stacul <laurent.stacul@gmail.com>", are copyright of
+Laurent Stacul .
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Laurent Stacul
+2020/02/21


### PR DESCRIPTION
The PR fixed the unused-variable warning/error in perf/proxy_thr.cpp:
```
perf/proxy_thr.cpp: In function ‘int main(int, char**)’:
perf/proxy_thr.cpp:335:9: error: unused variable ‘rv’ [-Werror=unused-variable]
  335 |     int rv = zmq_ctx_set (context, ZMQ_IO_THREADS, 4);
      |         ^~
perf/proxy_thr.cpp:403:9: error: unused variable ‘rc’ [-Werror=unused-variable]
  403 |     int rc = zmq_ctx_term (context);
      |         ^~
```