### PR TITLE
Adds QNX as possible to compile on

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ case of a released version.
 | Solaris 10     | x86, amd64, sparc | GCC 8.1.0            | CMake        | 2019/03/18              |         |
 | DragonFly BSD  | amd64             | gcc 8.3              | autotools    | 2018/08/07 git-72854e63 |         |
 | IBM i          | ppc64             | gcc 6.3              | autotools    | 2019/10/02 git-25320a3  |         |
+| QNX 7.0		 | x86_64			 | gcc 5.4.0			| CMake 	   | 4.3.2					 |		   |
 
 
 ### Supported platforms without known active users

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ case of a released version.
 | Solaris 10     | x86, amd64, sparc | GCC 8.1.0            | CMake        | 2019/03/18              |         |
 | DragonFly BSD  | amd64             | gcc 8.3              | autotools    | 2018/08/07 git-72854e63 |         |
 | IBM i          | ppc64             | gcc 6.3              | autotools    | 2019/10/02 git-25320a3  |         |
-| QNX 7.0		 | x86_64			 | gcc 5.4.0			| CMake 	   | 4.3.2					 |		   |
+| QNX 7.0        | x86_64            | gcc 5.4.0            | CMake        | 4.3.2                   |         |
 
 
 ### Supported platforms without known active users

--- a/RELICENSE/mjvk.md
+++ b/RELICENSE/mjvk.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Simon Giesecke that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "mjvk", with
+commit author "Mark Jan van Kampen <markjanvankampen@gmail.com>", are
+copyright of Mark Jan van Kampen.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Mark Jan van Kampen
+2020/02/24

--- a/RELICENSE/mjvk.md
+++ b/RELICENSE/mjvk.md
@@ -1,6 +1,6 @@
 # Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
 
-This is a statement by Simon Giesecke that grants permission to
+This is a statement by Mark Jan van Kampen that grants permission to
 relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
 Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
 approved license chosen by the current ZeroMQ BDFL (Benevolent


### PR DESCRIPTION
Problem: QNX 7.0 is not listed as being possible to compile on

Solution: Add to list with active users