### PR TITLE
ip_resolver_t: Silencing C++-warning -Wnon-virtual-dtor

### DIFF
--- a/RELICENSE/Ricardicus.md
+++ b/RELICENSE/Ricardicus.md
@@ -3,4 +3,4 @@ This is a statement by Rickard Hallerbäck that grants permission to relicense i
 
 A portion of the commits made by the Github handle "Ricardicus", with commit author "Rickard Hallerbäck", are copyright of Sébastien Rombauts. This document hereby grants the libzmq project team to relicense libzmq, including all past, present and future contributions of the author listed above.
 
-Ricardicus 2020/02/28
+Rickard Hallerbäck 2020/02/28

--- a/RELICENSE/Ricardicus.md
+++ b/RELICENSE/Ricardicus.md
@@ -1,6 +1,6 @@
 Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
 This is a statement by Rickard Hallerbäck that grants permission to relicense its copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other Open Source Initiative approved license chosen by the current ZeroMQ BDFL (Benevolent Dictator for Life).
 
-A portion of the commits made by the Github handle "Ricardicus", with commit author "Rickard Hallerbäck", are copyright of Sébastien Rombauts. This document hereby grants the libzmq project team to relicense libzmq, including all past, present and future contributions of the author listed above.
+A portion of the commits made by the Github handle "Ricardicus", with commit author "Rickard Hallerbäck", are copyright of Rickard Hallerbäck. This document hereby grants the libzmq project team to relicense libzmq, including all past, present and future contributions of the author listed above.
 
 Rickard Hallerbäck 2020/02/28

--- a/RELICENSE/Ricardicus.md
+++ b/RELICENSE/Ricardicus.md
@@ -1,0 +1,6 @@
+Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+This is a statement by Rickard Hallerbäck that grants permission to relicense its copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other Open Source Initiative approved license chosen by the current ZeroMQ BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "Ricardicus", with commit author "Rickard Hallerbäck", are copyright of Sébastien Rombauts. This document hereby grants the libzmq project team to relicense libzmq, including all past, present and future contributions of the author listed above.
+
+Ricardicus 2020/02/28

--- a/src/ip_resolver.hpp
+++ b/src/ip_resolver.hpp
@@ -90,6 +90,7 @@ class ip_resolver_t
 {
   public:
     ip_resolver_t (ip_resolver_options_t opts_);
+    virtual ~ip_resolver_t() {};
 
     int resolve (ip_addr_t *ip_addr_, const char *name_);
 

--- a/src/ip_resolver.hpp
+++ b/src/ip_resolver.hpp
@@ -90,7 +90,7 @@ class ip_resolver_t
 {
   public:
     ip_resolver_t (ip_resolver_options_t opts_);
-    virtual ~ip_resolver_t () {};
+    virtual ~ip_resolver_t (){};
 
     int resolve (ip_addr_t *ip_addr_, const char *name_);
 

--- a/src/ip_resolver.hpp
+++ b/src/ip_resolver.hpp
@@ -90,7 +90,7 @@ class ip_resolver_t
 {
   public:
     ip_resolver_t (ip_resolver_options_t opts_);
-    virtual ~ip_resolver_t() {};
+    virtual ~ip_resolver_t () {};
 
     int resolve (ip_addr_t *ip_addr_, const char *name_);
 


### PR DESCRIPTION
I was building libzmq 4.3.2 and I came across this C++ warning: 

>  warning: ‘class zmq::ip_resolver_t’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]

There is a class named **ip_resolver_t** that has virtual functions but
no virtual destructor.  That can cause undefined behavior if someone deletes a derived-class via a base-class pointer

I made a change to silence the warning, and I though maybe
perhaps you would like to have this change.   