### PR TITLE
Problem: building on OS X may failed

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -137,6 +137,17 @@ The simplest way to compile this package is:
   6. Often, you can also type `make uninstall' to remove the installed
      files again.
 
+OS X Builds - Documentation
+===========================
+
+Basic installation on OS X may fail in `Making all in doc' step. This
+error can be resolved by adding environment variable for shell.
+
+export XML_CATALOG_FILES=/usr/local/etc/xml/catalog 
+
+Write comamnd above in shell for instant resolve, or append command into
+shell profile file and reload for permanent resolve.
+
 Compilers and Options
 =====================
 

--- a/RELICENSE/jsyoo5b.md
+++ b/RELICENSE/jsyoo5b.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by JaeSang Yoo
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "JSYoo5B", with
+commit author "JaeSang Yoo <jsyoo5b@gmail.com>", are copyright of JaeSang Yoo.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+JaeSang Yoo  
+2020.02.29


### PR DESCRIPTION
Solution: Add troubleshooting guidelines to resolve

In OS X, generating man pages by asciidoc and xmlto may not work correctly.  
This issues were mentioned in other projects which supports build in OS X.

Following files are captured logs in OS X.
[configure.log](https://github.com/zeromq/libzmq/files/4270188/configure.log)
[make-failed.log](https://github.com/zeromq/libzmq/files/4270189/make-failed.log)

Also checked on Ubuntu 18.04 and archlinux.  They didn't have any similar problem.