### PR TITLE
Add UDP transport to related docs

### DIFF
--- a/doc/zmq_bind.txt
+++ b/doc/zmq_bind.txt
@@ -28,6 +28,7 @@ The 'endpoint' is a string consisting of a 'transport'`://` followed by an
 'inproc':: local in-process (inter-thread) communication transport, see linkzmq:zmq_inproc[7]
 'pgm', 'epgm':: reliable multicast transport using PGM, see linkzmq:zmq_pgm[7]
 'vmci':: virtual machine communications interface (VMCI), see linkzmq:zmq_vmci[7]
+'udp':: unreliable unicast and multicast using UDP, see linkzmq:zmq_udp[7]
 
 Every 0MQ socket type except 'ZMQ_PAIR' supports one-to-many and many-to-one
 semantics. The precise semantics depend on the socket type and are defined in

--- a/doc/zmq_bind.txt
+++ b/doc/zmq_bind.txt
@@ -34,8 +34,9 @@ Every 0MQ socket type except 'ZMQ_PAIR' supports one-to-many and many-to-one
 semantics. The precise semantics depend on the socket type and are defined in
 linkzmq:zmq_socket[3].
 
-The 'ipc', 'tcp' and 'vmci' transports accept wildcard addresses: see linkzmq:zmq_ipc[7],
-linkzmq:zmq_tcp[7] and linkzmq:zmq_vmci[7] for details.
+The 'ipc', 'tcp', 'vmci' and 'udp' transports accept wildcard addresses: see
+linkzmq:zmq_ipc[7], linkzmq:zmq_tcp[7], linkzmq:zmq_vmci[7] and
+linkzmq:zmq_udp[7] for details.
 
 NOTE: the address syntax may be different for _zmq_bind()_ and _zmq_connect()_
 especially for the 'tcp', 'pgm' and 'epgm' transports.

--- a/doc/zmq_connect.txt
+++ b/doc/zmq_connect.txt
@@ -28,6 +28,7 @@ The 'endpoint' is a string consisting of a 'transport'`://` followed by an
 'inproc':: local in-process (inter-thread) communication transport, see linkzmq:zmq_inproc[7]
 'pgm', 'epgm':: reliable multicast transport using PGM, see linkzmq:zmq_pgm[7]
 'vmci':: virtual machine communications interface (VMCI), see linkzmq:zmq_vmci[7]
+'udp':: unreliable unicast and multicast using UDP, see linkzmq:zmq_udp[7]
 
 Every 0MQ socket type except 'ZMQ_PAIR' supports one-to-many and many-to-one
 semantics. The precise semantics depend on the socket type and are defined in

--- a/doc/zmq_unbind.txt
+++ b/doc/zmq_unbind.txt
@@ -28,9 +28,9 @@ The 'endpoint' argument is as described in linkzmq:zmq_bind[3]
 Unbinding wild-card address from a socket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When wild-card `*` 'endpoint' (described in linkzmq:zmq_tcp[7],
-linkzmq:zmq_ipc[7] and linkzmq:zmq_vmci[7]) was used in _zmq_bind()_, the caller should use
-real 'endpoint' obtained from the ZMQ_LAST_ENDPOINT socket option
-to unbind this 'endpoint' from a socket.
+linkzmq:zmq_ipc[7], linkzmq:zmq_udp[7] and linkzmq:zmq_vmci[7]) was used in
+_zmq_bind()_, the caller should use real 'endpoint' obtained from the 
+ZMQ_LAST_ENDPOINT socket option to unbind this 'endpoint' from a socket.
 
 RETURN VALUE
 ------------


### PR DESCRIPTION
Problem: UDP is not mentioned as avaliable transports in zmq_bind() and zmq_connect()

I've found zmq_udp(7) has been added with RADIO-DISH describing commit fee84134e7c1f30578bb8b013e911b7dbde79ea6  
I think this commit missed referencing UDP in zmq_bind(7) and zmq_connect(7)
I think UDP also need to be mentioned in wild-card addressing parts (zmq_bind and zmq_unbind)