### PR TITLE
[WiP] Refactor protocol literals into constants

### DIFF
--- a/src/address.hpp
+++ b/src/address.hpp
@@ -62,9 +62,13 @@ namespace protocol_name
 static const char inproc[] = "inproc";
 static const char tcp[] = "tcp";
 static const char udp[] = "udp";
+#ifdef ZMQ_HAVE_OPENPGM
 static const char pgm[] = "pgm";
 static const char epgm[] = "epgm";
+#endif
+#ifdef ZMQ_HAVE_NORM
 static const char norm[] = "norm";
+#endif
 #ifdef ZMQ_HAVE_WS
 static const char ws[] = "ws";
 #endif

--- a/src/address.hpp
+++ b/src/address.hpp
@@ -62,6 +62,9 @@ namespace protocol_name
 static const char inproc[] = "inproc";
 static const char tcp[] = "tcp";
 static const char udp[] = "udp";
+static const char pgm[] = "pgm";
+static const char epgm[] = "epgm";
+static const char norm[] = "norm";
 #ifdef ZMQ_HAVE_WS
 static const char ws[] = "ws";
 #endif

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -534,10 +534,14 @@ void zmq::session_base_t::reconnect ()
 {
     //  For delayed connect situations, terminate the pipe
     //  and reestablish later on
-    if (_pipe && options.immediate == 1 
+    if (_pipe && options.immediate == 1
+#ifdef ZMQ_HAVE_OPENPGM
         && _addr->protocol != protocol_name::pgm
         && _addr->protocol != protocol_name::epgm
+#endif
+#ifdef ZMQ_HAVE_NORM
         && _addr->protocol != protocol_name::norm
+#endif
         && _addr->protocol != protocol_name::udp) {
         _pipe->hiccup ();
         _pipe->terminate (false);

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -534,8 +534,10 @@ void zmq::session_base_t::reconnect ()
 {
     //  For delayed connect situations, terminate the pipe
     //  and reestablish later on
-    if (_pipe && options.immediate == 1 && _addr->protocol != "pgm"
-        && _addr->protocol != "epgm" && _addr->protocol != "norm"
+    if (_pipe && options.immediate == 1 
+        && _addr->protocol != protocol_name::pgm
+        && _addr->protocol != protocol_name::epgm
+        && _addr->protocol != protocol_name::norm
         && _addr->protocol != protocol_name::udp) {
         _pipe->hiccup ();
         _pipe->terminate (false);
@@ -604,13 +606,13 @@ zmq::session_base_t::start_connecting_entry_t
     start_connecting_entry_t (protocol_name::udp,
                               &zmq::session_base_t::start_connecting_udp),
 #if defined ZMQ_HAVE_OPENPGM
-    start_connecting_entry_t ("pgm",
+    start_connecting_entry_t (protocol_name::pgm,
                               &zmq::session_base_t::start_connecting_pgm),
-    start_connecting_entry_t ("epgm",
+    start_connecting_entry_t (protocol_name::epgm,
                               &zmq::session_base_t::start_connecting_pgm),
 #endif
 #if defined ZMQ_HAVE_NORM
-    start_connecting_entry_t ("norm",
+    start_connecting_entry_t (protocol_name::norm,
                               &zmq::session_base_t::start_connecting_norm),
 #endif
 };
@@ -724,7 +726,7 @@ void zmq::session_base_t::start_connecting_pgm (io_thread_t *io_thread_)
                 || options.type == ZMQ_SUB || options.type == ZMQ_XSUB);
 
     //  For EPGM transport with UDP encapsulation of PGM is used.
-    bool const udp_encapsulation = _addr->protocol == "epgm";
+    bool const udp_encapsulation = _addr->protocol == protocol_name::epgm;
 
     //  At this point we'll create message pipes to the session straight
     //  away. There's no point in delaying it as no concept of 'connect'

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -369,14 +369,14 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_) const
     //  Specifically, multicast protocols can't be combined with
     //  bi-directional messaging patterns (socket types).
 #if defined ZMQ_HAVE_OPENPGM || defined ZMQ_HAVE_NORM
-    if ((false
-#ifdef ZMQ_HAVE_OPENPGM
-         || protocol_ == protocol_name::pgm || protocol_ == protocol_name::epgm
+#if defined ZMQ_HAVE_OPENPGM && defined ZMQ_HAVE_NORM
+    if ((protocol_ == protocol_name::pgm || protocol_ == protocol_name::epgm
+         || protocol_ == protocol_name::norm)
+#elif defined ZMQ_HAVE_OPENPGM
+    if ((protocol_ == protocol_name::pgm || protocol_ == protocol_name::epgm)
+#else // defined ZMQ_HAVE_NORM
+    if (protocol_ == protocol_name::norm
 #endif
-#ifdef ZMQ_HAVE_NORM
-         || protocol_ == protocol_name::norm
-#endif
-         || false)
         && options.type != ZMQ_PUB && options.type != ZMQ_SUB
         && options.type != ZMQ_XPUB && options.type != ZMQ_XSUB) {
         errno = ENOCOMPATPROTO;
@@ -553,14 +553,15 @@ int zmq::socket_base_t::bind (const char *endpoint_uri_)
         return rc;
     }
 
-    if (false
-#ifdef ZMQ_HAVE_OPENPGM
-        || protocol == protocol_name::pgm || protocol == protocol_name::epgm
+#if defined ZMQ_HAVE_OPENPGM || defined ZMQ_HAVE_NORM
+#if defined ZMQ_HAVE_OPENPGM && defined ZMQ_HAVE_NORM
+    if (protocol == protocol_name::pgm || protocol == protocol_name::epgm
+        || protocol == protocol_name::norm) {
+#elif defined ZMQ_HAVE_OPENPGM
+    if (protocol == protocol_name::pgm || protocol == protocol_name::epgm) {
+#else // defined ZMQ_HAVE_NORM
+    if (protocol == protocol_name::norm) {
 #endif
-#ifdef ZMQ_HAVE_NORM
-        || protocol == protocol_name::norm
-#endif
-        || false) {
         //  For convenience's sake, bind can be used interchangeable with
         //  connect for PGM, EPGM, NORM transports.
         rc = connect (endpoint_uri_);
@@ -568,6 +569,7 @@ int zmq::socket_base_t::bind (const char *endpoint_uri_)
             options.connected = true;
         return rc;
     }
+#endif
 
     if (protocol == protocol_name::udp) {
         if (!(options.type == ZMQ_DGRAM || options.type == ZMQ_DISH)) {
@@ -1035,15 +1037,20 @@ int zmq::socket_base_t::connect_internal (const char *endpoint_uri_)
 
     //  PGM does not support subscription forwarding; ask for all data to be
     //  sent to this pipe. (same for NORM, currently?)
-    const bool subscribe_to_all = false
-#ifdef ZMQ_HAVE_OPENPGM
-                                  || protocol == protocol_name::pgm
+#if defined ZMQ_HAVE_OPENPGM && defined ZMQ_HAVE_NORM
+    const bool subscribe_to_all =
+      protocol == protocol_name::pgm || protocol == protocol_name::epgm
+      || protocol == protocol_name::norm || protocol == protocol_name::udp;
+#elif defined ZMQ_HAVE_OPENPGM
+    const bool subscribe_to_all = protocol == protocol_name::pgm
                                   || protocol == protocol_name::epgm
-#endif
-#ifdef ZMQ_HAVE_NORM
-                                  || protocol == protocol_name::norm
-#endif
                                   || protocol == protocol_name::udp;
+#elif defined ZMQ_HAVE_NORM
+    const bool subscribe_to_all =
+      protocol == protocol_name::norm || protocol == protocol_name::udp;
+#else
+    const bool subscribe_to_all = protocol == protocol_name::udp;
+#endif
     pipe_t *newpipe = NULL;
 
     if (options.immediate != 1 || subscribe_to_all) {

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -369,8 +369,14 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_) const
     //  Specifically, multicast protocols can't be combined with
     //  bi-directional messaging patterns (socket types).
 #if defined ZMQ_HAVE_OPENPGM || defined ZMQ_HAVE_NORM
-    if ((protocol_ == protocol_name::pgm || protocol_ == protocol_name::epgm
-         || protocol_ == protocol_name::norm)
+    if ((false
+#ifdef ZMQ_HAVE_OPENPGM
+         || protocol_ == protocol_name::pgm || protocol_ == protocol_name::epgm
+#endif
+#ifdef ZMQ_HAVE_NORM
+         || protocol_ == protocol_name::norm
+#endif
+         || false)
         && options.type != ZMQ_PUB && options.type != ZMQ_SUB
         && options.type != ZMQ_XPUB && options.type != ZMQ_XSUB) {
         errno = ENOCOMPATPROTO;
@@ -547,8 +553,14 @@ int zmq::socket_base_t::bind (const char *endpoint_uri_)
         return rc;
     }
 
-    if (protocol == protocol_name::pgm || protocol == protocol_name::epgm
-        || protocol == protocol_name::norm) {
+    if (false
+#ifdef ZMQ_HAVE_OPENPGM
+        || protocol == protocol_name::pgm || protocol == protocol_name::epgm
+#endif
+#ifdef ZMQ_HAVE_NORM
+        || protocol == protocol_name::norm
+#endif
+        || false) {
         //  For convenience's sake, bind can be used interchangeable with
         //  connect for PGM, EPGM, NORM transports.
         rc = connect (endpoint_uri_);
@@ -1023,9 +1035,14 @@ int zmq::socket_base_t::connect_internal (const char *endpoint_uri_)
 
     //  PGM does not support subscription forwarding; ask for all data to be
     //  sent to this pipe. (same for NORM, currently?)
-    const bool subscribe_to_all = protocol == protocol_name::pgm 
+    const bool subscribe_to_all = false
+#ifdef ZMQ_HAVE_OPENPGM
+                                  || protocol == protocol_name::pgm
                                   || protocol == protocol_name::epgm
+#endif
+#ifdef ZMQ_HAVE_NORM
                                   || protocol == protocol_name::norm
+#endif
                                   || protocol == protocol_name::udp;
     pipe_t *newpipe = NULL;
 

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -347,15 +347,15 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_) const
 #endif
 #if defined ZMQ_HAVE_OPENPGM
         //  pgm/epgm transports only available if 0MQ is compiled with OpenPGM.
-        && protocol_ != "pgm"
-        && protocol_ != "epgm"
+        && protocol_ != protocol_name::pgm
+        && protocol_ != protocol_name::epgm
 #endif
 #if defined ZMQ_HAVE_TIPC
         // TIPC transport is only available on Linux.
         && protocol_ != protocol_name::tipc
 #endif
 #if defined ZMQ_HAVE_NORM
-        && protocol_ != "norm"
+        && protocol_ != protocol_name::norm
 #endif
 #if defined ZMQ_HAVE_VMCI
         && protocol_ != protocol_name::vmci
@@ -369,7 +369,8 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_) const
     //  Specifically, multicast protocols can't be combined with
     //  bi-directional messaging patterns (socket types).
 #if defined ZMQ_HAVE_OPENPGM || defined ZMQ_HAVE_NORM
-    if ((protocol_ == "pgm" || protocol_ == "epgm" || protocol_ == "norm")
+    if ((protocol_ == protocol_name::pgm || protocol_ == protocol_name::epgm
+         || protocol_ == protocol_name::norm)
         && options.type != ZMQ_PUB && options.type != ZMQ_SUB
         && options.type != ZMQ_XPUB && options.type != ZMQ_XSUB) {
         errno = ENOCOMPATPROTO;
@@ -546,7 +547,8 @@ int zmq::socket_base_t::bind (const char *endpoint_uri_)
         return rc;
     }
 
-    if (protocol == "pgm" || protocol == "epgm" || protocol == "norm") {
+    if (protocol == protocol_name::pgm || protocol == protocol_name::epgm
+        || protocol == protocol_name::norm) {
         //  For convenience's sake, bind can be used interchangeable with
         //  connect for PGM, EPGM, NORM transports.
         rc = connect (endpoint_uri_);
@@ -968,7 +970,7 @@ int zmq::socket_base_t::connect_internal (const char *endpoint_uri_)
     // TBD - Should we check address for ZMQ_HAVE_NORM???
 
 #ifdef ZMQ_HAVE_OPENPGM
-    if (protocol == "pgm" || protocol == "epgm") {
+    if (protocol == protocol_name::pgm || protocol == protocol_name::epgm) {
         struct pgm_addrinfo_t *res = NULL;
         uint16_t port_number = 0;
         int rc =
@@ -1021,8 +1023,9 @@ int zmq::socket_base_t::connect_internal (const char *endpoint_uri_)
 
     //  PGM does not support subscription forwarding; ask for all data to be
     //  sent to this pipe. (same for NORM, currently?)
-    const bool subscribe_to_all = protocol == "pgm" || protocol == "epgm"
-                                  || protocol == "norm"
+    const bool subscribe_to_all = protocol == protocol_name::pgm 
+                                  || protocol == protocol_name::epgm
+                                  || protocol == protocol_name::norm
                                   || protocol == protocol_name::udp;
     pipe_t *newpipe = NULL;
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -1477,7 +1477,7 @@ int zmq_has (const char *capability_)
         return true;
 #endif
 #if defined(ZMQ_HAVE_OPENPGM)
-    if (strcmp (capability_, "pgm") == 0)
+    if (strcmp (capability_, zmq::protocol_name::pgm) == 0)
         return true;
 #endif
 #if defined(ZMQ_HAVE_TIPC)
@@ -1485,7 +1485,7 @@ int zmq_has (const char *capability_)
         return true;
 #endif
 #if defined(ZMQ_HAVE_NORM)
-    if (strcmp (capability_, "norm") == 0)
+    if (strcmp (capability_, zmq::protocol_name::norm) == 0)
         return true;
 #endif
 #if defined(ZMQ_HAVE_CURVE)


### PR DESCRIPTION
Protcol string for PGM, EPGM and NORM is still represented in literal strings.

While changing literals into constants, I also applied conditional compile for them.  
Some code blocks didn't covered with conditional compile, and the others is using both PGM and NORM.  
I tried to change those code blocks as simple as possible, but some code blocks seems messy.

I want someone review and comment especially for following code blocks. (I've marked WiP just for review)
[Code block1](https://github.com/JSYoo5B/libzmq/blob/5a933a0/src/socket_base.cpp#L371-L385)
[Code block2](https://github.com/JSYoo5B/libzmq/blob/5a933a0/src/socket_base.cpp#L556-L563)
[Code block3](https://github.com/JSYoo5B/libzmq/blob/5a933a0/src/socket_base.cpp#L1038-L1046)