### PR TITLE
Install CMake config to LIBDIR by default, to correctly support multiarch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1513,8 +1513,9 @@ endif()
 if(WIN32)
   set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "CMake" CACHE STRING "install path for ZeroMQConfig.cmake")
 else()
-  # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
-  set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
+  # CMake search path wants either "share" (AKA GNUInstallDirs DATAROOTDIR)
+  # for arch-independent, or LIBDIR for arch-dependent, plus "cmake" as prefix
+  set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
 endif()
 
 if((NOT CMAKE_VERSION VERSION_LESS 3.0) AND (BUILD_SHARED OR BUILD_STATIC))

--- a/RELICENSE/ferdnyc.md
+++ b/RELICENSE/ferdnyc.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Frank R. Dana Jr.
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "ferdnyc", with
+commit author "FeRD (Frank Dana)", are copyright of Frank R. Dana, Jr.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Frank Richard Dana, Jr.
+2020-03-16


### PR DESCRIPTION
Using `share/cmake/${PROJECT_NAME}` as `DESTINATION` for installing `ZeroMQConfig.cmake` et al works for arch-independent configs (like cppzmq's header-only package), but is wrong for arch-dependent packages when installed on multiarch systems.

The `...Config.cmake` file is the _library interface_ definition, and in arch-dependent multiarch builds is specific to the architecture currently being built. Each build of a library should have its interface installed below the arch-dependent LIBDIR.

This PR sets the default `ZEROMQ_CMAKECONFIG_INSTALL_DIR` to `"${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"`, using the GNUInstallDirs `${CMAKE_INSTALL_LIBDIR}` variable to target the correct arch-dependent dir.

See e.g. Daniel Pfeifer's "Effective CMake" ([PDF of slides from CPPNow 2017](https://github.com/boostcon/cppnow_presentations_2017/blob/master/05-19-2017_friday/effective_cmake__daniel_pfeifer__cppnow_05-19-2017.pdf)), though he doesn't use GNUInstallDirs:
> #### Export your library interface!
> ```cmake
> include(CMakePackageConfigHelpers)
> write_basic_package_version_file("FooConfigVersion.cmake"
>   VERSION ${Foo_VERSION}
>   COMPATIBILITY SameMajorVersion
>   )
> install(FILES "FooConfig.cmake" "FooConfigVersion.cmake"
>   DESTINATION lib/cmake/Foo
>   )
> ```

Or Pablo Arias' "[It's Time To Do CMake Right](https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/)" post, which does:

> ```cmake
> install(EXPORT jsonutils-targets
>   FILE
>     JSONUtilsTargets.cmake
>   NAMESPACE
>     JSONUtils::
>   DESTINATION
>     ${CMAKE_INSTALL_LIBDIR}/cmake/JSONUtils
> )
> ```

Administrative: Relicensing statement included, signoffs in commit messages