### PR TITLE
Fix gitignore tracking file list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,8 @@ src/libzmq.pc
 ## Executable binaries are ignored
 tools/curve_keygen
 ## Executable source files must be tracked
-tools/*.[ch]
-tools/*.[ch]pp
+!tools/*.[ch]
+!tools/*.[ch]pp
 
 # /tests
 ## Test binaries and logs are ignored


### PR DESCRIPTION
Source files in tools/ must be tracked.  
But exception marking was missing.  
It was mistake in commit 2478887.