### PR TITLE
Problem: ZMQ_THREAD_SAFE is not bool

### DIFF
--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -790,7 +790,8 @@ or not the socket is threadsafe. See linkzmq:zmq_socket[3] for which sockets are
 thread-safe.
 
 [horizontal]
-Option value type:: boolean
+Option value type:: int
+Option value unit:: boolean
 Applicable socket types:: all
 
 


### PR DESCRIPTION
Solution: Change documentation value type to int

The tests for this option do use `int` as value type.