### PR TITLE
Problem: boilerplate when init msg from data copy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -450,6 +450,7 @@ test_apps = \
 	tests/test_sub_forward \
 	tests/test_invalid_rep \
 	tests/test_msg_flags \
+	tests/test_msg_ffn \
 	tests/test_msg_init \
 	tests/test_connect_resolve \
 	tests/test_immediate \
@@ -579,6 +580,10 @@ tests_test_invalid_rep_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 tests_test_msg_flags_SOURCES = tests/test_msg_flags.cpp
 tests_test_msg_flags_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
 tests_test_msg_flags_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+
+tests_test_msg_ffn_SOURCES = tests/test_msg_ffn.cpp
+tests_test_msg_ffn_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
+tests_test_msg_ffn_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 
 tests_test_msg_init_SOURCES = tests/test_msg_init.cpp
 tests_test_msg_init_LDADD = ${TESTUTIL_LIBS} src/libzmq.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -450,7 +450,7 @@ test_apps = \
 	tests/test_sub_forward \
 	tests/test_invalid_rep \
 	tests/test_msg_flags \
-	tests/test_msg_ffn \
+	tests/test_msg_init \
 	tests/test_connect_resolve \
 	tests/test_immediate \
 	tests/test_last_endpoint \
@@ -580,9 +580,9 @@ tests_test_msg_flags_SOURCES = tests/test_msg_flags.cpp
 tests_test_msg_flags_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
 tests_test_msg_flags_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 
-tests_test_msg_ffn_SOURCES = tests/test_msg_ffn.cpp
-tests_test_msg_ffn_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
-tests_test_msg_ffn_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+tests_test_msg_init_SOURCES = tests/test_msg_init.cpp
+tests_test_msg_init_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
+tests_test_msg_init_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 
 tests_test_connect_resolve_SOURCES = tests/test_connect_resolve.cpp
 tests_test_connect_resolve_LDADD = ${TESTUTIL_LIBS} src/libzmq.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -451,7 +451,6 @@ test_apps = \
 	tests/test_invalid_rep \
 	tests/test_msg_flags \
 	tests/test_msg_ffn \
-	tests/test_msg_init \
 	tests/test_connect_resolve \
 	tests/test_immediate \
 	tests/test_last_endpoint \
@@ -584,10 +583,6 @@ tests_test_msg_flags_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 tests_test_msg_ffn_SOURCES = tests/test_msg_ffn.cpp
 tests_test_msg_ffn_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
 tests_test_msg_ffn_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
-
-tests_test_msg_init_SOURCES = tests/test_msg_init.cpp
-tests_test_msg_init_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
-tests_test_msg_init_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 
 tests_test_connect_resolve_SOURCES = tests/test_connect_resolve.cpp
 tests_test_connect_resolve_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
@@ -1045,7 +1040,8 @@ test_apps += tests/test_poller \
 	tests/test_xpub_manual_last_value \
 	tests/test_router_notify \
 	tests/test_peer \
-	tests/test_reconnect_options
+	tests/test_reconnect_options \
+	tests/test_msg_init
 
 tests_test_poller_SOURCES = tests/test_poller.cpp
 tests_test_poller_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
@@ -1094,6 +1090,10 @@ tests_test_peer_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 tests_test_reconnect_options_SOURCES = tests/test_reconnect_options.cpp
 tests_test_reconnect_options_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
 tests_test_reconnect_options_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+
+tests_test_msg_init_SOURCES = tests/test_msg_init.cpp
+tests_test_msg_init_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
+tests_test_msg_init_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 endif
 
 if ENABLE_STATIC

--- a/builds/gyp/project-tests.gypi
+++ b/builds/gyp/project-tests.gypi
@@ -122,6 +122,17 @@
       ],
     },
     {
+      'target_name': 'test_msg_ffn',
+      'type': 'executable',
+      'sources': [
+        '../../tests/test_msg_ffn.cpp',
+        '../../tests/testutil.hpp'
+      ],
+      'dependencies': [
+        'libzmq'
+      ],
+    },
+    {
       'target_name': 'test_msg_init',
       'type': 'executable',
       'sources': [

--- a/builds/gyp/project-tests.gypi
+++ b/builds/gyp/project-tests.gypi
@@ -122,10 +122,10 @@
       ],
     },
     {
-      'target_name': 'test_msg_ffn',
+      'target_name': 'test_msg_init',
       'type': 'executable',
       'sources': [
-        '../../tests/test_msg_ffn.cpp',
+        '../../tests/test_msg_init.cpp',
         '../../tests/testutil.hpp'
       ],
       'dependencies': [

--- a/builds/gyp/project-tests.xml
+++ b/builds/gyp/project-tests.xml
@@ -10,6 +10,7 @@
     <test name = "test_sub_forward" />
     <test name = "test_invalid_rep" />
     <test name = "test_msg_flags" />
+    <test name = "test_msg_ffn" />
     <test name = "test_msg_init" />
     <test name = "test_connect_resolve" />
     <test name = "test_immediate" />

--- a/builds/gyp/project-tests.xml
+++ b/builds/gyp/project-tests.xml
@@ -10,7 +10,7 @@
     <test name = "test_sub_forward" />
     <test name = "test_invalid_rep" />
     <test name = "test_msg_flags" />
-    <test name = "test_msg_ffn" />
+    <test name = "test_msg_init" />
     <test name = "test_connect_resolve" />
     <test name = "test_immediate" />
     <test name = "test_last_endpoint" />

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,7 +3,7 @@
 #
 MAN3 = zmq_bind.3 zmq_unbind.3 zmq_connect.3 zmq_connect_peer.3 zmq_disconnect.3 zmq_close.3 \
     zmq_ctx_new.3 zmq_ctx_term.3 zmq_ctx_get.3 zmq_ctx_set.3 zmq_ctx_shutdown.3 \
-    zmq_msg_init.3 zmq_msg_init_data.3 zmq_msg_init_size.3 \
+    zmq_msg_init.3 zmq_msg_init_data.3 zmq_msg_init_size.3 zmq_msg_init_buffer.3 \
     zmq_msg_move.3 zmq_msg_copy.3 zmq_msg_size.3 zmq_msg_data.3 zmq_msg_close.3 \
     zmq_msg_send.3 zmq_msg_recv.3 \
     zmq_msg_routing_id.3 zmq_msg_set_routing_id.3 \

--- a/doc/zmq.txt
+++ b/doc/zmq.txt
@@ -82,6 +82,7 @@ The following functions are provided to work with messages:
 Initialise a message::
     linkzmq:zmq_msg_init[3]
     linkzmq:zmq_msg_init_size[3]
+    linkzmq:zmq_msg_init_buffer[3]
     linkzmq:zmq_msg_init_data[3]
 
 Sending and receiving a message::

--- a/doc/zmq_msg_close.txt
+++ b/doc/zmq_msg_close.txt
@@ -44,6 +44,7 @@ SEE ALSO
 --------
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_init_size[3]
+linkzmq:zmq_msg_init_buffer[3]
 linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_data[3]
 linkzmq:zmq_msg_size[3]

--- a/doc/zmq_msg_copy.txt
+++ b/doc/zmq_msg_copy.txt
@@ -22,8 +22,8 @@ CAUTION: The implementation may choose not to physically copy the message
 content, rather to share the underlying buffer between 'src' and 'dest'. Avoid
 modifying message content after a message has been copied with
 _zmq_msg_copy()_, doing so can result in undefined behaviour. If what you need
-is an actual hard copy, allocate a new message using _zmq_msg_init_size()_ and
-copy the message content using _memcpy()_.
+is an actual hard copy, initialize a new message using _zmq_msg_init_buffer()_
+with the message content.
 
 CAUTION: Never access 'zmq_msg_t' members directly, instead always use the
 _zmq_msg_ family of functions.
@@ -46,8 +46,7 @@ EXAMPLE
 .Copying a message
 ----
 zmq_msg_t msg;
-zmq_msg_init_size (&msg, 255);
-memcpy (zmq_msg_data (&msg, "Hello, World", 12);
+zmq_msg_init_buffer (&msg, "Hello, World", 12);
 zmq_msg_t copy;
 zmq_msg_init (&copy);
 zmq_msg_copy (&copy, &msg);
@@ -61,6 +60,7 @@ SEE ALSO
 linkzmq:zmq_msg_move[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_init_size[3]
+linkzmq:zmq_msg_init_buffer[3]
 linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq[7]

--- a/doc/zmq_msg_data.txt
+++ b/doc/zmq_msg_data.txt
@@ -37,6 +37,7 @@ SEE ALSO
 linkzmq:zmq_msg_size[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_init_size[3]
+linkzmq:zmq_msg_init_buffer[3]
 linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq[7]

--- a/doc/zmq_msg_init.txt
+++ b/doc/zmq_msg_init.txt
@@ -21,9 +21,9 @@ before receiving a message with _zmq_msg_recv()_.
 CAUTION: Never access 'zmq_msg_t' members directly, instead always use the
 _zmq_msg_ family of functions.
 
-CAUTION: The functions _zmq_msg_init()_, _zmq_msg_init_data()_ and
-_zmq_msg_init_size()_ are mutually exclusive. Never initialise the same
-'zmq_msg_t' twice.
+CAUTION: The functions _zmq_msg_init()_, _zmq_msg_init_data()_,
+_zmq_msg_init_size()_ and _zmq_msg_init_buffer()_ are mutually exclusive.
+Never initialise the same 'zmq_msg_t' twice.
 
 
 RETURN VALUE
@@ -51,6 +51,7 @@ assert (nbytes != -1);
 SEE ALSO
 --------
 linkzmq:zmq_msg_init_size[3]
+linkzmq:zmq_msg_init_buffer[3]
 linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq_msg_data[3]

--- a/doc/zmq_msg_init_buffer.txt
+++ b/doc/zmq_msg_init_buffer.txt
@@ -1,38 +1,38 @@
-zmq_msg_init_size(3)
-====================
+zmq_msg_init_buffer(3)
+======================
 
 
 NAME
 ----
-zmq_msg_init_size - initialise 0MQ message of a specified size
+zmq_msg_init_buffer - initialise 0MQ message with buffer copy
 
 
 SYNOPSIS
 --------
-*int zmq_msg_init_size (zmq_msg_t '*msg', size_t 'size');*
+*int zmq_msg_init_buffer (zmq_msg_t '*msg', const void '*buf', size_t 'size');*
 
 
 DESCRIPTION
 -----------
-The _zmq_msg_init_size()_ function shall allocate any resources required to
+The _zmq_msg_init_buffer()_ function shall allocate any resources required to
 store a message 'size' bytes long and initialise the message object referenced
-by 'msg' to represent the newly allocated message.
+by 'msg' to represent a copy of the buffer referenced by the 'buf' and
+'size' arguments.
 
 The implementation shall choose whether to store message content on the stack
-(small messages) or on the heap (large messages). For performance reasons
-_zmq_msg_init_size()_ shall not clear the message data.
+(small messages) or on the heap (large messages).
 
 CAUTION: Never access 'zmq_msg_t' members directly, instead always use the
 _zmq_msg_ family of functions.
 
 CAUTION: The functions _zmq_msg_init()_, _zmq_msg_init_data()_,
-_zmq_msg_init_size()_ and _zmq_msg_init_buffer()_ are mutually exclusive.
+_zmq_msg_init_buffer()_ and _zmq_msg_init_buffer()_ are mutually exclusive.
 Never initialise the same 'zmq_msg_t' twice.
 
 
 RETURN VALUE
 ------------
-The _zmq_msg_init_size()_ function shall return zero if successful. Otherwise
+The _zmq_msg_init_buffer()_ function shall return zero if successful. Otherwise
 it shall return `-1` and set 'errno' to one of the values defined below.
 
 
@@ -45,7 +45,7 @@ Insufficient storage space is available.
 SEE ALSO
 --------
 linkzmq:zmq_msg_init_data[3]
-linkzmq:zmq_msg_init_buffer[3]
+linkzmq:zmq_msg_init_size[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq_msg_data[3]

--- a/doc/zmq_msg_init_data.txt
+++ b/doc/zmq_msg_init_data.txt
@@ -35,9 +35,9 @@ CAUTION: If the deallocation function is not provided, the allocated memory
 will not be freed, and this may cause a memory leak.
 
 
-CAUTION: The functions _zmq_msg_init()_, _zmq_msg_init_data()_ and
-_zmq_msg_init_size()_ are mutually exclusive. Never initialise the same
-'zmq_msg_t' twice.
+CAUTION: The functions _zmq_msg_init()_, _zmq_msg_init_data()_,
+_zmq_msg_init_size()_ and _zmq_msg_init_buffer()_ are mutually exclusive.
+Never initialise the same 'zmq_msg_t' twice.
 
 
 RETURN VALUE
@@ -76,6 +76,7 @@ assert (rc == 0);
 SEE ALSO
 --------
 linkzmq:zmq_msg_init_size[3]
+linkzmq:zmq_msg_init_buffer[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq_msg_data[3]

--- a/doc/zmq_msg_move.txt
+++ b/doc/zmq_msg_move.txt
@@ -41,6 +41,7 @@ SEE ALSO
 linkzmq:zmq_msg_copy[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_init_size[3]
+linkzmq:zmq_msg_init_buffer[3]
 linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq[7]

--- a/doc/zmq_msg_size.txt
+++ b/doc/zmq_msg_size.txt
@@ -37,6 +37,7 @@ SEE ALSO
 linkzmq:zmq_msg_data[3]
 linkzmq:zmq_msg_init[3]
 linkzmq:zmq_msg_init_size[3]
+linkzmq:zmq_msg_init_buffer[3]
 linkzmq:zmq_msg_init_data[3]
 linkzmq:zmq_msg_close[3]
 linkzmq:zmq[7]

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -267,6 +267,7 @@ typedef void(zmq_free_fn) (void *data_, void *hint_);
 
 ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg_);
 ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_);
+ZMQ_EXPORT int zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
 ZMQ_EXPORT int zmq_msg_init_data (
   zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
 ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_);

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -705,9 +705,8 @@ ZMQ_EXPORT int zmq_msg_set_routing_id (zmq_msg_t *msg, uint32_t routing_id);
 ZMQ_EXPORT uint32_t zmq_msg_routing_id (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_set_group (zmq_msg_t *msg, const char *group);
 ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_init_buffer (zmq_msg_t *msg_,
-                                    const void *buf_,
-                                    size_t size_);
+ZMQ_EXPORT int
+zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
 
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -267,7 +267,6 @@ typedef void(zmq_free_fn) (void *data_, void *hint_);
 
 ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg_);
 ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_);
-ZMQ_EXPORT int zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
 ZMQ_EXPORT int zmq_msg_init_data (
   zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
 ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_);
@@ -706,6 +705,9 @@ ZMQ_EXPORT int zmq_msg_set_routing_id (zmq_msg_t *msg, uint32_t routing_id);
 ZMQ_EXPORT uint32_t zmq_msg_routing_id (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_set_group (zmq_msg_t *msg, const char *group);
 ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_init_buffer (zmq_msg_t *msg_,
+                                    const void *buf_,
+                                    size_t size_);
 
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -120,6 +120,20 @@ int zmq::msg_t::init_size (size_t size_)
     return 0;
 }
 
+int zmq::msg_t::init_buffer (const void *buf_, size_t size_)
+{
+    int rc = init_size (size_);
+    if (unlikely (rc < 0)) {
+        return -1;
+    }
+    if (size_) {
+        // NULL data and 0 size is allowed
+        assert (NULL != buf_);
+        memcpy(data (), buf_, size_);
+    }
+    return 0;
+}
+
 int zmq::msg_t::init_external_storage (content_t *content_,
                                        void *data_,
                                        size_t size_,

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -129,7 +129,7 @@ int zmq::msg_t::init_buffer (const void *buf_, size_t size_)
     if (size_) {
         // NULL and zero size is allowed
         assert (NULL != buf_);
-        memcpy(data (), buf_, size_);
+        memcpy (data (), buf_, size_);
     }
     return 0;
 }

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -122,12 +122,12 @@ int zmq::msg_t::init_size (size_t size_)
 
 int zmq::msg_t::init_buffer (const void *buf_, size_t size_)
 {
-    int rc = init_size (size_);
+    const int rc = init_size (size_);
     if (unlikely (rc < 0)) {
         return -1;
     }
     if (size_) {
-        // NULL data and 0 size is allowed
+        // NULL and zero size is allowed
         assert (NULL != buf_);
         memcpy(data (), buf_, size_);
     }

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -103,6 +103,7 @@ class msg_t
               content_t *content_ = NULL);
 
     int init_size (size_t size_);
+    int init_buffer (const void *buf_, size_t size_);
     int init_data (void *data_, size_t size_, msg_free_fn *ffn_, void *hint_);
     int init_external_storage (content_t *content_,
                                void *data_,

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -405,15 +405,11 @@ int zmq_send (void *s_, const void *buf_, size_t len_, int flags_)
     if (!s)
         return -1;
     zmq_msg_t msg;
-    if (zmq_msg_init_size (&msg, len_))
+    int rc = zmq_msg_init_buffer (&msg, buf_, len_);
+    if (unlikely (rc < 0))
         return -1;
 
-    //  We explicitly allow a send from NULL, size zero
-    if (len_) {
-        assert (buf_);
-        memcpy (zmq_msg_data (&msg), buf_, len_);
-    }
-    const int rc = s_sendmsg (s, &msg, flags_);
+    rc = s_sendmsg (s, &msg, flags_);
     if (unlikely (rc < 0)) {
         const int err = errno;
         const int rc2 = zmq_msg_close (&msg);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -623,6 +623,11 @@ int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_)
     return (reinterpret_cast<zmq::msg_t *> (msg_))->init_size (size_);
 }
 
+int zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_)
+{
+    return (reinterpret_cast<zmq::msg_t *> (msg_))->init_buffer (buf_, size_);
+}
+
 int zmq_msg_init_data (
   zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_)
 {

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -91,6 +91,9 @@ int zmq_msg_set_routing_id (zmq_msg_t *msg_, uint32_t routing_id_);
 uint32_t zmq_msg_routing_id (zmq_msg_t *msg_);
 int zmq_msg_set_group (zmq_msg_t *msg_, const char *group_);
 const char *zmq_msg_group (zmq_msg_t *msg_);
+int zmq_msg_init_buffer (zmq_msg_t *msg_,
+                         const void *buf_,
+                         size_t size_);
 
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -91,9 +91,7 @@ int zmq_msg_set_routing_id (zmq_msg_t *msg_, uint32_t routing_id_);
 uint32_t zmq_msg_routing_id (zmq_msg_t *msg_);
 int zmq_msg_set_group (zmq_msg_t *msg_, const char *group_);
 const char *zmq_msg_group (zmq_msg_t *msg_);
-int zmq_msg_init_buffer (zmq_msg_t *msg_,
-                         const void *buf_,
-                         size_t size_);
+int zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
 
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ set(tests
   test_sub_forward
   test_invalid_rep
   test_msg_flags
-  test_msg_ffn
+  test_msg_init
   test_connect_resolve
   test_immediate
   test_last_endpoint

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,6 @@ set(tests
   test_invalid_rep
   test_msg_flags
   test_msg_ffn
-  test_msg_init
   test_connect_resolve
   test_immediate
   test_last_endpoint
@@ -165,6 +164,7 @@ if(ENABLE_DRAFTS)
     test_xpub_manual_last_value
     test_peer
     test_reconnect_options
+    test_msg_init
   )
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(tests
   test_sub_forward
   test_invalid_rep
   test_msg_flags
+  test_msg_ffn
   test_msg_init
   test_connect_resolve
   test_immediate

--- a/tests/test_msg_ffn.cpp
+++ b/tests/test_msg_ffn.cpp
@@ -1,0 +1,126 @@
+/*
+    Copyright (c) 2007-2017 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+
+#include <string.h>
+
+SETUP_TEARDOWN_TESTCONTEXT
+
+void ffn (void *data_, void *hint_)
+{
+    // Signal that ffn has been called by writing "freed" to hint
+    (void) data_; //  Suppress 'unused' warnings at compile time
+    memcpy (hint_, (void *) "freed", 5);
+}
+
+void test_msg_init_ffn ()
+{
+    //  Create the infrastructure
+    char my_endpoint[MAX_SOCKET_STRING];
+
+    void *router = test_context_socket (ZMQ_ROUTER);
+    bind_loopback_ipv4 (router, my_endpoint, sizeof my_endpoint);
+
+    void *dealer = test_context_socket (ZMQ_DEALER);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (dealer, my_endpoint));
+
+    // Test that creating and closing a message triggers ffn
+    zmq_msg_t msg;
+    char hint[5];
+    char data[255];
+    memset (data, 0, 255);
+    memcpy (data, (void *) "data", 4);
+    memcpy (hint, (void *) "hint", 4);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    msleep (SETTLE_TIME);
+    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
+    memcpy (hint, (void *) "hint", 4);
+
+    // Making and closing a copy triggers ffn
+    zmq_msg_t msg2;
+    zmq_msg_init (&msg2);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&msg2, &msg));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    msleep (SETTLE_TIME);
+    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
+    memcpy (hint, (void *) "hint", 4);
+
+    // Test that sending a message triggers ffn
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+
+    zmq_msg_send (&msg, dealer, 0);
+    char buf[255];
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_recv (router, buf, 255, 0));
+    TEST_ASSERT_EQUAL_INT (255, zmq_recv (router, buf, 255, 0));
+    TEST_ASSERT_EQUAL_STRING_LEN (data, buf, 4);
+
+    msleep (SETTLE_TIME);
+    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
+    memcpy (hint, (void *) "hint", 4);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    // Sending a copy of a message triggers ffn
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&msg2));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&msg2, &msg));
+
+    zmq_msg_send (&msg, dealer, 0);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_recv (router, buf, 255, 0));
+    TEST_ASSERT_EQUAL_INT (255, zmq_recv (router, buf, 255, 0));
+    TEST_ASSERT_EQUAL_STRING_LEN (data, buf, 4);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    msleep (SETTLE_TIME);
+    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
+
+    //  Deallocate the infrastructure.
+    test_context_socket_close (router);
+    test_context_socket_close (dealer);
+}
+
+int main (void)
+{
+    setup_test_environment ();
+
+    UNITY_BEGIN ();
+    RUN_TEST (test_msg_init_ffn);
+    return UNITY_END ();
+}

--- a/tests/test_msg_init.cpp
+++ b/tests/test_msg_init.cpp
@@ -46,16 +46,14 @@ void test_msg_init_size ()
 {
     const char *data = "foobar";
     zmq_msg_t msg;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_size (&msg, 6));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init_size (&msg, 6));
     TEST_ASSERT_EQUAL_INT (6, zmq_msg_size (&msg));
-    memcpy(zmq_msg_data (&msg), data, 6);
+    memcpy (zmq_msg_data (&msg), data, 6);
     TEST_ASSERT_EQUAL_STRING_LEN (data, zmq_msg_data (&msg), 6);
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
 
     zmq_msg_t msg2;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_size (&msg2, 0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init_size (&msg2, 0));
     TEST_ASSERT_EQUAL_INT (0, zmq_msg_size (&msg2));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
 }
@@ -64,16 +62,14 @@ void test_msg_init_buffer ()
 {
     const char *data = "foobar";
     zmq_msg_t msg;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_buffer (&msg, data, 6));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init_buffer (&msg, data, 6));
     TEST_ASSERT_EQUAL_INT (6, zmq_msg_size (&msg));
     TEST_ASSERT (data != zmq_msg_data (&msg));
     TEST_ASSERT_EQUAL_STRING_LEN (data, zmq_msg_data (&msg), 6);
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
 
     zmq_msg_t msg2;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_buffer (&msg2, NULL, 0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init_buffer (&msg2, NULL, 0));
     TEST_ASSERT_EQUAL_INT (0, zmq_msg_size (&msg2));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
 }

--- a/tests/test_msg_init.cpp
+++ b/tests/test_msg_init.cpp
@@ -41,7 +41,7 @@ void ffn (void *data_, void *hint_)
     memcpy (hint_, (void *) "freed", 5);
 }
 
-void test_msg_ffn ()
+void test_msg_init_ffn ()
 {
     //  Create the infrastructure
     char my_endpoint[MAX_SOCKET_STRING];
@@ -116,11 +116,30 @@ void test_msg_ffn ()
     test_context_socket_close (dealer);
 }
 
+void test_msg_init_buffer ()
+{
+    const char *data = "foobar";
+    zmq_msg_t msg;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_buffer (&msg, data, 6));
+    TEST_ASSERT_EQUAL_INT (6, zmq_msg_size (&msg));
+    TEST_ASSERT (data != zmq_msg_data (&msg));
+    TEST_ASSERT_EQUAL_STRING_LEN (data, zmq_msg_data (&msg), 6);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    zmq_msg_t msg2;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_buffer (&msg2, NULL, 0));
+    TEST_ASSERT_EQUAL_INT (0, zmq_msg_size (&msg2));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
+}
+
 int main (void)
 {
     setup_test_environment ();
 
     UNITY_BEGIN ();
-    RUN_TEST (test_msg_ffn);
+    RUN_TEST (test_msg_init_ffn);
+    RUN_TEST (test_msg_init_buffer);
     return UNITY_END ();
 }

--- a/tests/test_msg_init.cpp
+++ b/tests/test_msg_init.cpp
@@ -34,88 +34,6 @@
 
 SETUP_TEARDOWN_TESTCONTEXT
 
-void ffn (void *data_, void *hint_)
-{
-    // Signal that ffn has been called by writing "freed" to hint
-    (void) data_; //  Suppress 'unused' warnings at compile time
-    memcpy (hint_, (void *) "freed", 5);
-}
-
-void test_msg_init_ffn ()
-{
-    //  Create the infrastructure
-    char my_endpoint[MAX_SOCKET_STRING];
-
-    void *router = test_context_socket (ZMQ_ROUTER);
-    bind_loopback_ipv4 (router, my_endpoint, sizeof my_endpoint);
-
-    void *dealer = test_context_socket (ZMQ_DEALER);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (dealer, my_endpoint));
-
-    // Test that creating and closing a message triggers ffn
-    zmq_msg_t msg;
-    char hint[5];
-    char data[255];
-    memset (data, 0, 255);
-    memcpy (data, (void *) "data", 4);
-    memcpy (hint, (void *) "hint", 4);
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
-
-    msleep (SETTLE_TIME);
-    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
-    memcpy (hint, (void *) "hint", 4);
-
-    // Making and closing a copy triggers ffn
-    zmq_msg_t msg2;
-    zmq_msg_init (&msg2);
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&msg2, &msg));
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
-
-    msleep (SETTLE_TIME);
-    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
-    memcpy (hint, (void *) "hint", 4);
-
-    // Test that sending a message triggers ffn
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
-
-    zmq_msg_send (&msg, dealer, 0);
-    char buf[255];
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_recv (router, buf, 255, 0));
-    TEST_ASSERT_EQUAL_INT (255, zmq_recv (router, buf, 255, 0));
-    TEST_ASSERT_EQUAL_STRING_LEN (data, buf, 4);
-
-    msleep (SETTLE_TIME);
-    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
-    memcpy (hint, (void *) "hint", 4);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
-
-    // Sending a copy of a message triggers ffn
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&msg2));
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&msg2, &msg));
-
-    zmq_msg_send (&msg, dealer, 0);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_recv (router, buf, 255, 0));
-    TEST_ASSERT_EQUAL_INT (255, zmq_recv (router, buf, 255, 0));
-    TEST_ASSERT_EQUAL_STRING_LEN (data, buf, 4);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
-
-    msleep (SETTLE_TIME);
-    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
-
-    //  Deallocate the infrastructure.
-    test_context_socket_close (router);
-    test_context_socket_close (dealer);
-}
-
 void test_msg_init_buffer ()
 {
     const char *data = "foobar";
@@ -139,7 +57,6 @@ int main (void)
     setup_test_environment ();
 
     UNITY_BEGIN ();
-    RUN_TEST (test_msg_init_ffn);
     RUN_TEST (test_msg_init_buffer);
     return UNITY_END ();
 }

--- a/tests/test_msg_init.cpp
+++ b/tests/test_msg_init.cpp
@@ -34,6 +34,32 @@
 
 SETUP_TEARDOWN_TESTCONTEXT
 
+void test_msg_init ()
+{
+    zmq_msg_t msg;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&msg));
+    TEST_ASSERT_EQUAL_INT (0, zmq_msg_size (&msg));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+}
+
+void test_msg_init_size ()
+{
+    const char *data = "foobar";
+    zmq_msg_t msg;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_size (&msg, 6));
+    TEST_ASSERT_EQUAL_INT (6, zmq_msg_size (&msg));
+    memcpy(zmq_msg_data (&msg), data, 6);
+    TEST_ASSERT_EQUAL_STRING_LEN (data, zmq_msg_data (&msg), 6);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    zmq_msg_t msg2;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_size (&msg2, 0));
+    TEST_ASSERT_EQUAL_INT (0, zmq_msg_size (&msg2));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
+}
+
 void test_msg_init_buffer ()
 {
     const char *data = "foobar";
@@ -57,6 +83,8 @@ int main (void)
     setup_test_environment ();
 
     UNITY_BEGIN ();
+    RUN_TEST (test_msg_init);
+    RUN_TEST (test_msg_init_size);
     RUN_TEST (test_msg_init_buffer);
     return UNITY_END ();
 }


### PR DESCRIPTION
Solution: Add zmq_msg_init_buffer to construct
a message by copying memory from buffer.

See issue https://github.com/zeromq/libzmq/issues/3858