### PR TITLE
Problem: Spinning on atomics can cause hangs

### DIFF
--- a/unittests/unittest_poller.cpp
+++ b/unittests/unittest_poller.cpp
@@ -103,6 +103,7 @@ void wait_in_events (test_events_t &events_)
 {
     void *watch = zmq_stopwatch_start ();
     while (events_.in_events.get () < 1) {
+        msleep (1);
 #ifdef ZMQ_BUILD_DRAFT
         TEST_ASSERT_LESS_OR_EQUAL_MESSAGE (SETTLE_TIME,
                                            zmq_stopwatch_intermediate (watch),
@@ -116,6 +117,7 @@ void wait_timer_events (test_events_t &events_)
 {
     void *watch = zmq_stopwatch_start ();
     while (events_.timer_events.get () < 1) {
+        msleep (1);
 #ifdef ZMQ_BUILD_DRAFT
         TEST_ASSERT_LESS_OR_EQUAL_MESSAGE (SETTLE_TIME,
                                            zmq_stopwatch_intermediate (watch),


### PR DESCRIPTION
Solution: Add a sleep in the loop. Some versions of
valgrind may hang when spinning on atomic variables.

See e.g. https://bugs.kde.org/show_bug.cgi?id=336435
This may be a solution to https://github.com/zeromq/libzmq/issues/3873