### PR TITLE
Problem: out-of-bounds array access in socket_poller::check_events.

### DIFF
--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -455,9 +455,9 @@ int zmq::socket_poller_t::check_events (zmq::socket_poller_t::event_t *events_,
         }
         //  Else, the poll item is a raw file descriptor, simply convert
         //  the events to zmq_pollitem_t-style format.
-        else {
+        else if (it->events) {
 #if defined ZMQ_POLL_BASED_ON_POLL
-
+            zmq_assert (it->pollfd_index >= 0);
             const short revents = _pollfds[it->pollfd_index].revents;
             short events = 0;
 


### PR DESCRIPTION
I noticed that an application of mine behaved weirdly when using `-fsanitize=address`, and I traced the problem to an out-of-bounds array index in ZeroMQ.

As far as I can tell, the logic error is that:

- For fd items, the [loop in rebuild()](https://github.com/zeromq/libzmq/blob/d882e807dd3125e8edece749de04ee403b30d2ab/src/socket_poller.cpp#L321) that sets the `pollfd_index` field only sets it for items that have nonzero event mask.

- But the [loop in check_events()](https://github.com/zeromq/libzmq/blob/d882e807dd3125e8edece749de04ee403b30d2ab/src/socket_poller.cpp#L461) accesses the `pollfd_index` field of *all* fd items, even the ones that do *not* have a nonzero event mask!

- For those items, their `pollfd_index` still has the value that it was initialized with in [add_fd](https://github.com/zeromq/libzmq/blob/d882e807dd3125e8edece749de04ee403b30d2ab/src/socket_poller.cpp#L169), which is -1.

- As a result, for these items, `check_events` tries to access the -1th element in `_pollfds`, but there's no element there because `_pollfds` just points to a `malloc`-allocated block.

On my machine, without the fix, the `zmq_assert` I added in the commit is triggered by the following test program:

    #define ZMQ_BUILD_DRAFT_API
    #include <cassert>
    #include <unistd.h>
    #include <chrono>
    #include <zmq.h>
    #include <fcntl.h>

    int main()
    {
        void * context = zmq_ctx_new ();
        void * router = zmq_socket (context, ZMQ_ROUTER);
        void * poller = zmq_poller_new();

        zmq_poller_add(poller, router, nullptr, ZMQ_POLLIN);

        int fd = open("/dev/null", O_RDONLY);
        assert(fd != -1);
        zmq_poller_add_fd(poller, fd, nullptr, 0);

        zmq_poller_event_t events[20]{};
        zmq_poller_wait_all(poller, events, 20, 1000);

        zmq_poller_destroy(&poller);
    }
