### PR TITLE
Problem: MSVC always reports __cplusplus macro value as 199711L. Some…

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -725,7 +725,7 @@ void zmq::ctx_t::unregister_endpoints (const socket_base_t *const socket_)
                                end = _endpoints.end ();
          it != end;) {
         if (it->second.socket == socket_)
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined _MSC_VER && _MSC_VER >= 1700)
             it = _endpoints.erase (it);
 #else
             _endpoints.erase (it++);

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -47,7 +47,7 @@
 #include <sys/ucred.h>
 #endif
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined _MSC_VER && _MSC_VER >= 1700)
 #include <type_traits>
 #endif
 

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -126,7 +126,7 @@ void zmq::radio_t::xpipe_terminated (pipe_t *pipe_)
                                    end = _subscriptions.end ();
          it != end;) {
         if (it->second == pipe_) {
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined _MSC_VER && _MSC_VER >= 1700)
             it = _subscriptions.erase (it);
 #else
             _subscriptions.erase (it++);


### PR DESCRIPTION
… newer features are switched off even with latest Visual studio version.

Solution: Add check for MSVC version along with __cplusplus check.

See [MSVC now correctly reports __cplusplus](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/).
`__cplusplus` has the correct value only since Visual Studio 2017 version 15.7 Preview 3 **and** with compiler switch `/Zc:__cplusplus` added.
These features work with VS 2012 also so `_MSC_VER` value check is added.



