### PR TITLE
Problem: release script for OBS build fails often

### DIFF
--- a/ci_deploy.sh
+++ b/ci_deploy.sh
@@ -16,16 +16,11 @@ if [[ $BUILD_TYPE == "default" && $CURVE == "libsodium" && -z $DRAFT ]]; then
     sha1sum *.zip *.tar.gz > SHA1SUMS
     cd -
 
-    # Trigger source run on new tag on OBS.
-    # We have to keep a release branch on the lastest tag, as it is
-    # not possible to edit files on OBS with secure tokens, and it is not
-    # possible to dynamically fetch the latest git tag either.
-    if [ -n "${GH_TOKEN}" -a -n "${OBS_STABLE_TOKEN}" -a -n "${OBS_DRAFT_TOKEN}" ]; then
-        TAG_SHA=$(curl -s -H "Authorization: token ${GH_TOKEN}" -X GET https://api.github.com/repos/zeromq/libzmq/git/refs/tags/${TRAVIS_TAG} | grep -o -P '(?<=sha":\s).*(?=,)')
-        curl -H "Authorization: token ${GH_TOKEN}" -X DELETE https://api.github.com/repos/zeromq/libzmq/git/refs/heads/latest_release
-        curl -H "Authorization: token ${GH_TOKEN}" -X POST --data "{\"ref\":\"refs/heads/latest_release\",\"sha\":${TAG_SHA}}" https://api.github.com/repos/zeromq/libzmq/git/refs
-        sleep 2 # try to avoid races if Github is slow
+    # Trigger source run on new tag on OBS. The latest tag will be fetched.
+    if [ -n "${OBS_STABLE_TOKEN}" ]; then
         curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+    fi
+    if [ -n "${OBS_DRAFT_TOKEN}" ]; then
         curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
     fi
 else

--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -2,6 +2,7 @@
   <service name="tar_scm">
     <param name="url">https://github.com/zeromq/libzmq</param>
     <param name="scm">git</param>
+    <param name="revision">@PARENT_TAG@</param>
     <param name="versionformat">@PARENT_TAG@+git%cd</param>
     <param name="versionrewrite-pattern">v(.*)</param>
     <param name="versionrewrite-replacement">\1</param>


### PR DESCRIPTION
Solution: now that tar_scm supports @PARENT_TAG@ as a revision to
automatically fetch the most recent tag on the default branch, use
it to simplify everything

https://github.com/openSUSE/obs-service-tar_scm/pull/359