### PR TITLE
Initialize some CMake variables as empty before build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ include(ZMQSupportMacros)
 
 find_package(PkgConfig)
 
+# Set lists to empty beforehand as to not accidentally take values from parent
+set(sources)
+set(cxx-sources)
+set(html-docs)
+set(target_outputs)
+
 option(ENABLE_ASAN "Build with address sanitizer" OFF)
 if(ENABLE_ASAN)
   message(STATUS "Instrumenting with Address Sanitizer")

--- a/RELICENSE/serg06.md
+++ b/RELICENSE/serg06.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by serg06 (serg06)
+that grants permission to relicense his copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "serg06", with commit author
+"serg06 <serkhas@hotmail.com>" are copyright of serg06.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+serg06
+2020/05/25


### PR DESCRIPTION
This prevents a bug where:
- Parent has a `sources` variable
- Parent does `add_subdirectory("libzmq")`
- LibZMQ does `list(APPEND sources ...)` and proceeds to use that list even though it has some of the parent's value inside of it