### PR TITLE
Add semicolon to ZMQ_NON_COPYABLE_NOR_MOVABLE macro

### DIFF
--- a/RELICENSE/javabudd.md
+++ b/RELICENSE/javabudd.md
@@ -1,0 +1,17 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Andres O'Brien (javabudd)
+that grants permission to relicense his copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "javabudd", with
+commit author "Andres O'Brien <javabudd@gmail.com>" or
+"Andres O'Brien <oban0601@gmail.com>", are copyright of Andres O'Brien.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed
+above.
+
+Andres O'Brien
+2020/06/05

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -60,6 +60,6 @@
   private:                                                                     \
     classname (const classname &);                                             \
     classname &operator= (const classname &);                                  \
-		enum {};
+  enum {};
 #endif
 #endif

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -53,11 +53,13 @@
     classname (const classname &) = delete;                                    \
     classname &operator= (const classname &) = delete;                         \
     classname (classname &&) = delete;                                         \
-    classname &operator= (classname &&) = delete;
+    classname &operator= (classname &&) = delete;                              \
+  enum {};
 #else
 #define ZMQ_NON_COPYABLE_NOR_MOVABLE(classname)                                \
   private:                                                                     \
     classname (const classname &);                                             \
-    classname &operator= (const classname &);
+    classname &operator= (const classname &);                                  \
+		enum {};
 #endif
 #endif

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -54,12 +54,12 @@
     classname &operator= (const classname &) = delete;                         \
     classname (classname &&) = delete;                                         \
     classname &operator= (classname &&) = delete;                              \
-  enum {};
+  static_assert(true, "require a semicolon at the end of the function");
 #else
 #define ZMQ_NON_COPYABLE_NOR_MOVABLE(classname)                                \
   private:                                                                     \
     classname (const classname &);                                             \
     classname &operator= (const classname &);                                  \
-  enum {};
+  static_assert(true, "require a semicolon at the end of the function");
 #endif
 #endif

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -54,12 +54,12 @@
     classname &operator= (const classname &) = delete;                         \
     classname (classname &&) = delete;                                         \
     classname &operator= (classname &&) = delete;                              \
-  static_assert(true, "require a semicolon at the end of the function");
+  int static_assert(true, "require a semicolon at the end of the function");
 #else
 #define ZMQ_NON_COPYABLE_NOR_MOVABLE(classname)                                \
   private:                                                                     \
     classname (const classname &);                                             \
     classname &operator= (const classname &);                                  \
-  static_assert(true, "require a semicolon at the end of the function");
+  int static_assert(true, "require a semicolon at the end of the function");
 #endif
 #endif

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -54,12 +54,12 @@
     classname &operator= (const classname &) = delete;                         \
     classname (classname &&) = delete;                                         \
     classname &operator= (classname &&) = delete;                              \
-  int static_assert(true, "require a semicolon at the end of the function");
+  static_assert(true, "require a semicolon at the end of the function");
 #else
 #define ZMQ_NON_COPYABLE_NOR_MOVABLE(classname)                                \
   private:                                                                     \
     classname (const classname &);                                             \
     classname &operator= (const classname &);                                  \
-  int static_assert(true, "require a semicolon at the end of the function");
+  static_assert(true, "require a semicolon at the end of the function");
 #endif
 #endif


### PR DESCRIPTION
Adds a missing semicolon that breaks building on windows/msys2 