### PR TITLE
resolve FPE when ZMQ_RECONNECT_IVL == 0

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -587,7 +587,7 @@ void zmq::session_base_t::reconnect ()
     reset ();
 
     //  Reconnect.
-    if (options.reconnect_ivl != -1)
+    if (options.reconnect_ivl > 0)
         start_connecting (true);
     else {
         std::string *ep = new (std::string);

--- a/src/stream_connecter_base.cpp
+++ b/src/stream_connecter_base.cpp
@@ -101,7 +101,7 @@ void zmq::stream_connecter_base_t::process_term (int linger_)
 
 void zmq::stream_connecter_base_t::add_reconnect_timer ()
 {
-    if (options.reconnect_ivl != -1) {
+    if (options.reconnect_ivl > 0) {
         const int interval = get_new_reconnect_ivl ();
         add_timer (interval, reconnect_timer_id);
         _socket->event_connect_retried (

--- a/src/vmci_connecter.cpp
+++ b/src/vmci_connecter.cpp
@@ -179,7 +179,7 @@ void zmq::vmci_connecter_t::start_connecting ()
 
 void zmq::vmci_connecter_t::add_reconnect_timer ()
 {
-    if (options.reconnect_ivl != -1) {
+    if (options.reconnect_ivl > 0) {
         int rc_ivl = get_new_reconnect_ivl ();
         add_timer (rc_ivl, reconnect_timer_id);
         socket->event_connect_retried (


### PR DESCRIPTION
If ZMQ_RECONNECT_IVL is set to 0, any reconnection attempt will crash with a FPE:

```
[btorpey@bt-brix test]$ file core.17653
core.17653: ELF 64-bit LSB core file x86-64, version 1 (SYSV), SVR4-style, from './listenTest -quiet', real uid: 8177, effective uid: 8177, real gid: 8177, effective gid: 8177, execfn: './listenTest', platform: 'x86_64'
[btorpey@bt-brix test]$ gdb listenTest core.17653
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-115.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
/home/btorpey/.gdbinit:5: Error in sourced command file:
Target 'None' cannot support this command.
Reading symbols from /home/btorpey/work/transact/master/src/common/Middleware/MamaAdapter/test/listenTest...done.
[New LWP 17657]
[New LWP 17653]
[New LWP 17662]
[New LWP 17656]
[New LWP 17663]
[New LWP 17655]
[New LWP 17661]
[New LWP 17654]
[New LWP 17659]
[New LWP 17658]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Missing separate debuginfo for /home/btorpey/install/OpenMAMA/master/dev/lib/libapr-1.so.0
Try: yum --enablerepo='*debug*' install /usr/lib/debug/.build-id/e0/561681c00ff51eb54853885a0349ed43768e11.debug
Core was generated by `./listenTest -quiet'.
Program terminated with signal 8, Arithmetic exception.
#0  0x00007f11835c4495 in zmq::stream_connecter_base_t::get_new_reconnect_ivl (this=0x7f11740430e0) at /home/btorpey/work/libzmq/master/src/src/stream_connecter_base.cpp:120
120	    const int random_jitter = generate_random () % options.reconnect_ivl;
Reading in symbols for /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/c/transport.c...done.
Reading in symbols for /home/btorpey/work/OpenMAMA-zmq/master/src/src/transport.c...done.
Breakpoint 1 at 0x7f118381e460: transport.c:670. (2 locations)
Registering libstdc++-v6 pretty-printer for /lib64/libstdc++.so.6 ...
Missing separate debuginfos, use: debuginfo-install glibc-2.17-292.el7.x86_64 libevent-2.0.21-4.el7.x86_64 libgcc-4.8.5-39.el7.x86_64 libstdc++-4.8.5-39.el7.x86_64 libuuid-2.23.2-63.el7.x86_64 libxml2-2.9.1-6.el7.4.x86_64 nss-softokn-freebl-3.44.0-5.el7.x86_64 xz-libs-5.2.2-1.el7.x86_64 zlib-1.2.7-18.el7.x86_64
(gdb) bt
Reading in symbols for /home/btorpey/work/libzmq/master/src/src/object.cpp...done.
Reading in symbols for /home/btorpey/work/libzmq/master/src/src/io_thread.cpp...done.
Reading in symbols for /home/btorpey/work/libzmq/master/src/src/epoll.cpp...done.
Reading in symbols for /home/btorpey/work/libzmq/master/src/src/poller_base.cpp...done.
Reading in symbols for /home/btorpey/work/libzmq/master/src/src/thread.cpp...done.
#0  0x00007f11835c4495 in zmq::stream_connecter_base_t::get_new_reconnect_ivl (this=0x7f11740430e0) at /home/btorpey/work/libzmq/master/src/src/stream_connecter_base.cpp:120
#1  0x00007f11835c43de in zmq::stream_connecter_base_t::add_reconnect_timer (this=0x7f11740430e0) at /home/btorpey/work/libzmq/master/src/src/stream_connecter_base.cpp:105
#2  0x00007f11835c430b in zmq::stream_connecter_base_t::process_plug (this=0x7f11740430e0) at /home/btorpey/work/libzmq/master/src/src/stream_connecter_base.cpp:80
#3  0x00007f118356bf27 in zmq::object_t::process_command (this=0x7f11740430e0, cmd_=...) at /home/btorpey/work/libzmq/master/src/src/object.cpp:87
#4  0x00007f118355e990 in zmq::io_thread_t::in_event (this=0x242ca50) at /home/btorpey/work/libzmq/master/src/src/io_thread.cpp:91
#5  0x00007f118355c7bf in zmq::epoll_t::loop (this=0x242cf90) at /home/btorpey/work/libzmq/master/src/src/epoll.cpp:206
#6  0x00007f1183579dd3 in zmq::worker_poller_base_t::worker_routine (arg_=0x242cf90) at /home/btorpey/work/libzmq/master/src/src/poller_base.cpp:146
#7  0x00007f118359f320 in thread_routine (arg_=0x242cfe8) at /home/btorpey/work/libzmq/master/src/src/thread.cpp:250
#8  0x00007f1185b09e65 in start_thread () from /lib64/libpthread.so.0
#9  0x00007f1184efc88d in clone () from /lib64/libc.so.6
(gdb)
```

This patch treats ZMQ_RECONNECT_IVL == 0 the same as ZMQ_RECONNECT_IVL == -1.
