### PR TITLE
Problems: OBS build on sid fails, test_req_relaxed occasionally fails

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-zeromq (4.3.3) UNRELEASED; urgency=low
+zeromq (4.3.3-0.1) UNRELEASED; urgency=low
 
   * Initial packaging.
 

--- a/packaging/debian/zeromq.dsc.obs
+++ b/packaging/debian/zeromq.dsc.obs
@@ -2,7 +2,7 @@ Format: 3.0 (quilt)
 Source: zeromq
 Binary: libzmq5, libzmq3-dev, libzmq5-dbg
 Architecture: any
-Version: 4.3.3
+Version: 4.3.3-0.1
 Maintainer: libzmq Developers <zeromq-dev@lists.zeromq.org>
 Homepage: http://www.zeromq.org/
 Standards-Version: 3.9.8


### PR DESCRIPTION
Solution: change the version format to non-native as a hack, to match
OBS' debstransform usage of 1.0 format