### PR TITLE
Problem: test_req_relaxed occasionally fails

### DIFF
--- a/tests/test_req_relaxed.cpp
+++ b/tests/test_req_relaxed.cpp
@@ -28,8 +28,6 @@
 */
 
 #include "testutil.hpp"
-
-#include "testutil.hpp"
 #include "testutil_unity.hpp"
 
 #include <unity.h>
@@ -63,11 +61,12 @@ void setUp ()
           zmq_setsockopt (rep[peer], ZMQ_RCVTIMEO, &timeout, sizeof (int)));
 
         TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (rep[peer], my_endpoint));
+
+        //  These tests require strict ordering, so wait for the connections to
+        //  happen before opening the next, so that messages flow in the
+        //  expected direction
+        msleep (SETTLE_TIME);
     }
-    //  We have to give the connects time to finish otherwise the requests
-    //  will not properly round-robin. We could alternatively connect the
-    //  REQ sockets to the REP sockets.
-    msleep (SETTLE_TIME);
 }
 
 void tearDown ()


### PR DESCRIPTION
Solution: instead of relying on timing to get the order
of connected rep sockets just right, wait for each connection