### PR TITLE
Fix zmq_poller.txt

### DIFF
--- a/doc/zmq_poller.txt
+++ b/doc/zmq_poller.txt
@@ -12,32 +12,32 @@ SYNOPSIS
 
 *void *zmq_poller_new (void);*
 
-*int zmq_poller_destroy (void ****'poller_p');*
+*int zmq_poller_destroy (void '*poller_p');*
 
-*int zmq_poller_size (void *'poller');*
+*int zmq_poller_size (void '*poller');*
 
-*int zmq_poller_add (void *'poller', void *'socket', void *'user_data', short 'events');*
+*int zmq_poller_add (void '*poller', void '*socket', void '*user_data', short 'events');*
 
-*int zmq_poller_modify (void *'poller', void *'socket', short 'events');*
+*int zmq_poller_modify (void '*poller', void '*socket', short 'events');*
 
-*int zmq_poller_remove (void *'poller', void *'socket');*
+*int zmq_poller_remove (void '*poller', void '*socket');*
 
-*int zmq_poller_add_fd (void *'poller', int 'fd', void *'user_data', short 'events');*
+*int zmq_poller_add_fd (void '*poller', int 'fd', void '*user_data', short 'events');*
 
-*int zmq_poller_modify_fd (void *'poller', int 'fd', short 'events');*
+*int zmq_poller_modify_fd (void '*poller', int 'fd', short 'events');*
 
-*int zmq_poller_remove_fd (void *'poller', int 'fd');*
+*int zmq_poller_remove_fd (void '*poller', int 'fd');*
 
-*int zmq_poller_wait (void *'poller',
-                          zmq_poller_event_t *'event',
+*int zmq_poller_wait (void '*poller',
+                          zmq_poller_event_t '*event',
                           long 'timeout');*
 
-*int zmq_poller_wait_all (void *'poller',
-                          zmq_poller_event_t *'events',
+*int zmq_poller_wait_all (void '*poller',
+                          zmq_poller_event_t '*events',
                           int 'n_events',
                           long 'timeout');*
 
-*int zmq_poller_fd (void *'poller', zmq_fd_t *'fd');*
+*int zmq_poller_fd (void '*poller', zmq_fd_t '*fd');*
 
 DESCRIPTION
 -----------
@@ -295,10 +295,10 @@ zmq_poller_add (poller, socket, NULL, ZMQ_POLLIN);
 /* Second item refers to standard socket 'fd' */
 zmq_poller_add_fd (poller, fd, NULL, ZMQ_POLLIN);
 /* Poll for events indefinitely */
-int rc = zmq_poller_wait_all (items, events, 2, -1);
+int rc = zmq_poller_wait_all (poller, events, 2, -1);
 assert (rc >= 0);
 /* Returned events will be stored in 'events' */
-zmq_poller_destroy (&poller);
+zmq_poller_destroy (poller);
 ----
 
 


### PR DESCRIPTION
Fixed three things:
1. Moved asterisks by variable names into the single quotes (to match [zmq_poll](https://github.com/zeromq/libzmq/edit/master/doc/zmq_init.txt) and other pages.)
2. Fixed variable name in example.
3. Fixed extra & in example.