### PR TITLE
Problem: test_security_zap occasionally segfaults

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -308,7 +308,8 @@ void zmq::session_base_t::read_activated (pipe_t *pipe_)
     }
 
     if (unlikely (_engine == NULL)) {
-        _pipe->check_read ();
+        if (_pipe)
+            _pipe->check_read ();
         return;
     }
 


### PR DESCRIPTION
Solution: check if a session's _pipe has been allocated before using
it, since as a consequence of creating the pipes after the handshake
it's no longer guaranteed to be there.

Fixes #3971