### PR TITLE
implementation of ZMTP_STRICT

### DIFF
--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -435,7 +435,7 @@ Applicable socket types:: all, when using TCP or IPC transports
 
 
 ZMQ_ZMTP_STRICT: Require versioned ZMTP protocol
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_ZMTP_STRICT' option shall retrieve the current setting for the socket.
 
 If set, the handshake will fail if the peer socket's ZMTP version is unspecified.
@@ -446,7 +446,8 @@ NOTE: in DRAFT state, not yet available in stable releases.
 Option value type:: int
 Option value unit:: boolean
 Default value:: 0 (false)
-Applicable socket types:: all but ZMQ_STREAM
+Applicable socket types:: all, only for connection-oriented transports
+(except ZMQ_STREAM)
 
 ZMQ_MULTICAST_HOPS: Maximum network hops for multicast packets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -434,6 +434,20 @@ Default value:: ZMQ_NULL
 Applicable socket types:: all, when using TCP or IPC transports
 
 
+ZMQ_ZMTP_STRICT: Require versioned ZMTP protocol
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The 'ZMQ_ZMTP_STRICT' option shall retrieve the current setting for the socket.
+
+If set, the handshake will fail if the peer socket's ZMTP version is unspecified.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: boolean
+Default value:: 0 (false)
+Applicable socket types:: all but ZMQ_STREAM
+
 ZMQ_MULTICAST_HOPS: Maximum network hops for multicast packets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The option shall retrieve time-to-live used for outbound multicast packets.

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -514,7 +514,7 @@ Applicable socket types:: all
 
 
 ZMQ_ZMTP_STRICT: Require versioned ZMTP protocol
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If set, the handshake will fail if the peer socket's ZMTP version is unspecified.
 
 NOTE: in DRAFT state, not yet available in stable releases.
@@ -523,7 +523,8 @@ NOTE: in DRAFT state, not yet available in stable releases.
 Option value type:: int
 Option value unit:: boolean
 Default value:: 0 (false)
-Applicable socket types:: all but ZMQ_STREAM
+Applicable socket types:: all, only for connection-oriented transports
+(except ZMQ_STREAM)
 
 ZMQ_MULTICAST_HOPS: Maximum network hops for multicast packets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -513,6 +513,18 @@ Default value:: not set
 Applicable socket types:: all
 
 
+ZMQ_ZMTP_STRICT: Require versioned ZMTP protocol
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If set, the handshake will fail if the peer socket's ZMTP version is unspecified.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: boolean
+Default value:: 0 (false)
+Applicable socket types:: all but ZMQ_STREAM
+
 ZMQ_MULTICAST_HOPS: Maximum network hops for multicast packets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sets the time-to-live field in every multicast packet sent from this socket.

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -681,6 +681,7 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_RECONNECT_STOP 109
 #define ZMQ_HELLO_MSG 110
 #define ZMQ_DISCONNECT_MSG 111
+#define ZMQ_ZMTP_STRICT 112
 
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -249,6 +249,7 @@ zmq::options_t::options_t () :
     zero_copy (true),
     router_notify (0),
     monitor_event_version (1),
+    zmtp_strict(0),
     wss_trust_system (false),
     hello_msg (),
     can_send_hello_msg (false),
@@ -783,6 +784,14 @@ int zmq::options_t::setsockopt (int option_,
                                                       &multicast_loop);
 
 #ifdef ZMQ_BUILD_DRAFT_API
+
+        case ZMQ_ZMTP_STRICT:
+            if ((is_int) && ((value == 0) || (value == 1))) {
+                zmtp_strict = value;
+                return 0;
+            }
+            break;
+
         case ZMQ_IN_BATCH_SIZE:
             if (is_int && value > 0) {
                 in_batch_size = value;
@@ -1246,6 +1255,14 @@ int zmq::options_t::getsockopt (int option_,
             break;
 
 #ifdef ZMQ_BUILD_DRAFT_API
+
+        case ZMQ_ZMTP_STRICT:
+            if (is_int) {
+                *value = zmtp_strict;
+                return 0;
+            }
+            break;
+
         case ZMQ_ROUTER_NOTIFY:
             if (is_int) {
                 *value = router_notify;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -291,7 +291,7 @@ struct options_t
     // Version of monitor events to emit
     int monitor_event_version;
 
-    // minimum supported version of ZMTP
+    // if set, reject connections to unversioned zmtp
     int zmtp_strict;
 
     //  WSS Keys

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -291,6 +291,9 @@ struct options_t
     // Version of monitor events to emit
     int monitor_event_version;
 
+    // minimum supported version of ZMTP
+    int zmtp_strict;
+
     //  WSS Keys
     std::string wss_key_pem;
     std::string wss_cert_pem;

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -68,6 +68,7 @@
 #define ZMQ_RECONNECT_STOP 109
 #define ZMQ_HELLO_MSG 110
 #define ZMQ_DISCONNECT_MSG 111
+#define ZMQ_ZMTP_STRICT 112
 
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1

--- a/src/zmtp_engine.cpp
+++ b/src/zmtp_engine.cpp
@@ -251,6 +251,12 @@ zmq::zmtp_engine_t::handshake_fun_t zmq::zmtp_engine_t::select_handshake_fun (
 
 bool zmq::zmtp_engine_t::handshake_v1_0_unversioned ()
 {
+    if (_options.zmtp_strict == 1) {
+        // reject unversioned connections if ZMQ_ZMTP_STRICT specified
+        error (protocol_error);
+        return false;
+    }
+
     //  We send and receive rest of routing id message
     if (session ()->zap_enabled ()) {
         // reject ZMTP 1.0 connections if ZAP is enabled

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,6 +160,7 @@ if(ENABLE_DRAFTS)
     test_channel
     test_hello_msg
     test_disconnect_msg
+    test_zmtp_strict
   )
 endif()
 

--- a/tests/test_zmtp_strict.cpp
+++ b/tests/test_zmtp_strict.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2017 Contributors as noted in the AUTHORS file
+    Copyright (c) 2020 Contributors as noted in the AUTHORS file
 
     This file is part of libzmq, the ZeroMQ core engine in C++.
 
@@ -27,14 +27,13 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <assert.h>
+#include <memory.h>
 
 #include "testutil.hpp"
 #include "testutil_unity.hpp"
 #include "testutil_monitoring.hpp"
 
 #include <unity.h>
-
-#include <memory.h>
 
 // test connecting to unversioned zmtp w/o strict succeeds
 void connect_success_versioned ()

--- a/tests/test_zmtp_strict.cpp
+++ b/tests/test_zmtp_strict.cpp
@@ -1,0 +1,139 @@
+/*
+    Copyright (c) 2017 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <assert.h>
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+#include "testutil_monitoring.hpp"
+
+#include <unity.h>
+
+// test connecting to unversioned zmtp w/o strict succeeds
+void connect_success ()
+{
+    char bind_address[MAX_SOCKET_STRING];
+    size_t addr_length = sizeof (bind_address);
+    void *dummy = test_context_socket (ZMQ_STREAM);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (dummy, "tcp://127.0.0.1:0"));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_getsockopt (dummy, ZMQ_LAST_ENDPOINT, bind_address, &addr_length));
+
+    // setup sub socket
+    void *sub = test_context_socket (ZMQ_SUB);
+    //  Monitor all events on sub
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_socket_monitor (sub, "inproc://monitor-sub", ZMQ_EVENT_ALL));
+    //  Create socket for collecting monitor events
+    void *sub_mon = test_context_socket (ZMQ_PAIR);
+    //  Connect so they'll get events
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub_mon, "inproc://monitor-sub"));
+    // connect to dummy stream socket above
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub, bind_address));
+
+#if 1
+    expect_monitor_event (sub_mon, ZMQ_EVENT_CONNECT_DELAYED);
+    expect_monitor_event (sub_mon, ZMQ_EVENT_CONNECTED);
+#else
+    print_events (sub_mon, 2 * 1000, 1000);
+#endif
+
+    //  Close sub
+    //  TODO why does this use zero_linger?
+    test_context_socket_close_zero_linger (sub);
+    test_context_socket_close_zero_linger (dummy);
+
+    //  Close monitor
+    //  TODO why does this use zero_linger?
+    test_context_socket_close_zero_linger (sub_mon);
+}
+
+// test connecting to unversioned zmtp w/strict fails
+void connect_failed ()
+{
+    char bind_address[MAX_SOCKET_STRING];
+    size_t addr_length = sizeof (bind_address);
+    void *dummy = test_context_socket (ZMQ_STREAM);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (dummy, "tcp://127.0.0.1:0"));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_getsockopt (dummy, ZMQ_LAST_ENDPOINT, bind_address, &addr_length));
+
+    // setup sub socket
+    void *sub = test_context_socket (ZMQ_SUB);
+    // set strict option
+    int zmtpStrict = 1;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      sub, ZMQ_ZMTP_STRICT, &zmtpStrict, sizeof (zmtpStrict)));
+    //  Monitor all events on sub
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_socket_monitor (sub, "inproc://monitor-sub", ZMQ_EVENT_ALL));
+    //  Create socket for collecting monitor events
+    void *sub_mon = test_context_socket (ZMQ_PAIR);
+    //  Connect so they'll get events
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub_mon, "inproc://monitor-sub"));
+    // connect to dummy stream socket above
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub, bind_address));
+
+#if 0
+    expect_monitor_event (sub_mon, ZMQ_EVENT_CONNECT_DELAYED);
+    expect_monitor_event (sub_mon, ZMQ_EVENT_CONNECTED);
+    expect_monitor_event (sub_mon, ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL);
+#else
+    print_events (sub_mon, 2 * 1000, 1000);
+#endif
+
+    //  Close sub
+    //  TODO why does this use zero_linger?
+    test_context_socket_close_zero_linger (sub);
+    test_context_socket_close_zero_linger (dummy);
+
+    //  Close monitor
+    //  TODO why does this use zero_linger?
+    test_context_socket_close_zero_linger (sub_mon);
+}
+
+void setUp ()
+{
+    setup_test_context ();
+}
+
+void tearDown ()
+{
+    teardown_test_context ();
+}
+
+int main (void)
+{
+    setup_test_environment ();
+
+    UNITY_BEGIN ();
+
+    RUN_TEST (connect_success);
+    RUN_TEST (connect_failed);
+    return UNITY_END ();
+}

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -67,6 +67,9 @@
 #define PORT_6 5561
 
 //  For tests that mock ZMTP
+const uint8_t zmtp_greeting_unversioned[] = {
+  0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
 const uint8_t zmtp_greeting_null[64] = {
   0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0x7f, 3, 0, 'N', 'U', 'L', 'L',
   0,    0, 0, 0, 0, 0, 0, 0, 0, 0,    0, 0, 0,   0,   0,   0,


### PR DESCRIPTION
As per https://github.com/zeromq/libzmq/pull/3960#issuecomment-650708791 this is an attempt to implement ZMTP_STRICT.

I believe the code is OK, but I'm having trouble coming up with a test program -- the problem appears to be how to "fake" an unversioned greeting.  

The current test results look like this:

```
[btorpey@bt-brix build]$ bin/test_zmtp_strict
Got event: CONNECT_DELAYED
Got event: CONNECTED
Got event: HANDSHAKE_SUCCEEDED
/home/btorpey/work/libzmq/master/src/tests/test_zmtp_strict.cpp:234:connect_success_versioned:PASS
Got event: CONNECT_DELAYED
Got event: CONNECTED
Got event: DISCONNECTED
/home/btorpey/work/libzmq/master/src/tests/test_zmtp_strict.cpp:235:connect_success_unversioned:PASS
Got event: CONNECT_DELAYED
Got event: CONNECTED
Got event: DISCONNECTED
/home/btorpey/work/libzmq/master/src/tests/test_zmtp_strict.cpp:236:connect_failed_unversioned:PASS

-----------------------
3 Tests 0 Failures 0 Ignored 
```


I clearly need to better understand how "unversioned" works -- suggestions welcome.