### PR TITLE
build: don't compile with -Wno-uninitialized on darwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,9 +280,6 @@ case "${host_os}" in
         libzmq_pedantic="no"
         libzmq_werror="no"
         AC_DEFINE(ZMQ_HAVE_OSX, 1, [Have DarwinOSX OS])
-        AC_LANG_PUSH([C++])
-        LIBZMQ_CHECK_LANG_FLAG_PREPEND([-Wno-uninitialized])
-        AC_LANG_POP([C++])
         ;;
     *haiku*)
         AC_DEFINE(ZMQ_HAVE_HAIKU, 1, [Have Haiku OS])


### PR DESCRIPTION
This flag has been enabled for Darwin targets since the initial commit
in [4ed70a930202b103e7e80b8dc925e0aaa4622595](https://github.com/zeromq/libzmq/commit/4ed70a930202b103e7e80b8dc925e0aaa4622595). However, aside from the
fact that we likely no longer want to suppress uninitialized warnings,
this flag wont suppress them anyways, as it's included in the
CXX flags before -Wall (which enables -Wuninitialized). i.e:

```bash
g++ -std=gnu++11 ... -Wno-uninitialized ... -Wall <rest of flags>
```