### PR TITLE
build: test for warning options before enabling -Wno-* variant

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -751,7 +751,7 @@ AM_CONDITIONAL(ON_GNU, test "x$libzmq_on_gnu" = "xyes")
 
 # Check for __atomic_Xxx compiler intrinsics
 AC_LANG_PUSH([C++])
-AX_CHECK_COMPILE_FLAG([-Wno-atomic-alignment],
+AX_CHECK_COMPILE_FLAG([-Watomic-alignment],
     [CXXFLAGS+=" -Wno-atomic-alignment"],
     [],
     [-Werror])
@@ -1053,12 +1053,12 @@ AM_CONDITIONAL(FUZZING_ENGINE_LIB, test "x$FUZZING_ENGINE_LIB" != "x")
 
 # clang 6 has a warning that does not make sense on multi-platform code
 AC_LANG_PUSH([C])
-AX_CHECK_COMPILE_FLAG([-Wno-tautological-constant-compare],
+AX_CHECK_COMPILE_FLAG([-Wtautological-constant-compare],
     [CFLAGS+=" -Wno-tautological-constant-compare"],
     [],
     [-Werror])
 AC_LANG_POP([C])
-AX_CHECK_COMPILE_FLAG([-Wno-tautological-constant-compare],
+AX_CHECK_COMPILE_FLAG([-Wtautological-constant-compare],
     [CXXFLAGS+=" -Wno-tautological-constant-compare"],
     [],
     [-Werror])


### PR DESCRIPTION
Some compilers, like GCC, will only warn about unknown -Wno-* options when other warnings are being thrown, i.e:
```bash
  CXX      src/libzmq_la-address.lo
src/address.cpp: In function 'zmq::zmq_socklen_t zmq::get_socket_address(zmq::fd_t, zmq::socket_end_t, sockaddr_storage*)':
src/address.cpp:137:9: warning: unused variable 'unused' [-Wunused-variable]
  137 |     int unused;
      |         ^~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option '-Wno-tautological-constant-compare' may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option '-Wno-atomic-alignment' may have been intended to silence earlier diagnostics
  CXX      src/libzmq_la-channel.lo
```

They will also seem to accept the -Wno-* variant when it's tested for
using AX_CHECK_COMPILE_FLAG. So, rather than test for -Wno-* variants
that the compiler may pretend to understand, test for the actual option,
and only enable the -Wno-* case when it is available.

From the [GCC Warning Options](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html) docs:
> However, if the -Wno- form is used, the behavior is slightly different: no diagnostic is produced for -Wno-unknown-warning unless other diagnostics are being produced. This allows the use of new -Wno- options with old compilers, but if something goes wrong, the compiler warns that an unrecognized option is present.