### PR TITLE
build: disable IPC when cross-compiling with mingw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,9 +143,9 @@ if test "x$zmq_militant" = "xyes"; then
     AC_DEFINE(ZMQ_ACT_MILITANT, 1, [Enable militant API assertions])
 fi
 
-# IPC is available on all platforms supported by autotools build at the moment except OpenVMS and VxWorks.
+# Disable IPC on unsupported platforms.
 case "${host_os}" in
-    *vxworks*|*openvms*)
+    *vxworks*|*openvms*|*mingw*)
         ;;
     *)
         AC_DEFINE(ZMQ_HAVE_IPC, 1, [Have AF_UNIX sockets for ipc transport])


### PR DESCRIPTION
Master doesn't currently compile when cross-compiling using autotools and mingw-w64. i.e:

```bash
# x86_64-w64-mingw32-g++ (GCC) 9.3.0

./autogen.sh
./configure --host=x86_64-w64-mingw32
make src/libzmq.la
....
  CXX      src/libzmq_la-curve_server.lo
In file included from src/address.cpp:37:
src/ipc_address.hpp:40:10: fatal error: sys/socket.h: No such file or directory
   40 | #include <sys/socket.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
```

I assume this hasn't been caught because appveyor is using CMake, and  has been the case since #3717.

Mingw also does not have an `afunix.h` header. There is a thread upstream, but there doesn't seem to have been any discussion: https://sourceforge.net/p/mingw-w64/discussion/723797/thread/4c8ecdbe0d/.