### PR TITLE
build: fix gethrtime() function check in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,7 +586,7 @@ if(NOT MSVC)
   set(CMAKE_REQUIRED_LIBRARIES)
 
   check_cxx_symbol_exists(fork unistd.h HAVE_FORK)
-  check_cxx_symbol_exists(gethrtimei sys/time.h HAVE_GETHRTIME)
+  check_cxx_symbol_exists(gethrtime sys/time.h HAVE_GETHRTIME)
   check_cxx_symbol_exists(mkdtemp stdlib.h HAVE_MKDTEMP)
   check_cxx_symbol_exists(accept4 sys/socket.h HAVE_ACCEPT4)
   check_cxx_symbol_exists(strnlen string.h HAVE_STRNLEN)


### PR DESCRIPTION
This looks like a typo introduced by 2d8ef84760b673d90db331e077fac369665cdbbd.