### PR TITLE
Problem: XPUB keeps matched pipes between failed non-blocking sends

### DIFF
--- a/RELICENSE/tarmo.md
+++ b/RELICENSE/tarmo.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Tarmo Tänav that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "tarmo", with
+commit author "Tarmo Tänav <tarmo@itech.ee>", are copyright of Tarmo Tänav.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Tarmo Tänav
+2020/08/29

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -298,6 +298,9 @@ int zmq::xpub_t::xsend (msg_t *msg_)
 
     //  For the first part of multi-part message, find the matching pipes.
     if (!_more_send) {
+        // Ensure nothing from previous failed attempt to send is left matched
+        _dist.unmatch ();
+
         if (unlikely (_manual && _last_pipe && _send_last_pipe)) {
             _subscriptions.match (static_cast<unsigned char *> (msg_->data ()),
                                   msg_->size (), mark_last_pipe_as_matching,


### PR DESCRIPTION
Solution: always unmatch all pipes before matching for an initial message part.


When using non-blocking and non-lossy (ZMQ_XPUB_NODROP enabled) sends with XPUB, if at least one pipe is full due to HWM, causes `xsend` to return EAGAIN while keeping the pipes matched. This means if another send is made to a different subscription the previously matched pipes remain matched although they might not have any relationship to the later subscription.

There are two issues with this behaviour:
1. the previously matched pipes might not be subscribed to the later message and thus should not receive it (though the sub socket would filter it after it's been transferred)
2. if the previously matched pipes that hit HWM are still full the send to an unrelated subscription will also block regardless of how full the pipes matching just the later subscription are