### PR TITLE
make Docker image smaller + use `debian:buster-slim` base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,32 @@
-FROM ubuntu:14.04
+FROM debian:buster-slim AS builder
+LABEL maintainer="ZeroMQ Project <zeromq@imatix.com>"
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+    && apt-get install -qq --yes --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        git \
+        libkrb5-dev \
+        libsodium-dev \
+        libtool \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/libzmq
+COPY . .
+RUN ./autogen.sh \
+    && ./configure --prefix=/usr/local --with-libsodium --with-libgssapi_krb5 \
+    && make \
+    && make check \
+    && make install
 
-MAINTAINER ZeroMQ Project <zeromq@imatix.com>
-
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential libtool autoconf automake pkg-config unzip libkrb5-dev
-RUN cd /tmp && git clone git://github.com/jedisct1/libsodium.git && cd libsodium && git checkout e2a30a && ./autogen.sh && ./configure && make check && make install && ldconfig
-RUN cd /tmp && git clone --depth 1 git://github.com/zeromq/libzmq.git && cd libzmq && ./autogen.sh && ./configure && make
-# RUN cd /tmp/libzmq && make check
-RUN cd /tmp/libzmq && make install && ldconfig
-RUN rm /tmp/* -rf
+FROM debian:buster-slim
+LABEL maintainer="ZeroMQ Project <zeromq@imatix.com>"
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+    && apt-get install -qq --yes --no-install-recommends \
+        libkrb5-dev \
+        libsodium23 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local /usr/local
+RUN ldconfig && ldconfig -p | grep libzmq

--- a/RELICENSE/kaczmarj.md
+++ b/RELICENSE/kaczmarj.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Jakub Kaczmarzyk
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "kaczmarj", with
+commit author "Jakub Kaczmarzyk jakub.kaczmarzyk@gmail.com", are copyright of Jakub Kaczmarzyk.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Jakub Kaczmarzyk
+2020/07/29


### PR DESCRIPTION
The Dockerfile for this project has not been updated in several years, so I tried to improve it in this PR. This PR updates the Dockerfile to use multiple stages. In the first stage, compile-time dependencies are installed, and libzmq is compiled and tested. The second stage starts with a fresh, slim Docker image, and the compiled outputs of the first stage are copied over. Runtime dependencies, like libsodium and kerberos, are installed as well. The resulting Docker image is 28% the size of the original image.