### PR TITLE
Modifications to compile code for WINDOWS ARM and ARM64

### DIFF
--- a/RELICENSE/kalantar.md
+++ b/RELICENSE/kalantar.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Davit Kalantaryan
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made with commit author 
+"Davit Kalantaryan <davit.kalantaryan@desy.de>", are copyright of Davit Kalantaryan.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Davit Kalantaryan
+2020/08/06

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -41,6 +41,9 @@
 #include <cmnintrin.h>
 #else
 #include <intrin.h>
+#if defined(_M_ARM) || defined(_M_ARM64)
+#include <arm_neon.h>
+#endif
 #endif
 #endif
 
@@ -235,6 +238,14 @@ uint64_t zmq::clock_t::rdtsc ()
 {
 #if (defined _MSC_VER && (defined _M_IX86 || defined _M_X64))
     return __rdtsc ();
+#elif defined(_MSC_VER) && defined(_M_ARM) // NC => added for windows ARM
+    return __rdpmccntr64 ();
+#elif defined(_MSC_VER) && defined(_M_ARM64) // NC => added for windows ARM64
+    //return __rdpmccntr64 ();
+    //return __rdtscp (nullptr);
+	// todo: find proper implementation for ARM64
+    static uint64_t snCounter = 0;
+    return ++snCounter;
 #elif (defined __GNUC__ && (defined __i386__ || defined __x86_64__))
     uint32_t low, high;
     __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -243,7 +243,7 @@ uint64_t zmq::clock_t::rdtsc ()
 #elif defined(_MSC_VER) && defined(_M_ARM64) // NC => added for windows ARM64
     //return __rdpmccntr64 ();
     //return __rdtscp (nullptr);
-	// todo: find proper implementation for ARM64
+    // todo: find proper implementation for ARM64
     static uint64_t snCounter = 0;
     return ++snCounter;
 #elif (defined __GNUC__ && (defined __i386__ || defined __x86_64__))


### PR DESCRIPTION
[why]
In order to compile ZMQ related software on WINDOWS ARM

[how]
Replaced code in the file clock.cpp around the line 240.
Added intrinsics for ARM to replace '__rdtsc'

[todo]
Find proper tick counter query for ARM64 (see file:clock.cpp,line:~250)