### PR TITLE
Problem: WS might use handshake buffer for data

### DIFF
--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -238,7 +238,7 @@ uint64_t zmq::clock_t::rdtsc ()
 {
 #if (defined _MSC_VER && (defined _M_IX86 || defined _M_X64))
     return __rdtsc ();
-#elif defined(_MSC_VER) && defined(_M_ARM) // NC => added for windows ARM
+#elif defined(_MSC_VER) && defined(_M_ARM)   // NC => added for windows ARM
     return __rdpmccntr64 ();
 #elif defined(_MSC_VER) && defined(_M_ARM64) // NC => added for windows ARM64
     //return __rdpmccntr64 ();

--- a/src/ws_decoder.cpp
+++ b/src/ws_decoder.cpp
@@ -212,10 +212,13 @@ int zmq::ws_decoder_t::size_ready (unsigned char const *read_pos_)
     // data into a new message and complete it in the next receive.
 
     shared_message_memory_allocator &allocator = get_allocator ();
-    if (unlikely (!_zero_copy
+    if (unlikely (!_zero_copy || allocator.data () > read_pos_
+                  || static_cast<size_t> (read_pos_ - allocator.data ())
+                       > allocator.size ()
                   || _size > static_cast<size_t> (
                        allocator.data () + allocator.size () - read_pos_))) {
         // a new message has started, but the size would exceed the pre-allocated arena
+        // (or read_pos_ is in the initial handshake buffer)
         // this happens every time when a message does not fit completely into the buffer
         rc = _in_progress.init_size (static_cast<size_t> (_size));
     } else {


### PR DESCRIPTION
Solution: check for it before reusing it to avoid overflows

@somdoron not sure where the handshake buffer gets passed along, but the pointers match