### PR TITLE
Problem: zmq_ctx_get API broken

### DIFF
--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -195,14 +195,11 @@ int zmq_ctx_set_ext (void *ctx_,
 
 int zmq_ctx_get (void *ctx_, int option_)
 {
-    int optval = 0;
-    size_t optvallen = sizeof (int);
-    if (zmq_ctx_get_ext (ctx_, option_, &optval, &optvallen) == 0) {
-        return optval;
+    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+        errno = EFAULT;
+        return -1;
     }
-
-    errno = EFAULT;
-    return -1;
+    return (static_cast<zmq::ctx_t *> (ctx_))->get (option_);
 }
 
 int zmq_ctx_get_ext (void *ctx_, int option_, void *optval_, size_t *optvallen_)

--- a/tests/test_ctx_options.cpp
+++ b/tests/test_ctx_options.cpp
@@ -283,6 +283,14 @@ void test_ctx_option_blocky ()
     test_context_socket_close (router);
 }
 
+void test_ctx_option_invalid ()
+{
+    TEST_ASSERT_EQUAL_INT (-1, zmq_ctx_set (get_test_context (), -1, 0));
+    TEST_ASSERT_EQUAL_INT (EINVAL, errno);
+    TEST_ASSERT_EQUAL_INT (-1, zmq_ctx_get (get_test_context (), -1));
+    TEST_ASSERT_EQUAL_INT (EINVAL, errno);
+}
+
 int main (void)
 {
     setup_test_environment ();
@@ -297,5 +305,6 @@ int main (void)
     RUN_TEST (test_ctx_thread_opts);
     RUN_TEST (test_ctx_zero_copy);
     RUN_TEST (test_ctx_option_blocky);
+    RUN_TEST (test_ctx_option_invalid);
     return UNITY_END ();
 }


### PR DESCRIPTION
Solution: restore EINVAL as errno on unknown option.
Broken by https://github.com/zeromq/libzmq/pull/3642 which started to
return EFAULT instead