### PR TITLE
stop reconnect after called zmq_disconnect()

### DIFF
--- a/RELICENSE/C-Sir.md
+++ b/RELICENSE/C-Sir.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by C-Sir
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "C-Sir", with
+commit author "C-Sir <942510829@qq.com>", are copyright of C-Sir.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+C-Sir
+2020/09/28

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -741,6 +741,10 @@ connection attempts to non-0MQ sockets.  Note that when specifying this option
 you may also want to set `ZMQ_HANDSHAKE_IVL` -- the default handshake interval
 is 30000 (30 seconds), which is typically too large.
 
+The 'ZMQ_RECONNECT_STOP_AFTER_DISCONNECT' option will stop reconnection when 
+called zmq_disconnect(). This can be useful when the user request failed(server not
+ready),the sokcet do not need to continue to reconnect after user disconnect actively.
+
 NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -685,6 +685,7 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1
 #define ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED 0x2
+#define ZMQ_RECONNECT_STOP_AFTER_DISCONNECT 0x3
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10

--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -100,6 +100,13 @@ void zmq::ipc_connecter_t::start_connecting ()
         // should be done here as well (and then this could be pulled up to
         // stream_connecter_base_t).
     }
+    //stop connecting after called zmq_disconnect
+    else if (rc == -1
+             && (options.reconnect_stop & ZMQ_RECONNECT_STOP_AFTER_DISCONNECT)
+             && errno == ECONNREFUSED && _socket->is_disconnected ()) {
+        if (_s != retired_fd)
+            close ();
+    }
 
     //  Handle any other error condition by eventual reconnect.
     else {

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1216,6 +1216,11 @@ int zmq::socket_base_t::term_endpoint (const char *endpoint_uri_)
         term_child (it->second.first);
     }
     _endpoints.erase (range.first, range.second);
+
+    if (options.reconnect_stop & ZMQ_RECONNECT_STOP_AFTER_DISCONNECT) {
+        _disconnected = true;
+    }
+
     return 0;
 }
 
@@ -2049,6 +2054,11 @@ void zmq::socket_base_t::stop_monitor (bool send_monitor_stopped_event_)
         _monitor_socket = NULL;
         _monitor_events = 0;
     }
+}
+
+bool zmq::socket_base_t::is_disconnected () const
+{
+    return _disconnected;
 }
 
 zmq::routing_socket_base_t::routing_socket_base_t (class ctx_t *parent_,

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -164,6 +164,8 @@ class socket_base_t : public own_t,
     //  after gathering the data asynchronously. Requires event monitoring to
     //  be enabled.
     int query_pipes_stats ();
+    
+    bool is_disconnected () const;
 
   protected:
     socket_base_t (zmq::ctx_t *parent_,

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -345,6 +345,9 @@ class socket_base_t : public own_t,
     mutex_t _monitor_sync;
 
     ZMQ_NON_COPYABLE_NOR_MOVABLE (socket_base_t)
+    
+    // Add a flag for mark disconnect action
+    bool _disconnected;
 };
 
 class routing_socket_base_t : public socket_base_t

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -72,6 +72,7 @@
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1
 #define ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED 0x2
+#define ZMQ_RECONNECT_STOP_AFTER_DISCONNECT 0x3
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10


### PR DESCRIPTION
When the server does not exist(Never started), the client is disconnected after the request receive timeout,
but the client socket is still reconnecting in the background.

expected result:
the client socket stop reconnect after called zmq_disconnect().

so,I add a disconnect flag for mark disconnect action,
if user set option ZMQ_RECONNECT_STOP:ZMQ_RECONNECT_STOP_AFTER_DISCONNECT for socket,
it will stop reconnet if disconnect flag is true.
