### PR TITLE
initialize error in test_security_gssapi.c:test_null_creds

### DIFF
--- a/tests/test_security_gssapi.cpp
+++ b/tests/test_security_gssapi.cpp
@@ -219,7 +219,7 @@ void test_null_creds ()
     expect_bounce_fail (server, client);
     test_context_socket_close_zero_linger (client);
 
-    int error;
+    int error = 0;
     int event = get_monitor_event (server_mon, &error, NULL);
     TEST_ASSERT_EQUAL_INT (ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL, event);
     TEST_ASSERT_EQUAL_INT (ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH, error);


### PR DESCRIPTION
Under some circumstances (which probably no longer apply in master) gcc inlined get_monitor_event into test_null_creds and then emitted a "maybe uninitialized" warning on the use of error. This would only be a problem if the tested code was misbehaving but I guess that's the point of a test!