### PR TITLE
fix stack overflow on windows x64

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -63,11 +63,18 @@ void zmq::thread_t::start (thread_fn *tfn_, void *arg_, const char *name_)
     _arg = arg_;
     if (name_)
         strncpy (_name, name_, sizeof (_name) - 1);
+
+    // set default stack size to 4MB to avoid std::map stack overflow on x64
+    unsigned int stack = 0;
+#if defined _WIN64
+    stack = 0x400000; 
+#endif
+
 #if defined _WIN32_WCE
     _descriptor =
-      (HANDLE) CreateThread (NULL, 0, &::thread_routine, this, 0, &_thread_id);
+      (HANDLE) CreateThread (NULL, stack, &::thread_routine, this, 0, &_thread_id);
 #else
-    _descriptor = (HANDLE) _beginthreadex (NULL, 0, &::thread_routine, this, 0,
+    _descriptor = (HANDLE) _beginthreadex (NULL, stack, &::thread_routine, this, 0,
                                            &_thread_id);
 #endif
     win_assert (_descriptor != NULL);


### PR DESCRIPTION
in our project we have to use VS2010 Win64 compiler and we have fixed the stack overflow by using this suggestion:
https://github.com/zeromq/libzmq/issues/2876#issuecomment-601434808