### PR TITLE
src/compat.hpp: fix build with libbsd and strlcpy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,9 +250,7 @@ if(NOT MSVC)
       set(ZMQ_HAVE_LIBBSD 1)
     endif()
   endif()
-  if(NOT WITH_LIBBSD OR NOT LIBBSD_FOUND)
-    check_cxx_symbol_exists(strlcpy string.h ZMQ_HAVE_STRLCPY)
-  endif()
+  check_cxx_symbol_exists(strlcpy string.h ZMQ_HAVE_STRLCPY)
 endif()
 
 # Select curve encryption library, defaults to tweetnacl To use libsodium instead, use --with-libsodium(must be

--- a/configure.ac
+++ b/configure.ac
@@ -812,20 +812,18 @@ if test "x$enable_libbsd" != "xno"; then
             fi
         ])
 fi
-if test "x$found_libbsd" != "xyes"; then
-    AC_MSG_CHECKING([whether strlcpy is available])
-    AC_COMPILE_IFELSE(
-        [AC_LANG_PROGRAM(
-            [[#include <string.h>]],
-            [[char buf [100]; size_t bar = strlcpy (buf, "foo", 100); (void)bar; return 0;]])
-        ],[
-            AC_MSG_RESULT([yes])
-            AC_DEFINE(ZMQ_HAVE_STRLCPY, [1],
-                [strlcpy is available])
-        ],[
-            AC_MSG_RESULT([no])
-    ])
-fi
+AC_MSG_CHECKING([whether strlcpy is available])
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+        [[#include <string.h>]],
+        [[char buf [100]; size_t bar = strlcpy (buf, "foo", 100); (void)bar; return 0;]])
+    ],[
+        AC_MSG_RESULT([yes])
+        AC_DEFINE(ZMQ_HAVE_STRLCPY, [1],
+            [strlcpy is available])
+    ],[
+        AC_MSG_RESULT([no])
+])
 
 # pthread_setname is non-posix, and there are at least 4 different implementations
 AC_MSG_CHECKING([whether signature of pthread_setname_np() has 1 argument])

--- a/src/compat.hpp
+++ b/src/compat.hpp
@@ -37,9 +37,10 @@
 #define strcasecmp _stricmp
 #define strtok_r strtok_s
 #else
+#ifndef ZMQ_HAVE_STRLCPY
 #ifdef ZMQ_HAVE_LIBBSD
 #include <bsd/string.h>
-#elif !defined(ZMQ_HAVE_STRLCPY)
+#else
 static inline size_t
 strlcpy (char *dest_, const char *src_, const size_t dest_size_)
 {
@@ -49,6 +50,7 @@ strlcpy (char *dest_, const char *src_, const size_t dest_size_)
     }
     return dest_size_ - remain;
 }
+#endif
 #endif
 template <size_t size>
 static inline int strcpy_s (char (&dest_)[size], const char *const src_)


### PR DESCRIPTION
Don't include bsd/string.h if strlcpy is also defined in string.h to avoid the following build failure on uclibc:

```
In file included from src/compat.hpp:41:0,
                 from src/ipc_address.cpp:31:
/tmp/instance-0/output-1/host/mips64el-buildroot-linux-uclibc/sysroot/usr/include/bsd/string.h:44:54: error: declaration of 'size_t strlcpy(char*, const char*, size_t)' has a different exception specifier
 size_t strlcpy(char *dst, const char *src, size_t siz);
                                                      ^
In file included from src/compat.hpp:34:0,
                 from src/ipc_address.cpp:31:
/tmp/instance-0/output-1/host/mips64el-buildroot-linux-uclibc/sysroot/usr/include/string.h:424:15: error: from previous declaration 'size_t strlcpy(char*, const char*, size_t) throw ()'
 extern size_t strlcpy(char *__restrict dst, const char *__restrict src,
               ^
```

Fixes:
 - http://autobuild.buildroot.org/results/51220b1b82774e8f6f6ed8593c58d2e3c31a1531

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>