### PR TITLE
The _DEBUG preprocessor definition is typically only set on Windows. …

### DIFF
--- a/src/poller_base.cpp
+++ b/src/poller_base.cpp
@@ -136,7 +136,7 @@ void zmq::worker_poller_base_t::start (const char *name_)
 
 void zmq::worker_poller_base_t::check_thread () const
 {
-#ifdef _DEBUG
+#ifndef NDEBUG
     zmq_assert (!_worker.get_started () || _worker.is_current_thread ());
 #endif
 }


### PR DESCRIPTION
… (e.g., see https://stackoverflow.com/questions/2290509/debug-vs-ndebug/29253284#29253284)