### PR TITLE
autogen.sh: fix autoreconf exit code log

### DIFF
--- a/RELICENSE/zoedberg.md
+++ b/RELICENSE/zoedberg.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Zoe Faltibà
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "zoedberg", with
+commit author "Zoe Faltibà zoefaltiba@gmail.com", are copyright of Zoe Faltibà.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Zoe Faltibà
+2020/11/10

--- a/autogen.sh
+++ b/autogen.sh
@@ -43,7 +43,8 @@ if [ $? -ne 0 ]; then
 fi
 
 autoreconf --install --force --verbose -I config
-if [ $? -ne 0 ]; then
-    echo "autogen.sh: error: autoreconf exited with status $?" 1>&2
+res=$?
+if [ "$res" -ne 0 ]; then
+    echo "autogen.sh: error: autoreconf exited with status $res" 1>&2
     exit 1
 fi


### PR DESCRIPTION
this PR contains a small fix to `autogen.sh`

before this fix the logged autoreconf exit status (`echo "autogen.sh: error: autoreconf exited with status $?" 1>&2`) was always equal to `0`, because it referred to the exit code of the `if` espression (`if [ $? -ne 0 ];`)