### PR TITLE
Problem: tests fails to receive with EAGAIN on slow architectures

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -53,10 +53,12 @@ jobs:
       LIBZMQ_SRCDIR: ${{ github.workspace }}\libzmq
     steps:    
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
       if: matrix.os == 'windows-2019'
     - name: Add msbuild to PATH 2016
-      run: echo "##[add-path]C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin"
+      uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '[15.0,16.0)'
       if: matrix.os == 'windows-2016'    
     - uses: actions/checkout@v2
       if: matrix.WITH_LIBSODIUM == 'ON'

--- a/tests/test_req_correlate.cpp
+++ b/tests/test_req_correlate.cpp
@@ -41,10 +41,6 @@ void test_req_correlate ()
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (req, ZMQ_REQ_CORRELATE, &enabled, sizeof (int)));
 
-    int rcvtimeo = 100;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_setsockopt (req, ZMQ_RCVTIMEO, &rcvtimeo, sizeof (int)));
-
     char my_endpoint[MAX_SOCKET_STRING];
     bind_loopback_ipv4 (router, my_endpoint, sizeof my_endpoint);
 

--- a/tests/test_req_relaxed.cpp
+++ b/tests/test_req_relaxed.cpp
@@ -56,10 +56,6 @@ void setUp ()
     for (size_t peer = 0; peer < services; peer++) {
         rep[peer] = test_context_socket (ZMQ_REP);
 
-        int timeout = 500;
-        TEST_ASSERT_SUCCESS_ERRNO (
-          zmq_setsockopt (rep[peer], ZMQ_RCVTIMEO, &timeout, sizeof (int)));
-
         TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (rep[peer], my_endpoint));
 
         //  These tests require strict ordering, so wait for the connections to

--- a/tests/test_spec_dealer.cpp
+++ b/tests/test_spec_dealer.cpp
@@ -47,10 +47,6 @@ void test_round_robin_out (const char *bind_address_)
     for (size_t peer = 0; peer < services; ++peer) {
         rep[peer] = test_context_socket (ZMQ_REP);
 
-        int timeout = 250;
-        TEST_ASSERT_SUCCESS_ERRNO (
-          zmq_setsockopt (rep[peer], ZMQ_RCVTIMEO, &timeout, sizeof (int)));
-
         TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (rep[peer], connect_address));
     }
 
@@ -82,10 +78,6 @@ void test_fair_queue_in (const char *bind_address_)
 {
     void *receiver = test_context_socket (ZMQ_DEALER);
 
-    int timeout = 250;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_setsockopt (receiver, ZMQ_RCVTIMEO, &timeout, sizeof (int)));
-
     char connect_address[MAX_SOCKET_STRING];
     test_bind (receiver, bind_address_, connect_address,
                sizeof (connect_address));
@@ -94,9 +86,6 @@ void test_fair_queue_in (const char *bind_address_)
     void *senders[services];
     for (size_t peer = 0; peer < services; ++peer) {
         senders[peer] = test_context_socket (ZMQ_DEALER);
-
-        TEST_ASSERT_SUCCESS_ERRNO (
-          zmq_setsockopt (senders[peer], ZMQ_RCVTIMEO, &timeout, sizeof (int)));
 
         TEST_ASSERT_SUCCESS_ERRNO (
           zmq_connect (senders[peer], connect_address));

--- a/tests/test_spec_pushpull.cpp
+++ b/tests/test_spec_pushpull.cpp
@@ -53,9 +53,6 @@ void test_push_round_robin_out (const char *bind_address_)
     for (size_t peer = 0; peer < services; ++peer) {
         pulls[peer] = test_context_socket (ZMQ_PULL);
 
-        int timeout = 250;
-        TEST_ASSERT_SUCCESS_ERRNO (
-          zmq_setsockopt (pulls[peer], ZMQ_RCVTIMEO, &timeout, sizeof (int)));
         TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (pulls[peer], connect_address));
     }
 

--- a/tests/test_spec_rep.cpp
+++ b/tests/test_spec_rep.cpp
@@ -39,11 +39,6 @@ char connect_address[MAX_SOCKET_STRING];
 void test_fair_queue_in (const char *bind_address_)
 {
     void *rep = test_context_socket (ZMQ_REP);
-
-    int timeout = 250;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_setsockopt (rep, ZMQ_RCVTIMEO, &timeout, sizeof (int)));
-
     TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (rep, bind_address_));
     size_t len = MAX_SOCKET_STRING;
     TEST_ASSERT_SUCCESS_ERRNO (
@@ -54,8 +49,6 @@ void test_fair_queue_in (const char *bind_address_)
     for (size_t peer = 0; peer < services; ++peer) {
         reqs[peer] = test_context_socket (ZMQ_REQ);
 
-        TEST_ASSERT_SUCCESS_ERRNO (
-          zmq_setsockopt (reqs[peer], ZMQ_RCVTIMEO, &timeout, sizeof (int)));
         TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (reqs[peer], connect_address));
     }
 

--- a/tests/test_spec_req.cpp
+++ b/tests/test_spec_req.cpp
@@ -48,9 +48,6 @@ void test_round_robin_out (const char *bind_address_)
     for (size_t peer = 0; peer < services; peer++) {
         rep[peer] = test_context_socket (ZMQ_REP);
 
-        int timeout = 250;
-        TEST_ASSERT_SUCCESS_ERRNO (
-          zmq_setsockopt (rep[peer], ZMQ_RCVTIMEO, &timeout, sizeof (int)));
         TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (rep[peer], connect_address));
     }
     //  We have to give the connects time to finish otherwise the requests
@@ -87,10 +84,6 @@ void test_req_only_listens_to_current_peer (const char *bind_address_)
 
     for (size_t i = 0; i < services; ++i) {
         router[i] = test_context_socket (ZMQ_ROUTER);
-
-        int timeout = 250;
-        TEST_ASSERT_SUCCESS_ERRNO (
-          zmq_setsockopt (router[i], ZMQ_RCVTIMEO, &timeout, sizeof (timeout)));
 
         int enabled = 1;
         TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (

--- a/tests/test_spec_router.cpp
+++ b/tests/test_spec_router.cpp
@@ -41,11 +41,6 @@ void test_fair_queue_in (const char *bind_address_)
 {
     char connect_address[MAX_SOCKET_STRING];
     void *receiver = test_context_socket (ZMQ_ROUTER);
-
-    int timeout = 250;
-    TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_setsockopt (receiver, ZMQ_RCVTIMEO, &timeout, sizeof (int)));
-
     TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (receiver, bind_address_));
     size_t len = MAX_SOCKET_STRING;
     TEST_ASSERT_SUCCESS_ERRNO (
@@ -55,9 +50,6 @@ void test_fair_queue_in (const char *bind_address_)
     void *senders[services];
     for (unsigned char peer = 0; peer < services; ++peer) {
         senders[peer] = test_context_socket (ZMQ_DEALER);
-
-        TEST_ASSERT_SUCCESS_ERRNO (
-          zmq_setsockopt (senders[peer], ZMQ_RCVTIMEO, &timeout, sizeof (int)));
 
         char *str = strdup ("A");
         str[0] += peer;


### PR DESCRIPTION
Solution: remove arbitrary timeouts, as they are testing reliable pipes
with no contention, so if it can connect eventually it has to
work. The overall test timeout covers cases where it doesn't.

If tests want to use receive timeouts, they need to handle EAGAIN
properly.