### PR TITLE
Cleanup socket FD after pair is established. Fix #4086

### DIFF
--- a/RELICENSE/zedalaye.md
+++ b/RELICENSE/zedalaye.md
@@ -1,0 +1,14 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Pierre Yager
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "zedalaye", with
+commit author "Pierre Yager <pierre.y@gmail.com>" or 
+"Pierre Yager <pierre.yager@crisalid.com", are copyright of Pierre Yager.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Pierre Yager 
+2021/01/04

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -53,6 +53,9 @@
 #endif
 
 #include <direct.h>
+
+#define rmdir _rmdir
+#define unlink _unlink
 #endif
 
 #if defined ZMQ_HAVE_OPENVMS || defined ZMQ_HAVE_VXWORKS
@@ -619,6 +622,16 @@ int zmq::make_fdpair (fd_t *r_, fd_t *w_)
     rc = closesocket (listener);
     wsa_assert (rc == 0);
 
+    //  Cleanup temporary socket file descriptor
+    if (!filename.empty ()) {
+        rc = ::unlink (filename.c_str ());
+        if ((rc == 0) && !dirname.empty ()) {
+            rc = ::rmdir (dirname.c_str ());
+            dirname.clear ();
+        }
+        filename.clear ();
+    }
+
     return 0;
 
 error_closeclient:
@@ -631,6 +644,17 @@ error_closelistener:
     saved_errno = errno;
     rc = closesocket (listener);
     wsa_assert (rc == 0);
+
+    //  Cleanup temporary socket file descriptor
+    if (!filename.empty ()) {
+        rc = ::unlink (filename.c_str ());
+        if ((rc == 0) && !dirname.empty ()) {
+            rc = ::rmdir (dirname.c_str ());
+            dirname.clear ();
+        }
+        filename.clear ();
+    }
+
     errno = saved_errno;
 
     return -1;


### PR DESCRIPTION
Avoid filling Temp directory with temporary files.