### PR TITLE
Avoid crash in wsa_error_to_error when isolated in Microsoft Defender ATP

### DIFF
--- a/src/err.cpp
+++ b/src/err.cpp
@@ -380,7 +380,7 @@ int zmq::wsa_error_to_errno (int errcode_)
         case WSANO_DATA:
             return EFAULT;
         default:
-            wsa_assert (false);
+            return EFAULT;
     }
     //  Not reachable
     return 0;


### PR DESCRIPTION
SOLUTION: The resason for this crash is it appears that an unknown GetLastError is getting returned when an application is "Isolated" within dATP.  It would seem to make the most sense to just return `EFAULT` in `wsa_error_to_error` instead of calling `zmq_abort` if a more accurate error could not be determined or mapped.