### PR TITLE
Build and test on ARM64 CPU architecture (#1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,22 @@ matrix:
         packages:
         - abi-dumper
         - abi-compliance-checker
-    
+  - name: Linux ARM64
+    env: BUILD_TYPE=default CURVE=tweetnacl GSSAPI=enabled PGM=enabled NORM=enabled IPv6=ON TLS=enabled DRAFT=enabled
+    os: linux
+    dist: bionic
+    arch: arm64
+    addons:
+      apt:
+        sources:
+        - sourceline: 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-stable/xUbuntu_18.04/ ./'
+          key_url: 'http://download.opensuse.org/repositories/network:/messaging:/zeromq:/git-stable/xUbuntu_18.04/Release.key'
+        packages:
+          - zip
+          - libkrb5-dev
+          - libnorm-dev
+          - libpgm-dev
+          - libgnutls28-dev
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "android" ] ; then brew update; brew install binutils ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -158,6 +158,8 @@ matrix:
           - libnorm-dev
           - libpgm-dev
           - libgnutls28-dev
+  allow_failures:
+    - arch: arm64
 
 before_install:
 - if [ $TRAVIS_OS_NAME == "osx" -a $BUILD_TYPE == "android" ] ; then brew update; brew install binutils ; fi

--- a/RELICENSE/MartinGrigorov.md
+++ b/RELICENSE/MartinGrigorov.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Martin Grigorov
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "martin-g", with
+commit author "Martin Grigorov", are copyright of Martin Grigorov.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Martin Grigorov
+2021/01/11


### PR DESCRIPTION
More and more software development is being done on ARM64 CPU architecture.
It would be good if libzmq is being regularly tested on ARM64!

Adds an extra TravisCI job that runs `ci_build.sh` on arm64/aarch64 CPU architecture.

There is one test failure on ARM64:

```
FAIL: tests/test_monitor
========================
WARNING: Forced closure of 4 sockets, this is an implementation error unless the test case failed
WARNING: Forced closure of 6 sockets, this is an implementation error unless the test case failed
../../tests/test_monitor.cpp:444:test_monitor_invalid_protocol_fails:PASS
../../tests/test_monitor.cpp:445:test_monitor_basic:PASS
../../tests/test_monitor.cpp:450:test_monitor_versioned_invalid_socket_type:PASS
../../tests/test_monitor.cpp:451:test_monitor_versioned_basic_tcp_ipv4:PASS
../../tests/test_monitor.cpp:452:test_monitor_versioned_basic_tcp_ipv6:PASS
../../tests/test_monitor.cpp:453:test_monitor_versioned_basic_ipc:PASS
../../tests/test_monitor.cpp:295:test_monitor_versioned_basic_tipc:IGNORE: tipc is not available
../../tests/test_monitor.cpp:456:test_monitor_versioned_stats_tcp_ipv4:PASS
../../tests/test_monitor.cpp:457:test_monitor_versioned_stats_tcp_ipv6:PASS
../../tests/test_monitor.cpp:406:test_monitor_versioned_stats_ipc:FAIL: Expected 500 Was 250
-----------------------
10 Tests 1 Failures 1 Ignored 
FAIL
FAIL tests/test_monitor (exit status: 1)
```
