### PR TITLE
Problem: build still broken on kFreeBSD

### DIFF
--- a/src/stream_engine_base.cpp
+++ b/src/stream_engine_base.cpp
@@ -91,7 +91,7 @@ static std::string get_peer_address (zmq::fd_t s_)
             if (cred.cr_ngroups > 0)
                 buf << cred.cr_groups[0];
             buf << ":";
-            _peer_address += buf.str ();
+            peer_address += buf.str ();
         }
     }
 #endif


### PR DESCRIPTION
Solution: fix refactor mistake introduced by:

091df743a81f3899bd70166060c2082ea0cbd57c

Fixes https://github.com/zeromq/libzmq/issues/4113