### PR TITLE
Problem: norm fails to compile under windows

### DIFF
--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -367,6 +367,12 @@ void zmq::norm_engine_t::in_event ()
         zmq_assert (false);
         return;
     }
+    
+#ifdef ZMQ_USE_NORM_SOCKET_WRAPPER
+    char buf;
+    int rc = recv(wrapper_read_fd, &buf, sizeof(buf), 0);
+    errno_assert(rc == 1);
+#endif 
 
     switch (event.type) {
         case NORM_TX_QUEUE_VACANCY:

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -5,13 +5,12 @@
 
 #if defined ZMQ_HAVE_NORM
 
-#if defined (ZMQ_HAVE_WINDOWS) && defined(ZMQ_IOTHREAD_POLLER_USE_EPOLL)
-    #define ZMQ_USE_NORM_SOCKET_WRAPPER
+#include "norm_engine.hpp"
+#ifdef ZMQ_USE_NORM_SOCKET_WRAPPER
     #include "ip.hpp"
     #include <iostream>
 #endif
 
-#include "norm_engine.hpp"
 #include "session_base.hpp"
 #include "v2_protocol.hpp"
 
@@ -237,9 +236,8 @@ void zmq::norm_engine_t::shutdown ()
 void zmq::norm_engine_t::plug (io_thread_t *io_thread_,
                                session_base_t *session_)
 {
-    fd_t read_fd;
     fd_t write_fd;
-    int rc = make_fdpair(&read_fd, &write_fd);
+    int rc = make_fdpair(&wrapper_read_fd, &write_fd);
     norm_wrapper_sockets_t * sockets = new norm_wrapper_sockets_t;
     sockets->norm_descriptor = NormGetDescriptor (norm_instance);
     sockets->wrapper_socket = write_fd;
@@ -251,7 +249,7 @@ void zmq::norm_engine_t::plug (io_thread_t *io_thread_,
     if (is_receiver)
         zmq_input_ready = true;
 
-    norm_descriptor_handle = add_fd (read_fd);
+    norm_descriptor_handle = add_fd (wrapper_read_fd);
     // Set POLLIN for notification of pending NormEvents
     set_pollin (norm_descriptor_handle);
 
@@ -775,7 +773,7 @@ DWORD WINAPI norm_handle_to_socket( LPVOID lpParam )
         
         std::cout << "Sending wrapper event" << std::endl;
 
-        //GetQueueStatus(QS_ALLINPUT);
+        GetQueueStatus(QS_ALLINPUT);
     }
     // wait for event to be handled
 

--- a/src/norm_engine.hpp
+++ b/src/norm_engine.hpp
@@ -192,7 +192,9 @@ class norm_engine_t ZMQ_FINAL : public io_object_t, public i_engine
       msg_ready_list; // rx streams w/ msg ready for push to zmq
 
 #ifdef ZMQ_USE_NORM_SOCKET_WRAPPER
-  fd_t wrapper_read_fd;
+  fd_t wrapper_read_fd; // filedescriptor used to read norm events through the wrapper
+  DWORD wrapper_thread_id;
+  HANDLE wrapper_thread_handle;
 #endif
 
 }; // end class norm_engine_t

--- a/src/norm_engine.hpp
+++ b/src/norm_engine.hpp
@@ -4,7 +4,6 @@
 
 #if defined ZMQ_HAVE_NORM
 
-
 #if defined (ZMQ_HAVE_WINDOWS) && defined(ZMQ_IOTHREAD_POLLER_USE_EPOLL)
     #define ZMQ_USE_NORM_SOCKET_WRAPPER
 #endif

--- a/src/norm_engine.hpp
+++ b/src/norm_engine.hpp
@@ -4,6 +4,12 @@
 
 #if defined ZMQ_HAVE_NORM
 
+
+#if defined (ZMQ_HAVE_WINDOWS) && defined(ZMQ_IOTHREAD_POLLER_USE_EPOLL)
+    #define ZMQ_USE_NORM_SOCKET_WRAPPER
+#endif
+
+
 #include "io_object.hpp"
 #include "i_engine.hpp"
 #include "options.hpp"
@@ -186,6 +192,9 @@ class norm_engine_t ZMQ_FINAL : public io_object_t, public i_engine
     NormRxStreamState::List
       msg_ready_list; // rx streams w/ msg ready for push to zmq
 
+#ifdef ZMQ_USE_NORM_SOCKET_WRAPPER
+  fd_t wrapper_read_fd;
+#endif
 
 }; // end class norm_engine_t
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tests
     test_term_endpoint
     test_router_mandatory
     test_probe_router
+    test_pubsub
     test_stream
     test_stream_empty
     test_stream_disconnect

--- a/tests/test_pubsub.cpp
+++ b/tests/test_pubsub.cpp
@@ -115,6 +115,8 @@ int main ()
     RUN_TEST (test_tcp);
     RUN_TEST (test_inproc);
     RUN_TEST (test_inproc_late_bind);
+#if defined ZMQ_HAVE_NORM
     RUN_TEST (test_norm);
+#endif
     return UNITY_END ();
 }

--- a/tests/test_pubsub.cpp
+++ b/tests/test_pubsub.cpp
@@ -1,0 +1,120 @@
+/*
+    Copyright (c) 2007-2020 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+
+SETUP_TEARDOWN_TESTCONTEXT
+
+void test (const char *address)
+{
+    //  Create a publisher
+    void *publisher = test_context_socket (ZMQ_PUB);
+    char my_endpoint[MAX_SOCKET_STRING];
+
+    //  Bind publisher
+    test_bind (publisher, address, my_endpoint, MAX_SOCKET_STRING);
+
+    //  Create a subscriber
+    void *subscriber = test_context_socket (ZMQ_SUB);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (subscriber, my_endpoint));
+
+    //  Subscribe to all messages.
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (subscriber, ZMQ_SUBSCRIBE, "", 0));
+
+    //  Wait a bit till the subscription gets to the publisher
+    msleep (SETTLE_TIME);
+
+    //  Send an empty message
+    send_string_expect_success (publisher, "test", 0);
+
+    //  Receive the message in the subscriber
+    recv_string_expect_success (subscriber, "test", 0);
+
+    //  Clean up.
+    test_context_socket_close (publisher);
+    test_context_socket_close (subscriber);
+}
+
+void test_norm ()
+{
+    test ("norm://224.1.2.3:5556");
+}
+
+void test_tcp ()
+{
+    test ("tcp://127.0.0.1:*");
+}
+
+void test_inproc ()
+{
+    test ("inproc://hello-msg");
+}
+
+void test_inproc_late_bind ()
+{
+    char address[] = "inproc://late-hello-msg";
+
+    //  Create a server
+    void *server = test_context_socket (ZMQ_SERVER);
+
+    //  set server socket options
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (server, ZMQ_HELLO_MSG, "W", 1));
+
+    //  Create a dealer
+    void *client = test_context_socket (ZMQ_CLIENT);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (client, ZMQ_HELLO_MSG, "H", 1));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (client, address));
+
+    //  bind server after the dealer
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (server, address));
+
+    // Receive the welcome message from server
+    recv_string_expect_success (client, "W", 0);
+
+    // Receive the hello message from client
+    recv_string_expect_success (server, "H", 0);
+
+    //  Clean up.
+    test_context_socket_close (client);
+    test_context_socket_close (server);
+}
+
+int main ()
+{
+    setup_test_environment ();
+
+    UNITY_BEGIN ();
+    RUN_TEST (test_tcp);
+    RUN_TEST (test_inproc);
+    RUN_TEST (test_inproc_late_bind);
+    RUN_TEST (test_norm);
+    return UNITY_END ();
+}


### PR DESCRIPTION
Fixes #1863 along the lines as discussed.

It adds socket pair of which one is used in a thread where NORM events are polled. It sends the events to the other socket which is registered to zmq.

@bebopagogo does this look like what you had in mind? It is not a signalling socket but it passes the events. Is that an issue for NORM? Somewhat easier to implement as polling is level-triggered.