### PR TITLE
Problem: exception thrown when debugging cl.exe x64 build with LLDB

### DIFF
--- a/RELICENSE/c-zhao-3g.md
+++ b/RELICENSE/c-zhao-3g.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Lingqiao Zhao
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "s-zhao-3g", with
+commit author "s-zhao-3g <forever.3g@hotmail.com>", are copyright of Lingqiao Zhao.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Lingqiao Zhao
+2021/01/26

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -157,13 +157,13 @@ void zmq::thread_t::
 
 #elif defined(__MINGW32__)
 
-    int rc = pthread_setname_np (pthread_self(), _name);
+    int rc = pthread_setname_np (pthread_self (), _name);
     if (rc)
         return;
 
 #else
 
-    // not implemented
+        // not implemented
 
 #endif
 }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -36,6 +36,10 @@
 #include <winnt.h>
 #endif
 
+#ifdef __MINGW32__
+#include "pthread.h"
+#endif
+
 bool zmq::thread_t::get_started () const
 {
     return _started;
@@ -111,6 +115,8 @@ void zmq::thread_t::
     // not implemented
 }
 
+#ifdef _MSC_VER
+
 namespace
 {
 #pragma pack(push, 8)
@@ -124,22 +130,7 @@ struct thread_info_t
 #pragma pack(pop)
 }
 
-struct MY_EXCEPTION_REGISTRATION_RECORD
-{
-    typedef EXCEPTION_DISPOSITION (NTAPI *HandlerFunctionType) (
-      EXCEPTION_RECORD *, void *, CONTEXT *, void *);
-
-    MY_EXCEPTION_REGISTRATION_RECORD *Next;
-    HandlerFunctionType Handler;
-};
-
-static EXCEPTION_DISPOSITION NTAPI continue_execution (EXCEPTION_RECORD *rec,
-                                                       void *frame,
-                                                       CONTEXT *ctx,
-                                                       void *disp)
-{
-    return ExceptionContinueExecution;
-}
+#endif
 
 void zmq::thread_t::
   applyThreadName () // to be called in secondary thread context
@@ -147,28 +138,36 @@ void zmq::thread_t::
     if (!_name[0] || !IsDebuggerPresent ())
         return;
 
+#ifdef _MSC_VER
+
     thread_info_t thread_info;
     thread_info._type = 0x1000;
     thread_info._name = _name;
     thread_info._thread_id = -1;
     thread_info._flags = 0;
 
-    NT_TIB *tib = ((NT_TIB *) NtCurrentTeb ());
+    __try {
+        const DWORD MS_VC_EXCEPTION = 0x406D1388;
+        RaiseException (MS_VC_EXCEPTION, 0,
+                        sizeof (thread_info) / sizeof (ULONG_PTR),
+                        (ULONG_PTR *) &thread_info);
+    }
+    __except (EXCEPTION_CONTINUE_EXECUTION) {
+    }
 
-    MY_EXCEPTION_REGISTRATION_RECORD rec;
-    rec.Next = (MY_EXCEPTION_REGISTRATION_RECORD *) tib->ExceptionList;
-    rec.Handler = continue_execution;
+#elif defined(__MINGW32__)
 
-    // push our handler, raise, and finally pop our handler
-    tib->ExceptionList = (_EXCEPTION_REGISTRATION_RECORD *) &rec;
-    const DWORD MS_VC_EXCEPTION = 0x406D1388;
-    RaiseException (MS_VC_EXCEPTION, 0,
-                    sizeof (thread_info) / sizeof (ULONG_PTR),
-                    (ULONG_PTR *) &thread_info);
-    tib->ExceptionList =
-      (_EXCEPTION_REGISTRATION_RECORD
-         *) (((MY_EXCEPTION_REGISTRATION_RECORD *) tib->ExceptionList)->Next);
+    int rc = pthread_setname_np (pthread_self(), _name);
+    if (rc)
+        return;
+
+#else
+
+    // not implemented
+
+#endif
 }
+
 
 #elif defined ZMQ_HAVE_VXWORKS
 


### PR DESCRIPTION
Problem: exception thrown when debugging cl.exe x64 build with LLDB

Solution: Use __try __except with cl.exe anduse pthread_setname_np with MinGW.
Remove usage of pushing exception handler to TIB->ExceptionList.