### PR TITLE
Problem: XPUB socket allows manual subscription on terminated pipe

### DIFF
--- a/src/dist.cpp
+++ b/src/dist.cpp
@@ -64,6 +64,18 @@ void zmq::dist_t::attach (pipe_t *pipe_)
     }
 }
 
+bool zmq::dist_t::has_pipe (pipe_t *pipe_)
+{
+    std::size_t claimed_index = _pipes.index (pipe_);
+
+    // If pipe claims to be outside the available index space it can't be in the distributor.
+    if (claimed_index >= _pipes.size ()) {
+        return false;
+    }
+
+    return _pipes[claimed_index] == pipe_;
+}
+
 void zmq::dist_t::match (pipe_t *pipe_)
 {
     //  If pipe is already matching do nothing.

--- a/src/dist.hpp
+++ b/src/dist.hpp
@@ -51,6 +51,9 @@ class dist_t
     //  Adds the pipe to the distributor object.
     void attach (zmq::pipe_t *pipe_);
 
+    //  Checks if this pipe is present in the distributor.
+    bool has_pipe (zmq::pipe_t *pipe_);
+
     //  Activates pipe that have previously reached high watermark.
     void activated (zmq::pipe_t *pipe_);
 

--- a/src/xpub.cpp
+++ b/src/xpub.cpp
@@ -272,6 +272,12 @@ void zmq::xpub_t::xpipe_terminated (pipe_t *pipe_)
         //  care of by the manual call above. subscriptions is the real mtrie,
         //  so the pipe must be removed from there or it will be left over.
         _subscriptions.rm (pipe_, stub, static_cast<void *> (NULL), false);
+
+        // In case the pipe is currently set as last we must clear it to prevent
+        // subscriptions from being re-added.
+        if (pipe_ == _last_pipe) {
+            _last_pipe = NULL;
+        }
     } else {
         //  Remove the pipe from the trie. If there are topics that nobody
         //  is interested in anymore, send corresponding unsubscriptions
@@ -348,6 +354,12 @@ int zmq::xpub_t::xrecv (msg_t *msg_)
     if (_manual && !_pending_pipes.empty ()) {
         _last_pipe = _pending_pipes.front ();
         _pending_pipes.pop_front ();
+
+        // If the distributor doesn't know about this pipe it must have already
+        // been terminated and thus we can't allow manual subscriptions.
+        if (_last_pipe != NULL && !_dist.has_pipe (_last_pipe)) {
+            _last_pipe = NULL;
+        }
     }
 
     int rc = msg_->close ();


### PR DESCRIPTION
Solution: Avoid setting pipe as _last_pipe if it has been terminated


When using XPUB with manual subscriptions the scheme is to:
1. read one subscription notification from the socket at a time
2. and then call an arbitrary number of `zmq_setsockopt` with `ZMQ_SUBSCRIBE` to add subscriptions for the pipe from which the most recent subscription notification (or other message) was read by the application. This works because the socket remembers the `_last_pipe` it read a message from and uses that as a target for adding subscriptions.

A serious problem however appears if the pipe has been terminated before the application has had a chance to read and process the messages associated with that pipe.

If the application reads a pending message from a pipe that has already been terminated, and then the application adds subscriptions for that pipe it leads to the already terminated pipe that has been removed from `dist` and from `_subscriptions` trie to be added to the `_subscriptions` trie but not back to `_dist`:

https://github.com/zeromq/libzmq/blob/b3722cf9834ba3028bdcc1650b1c9dcda1e69d73/src/xpub.cpp#L265-L283
https://github.com/zeromq/libzmq/blob/b3722cf9834ba3028bdcc1650b1c9dcda1e69d73/src/xpub.cpp#L231-L234

What this means is that sending a message to a topic can end up matching pipes no longer present in the distributor. Each such match will still go through `mark_as_matching`, the distributor will not be able to tell that some of the pipes sent to it are not actually in use by the distributor because the distributor trusts the pipe itself to know its index rather than check its array of pipes for the presence of the pipe. This can lead to messages being distributed to completely unrelated pipes.

https://github.com/zeromq/libzmq/blob/b3722cf9834ba3028bdcc1650b1c9dcda1e69d73/src/xpub.cpp#L285-L287
https://github.com/zeromq/libzmq/blob/b3722cf9834ba3028bdcc1650b1c9dcda1e69d73/src/dist.cpp#L67-L80
https://github.com/zeromq/libzmq/blob/b3722cf9834ba3028bdcc1650b1c9dcda1e69d73/src/array.hpp#L126-L129

1. It's important to note that it's not the terminated pipes that become matches and potential recipients of messages. It's the active pipes that happen to have the same index as the terminated pipe.
2. This happens very easily with rapidly reconnecting clients
3. The issue might get masked by client side SUB socket if it's not configured to subscribe to everything or to any of the topics that it's nor expected to receive messages for. (basically the server could be sending data the client should never see but the SUB socket hides that from the application)


Reproduced with a golang script (if it panics, it reproduced the issue, otherwise will run forever):
```go
package main

import (
	"fmt"
	"syscall"
	"time"

	"github.com/pebbe/zmq4"
)

func createSub(topic string) *zmq4.Socket {
	sock, _ := zmq4.NewSocket(zmq4.SUB)

	sock.Connect("tcp://127.0.0.1:32000")

	// This accepts everything on the SUB side but is ignored server-side.
	// Without it the SUB socket would receive the unexpected message but
	// drop it client-side.
	sock.SetSubscribe("") // accept everything

	sock.SetSubscribe(topic) // indicate what we really expect to receive

	return sock
}

// Regular SUB client that observes for expected messages
func sub(topic string) {
	sock := createSub(topic)
	defer sock.Close()

	for {
		msg, err := sock.RecvMessage(zmq4.Flag(0))
		if err == zmq4.Errno(syscall.EAGAIN) {
			continue
		}

		if msg[0] != topic {
			panic(fmt.Sprint("Reproduced: expected ", topic, " got ", msg[0]))
		}
	}
}

// SUB client that rapidly reconnects
func subReconnecter(topic string) {
	for {
		sock := createSub(topic)
		time.Sleep(10 * time.Millisecond)
		sock.Close()
	}
}

func xpub() {
	sock, _ := zmq4.NewSocket(zmq4.XPUB)
	sock.SetXpubVerbose(3)
	sock.SetXpubManual(1)
	sock.Bind("tcp://127.0.0.1:32000")

	subCheck := time.NewTicker(100 * time.Millisecond)

	for {
		select {
		case <-subCheck.C:
			// process subscription messages, but not too frequently to
			// allow time for the sending pipe to be terminated first
			for {
				msg, err := sock.RecvMessageBytes(zmq4.DONTWAIT)
				if err != nil {
					if err == zmq4.Errno(syscall.EAGAIN) {
						break
					}
					panic(err)
				}

				frame := msg[0]
				if frame[0] == 1 && len(frame) > 1 {
					sock.SetSubscribe(string(frame[1:]))
				}
			}
		default:
			sock.SendMessage([]string{"xxx"})
			sock.SendMessage([]string{"yyy"})
		}
	}
}

func main() {
	go sub("xxx")
	go subReconnecter("yyy")

	xpub()
}
```