### PR TITLE
Fix Fedora33 s390x build.

### DIFF
--- a/RELICENSE/jlsantiago0.md
+++ b/RELICENSE/jlsantiago0.md
@@ -1,0 +1,13 @@
+ Permission to Relicense under MPLv2
+
+This is a statement by Jose L. Santiago
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "jlsantiago0", with
+commit author "Jose L. Santiago", are copyright of Jose L. Santiago.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Jose L. Santiago
+2021/02/18

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1213,6 +1213,11 @@ AC_DEFUN([LIBZMQ_CHECK_CACHELINE], [{
             zmq_cacheline_size=$(cat /sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size 2>/dev/null || echo 64)
         fi
     fi
+    if test "x$zmq_cacheline_size" = "xundefined"; then
+        # On some platforms e.g. Fedora33 s390x the cacheline size reported
+        # by getconf as 'undefined'.
+        zmq_cacheline_size=64
+    fi
 	AC_MSG_NOTICE([Using "$zmq_cacheline_size" bytes alignment for lock-free data structures])
 	AC_DEFINE_UNQUOTED(ZMQ_CACHELINE_SIZE, $zmq_cacheline_size, [Using "$zmq_cacheline_size" bytes alignment for lock-free data structures])
 }])


### PR DESCRIPTION
getconf LEVEL1_DCACHE_LINESIZE reports 'undefined' on Fedora33 s390x. This pull request fixes the build on that platform.