### PR TITLE
fix formatting problems in .clang-tidy options

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,8 +12,8 @@ Checks:        "*,\
 -cppcoreguidelines-avoid-goto,\
 -cppcoreguidelines-pro-type-member-init,\
 -cppcoreguidelines-pro-type-static-cast-downcast,\
-# not applicable\
--fuchsia-default-argument-calls,\
+# not applicable,\
+-fuchsia-default-arguments-calls,\
 -fuchsia-overloaded-operator,\
 -fuchsia-statically-constructed-objects,\
 # not currently a coding convention, C++11-specific, but conceivable,\


### PR DESCRIPTION
a couple of problems:
- missing comma on comment line hides following line
- misspelled suppression for "-fuchsia-default-arguments-calls"