### PR TITLE
add more suppressions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,8 +10,10 @@ Checks:        "*,\
 -google-readability-todo,\
 -google-runtime-int,\
 -cppcoreguidelines-avoid-goto,\
+-hicpp-avoid-goto, \
 -cppcoreguidelines-pro-type-member-init,\
 -cppcoreguidelines-pro-type-static-cast-downcast,\
+-readability-identifier-naming,\
 # not applicable,\
 -fuchsia-default-arguments-calls,\
 -fuchsia-overloaded-operator,\
@@ -45,6 +47,7 @@ Checks:        "*,\
 -google-readability-braces-around-statements,\
 -cppcoreguidelines-pro-type-cstyle-cast,\
 -cppcoreguidelines-avoid-magic-numbers,\
+-readability-magic-numbers,\
 -hicpp-braces-around-statements,\
 -hicpp-use-equals-default,\
 -hicpp-deprecated-headers,\

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,8 +12,8 @@ Checks:        "*,\
 -cppcoreguidelines-avoid-goto,\
 -cppcoreguidelines-pro-type-member-init,\
 -cppcoreguidelines-pro-type-static-cast-downcast,\
-# not applicable\
--fuchsia-default-argument-calls,\
+# not applicable,\
+-fuchsia-default-arguments-calls,\
 -fuchsia-overloaded-operator,\
 -fuchsia-statically-constructed-objects,\
 # not currently a coding convention, C++11-specific, but conceivable,\


### PR DESCRIPTION
As a followup to https://github.com/zeromq/libzmq/pull/4155, these addl. suppressions reduce the noise level with clang-tidy-10 on ubuntu.  Two duplicate existing suppressions that have been rendered ineffective with new rules in clang-tidy.