### PR TITLE
MINGW Build Fix.

### DIFF
--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -41,6 +41,9 @@
 //  For AF_INET and IPPROTO_TCP
 #if defined _WIN32
 #include "../src/windows.hpp"
+#if defined(__MINGW32__)
+#include <unistd.h>
+#endif
 #else
 #include <arpa/inet.h>
 #include <unistd.h>


### PR DESCRIPTION
There is a macro that redefines close to closesocket, but then close is
later defined in unistd.h which is included in testutil_unity.cpp which
then causes the regular close() prototype to be defined with the new
function name closesocket which does not match the signature of the
original closesocket in winsock2.h from the toolchain.

We can work around this issue, by making sure that unistd.h is included
before the macro is defined. HMM> Yes macro substitution is the root of
evil.