### PR TITLE
Fix MINGW with pthread cv

### DIFF
--- a/src/mutex.hpp
+++ b/src/mutex.hpp
@@ -35,7 +35,7 @@
 
 //  Mutex class encapsulates OS mutex in a platform-independent way.
 
-#ifdef ZMQ_HAVE_WINDOWS
+#if defined(ZMQ_HAVE_WINDOWS) && !defined(ZMQ_USE_CV_IMPL_PTHREADS)
 
 #include "windows.hpp"
 


### PR DESCRIPTION
ZeroMQ works with MINGW and pthread conditional variables if pthread
mutexes are used. POSIX conditional variables require POSIX mutexes, but
ZeroMQ unconditionally uses WIN32 critital sections even when configured
with pthread conditional variables. This of course does not work. This
patch fixes the build so that MINGW builds do not use WIN32 critical
sections and instead use POSIX mutexes when configured with pthread
conditional variables.

Tested with:

```
 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ ../libzmq/configure --host=x86_64-w64-mingw32 --prefix=`pwd`/stage --enable-debug --disable-Werror --enable-libunwind=no   --with-cv-impl=pthread --enable-libbsd=no
```

```
x86_64-w64-mingw32-gcc --version

   x86_64-w64-mingw32-gcc (GCC) 10.2.0.....
```