### PR TITLE
ZMQ_RECONNECT_STOP options are intended to be inclusive

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -687,7 +687,7 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1
 #define ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED 0x2
-#define ZMQ_RECONNECT_STOP_AFTER_DISCONNECT 0x3
+#define ZMQ_RECONNECT_STOP_AFTER_DISCONNECT 0x4
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -73,7 +73,7 @@
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1
 #define ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED 0x2
-#define ZMQ_RECONNECT_STOP_AFTER_DISCONNECT 0x3
+#define ZMQ_RECONNECT_STOP_AFTER_DISCONNECT 0x4
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10


### PR DESCRIPTION
(i.e., can be OR'ed together),  and so values must be powers of two