### PR TITLE
fix unused variables under windows

### DIFF
--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -126,9 +126,11 @@ static f_compatible_get_tick_count64 my_get_tick_count64 =
   init_compatible_get_tick_count64 ();
 #endif
 
+#ifndef ZMQ_HAVE_WINDOWS
 const uint64_t usecs_per_msec = 1000;
-const uint64_t usecs_per_sec = 1000000;
 const uint64_t nsecs_per_usec = 1000;
+#endif
+const uint64_t usecs_per_sec = 1000000;
 
 zmq::clock_t::clock_t () :
     _last_tsc (rdtsc ()),


### PR DESCRIPTION
Fixes compilation as -Werror is passed.