### PR TITLE
Update fd slot type to zmq_fd_t

### DIFF
--- a/RELICENSE/yitzchak.md
+++ b/RELICENSE/yitzchak.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Tarn W. Burton
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "yitzchak", with
+commit author "Tarn W. Burton", are copyright of Tarn W. Burton.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Tarn W. Burton
+2021/05/16

--- a/doc/zmq_poll.txt
+++ b/doc/zmq_poll.txt
@@ -25,7 +25,7 @@ array. The *zmq_pollitem_t* structure is defined as follows:
 typedef struct
 {
     void '*socket';
-    int 'fd';
+    zmq_fd_t 'fd';
     short 'events';
     short 'revents';
 } zmq_pollitem_t;


### PR DESCRIPTION
The documentation for `zmq_pollitem_t` lists the type of the `fd` field as `int` but it changed to `zmq_fd_t` in v4.3.2

Please note that the documentation for previous versions is also incorrect in that it lists the type as `int` when it was `SOCKET` on Windows and `int` elsewhere. Is the documentation for previous releases corrected for errors?