### PR TITLE
Remove Windows-specific defines from zmq.h.

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -57,21 +57,6 @@ extern "C" {
 #endif
 #include <stddef.h>
 #include <stdio.h>
-#if defined _WIN32
-//  Set target version to Windows Server 2008, Windows Vista or higher.
-//  Windows XP (0x0501) is supported but without client & server socket types.
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
-#endif
-
-#ifdef __MINGW32__
-//  Require Windows XP or higher with MinGW for getaddrinfo().
-#if (_WIN32_WINNT >= 0x0501)
-#else
-#error You need at least Windows XP target
-#endif
-#endif
-#endif
 
 /*  Handle DSO symbol visibility                                             */
 #if defined _WIN32


### PR DESCRIPTION
These are redundant with the ones in windows.hpp and aren't needed for the public interface.

Since 4.3.3 zmq.h no longer includes windows.h and so these defines have no effect on zmq besides potentially interfering with what the user is doing.

Built on Windows VS 16.9.6, all tests passed.