### PR TITLE
fix unused parameter warning when POLL_BASED_ON_SELECT

### DIFF
--- a/RELICENSE/NLeScienceCenter.md
+++ b/RELICENSE/NLeScienceCenter.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by the Netherlands eScience Center
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "egpbos", with
+commit author "E. G. Patrick Bos p.bos@esciencecenter.nl", are copyright of the Netherlands eScience Center.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Rob van Nieuwpoort <R.vanNieuwpoort@esciencecenter.nl>
+2021/06/15

--- a/src/polling_util.hpp
+++ b/src/polling_util.hpp
@@ -109,9 +109,9 @@ timeout_t
 compute_timeout (bool first_pass_, long timeout_, uint64_t now_, uint64_t end_);
 
 #elif defined ZMQ_POLL_BASED_ON_SELECT
+#if defined ZMQ_HAVE_WINDOWS
 inline size_t valid_pollset_bytes (const fd_set &pollset_)
 {
-#if defined ZMQ_HAVE_WINDOWS
     // On Windows we don't need to copy the whole fd_set.
     // SOCKETS are continuous from the beginning of fd_array in fd_set.
     // We just need to copy fd_count elements of fd_array.
@@ -119,10 +119,14 @@ inline size_t valid_pollset_bytes (const fd_set &pollset_)
     return reinterpret_cast<const char *> (
              &pollset_.fd_array[pollset_.fd_count])
            - reinterpret_cast<const char *> (&pollset_);
-#else
-    return sizeof (fd_set);
-#endif
 }
+#else
+inline size_t valid_pollset_bytes (const fd_set &/*pollset_*/)
+{
+    return sizeof (fd_set);
+}
+#endif
+
 
 #if defined ZMQ_HAVE_WINDOWS
 // struct fd_set {


### PR DESCRIPTION
When the build is performed with cmake option `-DPOLLER=select`, the following warning is triggered from 4 locations that import `polling_util.hpp`:

```
[...]/src/polling_util.hpp:115:50: warning: unused parameter 'pollset_' [-Wunused-parameter]
inline size_t valid_pollset_bytes (const fd_set &pollset_)
                                                 ^
1 warning generated.
```

This is fixed here.