### PR TITLE
Problem: build with curve fails on GCC 11

### DIFF
--- a/src/curve_client_tools.hpp
+++ b/src/curve_client_tools.hpp
@@ -180,6 +180,12 @@ struct curve_client_tools_t
         //  Create Box [C + vouch + metadata](C'->S')
         std::fill (initiate_plaintext.begin (),
                    initiate_plaintext.begin () + crypto_box_ZEROBYTES, 0);
+
+        //  False positives due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578
+#if __GNUC__ >= 11
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow="
+#endif
         memcpy (&initiate_plaintext[crypto_box_ZEROBYTES], public_key_, 32);
         memcpy (&initiate_plaintext[crypto_box_ZEROBYTES + 32], vouch_nonce + 8,
                 16);
@@ -189,6 +195,10 @@ struct curve_client_tools_t
             memcpy (&initiate_plaintext[crypto_box_ZEROBYTES + 48 + 80],
                     metadata_plaintext_, metadata_length_);
         }
+#if __GNUC__ >= 11
+#pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
+#endif
 
         memcpy (initiate_nonce, "CurveZMQINITIATE", 16);
         put_uint64 (initiate_nonce + 16, cn_nonce_);


### PR DESCRIPTION
Solution: ignore false positives due to compiler bug:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578

Fixes https://github.com/zeromq/libzmq/issues/4206