### PR TITLE
fix: building libzmq fails with error src/clock.cpp

### DIFF
--- a/RELICENSE/sabotagebeats.md
+++ b/RELICENSE/sabotagebeats.md
@@ -1,0 +1,16 @@
+  
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by sabotagebeats
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "sabotagebeats", with
+commit author "sabotagebeats", are copyright of sabotagebeats .
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+sabotagebeats
+2021/7/24

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -195,6 +195,7 @@ uint64_t zmq::clock_t::now_us ()
 
 #else
 
+    LIBZMQ_UNUSED (nsecs_per_usec);
     //  Use POSIX gettimeofday function to get precise time.
     struct timeval tv;
     int rc = gettimeofday (&tv, NULL);


### PR DESCRIPTION
`unused variable 'nsecs_per_usec'`

https://github.com/zeromq/libzmq/issues/4231