### PR TITLE
Fix crash in context with wide characters in path

### DIFF
--- a/RELICENSE/saschavv.md
+++ b/RELICENSE/saschavv.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Sascha van Vliet 
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "saschavv", with
+commit author "Sascha van Vliet <saschavv@gmail.com>", are copyright of Sascha van Vliet.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Sascha van Vliet
+2021/07/30

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -868,24 +868,48 @@ void zmq::assert_success_or_recoverable (zmq::fd_t s_, int rc_)
 }
 
 #ifdef ZMQ_HAVE_IPC
+
+#if defined ZMQ_HAVE_WINDOWS
+char *widechar_to_utf8 (const wchar_t *widestring)
+{
+    int nch, n;
+    char *utf8 = 0;
+    nch = WideCharToMultiByte (CP_UTF8, 0, widestring, -1, 0, 0, NULL, NULL);
+    if (nch > 0) {
+        utf8 = (char *)malloc ((nch + 1) * sizeof (char));
+        n = WideCharToMultiByte (CP_UTF8, 0, widestring, -1, utf8,
+                                 nch, NULL, NULL);
+        utf8[nch] = 0;
+    }
+    return utf8;
+}
+#endif
+
 int zmq::create_ipc_wildcard_address (std::string &path_, std::string &file_)
 {
 #if defined ZMQ_HAVE_WINDOWS
-    char buffer[MAX_PATH];
+    wchar_t buffer[MAX_PATH];
 
     {
-        const errno_t rc = tmpnam_s (buffer);
+        const errno_t rc = _wtmpnam_s (buffer);
         errno_assert (rc == 0);
     }
 
     // TODO or use CreateDirectoryA and specify permissions?
-    const int rc = _mkdir (buffer);
+    const int rc = _wmkdir (buffer);
     if (rc != 0) {
         return -1;
     }
 
-    path_.assign (buffer);
+    char* tmp = widechar_to_utf8 (buffer);
+    if (tmp == 0) {
+	return -1;
+    }
+
+    path_.assign (tmp);
     file_ = path_ + "/socket";
+
+    free (tmp);
 #else
     std::string tmp_path;
 


### PR DESCRIPTION
Closes #4201 The create_ipc_wildcard_address can return a string that is inappropriate for the bind call that follows.
The bind requires an utf8 string and the create_ipc_wildcard_address with tmpnam_s that returns a string based on the oem code pages. The fix uses the wide character alternatives and uses a to utf8 conversion routing to fix the bind problem.