### PR TITLE
Problem: calling randombytes_close with libsodium can crash Contexts in other threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ endif()
 
 option(WITH_LIBSODIUM "Use libsodium instead of built-in tweetnacl" ON)
 option(WITH_LIBSODIUM_STATIC "Use static libsodium library" OFF)
+option(ENABLE_LIBSODIUM_RANDOMBYTES_CLOSE "Automatically close libsodium randombytes. Not threadsafe without getrandom()" ON)
 option(ENABLE_CURVE "Enable CURVE security" ON)
 
 if(ENABLE_CURVE)
@@ -271,6 +272,9 @@ if(ENABLE_CURVE)
       endif()
       set(ZMQ_USE_LIBSODIUM 1)
       set(ZMQ_HAVE_CURVE 1)
+      if (ENABLE_LIBSODIUM_RANDOMBYTES_CLOSE)
+        set(ZMQ_LIBSODIUM_RANDOMBYTES_CLOSE 1)
+      endif()
     else()
       message(
         WARNING

--- a/configure.ac
+++ b/configure.ac
@@ -550,6 +550,20 @@ AS_IF([test "x$with_libsodium" = "xyes"], [
 AC_ARG_ENABLE([curve],
     [AS_HELP_STRING([--disable-curve], [disable CURVE security [default=no]])])
 
+AC_ARG_ENABLE(
+    [libsodium_randombytes_close],
+    [AS_HELP_STRING(
+        [--disable-libsodium_randombytes_close],
+        [Do not call libsodium randombytes_close() when terminating contexts.
+        If disabled, may leave one FD open on /dev/urandom
+        until randombytes_close() is called explicitly,
+        but fixes a crash when multiple contexts are used with CURVE.
+        Has no effect when getrandom() is available. [default=enabled]]
+    )],
+    [],
+    [enable_libsodium_randombytes_close=yes]
+)
+
 if test "x$enable_curve" = "xno"; then
     curve_library=""
     AC_MSG_NOTICE([CURVE security is disabled])
@@ -558,6 +572,12 @@ elif test "x$with_libsodium" = "xyes"; then
     AC_MSG_NOTICE([Using libsodium for CURVE security])
     AC_DEFINE(ZMQ_HAVE_CURVE, [1], [Using curve encryption])
     AC_DEFINE(ZMQ_USE_LIBSODIUM, [1], [Using libsodium for curve encryption])
+    if test "x$enable_libsodium_randombytes_close" = "xyes"; then
+        AC_DEFINE(ZMQ_LIBSODIUM_RANDOMBYTES_CLOSE, [1], [Automatically close libsodium randombytes. Not threadsafe without getrandom()])
+    else
+        AC_MSG_NOTICE([Disabling libsodium randombytes_close(). randombytes_close() may need to be called in applcation code.])
+    fi
+
     curve_library="libsodium"
     enable_curve="yes"
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -151,8 +151,6 @@ static void manage_random (bool init_)
     if (init_) {
         int rc = sodium_init ();
         zmq_assert (rc != -1);
-    } else {
-        randombytes_close ();
     }
 #else
     LIBZMQ_UNUSED (init_);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -151,6 +151,13 @@ static void manage_random (bool init_)
     if (init_) {
         int rc = sodium_init ();
         zmq_assert (rc != -1);
+#if defined(ZMQ_LIBSODIUM_RANDOMBYTES_CLOSE)
+    } else {
+        // randombytes_close either a no-op or not threadsafe
+        // doing this without refcounting can cause crashes
+        // if called while a context is active
+        randombytes_close ();
+#endif
     }
 #else
     LIBZMQ_UNUSED (init_);


### PR DESCRIPTION
**Problem:** When using libsodium, calling `zmq::random_close()` closes a shared resources that may still be in use.

See #4241 for details and repro, but this is called unconditionally on every `curve_keypair()` and every context destructor, since #3001. Closing any context and/or issuing a new curve keypair can crash another context if it is working with curve-enabled sockets at the time, as it is still a consumer of a now-closed resource. libsodium will try to reinitialize the source, so it doesn't crash every time; instead, certain race conditions must be met to result in a crash.

**Solution:** Do not close this shared resource while it is still in use, as suggested by the libsodium [documentation](https://doc.libsodium.org/generating_random_data#usage).

For implementations using /dev/[u]random, this can leave up to one leftover FD per process (restores #2632, but should be bounded to one).

If we want to call `randombytes_close()`, we must restore the use of refcounting in #2636 when using libsodium to avoid crashes.

closes #4241