### PR TITLE
Fixing cmake_minimum_required() and project() calls order.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake build script for ZeroMQ
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(ZeroMQ)
 


### PR DESCRIPTION
According to the CMake doc for [`cmake_minimum_required()`](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html?highlight=project) and [`project()`](https://cmake.org/cmake/help/latest/command/project.html#command:project), the commands should be called in this order:

1) `cmake_minimum_required()`
2) `project()`

in order to correctly set up the policies for the project. Otherwise it can break the policy settings as described here: https://gitlab.kitware.com/cmake/cmake/-/issues/22671

Moving the conditional expression before `project()` however does not work because `CMAKE_SYSTEM_NAME` is not defined at this point. So the minimum version is bumped to the higher one for all platforms.