### PR TITLE
mingw-w64 10.3 build fix - winsock socket() return unsigned

### DIFF
--- a/RELICENSE/analogist.md
+++ b/RELICENSE/analogist.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by James Wu
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "analogist", with
+commit author "James Wu <james@analogist.net>", are copyright of James Wu.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+James Wu
+2020/09/24

--- a/tests/testutil.cpp
+++ b/tests/testutil.cpp
@@ -386,7 +386,11 @@ fd_t connect_socket (const char *endpoint_, const int af_, const int protocol_)
                                protocol_ == IPPROTO_UDP   ? IPPROTO_UDP
                                : protocol_ == IPPROTO_TCP ? IPPROTO_TCP
                                                           : 0);
+#ifdef ZMQ_HAVE_WINDOWS
+    TEST_ASSERT_NOT_EQUAL (INVALID_SOCKET, s_pre);
+#else
     TEST_ASSERT_NOT_EQUAL (-1, s_pre);
+#endif
 
     if (af_ == AF_INET || af_ == AF_INET6) {
         const char *port = strrchr (endpoint_, ':') + 1;
@@ -443,7 +447,11 @@ fd_t bind_socket_resolve_port (const char *address_,
                                protocol_ == IPPROTO_UDP   ? IPPROTO_UDP
                                : protocol_ == IPPROTO_TCP ? IPPROTO_TCP
                                                           : 0);
+#ifdef ZMQ_HAVE_WINDOWS
+    TEST_ASSERT_NOT_EQUAL (INVALID_SOCKET, s_pre);
+#else
     TEST_ASSERT_NOT_EQUAL (-1, s_pre);
+#endif
 
     if (af_ == AF_INET || af_ == AF_INET6) {
 #ifdef ZMQ_HAVE_WINDOWS


### PR DESCRIPTION
Fixes ~2~ 1 build issue~s~ under mingw-w64 and `ZMQ_HAVE_WINDOWS` in general:

### 1. winsock2.h socket() returns are unsigned

winsock `socket()` calls return an `fd_t` / `handle_t` that is uint64_t for 64-bit systems and uint32_t for 32-bit systems, which throws `-Werror=sign-compare` when compared against -1 in test:

> ```
>   CXX      tests/libtestutil_a-testutil.o
> In file included from ./external/unity/unity.h:16,
>                  from tests/testutil_unity.hpp:36,
>                  from tests/testutil.cpp:30:
> tests/testutil.cpp: In function 'fd_t connect_socket(const char*, int, int)':
> ./external/unity/unity.h:134:130: error: comparison of integer expressions of different signedness: 'int' and 'const fd_t' {aka 'const long long unsigned int'} [-Werror=sign-compare]
>   134 | #define TEST_ASSERT_NOT_EQUAL(expected, actual)                                                    UNITY_TEST_ASSERT(((expected) !=  (actual)), __LINE__, " Expected Not-Equal")
>       |                                                                                                                       ~~~~~~~~~~~^~~~~~~~~~~~
> ./external/unity/unity_internals.h:654:102: note: in definition of macro 'UNITY_TEST_ASSERT'
>   654 | #define UNITY_TEST_ASSERT(condition, line, message)                                              if (condition) {} else {UNITY_TEST_FAIL((UNITY_LINE_TYPE)(line), (message));}
> ```

The best practice is to [compare against `INVALID_SOCKET`](https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket); alternatively it's probably also possible to force cast `(int) s_pre`, as `INVALID_SOCKET` is generally understood to be (~0).

_Edit: #2 does not cause build issue in mingw, was correctly fixed by <unistd.h> include order in PR #4172, encountered by mistake due to mixed working tree state between MSVC and mingw. PR updated to omit that commit entirely_

### ~~2. Macro redefinition~~

~~Similar to breakage encountered in PR #4172 and issue #4044, macro definition of `closesocket` included at the top level `testutil.hpp` continue to cause build issues. As `#define close closesocket` already repeatedly occurs in multiple `test_*.cpp` modules, following convention this was moved from the top-level header into the `testutil.cpp` body, where the include order no longer causes issues.~~

> ```
> CXX      tests/libtestutil_a-testutil_unity.o 
> In file included from tests/testutil_unity.hpp:34,
>                  from tests/testutil_unity.cpp:29:
> tests/testutil.hpp:105:15: error: conflicting declaration of C function 'int closesocket(int)'
>   105 | #define close closesocket
>       |               ^~~~~~~~~~~
> In file included from tests/../src/windows.hpp:54,
>                  from tests/testutil.hpp:43,
>                  from tests/testutil_unity.hpp:34,
>                  from tests/testutil_unity.cpp:29:
> C:/msys64/mingw64/x86_64-w64-mingw32/include/winsock2.h:1005:34: note: previous declaration 'int closesocket(SOCKET)'
> 1005 |   WINSOCK_API_LINKAGE int WSAAPI closesocket(SOCKET s);
>       |                                  ^~~~~~~~~~~
> make[1]: *** [Makefile:5346: tests/libtestutil_a-testutil_unity.o] Error 1
> ```