### PR TITLE
Problem: polling_util.hpp missing sys/select.h include

### DIFF
--- a/src/polling_util.hpp
+++ b/src/polling_util.hpp
@@ -31,8 +31,13 @@
 #define __ZMQ_SOCKET_POLLING_UTIL_HPP_INCLUDED__
 
 #include <stdlib.h>
-#include <sys/select.h>
 #include <vector>
+
+#if defined ZMQ_HAVE_WINDOWS
+#include <winsock.h>
+#else
+#include <sys/select.h>
+#endif
 
 #include "macros.hpp"
 #include "stdint.hpp"


### PR DESCRIPTION
Solution: include sys/select.h
Fixes #4282

I think it is due to the addition of PPOL which includes polling_util.hpp and <sys/select.h> only afterwards. Before this commit it seemed like fd_set came from a different include somewhere in the files it was used.

- [x] Fix windows build as it does not have sys/select.h
- [x] Verify if other platforms miss sys/select.h but include polling_util.hpp (and fd_set) and which header to include then