### PR TITLE
Problem: if ZMQ_XPUB_VERBOSER is used with proxies unsubscribe messages are lost

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1066,7 +1066,8 @@ test_apps += tests/test_poller \
 	tests/test_disconnect_msg \
 	tests/test_channel \
 	tests/test_hiccup_msg \
-	tests/test_zmq_ppoll_fd
+	tests/test_zmq_ppoll_fd \
+	tests/test_xsub_verbose
 
 tests_test_poller_SOURCES = tests/test_poller.cpp
 tests_test_poller_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
@@ -1139,6 +1140,10 @@ tests_test_hiccup_msg_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 tests_test_zmq_ppoll_fd_SOURCES = tests/test_zmq_ppoll_fd.cpp
 tests_test_zmq_ppoll_fd_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
 tests_test_zmq_ppoll_fd_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+
+tests_test_xsub_verbose_SOURCES = tests/test_xsub_verbose.cpp
+tests_test_xsub_verbose_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
+tests_test_xsub_verbose_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 
 if HAVE_FORK
 test_apps += tests/test_zmq_ppoll_signals

--- a/RELICENSE/PaulThiele.md
+++ b/RELICENSE/PaulThiele.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Paul Thiele that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "thielepaul", with
+commit author "Paul Thiele <thielepaul@gmail.com>", are
+copyright of Paul Thiele.  This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Paul Thiele
+2021/11/04

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1252,6 +1252,21 @@ Default value:: NULL
 Applicable socket types:: ZMQ_XPUB
 
 
+ZMQ_XSUB_VERBOSE_UNSUBSCRIBE: pass duplicate unsubscribe messages on XSUB socket
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the 'XSUB' socket behaviour on duplicated unsubscriptions. If enabled, the socket
+passes all unsubscribe messages to the caller. If disabled, only the last unsubscription
+from each filter will be passed. The default is 0 (disabled).
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1
+Default value:: 0
+Applicable socket types:: ZMQ_XSUB
+
+
 ZMQ_ONLY_FIRST_SUBSCRIBE: Process only first subscribe/unsubscribe in a multipart message
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If set, only the first part of the multipart message is processed as

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -679,6 +679,7 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_PRIORITY 112
 #define ZMQ_BUSY_POLL 113
 #define ZMQ_HICCUP_MSG 114
+#define ZMQ_XSUB_VERBOSE_UNSUBSCRIBE 115
 
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1

--- a/src/xsub.cpp
+++ b/src/xsub.cpp
@@ -36,6 +36,7 @@
 
 zmq::xsub_t::xsub_t (class ctx_t *parent_, uint32_t tid_, int sid_) :
     socket_base_t (parent_, tid_, sid_),
+    _verbose_unsubs (false),
     _has_message (false),
     _more_send (false),
     _more_recv (false),
@@ -110,6 +111,12 @@ int zmq::xsub_t::xsetsockopt (int option_,
         _only_first_subscribe = (*static_cast<const int *> (optval_) != 0);
         return 0;
     }
+#ifdef ZMQ_BUILD_DRAFT_API
+    else if (option_ == ZMQ_XSUB_VERBOSE_UNSUBSCRIBE) {
+        _verbose_unsubs = (*static_cast<const int *> (optval_) != 0);
+        return 0;
+    }
+#endif
     errno = EINVAL;
     return -1;
 }
@@ -150,7 +157,8 @@ int zmq::xsub_t::xsend (msg_t *msg_)
             size = size - 1;
         }
         _process_subscribe = true;
-        if (_subscriptions.rm (data, size))
+        const bool rm_result = _subscriptions.rm (data, size);
+        if (rm_result || _verbose_unsubs)
             return _dist.send_to_all (msg_);
     } else
         //  User message sent upstream to XPUB socket

--- a/src/xsub.hpp
+++ b/src/xsub.hpp
@@ -91,6 +91,10 @@ class xsub_t : public socket_base_t
     trie_t _subscriptions;
 #endif
 
+    // If true, send all unsubscription messages upstream, not just
+    // unique ones
+    bool _verbose_unsubs;
+
     //  If true, 'message' contains a matching message to return on the
     //  next recv call.
     bool _has_message;

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -71,6 +71,7 @@
 #define ZMQ_PRIORITY 112
 #define ZMQ_BUSY_POLL 113
 #define ZMQ_HICCUP_MSG 114
+#define ZMQ_XSUB_VERBOSE_UNSUBSCRIBE 115
 
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,7 +166,8 @@ if(ENABLE_DRAFTS)
     test_disconnect_msg
     test_hiccup_msg
     test_zmq_ppoll_fd
-  )
+    test_xsub_verbose
+)
   if(HAVE_FORK)
     list(APPEND tests test_zmq_ppoll_signals)
   endif()

--- a/tests/test_xsub_verbose.cpp
+++ b/tests/test_xsub_verbose.cpp
@@ -1,0 +1,131 @@
+/*
+    Copyright (c) 2021 Contributors as noted in the AUTHORS file
+
+    This file is part of libzmq, the ZeroMQ core engine in C++.
+
+    libzmq is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    As a special exception, the Contributors give you permission to link
+    this library with independent modules to produce an executable,
+    regardless of the license terms of these independent modules, and to
+    copy and distribute the resulting executable under terms of your choice,
+    provided that you also meet, for each linked independent module, the
+    terms and conditions of the license of that module. An independent
+    module is a module which is not derived from or based on this library.
+    If you modify this library, you must extend this exception to your
+    version of the library.
+
+    libzmq is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+
+SETUP_TEARDOWN_TESTCONTEXT
+
+const uint8_t unsubscribe_a_msg[] = {0, 'A'};
+const uint8_t subscribe_a_msg[] = {1, 'A'};
+
+const char test_endpoint[] = "inproc://soname";
+
+void test_xsub_verbose_unsubscribe ()
+{
+    void *pub = test_context_socket (ZMQ_XPUB);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (pub, test_endpoint));
+
+    void *sub = test_context_socket (ZMQ_XSUB);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub, test_endpoint));
+
+    // set option ZMQ_XPUB_VERBOSER to get all messages
+    int xbup_verboser = 1;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (pub, ZMQ_XPUB_VERBOSER, &xbup_verboser, sizeof (int)));
+
+    // unsubscribe from topic A, does not exist yet
+    send_array_expect_success (sub, unsubscribe_a_msg, 0);
+
+    // does not exist, so it will be filtered out by XSUB
+    TEST_ASSERT_FAILURE_ERRNO (EAGAIN, zmq_recv (pub, NULL, 0, ZMQ_DONTWAIT));
+
+    // subscribe to topic A
+    send_array_expect_success (sub, subscribe_a_msg, 0);
+
+    // receive subscription from subscriber
+    recv_array_expect_success (pub, subscribe_a_msg, 0);
+
+    // subscribe again to topic A
+    send_array_expect_success (sub, subscribe_a_msg, 0);
+
+    // receive subscription from subscriber
+    recv_array_expect_success (pub, subscribe_a_msg, 0);
+
+    // unsubscribe from topic A
+    send_array_expect_success (sub, unsubscribe_a_msg, 0);
+
+    // The first unsubscribe will be filtered out
+    TEST_ASSERT_FAILURE_ERRNO (EAGAIN, zmq_recv (pub, NULL, 0, ZMQ_DONTWAIT));
+
+    // unsubscribe again from topic A
+    send_array_expect_success (sub, unsubscribe_a_msg, 0);
+
+    // receive unsubscription from subscriber
+    recv_array_expect_success (pub, unsubscribe_a_msg, 0);
+
+    // set option ZMQ_XSUB_VERBOSE_UNSUBSCRIBE to get duplicate unsubscribes
+    int xsub_verbose = 1;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      sub, ZMQ_XSUB_VERBOSE_UNSUBSCRIBE, &xsub_verbose, sizeof (int)));
+
+    // unsubscribe from topic A, does not exist yet
+    send_array_expect_success (sub, unsubscribe_a_msg, 0);
+
+    // does not exist, but with ZMQ_XSUB_VERBOSE_UNSUBSCRIBE set it will be forwarded anyway
+    recv_array_expect_success (pub, unsubscribe_a_msg, 0);
+
+    // subscribe to topic A
+    send_array_expect_success (sub, subscribe_a_msg, 0);
+
+    // receive subscription from subscriber
+    recv_array_expect_success (pub, subscribe_a_msg, 0);
+
+    // subscribe again to topic A
+    send_array_expect_success (sub, subscribe_a_msg, 0);
+
+    // receive subscription from subscriber
+    recv_array_expect_success (pub, subscribe_a_msg, 0);
+
+    // unsubscribe from topic A
+    send_array_expect_success (sub, unsubscribe_a_msg, 0);
+
+    // receive unsubscription from subscriber
+    recv_array_expect_success (pub, unsubscribe_a_msg, 0);
+
+    // unsubscribe again from topic A
+    send_array_expect_success (sub, unsubscribe_a_msg, 0);
+
+    // receive unsubscription from subscriber
+    recv_array_expect_success (pub, unsubscribe_a_msg, 0);
+
+    //  Clean up.
+    test_context_socket_close (pub);
+    test_context_socket_close (sub);
+}
+
+int main ()
+{
+    setup_test_environment ();
+
+    UNITY_BEGIN ();
+    RUN_TEST (test_xsub_verbose_unsubscribe);
+
+    return UNITY_END ();
+}


### PR DESCRIPTION
consider the following case:
all XPUB sockets have `ZMQ_XPUB_VERBOSER = true`
```
        :                                                   /--> SUB :
App     : XPUB ---> XSUB/proxy/XPUB ---> XSUB/proxy/XPUB -->+--> SUB :    App
        :                                                   \--> SUB :

<-sub   :     <-sub      <-sub     <-sub      <-sub       <-sub      : 
<-sub   :     <-sub      <-sub     <-sub      <-sub       <-sub      : 
<-sub   :     <-sub      <-sub     <-sub      <-sub       <-sub      : 

        :                                    <-unsub     <-unsub     : 
        :                                    <-unsub     <-unsub     : 
        :               <-unsub   <-unsub    <-unsub     <-unsub     : 
```
Problem: the app never receives a unsubscribe message and thus keeps sending although all subscribers have unsubscribed.

Fix: introduce new option `ZMQ_XSUB_VERBOSE_UNSUBSCRIBE` and set it to true for the proxy on the right
```
        :                                                   /--> SUB :
App     : XPUB ---> XSUB/proxy/XPUB ---> XSUB/proxy/XPUB -->+--> SUB :    App
        :                                                   \--> SUB :

<-sub   :     <-sub      <-sub     <-sub      <-sub       <-sub      : 
<-sub   :     <-sub      <-sub     <-sub      <-sub       <-sub      : 
<-sub   :     <-sub      <-sub     <-sub      <-sub       <-sub      : 

        :               <-unsub   <-unsub    <-unsub     <-unsub     : 
        :               <-unsub   <-unsub    <-unsub     <-unsub     : 
<-unsub :   <-unsub     <-unsub   <-unsub    <-unsub     <-unsub     : 
```

This is similar to the issue described [here](https://github.com/zeromq/libzmq/issues/1478), the difference here is only that there are two proxies and not one.