### PR TITLE
Get cycle count from ARM64 PMCCNTR_EL0 register

### DIFF
--- a/RELICENSE/niyassait.md
+++ b/RELICENSE/niyassait.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Niyas SAIT
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "nsait-linaro", with
+commit author "Niyas SAIT", are copyright of Niyas SAIT .
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Niyas SAIT (nsait-linaro)
+Done in Cambridge, UK on the 2021/11/15

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -244,11 +244,12 @@ uint64_t zmq::clock_t::rdtsc ()
 #elif defined(_MSC_VER) && defined(_M_ARM)   // NC => added for windows ARM
     return __rdpmccntr64 ();
 #elif defined(_MSC_VER) && defined(_M_ARM64) // NC => added for windows ARM64
-    //return __rdpmccntr64 ();
-    //return __rdtscp (nullptr);
-    // todo: find proper implementation for ARM64
-    static uint64_t snCounter = 0;
-    return ++snCounter;
+    const int64_t pmccntr_el0 = (((3 & 1) << 14)  |     // op0
+                                 ((3 & 7) << 11)  |     // op1
+                                 ((9 & 15) << 7)  |     // crn
+                                 ((13 & 15) << 3) |     // crm
+                                 ((0 & 7) << 0));       // op2
+    return _ReadStatusReg(pmccntr_el0);
 #elif (defined __GNUC__ && (defined __i386__ || defined __x86_64__))
     uint32_t low, high;
     __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -244,12 +244,12 @@ uint64_t zmq::clock_t::rdtsc ()
 #elif defined(_MSC_VER) && defined(_M_ARM)   // NC => added for windows ARM
     return __rdpmccntr64 ();
 #elif defined(_MSC_VER) && defined(_M_ARM64) // NC => added for windows ARM64
-    const int64_t pmccntr_el0 = (((3 & 1) << 14)  |     // op0
-                                 ((3 & 7) << 11)  |     // op1
-                                 ((9 & 15) << 7)  |     // crn
-                                 ((13 & 15) << 3) |     // crm
-                                 ((0 & 7) << 0));       // op2
-    return _ReadStatusReg(pmccntr_el0);
+    const int64_t pmccntr_el0 = (((3 & 1) << 14) |  // op0
+                                 ((3 & 7) << 11) |  // op1
+                                 ((9 & 15) << 7) |  // crn
+                                 ((13 & 15) << 3) | // crm
+                                 ((0 & 7) << 0));   // op2
+    return _ReadStatusReg (pmccntr_el0);
 #elif (defined __GNUC__ && (defined __i386__ || defined __x86_64__))
     uint32_t low, high;
     __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));


### PR DESCRIPTION
This patch removes a temporary workaround to get the cycle count on windows on arm64 devices. Many of the unit tests were failing and with this patch, all the tests are passing now.