### PR TITLE
Problem: Fix fork detection on gcc 7

### DIFF
--- a/RELICENSE/hewlett_packard_enterprise.md
+++ b/RELICENSE/hewlett_packard_enterprise.md
@@ -5,9 +5,11 @@ that grants permission to relicense its copyrights in the libzmq C++
 library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
 
 A portion of the commits made by the Github handle "brc859844", with
-commit author "Brett Cameron <Brett.Cameron@hp.com>", are copyright of Hewlett Packard Enterprise.
+commit author "Brett Cameron <Brett.Cameron@hp.com>", and the commits made
+by the Github handle "dgloe-hpe", with commit author
+"David Gloe <david.gloe@hpe.com>", are copyright of Hewlett Packard Enterprise.
 This document hereby grants the libzmq project team to relicense libzmq,
-including all past, present and future contributions of the author listed above.
+including all past, present and future contributions of the authors listed above.
 
 Hewlett Packard Enterprise
 2019/03/12

--- a/configure.ac
+++ b/configure.ac
@@ -795,8 +795,23 @@ AC_LANG_POP([C++])
 
 # Checks for library functions.
 AC_TYPE_SIGNAL
-AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs fork mkdtemp accept4)
+AC_CHECK_FUNCS(perror gettimeofday clock_gettime memset socket getifaddrs freeifaddrs mkdtemp accept4)
 AC_CHECK_HEADERS([alloca.h])
+
+# AC_CHECK_FUNCS(fork) fails on gcc 7
+AC_MSG_CHECKING([whether fork is available])
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM(
+		[[#include <unistd.h>]],
+		[[return fork();]])
+	],[
+		AC_MSG_RESULT([yes])
+		AC_DEFINE(HAVE_FORK, [1], [fork is available])
+		AM_CONDITIONAL(HAVE_FORK, true)
+	],[
+		AC_MSG_RESULT([no])
+		AM_CONDITIONAL(HAVE_FORK, false)
+])
 
 # string.h doesn't seem to be included by default in Fedora 30
 AC_MSG_CHECKING([whether strnlen is available])
@@ -994,8 +1009,6 @@ LIBZMQ_CHECK_GETRANDOM([
         [1],
         [Whether getrandom is supported.])
     ])
-
-AM_CONDITIONAL(HAVE_FORK, test "x$ac_cv_func_fork" = "xyes")
 
 if test "x$cross_compiling" = "xyes"; then
     #   Enable draft by default when cross-compiling


### PR DESCRIPTION
Solution: When compiling with gcc 7 and newer, the program produced by
AC_CHECK_FUNCS(fork) produces a warning, which results in configure
incorrectly disabling fork support. Fix the issue by using an
AC_COMPILE_IFELSE which correctly detects fork availability.
Tested by running configure and make check on a system with gcc 7
installed, and verifying that HAVE_FORK was defined correctly.

See issue #3313.