### PR TITLE
Issue 4312 : Fix epoll invalid event data pointer

### DIFF
--- a/RELICENSE/patrickvolante.md
+++ b/RELICENSE/patrickvolante.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other share-alike OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Patrick Volante
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+share-alike Open Source Initiative approved license chosen by the current 
+ZeroMQ BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "patrick-volante", with
+commit author "patrick-volante <patrick.volante@thalesgroup.com>", are copyright of patrick volante.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Patrick Volante  
+03/12/2021

--- a/src/epoll.cpp
+++ b/src/epoll.cpp
@@ -192,6 +192,10 @@ void zmq::epoll_t::loop ()
             const poll_entry_t *const pe =
               static_cast<const poll_entry_t *> (ev_buf[i].data.ptr);
 
+            if (NULL == pe)
+                continue;
+            if (NULL == pe->events)
+                continue;
             if (pe->fd == retired_fd)
                 continue;
             if (ev_buf[i].events & (EPOLLERR | EPOLLHUP))


### PR DESCRIPTION
Problem inside the event array, epoll return an event with invalid data pointer which create a segmentation fault.
Tests to prevent segmentation fault due to null pointer are added.