### PR TITLE
Problem: ZMQ_BUILD_DRAFT_API define is not propagated to dependent CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ endif()
 # Enable WebSocket transport and RadixTree
 if(ENABLE_DRAFTS)
   message(STATUS "Building draft classes and methods")
-  set(ZMQ_BUILD_DRAFT_API 1)
   option(ENABLE_WS "Enable WebSocket transport" ON)
   option(ENABLE_RADIX_TREE "Use radix tree implementation to manage subscriptions" ON)
 else()
@@ -1379,9 +1378,6 @@ else()
   if(NOT MINGW)
     add_library(objects OBJECT ${sources})
     set_property(TARGET objects PROPERTY POSITION_INDEPENDENT_CODE ON)
-    target_include_directories(
-      objects PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
   endif()
 
   if(BUILD_SHARED)
@@ -1450,10 +1446,19 @@ if(BUILD_STATIC)
   list(APPEND target_outputs "libzmq-static")
 endif()
 
-foreach(target ${target_outputs})
+set(build_targets ${target_outputs})
+if(TARGET objects)
+  list(APPEND build_targets "objects")
+endif()
+
+foreach(target ${build_targets})
   target_include_directories(
     ${target} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
+
+  if(ENABLE_DRAFTS)
+    target_compile_definitions(${target} PUBLIC ZMQ_BUILD_DRAFT_API)
+  endif()
 endforeach()
 
 if(BUILD_SHARED)

--- a/RELICENSE/boscosiu.md
+++ b/RELICENSE/boscosiu.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by boscosiu
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "boscosiu", with
+commit author "boscosiu", are copyright of boscosiu.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+boscosiu
+2021/12/28

--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -71,7 +71,6 @@
 #cmakedefine ZMQ_HAVE_NORM
 #cmakedefine ZMQ_MAKE_VALGRIND_HAPPY
 
-#cmakedefine ZMQ_BUILD_DRAFT_API
 #cmakedefine ZMQ_HAVE_CURVE
 #cmakedefine ZMQ_USE_TWEETNACL
 #cmakedefine ZMQ_USE_LIBSODIUM


### PR DESCRIPTION
Solution: Add the definition to the relevant CMake targets in public scope.  Fixes #4194