### PR TITLE
problem: kevent udata is now void* on NetBSD Current (10)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -308,6 +308,27 @@ case "${host_os}" in
         if test "x$libzmq_netbsd_has_atomic" = "xno"; then
             AC_DEFINE(ZMQ_FORCE_MUTEXES, 1, [Force to use mutexes])
         fi
+        # NetBSD Current (to become 10) has changed the type of udata in it's
+        # kevent struct from intptr_t to void * to align with darwin and other
+        # BSDs, see upstream commit:
+        # https://github.com/NetBSD/src/commit/e5ead823eb916b56589d2c6c560dbcfe4a2d0afc
+        AC_MSG_CHECKING([whether kevent udata type is intptr_t])
+        AC_LANG_PUSH([C++])
+        AC_LINK_IFELSE([AC_LANG_PROGRAM(
+            [[#include <sys/types.h>
+              #include <sys/event.h>
+              #include <sys/time.h>]],
+            [[struct kevent ev;
+              intptr_t udata;
+              EV_SET(&ev, 0, 0, EV_ADD, 0, 0, udata);
+              return 0;]])],
+            [libzmq_netbsd_kevent_udata_intptr_t=yes],
+            [libzmq_netbsd_kevent_udata_intptr_t=no])
+        AC_LANG_POP([C++])
+        AC_MSG_RESULT([$libzmq_netbsd_kevent_udata_intptr_t])
+        if test "x$libzmq_netbsd_kevent_udata_intptr_t" = "xyes"; then
+            AC_DEFINE(ZMQ_NETBSD_KEVENT_UDATA_INTPTR_T, 1, [kevent udata type is intptr_t])
+        fi
         ;;
     *openbsd*|*bitrig*)
         # Define on OpenBSD to enable all library features

--- a/src/kqueue.cpp
+++ b/src/kqueue.cpp
@@ -46,9 +46,9 @@
 #include "i_poll_events.hpp"
 #include "likely.hpp"
 
-//  NetBSD defines (struct kevent).udata as intptr_t, everyone else
-//  as void *.
-#if defined ZMQ_HAVE_NETBSD
+// NetBSD up to version 9 defines (struct kevent).udata as intptr_t,
+// everyone else as void *.
+#if defined ZMQ_HAVE_NETBSD && defined(ZMQ_NETBSD_KEVENT_UDATA_INTPTR_T)
 #define kevent_udata_t intptr_t
 #else
 #define kevent_udata_t void *


### PR DESCRIPTION
solution: check for the `intptr_t` variant in configure.

Building libzmq master (ee09926cbd089cec780896cf7aa65f8bfd4b1b86) on NETBSD Current fails with:
```bash
gmake[1]: Entering directory '/home/ec2-user/libzmq'
  CXX      src/libzmq_la-kqueue.lo
In file included from /usr/include/errno.h:42,
                 from src/../include/zmq.h:56,
                 from src/precompiled.hpp:57,
                 from src/kqueue.cpp:30:
src/kqueue.cpp: In member function 'void zmq::kqueue_t::kevent_add(zmq::fd_t, short int, void*)':
src/kqueue.cpp:79:5: error: invalid 'static_cast' from type 'intptr_t' {aka 'long int'} to type 'void*'
   79 |     EV_SET (&ev, fd_, filter_, EV_ADD, 0, 0, (kevent_udata_t) udata_);
      |     ^~~~~~
gmake[1]: *** [Makefile:5652: src/libzmq_la-kqueue.lo] Error 1
```

As of https://github.com/NetBSD/src/commit/e5ead823eb916b56589d2c6c560dbcfe4a2d0afc, NetBSD has switched the type of the udata field in it's kevent struct from `intptr_t` to `void *` (to align with other BSDs).