### PR TITLE
Fix minor casing issue in include files

### DIFF
--- a/RELICENSE/Jasper-Bekkers.md
+++ b/RELICENSE/Jasper-Bekkers.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by the Netherlands eScience Center
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2).
+
+A portion of the commits made by the Github handle "Jasper-Bekkers", with
+commit author "Jasper Bekkers bekkers@gmail.com", are copyright of Traverse Research BV.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Jasper Bekkers <bekkers@gmail.com
+2022/02/08

--- a/src/precompiled.hpp
+++ b/src/precompiled.hpp
@@ -70,7 +70,7 @@
 #include <ipexport.h>
 #include <iphlpapi.h>
 #include <limits.h>
-#include <Mstcpip.h>
+#include <mstcpip.h>
 #include <mswsock.h>
 #include <process.h>
 #include <rpc.h>


### PR DESCRIPTION
This fails when compiling x86_64-pc-windows-msvc targets on a case sensitive file system.