### PR TITLE
Exclude subscribe & Unexclude subscribe

### DIFF
--- a/RELICENSE/carlcc.md
+++ b/RELICENSE/carlcc.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by carlcc (chen.chen)
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "carlcc", with
+commit author "carlcc <carlmarxchen@formail.com>", are copyright of carlcc.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+carlcc
+2022/4/15

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -376,6 +376,8 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
 #define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
 #define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
 #define ZMQ_BINDTODEVICE 92
+#define ZMQ_EXCLUDE_SUBSCRIBE 200
+#define ZMQ_UNEXCLUDE_SUBSCRIBE 201
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1

--- a/src/dist.cpp
+++ b/src/dist.cpp
@@ -88,6 +88,15 @@ void zmq::dist_t::match (pipe_t *pipe_)
     _matching++;
 }
 
+void zmq::dist_t::unmatch (pipe_t *pipe_)
+{
+    //  Swap it out if the pipe is marked as matching
+    if (_pipes.index (pipe_) < _matching) {
+        _matching--;
+        _pipes.swap (_pipes.index (pipe_), _matching);
+    }
+}
+
 void zmq::dist_t::reverse_match ()
 {
     const pipes_t::size_type prev_matching = _matching;

--- a/src/dist.hpp
+++ b/src/dist.hpp
@@ -61,6 +61,10 @@ class dist_t
     //  will send message also to this pipe.
     void match (zmq::pipe_t *pipe_);
 
+    //  Mark the pipe as not matching. Subsequent call to send_to_matching
+    //  will no send message also to this pipe.
+    void unmatch (zmq::pipe_t *pipe_);
+
     //  Marks all pipes that are not matched as matched and vice-versa.
     void reverse_match ();
 

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -266,6 +266,38 @@ int zmq::msg_t::init_cancel (const size_t size_, const unsigned char *topic_)
     return rc;
 }
 
+int zmq::msg_t::init_exclude_subscribe (const size_t size_,
+                                  const unsigned char *topic_)
+{
+    int rc = init_size (size_);
+    if (rc == 0) {
+        set_flags (zmq::msg_t::exclude_subscribe);
+
+        //  We explicitly allow a NULL subscription with size zero
+        if (size_) {
+            assert (topic_);
+            memcpy (data (), topic_, size_);
+        }
+    }
+    return rc;
+}
+
+int zmq::msg_t::init_unexclude_subscribe (const size_t size_,
+                                         const unsigned char *topic_)
+{
+    int rc = init_size (size_);
+    if (rc == 0) {
+        set_flags (zmq::msg_t::unexclude_subscribe);
+
+        //  We explicitly allow a NULL subscription with size zero
+        if (size_) {
+            assert (topic_);
+            memcpy (data (), topic_, size_);
+        }
+    }
+    return rc;
+}
+
 int zmq::msg_t::close ()
 {
     //  Check the validity of the message.
@@ -561,6 +593,10 @@ size_t zmq::msg_t::command_body_size () const
         return this->size () - sub_cmd_name_size;
     else if (this->is_cancel ())
         return this->size () - cancel_cmd_name_size;
+    else if (this->is_exclude_subscribe ())
+        return this->size () - exclude_subscribe_cmd_name_size;
+    else if (this->is_unexclude_subscribe ())
+        return this->size () - unexclude_subscribe_cmd_name_size;
 
     return 0;
 }
@@ -578,6 +614,12 @@ void *zmq::msg_t::command_body ()
         data = static_cast<unsigned char *> (this->data ());
     else if (this->is_subscribe ())
         data = static_cast<unsigned char *> (this->data ()) + sub_cmd_name_size;
+    else if (this->is_exclude_subscribe ())
+        data =
+          static_cast<unsigned char *> (this->data ()) + exclude_subscribe_cmd_name_size;
+    else if (this->is_unexclude_subscribe ())
+        data = static_cast<unsigned char *> (this->data ())
+               + unexclude_subscribe_cmd_name_size;
     else if (this->is_cancel ())
         data =
           static_cast<unsigned char *> (this->data ()) + cancel_cmd_name_size;

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -267,7 +267,7 @@ int zmq::msg_t::init_cancel (const size_t size_, const unsigned char *topic_)
 }
 
 int zmq::msg_t::init_exclude_subscribe (const size_t size_,
-                                  const unsigned char *topic_)
+                                        const unsigned char *topic_)
 {
     int rc = init_size (size_);
     if (rc == 0) {
@@ -283,7 +283,7 @@ int zmq::msg_t::init_exclude_subscribe (const size_t size_,
 }
 
 int zmq::msg_t::init_unexclude_subscribe (const size_t size_,
-                                         const unsigned char *topic_)
+                                          const unsigned char *topic_)
 {
     int rc = init_size (size_);
     if (rc == 0) {
@@ -615,8 +615,8 @@ void *zmq::msg_t::command_body ()
     else if (this->is_subscribe ())
         data = static_cast<unsigned char *> (this->data ()) + sub_cmd_name_size;
     else if (this->is_exclude_subscribe ())
-        data =
-          static_cast<unsigned char *> (this->data ()) + exclude_subscribe_cmd_name_size;
+        data = static_cast<unsigned char *> (this->data ())
+               + exclude_subscribe_cmd_name_size;
     else if (this->is_unexclude_subscribe ())
         data = static_cast<unsigned char *> (this->data ())
                + unexclude_subscribe_cmd_name_size;

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -56,6 +56,10 @@ namespace zmq
 
 static const char cancel_cmd_name[] = "\6CANCEL";
 static const char sub_cmd_name[] = "\x9SUBSCRIBE";
+static const char exclude_subscribe_cmd_name[] = "\x7"
+                                                 "EXCLUDE";
+static const char unexclude_subscribe_cmd_name[] = "\x9"
+                                                   "UNEXCLUDE";
 
 class msg_t
 {
@@ -83,11 +87,13 @@ class msg_t
         command = 2, //  Command frame (see ZMTP spec)
         //  Command types, use only bits 2-5 and compare with ==, not bitwise,
         //  a command can never be of more that one type at the same time
-        ping = 4,
-        pong = 8,
-        subscribe = 12,
-        cancel = 16,
-        close_cmd = 20,
+        ping = 4,                 // 0000 0100
+        pong = 8,                 // 0000 1000
+        subscribe = 12,           // 0000 1100
+        cancel = 16,              // 0001 0000
+        close_cmd = 20,           // 0001 0100
+        exclude_subscribe = 24,   // 0001 1000
+        unexclude_subscribe = 28, // 0001 1100
         credential = 32,
         routing_id = 64,
         shared = 128
@@ -115,6 +121,9 @@ class msg_t
     int init_leave ();
     int init_subscribe (const size_t size_, const unsigned char *topic);
     int init_cancel (const size_t size_, const unsigned char *topic);
+    int init_exclude_subscribe (const size_t size_, const unsigned char *topic);
+    int init_unexclude_subscribe (const size_t size_,
+                                  const unsigned char *topic);
     int close ();
     int move (msg_t &src_);
     int copy (msg_t &src_);
@@ -145,6 +154,16 @@ class msg_t
     bool is_cancel () const
     {
         return (_u.base.flags & CMD_TYPE_MASK) == cancel;
+    }
+
+    bool is_exclude_subscribe () const
+    {
+        return (_u.base.flags & CMD_TYPE_MASK) == exclude_subscribe;
+    }
+
+    bool is_unexclude_subscribe () const
+    {
+        return (_u.base.flags & CMD_TYPE_MASK) == unexclude_subscribe;
     }
 
     size_t command_body_size () const;
@@ -183,9 +202,11 @@ class msg_t
     };
     enum
     {
-        ping_cmd_name_size = 5,   // 4PING
-        cancel_cmd_name_size = 7, // 6CANCEL
-        sub_cmd_name_size = 10    // 9SUBSCRIBE
+        ping_cmd_name_size = 5,                 // 4PING
+        cancel_cmd_name_size = 7,               // 6CANCEL
+        sub_cmd_name_size = 10,                 // 9SUBSCRIBE
+        exclude_subscribe_cmd_name_size = 8,    // 7EXCLUDE
+        unexclude_subscribe_cmd_name_size = 10, // 9UNEXCLUDE
     };
 
   private:

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -396,10 +396,9 @@ int zmq::proxy (class socket_base_t *frontend_,
             if (events[i].socket == frontend_) {
                 frontend_in = (events[i].events & ZMQ_POLLIN) != 0;
                 frontend_out = (events[i].events & ZMQ_POLLOUT) != 0;
-            } else
-              //  This 'if' needs to be after check for 'frontend_' in order never
-              //  to be reached in case frontend_==backend_, so we ensure backend_in=false in that case.
-              if (events[i].socket == backend_) {
+            } else if (events[i].socket == backend_) {
+                //  This 'if' needs to be after check for 'frontend_' in order never
+                //  to be reached in case frontend_==backend_, so we ensure backend_in=false in that case.
                 backend_in = (events[i].events & ZMQ_POLLIN) != 0;
                 backend_out = (events[i].events & ZMQ_POLLOUT) != 0;
             } else if (events[i].socket == control_)

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -184,7 +184,8 @@ int zmq::session_base_t::push_msg (msg_t *msg_)
 {
     //  pass subscribe/cancel to the sockets
     if ((msg_->flags () & msg_t::command) && !msg_->is_subscribe ()
-        && !msg_->is_cancel ())
+        && !msg_->is_cancel () && !msg_->is_exclude_subscribe ()
+        && !msg_->is_unexclude_subscribe ())
         return 0;
     if (_pipe && _pipe->write (msg_)) {
         const int rc = msg_->init ();

--- a/src/sub.cpp
+++ b/src/sub.cpp
@@ -49,7 +49,8 @@ int zmq::sub_t::xsetsockopt (int option_,
                              const void *optval_,
                              size_t optvallen_)
 {
-    if (option_ != ZMQ_SUBSCRIBE && option_ != ZMQ_UNSUBSCRIBE) {
+    if (option_ != ZMQ_SUBSCRIBE && option_ != ZMQ_UNSUBSCRIBE
+        && option_ != ZMQ_EXCLUDE_SUBSCRIBE && option_ != ZMQ_UNEXCLUDE_SUBSCRIBE) {
         errno = EINVAL;
         return -1;
     }
@@ -60,6 +61,10 @@ int zmq::sub_t::xsetsockopt (int option_,
     const unsigned char *data = static_cast<const unsigned char *> (optval_);
     if (option_ == ZMQ_SUBSCRIBE) {
         rc = msg.init_subscribe (optvallen_, data);
+    } else if (option_ == ZMQ_EXCLUDE_SUBSCRIBE) {
+        rc = msg.init_exclude_subscribe (optvallen_, data);
+    } else if (option_ == ZMQ_UNEXCLUDE_SUBSCRIBE) {
+        rc = msg.init_unexclude_subscribe (optvallen_, data);
     } else {
         rc = msg.init_cancel (optvallen_, data);
     }

--- a/src/sub.cpp
+++ b/src/sub.cpp
@@ -50,7 +50,8 @@ int zmq::sub_t::xsetsockopt (int option_,
                              size_t optvallen_)
 {
     if (option_ != ZMQ_SUBSCRIBE && option_ != ZMQ_UNSUBSCRIBE
-        && option_ != ZMQ_EXCLUDE_SUBSCRIBE && option_ != ZMQ_UNEXCLUDE_SUBSCRIBE) {
+        && option_ != ZMQ_EXCLUDE_SUBSCRIBE
+        && option_ != ZMQ_UNEXCLUDE_SUBSCRIBE) {
         errno = EINVAL;
         return -1;
     }

--- a/src/v3_1_encoder.cpp
+++ b/src/v3_1_encoder.cpp
@@ -59,12 +59,18 @@ void zmq::v3_1_encoder_t::message_ready ()
     if (in_progress ()->size () > UCHAR_MAX)
         protocol_flags |= v2_protocol_t::large_flag;
     if (in_progress ()->flags () & msg_t::command
-        || in_progress ()->is_subscribe () || in_progress ()->is_cancel ()) {
+        || in_progress ()->is_subscribe () || in_progress ()->is_cancel ()
+        || in_progress ()->is_exclude_subscribe ()
+        || in_progress ()->is_unexclude_subscribe ()) {
         protocol_flags |= v2_protocol_t::command_flag;
         if (in_progress ()->is_subscribe ())
             size += zmq::msg_t::sub_cmd_name_size;
         else if (in_progress ()->is_cancel ())
             size += zmq::msg_t::cancel_cmd_name_size;
+        else if (in_progress ()->is_exclude_subscribe ())
+            size += zmq::msg_t::exclude_subscribe_cmd_name_size;
+        else if (in_progress ()->is_unexclude_subscribe ())
+            size += zmq::msg_t::unexclude_subscribe_cmd_name_size;
     }
 
     //  Encode the message length. For messages less then 256 bytes,
@@ -92,6 +98,14 @@ void zmq::v3_1_encoder_t::message_ready ()
         memcpy (_tmp_buf + header_size, zmq::cancel_cmd_name,
                 zmq::msg_t::cancel_cmd_name_size);
         header_size += zmq::msg_t::cancel_cmd_name_size;
+    } else if (in_progress ()->is_exclude_subscribe ()) {
+        memcpy (_tmp_buf + header_size, zmq::exclude_subscribe_cmd_name,
+                zmq::msg_t::exclude_subscribe_cmd_name_size);
+        header_size += zmq::msg_t::exclude_subscribe_cmd_name_size;
+    } else if (in_progress ()->is_unexclude_subscribe ()) {
+        memcpy (_tmp_buf + header_size, zmq::unexclude_subscribe_cmd_name,
+                zmq::msg_t::unexclude_subscribe_cmd_name_size);
+        header_size += zmq::msg_t::unexclude_subscribe_cmd_name_size;
     }
 
     next_step (_tmp_buf, header_size, &v3_1_encoder_t::size_ready, false);

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -72,8 +72,8 @@ class xpub_t : public socket_base_t
                                      xpub_t *self_);
 
     static void send_unexclude_subscribescription (zmq::mtrie_t::prefix_t data_,
-                                     size_t size_,
-                                     xpub_t *self_);
+                                                   size_t size_,
+                                                   xpub_t *self_);
 
     //  Function to be applied to each matching pipes.
     static void mark_as_matching (zmq::pipe_t *pipe_, xpub_t *self_);

--- a/src/xpub.hpp
+++ b/src/xpub.hpp
@@ -71,11 +71,22 @@ class xpub_t : public socket_base_t
                                      size_t size_,
                                      xpub_t *self_);
 
+    static void send_unexclude_subscribescription (zmq::mtrie_t::prefix_t data_,
+                                     size_t size_,
+                                     xpub_t *self_);
+
     //  Function to be applied to each matching pipes.
     static void mark_as_matching (zmq::pipe_t *pipe_, xpub_t *self_);
+    //  Function to be applied to filter some matching pipes out
+    static void mark_as_unmatching (zmq::pipe_t *pipe_, xpub_t *self_);
 
     //  List of all subscriptions mapped to corresponding pipes.
     mtrie_t _subscriptions;
+
+    //  List of all exclude-subscriptions mapped to corresponding pipes.
+    //  'exclude-subscription' means the subscriber don't want some specified
+    //  topics, even though these tops are includeed in `_subscriptions`
+    mtrie_t _exclude_subscriptions;
 
     //  List of manual subscriptions mapped to corresponding pipes.
     mtrie_t _manual_subscriptions;

--- a/src/zmtp_engine.cpp
+++ b/src/zmtp_engine.cpp
@@ -560,6 +560,10 @@ int zmq::zmtp_engine_t::process_command_message (msg_t *msg_)
       *(static_cast<const uint8_t *> (msg_->data ()));
     const size_t ping_name_size = msg_t::ping_cmd_name_size - 1;
     const size_t sub_name_size = msg_t::sub_cmd_name_size - 1;
+    const size_t exclud_sub_name_size =
+      msg_t::exclude_subscribe_cmd_name_size - 1;
+    const size_t unexclude_sub_name_size =
+      msg_t::unexclude_subscribe_cmd_name_size - 1;
     const size_t cancel_name_size = msg_t::cancel_cmd_name_size - 1;
     //  Malformed command
     if (unlikely (msg_->size () < cmd_name_size + sizeof (cmd_name_size)))
@@ -579,6 +583,12 @@ int zmq::zmtp_engine_t::process_command_message (msg_t *msg_)
     if (cmd_name_size == cancel_name_size
         && memcmp (cmd_name, "CANCEL", cmd_name_size) == 0)
         msg_->set_flags (zmq::msg_t::cancel);
+    if (cmd_name_size == exclud_sub_name_size
+        && memcmp (cmd_name, "EXCLUDE", cmd_name_size) == 0)
+        msg_->set_flags (zmq::msg_t::exclude_subscribe);
+    if (cmd_name_size == unexclude_sub_name_size
+        && memcmp (cmd_name, "UNEXCLUDE", cmd_name_size) == 0)
+        msg_->set_flags (zmq::msg_t::unexclude_subscribe);
 
     if (msg_->is_ping () || msg_->is_pong ())
         return process_heartbeat_message (msg_);


### PR DESCRIPTION
# The problem

As mentioned [here](https://github.com/zeromq/libzmq/issues/4368) and [here](https://stackoverflow.com/questions/48901533/zeromq-can-subscribe-but-how-to-exclude-a-specific-filter)

**I added a new feature to libzmq**:

**Now SUB/XSUB sockets are able to `EXCLUDE` specified topics from more gerneral topics. **

e.g. One can subscribe the topic (prefix) `hello`, and exclude topic `hello,world`, then all messages with prefix `hello` but `hello,world` are subscribed by this guy.

# The feature's usage:

```C++

void ExcludeSubscribe(const std::string& channelName)
{
    ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_EXCLUDE_SUBSCRIBE, channelName.c_str(), channelName.size()));
}

void UnexcludeSubscribe(const std::string& channelName)
{
    ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_UNEXCLUDE_SUBSCRIBE, channelName.c_str(), channelName.size()));
}

```

# P.S.

I'm not very sure if this feature worth merging since this feature takes the only 2 remaining type of COMMAND_TYPE, it seems no more command types can be added with current protocol. 

But any way, in my opinion, I think this is a useful feature, thus I created this PR. 



<details>
  <summary>Below is a full example, click to expand</summary>
  
```C++
// The server

int main()
{
    // prepare you xsub/xpub socket
    // ...
   zmq_proxy(xsub, xpub);
   // ...
}

```

```C++
// The client
#include <atomic>
#include <cassert>
#include <iostream>
#include <sstream>
#include <thread>
#include <zmq.h>

#define ASSERT0(expr) assert(0 == expr && "Assertion failed: " #expr)
#define ASSERT_GT_0(expr) assert((0 < expr) && "Assertion failed: " #expr)
using namespace std::chrono_literals;

static std::string kPublishTopic1 = "ThisIsMyTopic";
static std::string kPublishTopic2 = "ThisIsMyTopic_withsuffix";

#define LOG(msg)                       \
    do {                               \
        std::stringstream tTmpBuffer;  \
        tTmpBuffer << msg;             \
        std::cout << tTmpBuffer.str(); \
    } while (false)

class BaseClient {
public:
    BaseClient(void* context, int socketType)
        : mZmqContext { context }
        , mZmqSocket { zmq_socket(mZmqContext, socketType) }
    {
        int linger = 0;
        ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_LINGER, &linger, sizeof(linger)));
        unsigned int keepAlive = 1;
        ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_TCP_KEEPALIVE, &keepAlive, sizeof(keepAlive)));
        int hwm = 50000;
        ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_RCVHWM, &hwm, sizeof(hwm)));
        if (socketType == ZMQ_PUB) {
            ASSERT0(zmq_connect(mZmqSocket, kXSubAddress)); // replace with your real address
        } else {
            ASSERT0(zmq_connect(mZmqSocket, kXPubAddress)); // replace with your real address
        }

        zmq_msg_init(&mMessage);
    }

    ~BaseClient()
    {
        zmq_close(mZmqSocket);
        zmq_msg_close(&mMessage);
    }

protected:
    void* mZmqContext;
    void* mZmqSocket;
    zmq_msg_t mMessage {};
};
#define N_MESSAGES 10
class Publisher : public BaseClient {
public:
    explicit Publisher(void* context)
        : BaseClient { context, ZMQ_PUB }
    {
    }

    void Run()
    {
        for (int i = 0; i < N_MESSAGES; ++i) {
            Send(kPublishTopic1, "Hello, data " + std::to_string(i));
            Send(kPublishTopic2, "World, data " + std::to_string(i));
            std::this_thread::sleep_for(1s);
        }
    }

    void Send(const std::string& prefix, const std::string& data)
    {
        ASSERT_GT_0(zmq_send(mZmqSocket, prefix.data(), prefix.size(), ZMQ_DONTWAIT | ZMQ_SNDMORE));
        ASSERT_GT_0(zmq_send(mZmqSocket, data.data(), data.size(), ZMQ_DONTWAIT));
    }
};

static std::atomic_bool gShouldReceive = true;

#include <latch>

class Latch {
public:
    void Wait(int count)
    {
        delete latch;
        latch = new std::latch(count);
        latch->wait();
    }

    void Done()
    {
        latch->count_down();
    }

private:
    std::latch* latch { nullptr };
};
Latch gPubLatch;
Latch gSubLatch1;
Latch gSubLatch2;

class Subscriber : public BaseClient {
public:
    explicit Subscriber(void* context, std::string label)
        : BaseClient { context, ZMQ_SUB }
        , mLabel { std::move(label) }
    {
    }

    void Subscribe(const std::string& channelName)
    {
        ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_SUBSCRIBE, channelName.c_str(), channelName.size()));
    }

    void CancelSubscribe(const std::string& channelName)
    {
        ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_UNSUBSCRIBE, channelName.c_str(), channelName.size()));
    }

    void ExcludeSubscribe(const std::string& channelName)
    {
        ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_EXCLUDE_SUBSCRIBE, channelName.c_str(), channelName.size()));
    }

    void UnexcludeSubscribe(const std::string& channelName)
    {
        ASSERT0(zmq_setsockopt(mZmqSocket, ZMQ_UNEXCLUDE_SUBSCRIBE, channelName.c_str(), channelName.size()));
    }

    void Run()
    {
        std::string prefix;
        std::string data;
        zmq_pollitem_t pollItem {
            .socket = mZmqSocket,
            .events = ZMQ_POLLIN,
        };

        for (; gShouldReceive;) {
            int n = zmq_poll(&pollItem, 1, 2000);
            if (n > 0) {
                Receive(prefix, data);

                LOG(mLabel << ": Got " << prefix << ":" << data << std::endl);
            }
            if (n < 0) {
                LOG(mLabel << ": Receive timeout" << std::endl);
            }
        }
    }

    void Receive(std::string& prefix, std::string& data)
    {
        ASSERT_GT_0(zmq_msg_recv(&mMessage, mZmqSocket, 0));
        prefix = std::string((const char*)zmq_msg_data(&mMessage), zmq_msg_size(&mMessage));
        int more = zmq_msg_more(&mMessage);
        assert(more == 1);

        ASSERT_GT_0(zmq_msg_recv(&mMessage, mZmqSocket, 0));
        data = std::string((const char*)zmq_msg_data(&mMessage), zmq_msg_size(&mMessage));
        more = zmq_msg_more(&mMessage);
        assert(more != 1);
    }

    std::string mLabel;
};

int main()
{
    auto* zmqContext = zmq_ctx_new();

    std::thread th1([zmqContext]() {
        Publisher publisher(zmqContext);
        std::this_thread::sleep_for(1s);
        LOG("Publisher started to send!" << std::endl);
        publisher.Run();
        gShouldReceive = false;
        gPubLatch.Wait(2);
        gShouldReceive = true;

        gSubLatch1.Done();
        gSubLatch2.Done();

        std::this_thread::sleep_for(1s);

        LOG("Publisher started to send again!" << std::endl);
        publisher.Run();
    });
    std::thread th2([zmqContext]() {
        Subscriber subscriber(zmqContext, "sub1");
        subscriber.Subscribe(kPublishTopic1);
        subscriber.ExcludeSubscribe(kPublishTopic2);
        subscriber.Run();
        gPubLatch.Done();

        subscriber.UnexcludeSubscribe(kPublishTopic2);
        gSubLatch1.Wait(1);
        subscriber.Run();
    });
    std::thread th3([zmqContext]() {
        Subscriber subscriber(zmqContext, "SUB2");
        subscriber.Subscribe(kPublishTopic1);
        subscriber.Run();
        gPubLatch.Done();
        subscriber.ExcludeSubscribe(kPublishTopic2);
        gSubLatch2.Wait(1);
        subscriber.Run();
    });

    std::this_thread::sleep_for(std::chrono::milliseconds(1000000));

    return 0;
}
```

</details> 