### PR TITLE
remove libbsd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,19 +240,6 @@ if(NOT ZMQ_USE_GNUTLS)
   endif()
 endif()
 
-if(NOT MSVC)
-  option(WITH_LIBBSD "Use libbsd instead of builtin strlcpy" ON)
-  if(WITH_LIBBSD)
-    pkg_check_modules(LIBBSD "libbsd")
-    if(LIBBSD_FOUND)
-      message(STATUS "Using libbsd")
-      set(pkg_config_names_private "${pkg_config_names_private} libbsd")
-      set(ZMQ_HAVE_LIBBSD 1)
-    endif()
-  endif()
-  check_cxx_symbol_exists(strlcpy string.h ZMQ_HAVE_STRLCPY)
-endif()
-
 # Select curve encryption library, defaults to tweetnacl To use libsodium instead, use --with-libsodium(must be
 # installed) To disable curve, use --disable-curve
 
@@ -1318,15 +1305,15 @@ if(MSVC)
   if(BUILD_SHARED)
     # Whole Program Optimization flags. http://msdn.microsoft.com/en-us/magazine/cc301698.aspx
     #
-    # "Finally, there's the subject of libraries. It's possible to create .LIB 
-    # files with code in its IL form. The linker will happily work with these 
-    # .LIB files. Be aware that these libraries will be tied to a specific 
-    # version of the compiler and linker. If you distribute these libraries, 
-    # you'll need to update them if Microsoft changes the format of IL in a 
+    # "Finally, there's the subject of libraries. It's possible to create .LIB
+    # files with code in its IL form. The linker will happily work with these
+    # .LIB files. Be aware that these libraries will be tied to a specific
+    # version of the compiler and linker. If you distribute these libraries,
+    # you'll need to update them if Microsoft changes the format of IL in a
     # future release."
-    # 
-    # /GL and /LTCG can cause problems when libraries built with different 
-    # versions of compiler are later linked into an executable while /LTCG is active. 
+    #
+    # /GL and /LTCG can cause problems when libraries built with different
+    # versions of compiler are later linked into an executable while /LTCG is active.
     # https://social.msdn.microsoft.com/Forums/vstudio/en-US/5c102025-c254-4f02-9a51-c775c6cc9f4b/problem-with-ltcg-when-building-a-static-library-in-vs2005?forum=vcgeneral
     #
     # For this reason, enable only when building a "Release" (e.g. non-DEBUG) DLL.
@@ -1471,10 +1458,6 @@ if(BUILD_SHARED)
     target_link_libraries(libzmq ${NSS3_LIBRARIES})
   endif()
 
-  if(LIBBSD_FOUND)
-    target_link_libraries(libzmq ${LIBBSD_LIBRARIES})
-  endif()
-
   if(SODIUM_FOUND)
     target_link_libraries(libzmq ${SODIUM_LIBRARIES})
     # On Solaris, libsodium depends on libssp
@@ -1510,10 +1493,6 @@ if(BUILD_STATIC)
   target_link_libraries(libzmq-static ${CMAKE_THREAD_LIBS_INIT})
   if(GNUTLS_FOUND)
     target_link_libraries(libzmq-static ${GNUTLS_LIBRARIES})
-  endif()
-
-  if(LIBBSD_FOUND)
-    target_link_libraries(libzmq-static ${LIBBSD_LIBRARIES})
   endif()
 
   if(NSS3_FOUND)
@@ -1578,10 +1557,6 @@ if(BUILD_SHARED)
 
       if(GNUTLS_FOUND)
         target_link_libraries(${perf-tool} ${GNUTLS_LIBRARIES})
-      endif()
-
-      if(LIBBSD_FOUND)
-        target_link_libraries(${perf-tool} ${LIBBSD_LIBRARIES})
       endif()
 
       if(NSS3_FOUND)

--- a/Makefile.am
+++ b/Makefile.am
@@ -351,11 +351,11 @@ if HAVE_VSCRIPT_COMPLEX
 src_libzmq_la_LDFLAGS += $(VSCRIPT_LDFLAGS),$(srcdir)/src/libzmq.vers
 endif
 
-src_libzmq_la_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS) $(LIBUNWIND_CFLAGS) $(LIBBSD_CFLAGS)
-src_libzmq_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(LIBUNWIND_CFLAGS) $(LIBBSD_CFLAGS)
+src_libzmq_la_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS) $(LIBUNWIND_CFLAGS)
+src_libzmq_la_CFLAGS = $(CODE_COVERAGE_CFLAGS) $(LIBUNWIND_CFLAGS)
 src_libzmq_la_CXXFLAGS = @LIBZMQ_EXTRA_CXXFLAGS@ $(CODE_COVERAGE_CXXFLAGS) \
-	$(LIBUNWIND_CFLAGS) $(LIBBSD_CFLAGS)
-src_libzmq_la_LIBADD = $(CODE_COVERAGE_LDFLAGS) $(LIBUNWIND_LIBS) $(LIBBSD_LIBS)
+	$(LIBUNWIND_CFLAGS)
+src_libzmq_la_LIBADD = $(CODE_COVERAGE_LDFLAGS) $(LIBUNWIND_LIBS)
 
 if USE_NSS
 src_libzmq_la_CPPFLAGS += ${NSS3_CFLAGS}
@@ -853,10 +853,10 @@ tests_test_security_curve_SOURCES += \
 endif
 
 tests_test_security_curve_LDADD = \
-        ${TESTUTIL_LIBS} src/libzmq.la $(LIBUNWIND_LIBS) $(LIBBSD_LIBS)
+        ${TESTUTIL_LIBS} src/libzmq.la $(LIBUNWIND_LIBS)
 tests_test_security_curve_CPPFLAGS = \
         ${TESTUTIL_CPPFLAGS} \
-	${LIBUNWIND_CFLAGS}  ${LIBBSD_CFLAGS}
+	${LIBUNWIND_CFLAGS}
 
 if USE_LIBSODIUM
 tests_test_security_curve_CPPFLAGS += \

--- a/builds/cmake/platform.hpp.in
+++ b/builds/cmake/platform.hpp.in
@@ -55,8 +55,6 @@
 #cmakedefine ZMQ_HAVE_PTHREAD_SET_AFFINITY
 #cmakedefine HAVE_ACCEPT4
 #cmakedefine HAVE_STRNLEN
-#cmakedefine ZMQ_HAVE_STRLCPY
-#cmakedefine ZMQ_HAVE_LIBBSD
 
 #cmakedefine ZMQ_HAVE_IPC
 #cmakedefine ZMQ_HAVE_STRUCT_SOCKADDR_UN

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS([src/platform.hpp])
 AM_INIT_AUTOMAKE(foreign subdir-objects tar-ustar dist-zip)
-# Allow "configure --disable-maintainer-mode" to disable timestamp checking 
+# Allow "configure --disable-maintainer-mode" to disable timestamp checking
 AM_MAINTAINER_MODE([enable])
 
 m4_pattern_allow([AC_PROG_CC_C99])
@@ -863,43 +863,6 @@ AC_COMPILE_IFELSE(
         AC_MSG_RESULT([yes])
         AC_DEFINE(HAVE_IF_NAMETOINDEX, [1],
         [if_nametoindex is available])
-    ],[
-        AC_MSG_RESULT([no])
-])
-
-AC_ARG_ENABLE([libbsd],
-    [AS_HELP_STRING([--enable-libbsd],
-        [enable libbsd [default=auto]])],
-    [enable_libbsd=$enableval],
-    [enable_libbsd="auto"])
-
-if test "x$enable_libbsd" != "xno"; then
-    PKG_CHECK_MODULES(LIBBSD, [libbsd],
-        [
-            AC_DEFINE(ZMQ_HAVE_LIBBSD, 1, [The libbsd library is to be used])
-            AC_SUBST([LIBBSD_CFLAGS])
-            AC_SUBST([LIBBSD_LIBS])
-            PKGCFG_NAMES_PRIVATE="$PKGCFG_NAMES_PRIVATE libbsd"
-            found_libbsd="yes"
-        ],
-        [
-            found_libbsd="no"
-            if test "x$enable_libbsd" = "xyes"; then
-                AC_MSG_ERROR([Cannot find libbsd])
-            else
-                AC_MSG_WARN([Cannot find libbsd])
-            fi
-        ])
-fi
-AC_MSG_CHECKING([whether strlcpy is available])
-AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM(
-        [[#include <string.h>]],
-        [[char buf [100]; size_t bar = strlcpy (buf, "foo", 100); (void)bar; return 0;]])
-    ],[
-        AC_MSG_RESULT([yes])
-        AC_DEFINE(ZMQ_HAVE_STRLCPY, [1],
-            [strlcpy is available])
     ],[
         AC_MSG_RESULT([no])
 ])

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -11,7 +11,6 @@ Build-Depends: debhelper (>= 9),
  libunwind-dev | libunwind8-dev | libunwind7-dev,
  libnss3-dev,
  libgnutls28-dev | libgnutls-dev,
- libbsd-dev,
  pkg-config,
  asciidoc-base | asciidoc, xmlto,
 Standards-Version: 3.9.8
@@ -43,7 +42,6 @@ Depends: libzmq5 (= ${binary:Version}), ${misc:Depends},
  libunwind-dev | libunwind8-dev | libunwind7-dev,
  libnss3-dev,
  libgnutls28-dev | libgnutls-dev,
- libbsd-dev,
 Conflicts: libzmq-dev, libzmq5-dev
 Replaces: libzmq5-dev
 Provides: libzmq5-dev

--- a/packaging/debian/zeromq.dsc
+++ b/packaging/debian/zeromq.dsc
@@ -6,7 +6,7 @@ Version: 4.3.5-0.1
 Maintainer: libzmq Developers <zeromq-dev@lists.zeromq.org>
 Homepage: http://www.zeromq.org/
 Standards-Version: 3.9.8
-Build-Depends: debhelper (>= 9), dh-autoreconf, libkrb5-dev, libpgm-dev, libnorm-dev, libsodium-dev, libunwind-dev | libunwind8-dev | libunwind7-dev, libnss3-dev, libgnutls28-dev | libgnutls-dev, libbsd-dev, pkg-config, asciidoc-base | asciidoc, xmlto
+Build-Depends: debhelper (>= 9), dh-autoreconf, libkrb5-dev, libpgm-dev, libnorm-dev, libsodium-dev, libunwind-dev | libunwind8-dev | libunwind7-dev, libnss3-dev, libgnutls28-dev | libgnutls-dev, pkg-config, asciidoc-base | asciidoc, xmlto
 Package-List:
  libzmq3-dev deb libdevel optional arch=any
  libzmq5 deb libs optional arch=any

--- a/packaging/redhat/zeromq.spec
+++ b/packaging/redhat/zeromq.spec
@@ -19,7 +19,7 @@ URL:           http://www.zeromq.org/
 Source:        http://download.zeromq.org/%{name}-%{version}.tar.gz
 Prefix:        %{_prefix}
 Buildroot:     %{_tmppath}/%{name}-%{version}-%{release}-root
-BuildRequires:  autoconf automake libtool glib2-devel libbsd-devel
+BuildRequires:  autoconf automake libtool glib2-devel
 %if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
 BuildRequires:  e2fsprogs-devel
 BuildRoot:      %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)


### PR DESCRIPTION
libbsd is only used once and as part of a larger, incorrect function.
I rewrote the code that used it without the need for it.

I did this because I wanted to switch libzmq to _libbsd-overlay_ instead of _libbsd_ to make it compatible with my libbsd alternative called [libobsd](https://github.com/guijan/libobsd/) (I only want to support the -overlay mode), my library needs to work with libzmq so I can try getting it into OpenWRT at https://github.com/openwrt/openwrt/pull/9714, but it seemed to make more sense to drop the dependency entirely.

I've build tested this PR on Alpine Linux with Autotools and CMake.