### PR TITLE
Revert "Problem: Libs crash at runtime on Android when built with NDK 23+

### DIFF
--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -97,17 +97,11 @@ function android_build_set_env {
         export TOOLCHAIN_ARCH="x86_64"
     fi
 
-    # Since NDK r23 LLVM is the default
-    if [ -x "${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ar" ]; then
-        # Choose a C++ standard library implementation from the ndk
-        ANDROID_BUILD_CXXSTL="gnustl_shared_49"
-    fi
-    
     # Since NDK r22 the "platforms" dir got removed
     if [ -d "${ANDROID_NDK_ROOT}/platforms" ]; then
-        export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-${MIN_SDK_VERSION}/arch-${TOOLCHAIN_ARCH}"
+       export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-${MIN_SDK_VERSION}/arch-${TOOLCHAIN_ARCH}"
     else
-        export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/sysroot"
+       export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/sysroot"
     fi
     export ANDROID_BUILD_PREFIX="${ANDROID_BUILD_DIR}/prefix/${TOOLCHAIN_ARCH}"
 }

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -11,6 +11,9 @@ ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-`pwd`}"
 # Get access to android_build functions and variables
 source ./android_build_helper.sh
 
+# Choose a C++ standard library implementation from the ndk
+ANDROID_BUILD_CXXSTL="gnustl_shared_49"
+
 BUILD_ARCH=$1
 if [ -z $BUILD_ARCH ]; then
     usage


### PR DESCRIPTION
This reverts commit 9c6f09cbe551e08782b67fae367b56dc69f656f7.