### PR TITLE
fall thru to tcp/ip for any AF_UNIX/ipc error

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -664,11 +664,10 @@ error_closelistener:
         }
         filename.clear ();
     }
-
+    /*
     errno = saved_errno;
-
     return -1;
-
+    */
 try_tcpip:
     // try to fallback to TCP/IP
     // TODO: maybe remember this decision permanently?


### PR DESCRIPTION
https://github.com/zeromq/pyzmq/issues/1505
a few pyzmq clients have encountered an issue where the program they're running ends after this assert:
Bad file descriptor (C:\ci\zeromq_1602704446950\work\src\epoll.cpp:100)

We found this happens for users that have a windows 10 build that supports AF_Unix sockets but does not for those who have older windows 10 builds.  this change is to remove the preserved errno (which doesn't appear to be used/checked anywhere-hence the later assert/abort) and instead after cleanup try to use a tcp/ip socket.