### PR TITLE
Permission to Relicense under relevant approved license

### DIFF
--- a/RELICENSE/abaelhe
+++ b/RELICENSE/abaelhe
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Yijun He
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "abaelhe", with
+commit author "Yijun He <abaelhe@icloud.com>", are copyright of Yijun He.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Yijun He
+2022/07/17


### PR DESCRIPTION
Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
By Abael He<abaelhe@icloud.com>