### PR TITLE
Problem: Incorrect formatting of documentation in zmq_udp.txt

### DIFF
--- a/RELICENSE/nevalsar.md
+++ b/RELICENSE/nevalsar.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other share-alike OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Nevin Valsaraj that grants permission to relicense its 
+copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License 
+v2 (MPLv2) or any other share-alike Open Source Initiative approved license 
+chosen by the current ZeroMQ BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "nevalsar", with
+commit author "Nevin Valsaraj <nevin.valsaraj32@gmail.com>", are copyright of 
+Nevin Valsaraj. This document hereby grants the libzmq project team to relicense
+libzmq, including all past, present and future contributions of the author 
+listed above.
+
+Nevin Valsaraj
+2022/08/03

--- a/doc/zmq_udp.txt
+++ b/doc/zmq_udp.txt
@@ -28,7 +28,7 @@ For the UDP transport, the transport is `udp`.
 The meaning of the 'address' part is defined below.
 
 Binding a socket
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------
 With 'udp' we can only bind the 'ZMQ_DISH' socket type.
 When binding a socket using _zmq_bind()_ with the 'udp'
 transport the 'endpoint' shall be interpreted as an 'interface' followed by a
@@ -45,7 +45,7 @@ The UDP port number may be specified a numeric value, usually above
 1024 on POSIX systems.
 
 Connecting a socket
-~~~~~~~~~~~~~~~~~~~
+-------------------
 With 'udp' we can only connect the 'ZMQ_RADIO' socket type.
 When connecting a socket to a peer address using _zmq_connect()_ with the 'udp'
 transport, the 'endpoint' shall be interpreted as a 'peer address' followed by


### PR DESCRIPTION
Solution: Replace incorrect underline pattern in zmq_udp.txt that
makes part of the text show up as pre-formatted code block with
regular underline pattern.

http://api.zeromq.org/master:zmq-udp