### PR TITLE
Problem: pc.in assumes usage of lstdc++

### DIFF
--- a/src/libzmq.pc.in
+++ b/src/libzmq.pc.in
@@ -7,6 +7,6 @@ Name: libzmq
 Description: 0MQ c++ library
 Version: @VERSION@
 Libs: -L${libdir} -lzmq
-Libs.private: -lstdc++ @pkg_config_libs_private@
+Libs.private: @pkg_config_libs_private@
 Requires.private: @pkg_config_names_private@
 Cflags: -I${includedir} @pkg_config_defines@


### PR DESCRIPTION
Solution: remove -lstdc++.

A different c++ std lib could be in use. i.e clang++ -stdlib=libc++, so
there shouldn't be an assumption that stdc++ is being used.

Originally added in https://github.com/zeromq/libzmq/pull/1398.