### PR TITLE
Problem: bind can fail after open_socket succeeds on Windows without AF_UNIX

### DIFF
--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -239,6 +239,8 @@ void zmq::norm_engine_t::plug (io_thread_t *io_thread_,
 #ifdef ZMQ_USE_NORM_SOCKET_WRAPPER
     norm_wrapper_thread_args_t *threadArgs = new norm_wrapper_thread_args_t;
     int rc = make_fdpair (&wrapper_read_fd, &threadArgs->wrapper_write_fd);
+    errno_assert (rc != -1);
+
     threadArgs->norm_descriptor = NormGetDescriptor (norm_instance);
     threadArgs->norm_instance_handle = norm_instance;
     norm_descriptor_handle = add_fd (wrapper_read_fd);


### PR DESCRIPTION
closes #4386

Following discussion in #4386, this is a more specific check [requested](https://github.com/zeromq/libzmq/pull/4386#issuecomment-1132078805) by @bluca rather than a catch-all. Only failures up to the initial bind are considered for fallback to tcpip.

I can't reproduce the error, so I don't know exactly what errno to check for to make the condition even more specific.

Also adds the missing check of the returned rc from make_fd_pair, which should have raised the actual error instead of the cryptic `src\epoll.cpp:100` reported in https://github.com/zeromq/pyzmq/issues/1505