### PR TITLE
[document] add vcpkg instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ For OSX users, packages are available via brew.
 
     brew install zeromq
 
+## Installation of package manager <a name="package manager"/>
+
+### vcpkg
+
+vcpkg is a full platform package manager, you can easily install libzmq via vcpkg.
+
+    git clone https://github.com/microsoft/vcpkg.git
+    ./bootstrap-vcpkg.bat # For powershell
+    ./bootstrap-vcpkg.sh # For bash
+    ./vcpkg install workflow
+
 ## Build from sources <a name="build"/>
 
 To build from sources, see the INSTALL file included with the distribution.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ vcpkg is a full platform package manager, you can easily install libzmq via vcpk
     git clone https://github.com/microsoft/vcpkg.git
     ./bootstrap-vcpkg.bat # For powershell
     ./bootstrap-vcpkg.sh # For bash
-    ./vcpkg install workflow
+    ./vcpkg install zeromq
 
 ## Build from sources <a name="build"/>
 


### PR DESCRIPTION
`libzmq` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `libzmq` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `libzmq`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/zeromq/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)

