### PR TITLE
Problem: builds/android/build.sh fails with CURVE=libsodium

### DIFF
--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -67,7 +67,7 @@ elif [ $CURVE == "libsodium" ]; then
 
     (android_build_verify_so "libsodium.so" &> /dev/null) || {
         rm -rf "${cache}/libsodium"
-        (cd "${cache}" && git clone -b stable --depth 1 git://github.com/jedisct1/libsodium.git) || exit 1
+        (cd "${cache}" && git clone -b stable --depth 1 https://github.com/jedisct1/libsodium.git) || exit 1
         (cd "${cache}/libsodium" && ./autogen.sh \
             && ./configure --quiet "${ANDROID_BUILD_OPTS[@]}" --disable-soname-versions \
             && make -j 4 \

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -44,7 +44,7 @@ elif [ $CURVE == "libsodium" ]; then
 
     if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list libsodium-dev >/dev/null 2>&1) || \
             (command -v brew >/dev/null 2>&1 && brew ls --versions libsodium >/dev/null 2>&1)); then
-        git clone --depth 1 -b stable git://github.com/jedisct1/libsodium.git
+        git clone --depth 1 -b stable https://github.com/jedisct1/libsodium.git
         ( cd libsodium; ./autogen.sh; ./configure --prefix=$BUILD_PREFIX; make install)
     fi
 fi

--- a/builds/valgrind/ci_build.sh
+++ b/builds/valgrind/ci_build.sh
@@ -25,7 +25,7 @@ elif [ $CURVE == "libsodium" ]; then
 
     if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list libsodium-dev >/dev/null 2>&1) || \
             (command -v brew >/dev/null 2>&1 && brew ls --versions libsodium >/dev/null 2>&1)); then
-        git clone --depth 1 -b stable git://github.com/jedisct1/libsodium.git
+        git clone --depth 1 -b stable https://github.com/jedisct1/libsodium.git
         ( cd libsodium; ./autogen.sh; ./configure --prefix=$BUILD_PREFIX; make install)
     fi
 fi

--- a/config.sh
+++ b/config.sh
@@ -28,7 +28,7 @@ function set_config_opts() {
 
         if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list libsodium-dev >/dev/null 2>&1) || \
                 (command -v brew >/dev/null 2>&1 && brew ls --versions libsodium >/dev/null 2>&1)); then
-            git clone --depth 1 -b stable git://github.com/jedisct1/libsodium.git
+            git clone --depth 1 -b stable https://github.com/jedisct1/libsodium.git
             ( cd libsodium; ./autogen.sh; ./configure --prefix=$BUILD_PREFIX; make install)
         fi
     fi


### PR DESCRIPTION
How to reproduce:
```
prompt> git clone libzmq
prompt> cd libzmq/builds/android
prompt> export CURVE=libsodium
prompt> ./ci_build.sh
Cloning into 'libsodium'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.4]: errno=Connection timed out

Cloning into 'libsodium'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=Connection timed out

Cloning into 'libsodium'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=Connection timed out

Cloning into 'libsodium'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.4]: errno=Connection timed out

prompt>
```

Reason: Invalid URL to download libsodium:
```
prompt> grep -s 'git clone' libzmq/builds/android/*.sh
libzmq/builds/android/build.sh:70:        (cd "${cache}" && git clone -b stable --depth 1 git://github.com/jedisct1/libsod
                                                                                          ^^^^^^^^^^^^^^^^^
```

URL should be either:
- `git@github.com:`
- `https://github.com/` same given in [zproject](https://github.com/zeromq/zproject/blob/master/zproject_known_projects.xml#L108-L111).

Solution: Change URL to `https://`.

Result:
```
prompt> export CURVE=libsodium
prompt> ./ci_build.sh
Cloning into 'libsodium'...
remote: Enumerating objects: 659, done.
remote: Counting objects: 100% (659/659), done.
remote: Compressing objects: 100% (586/586), done.
remote: Total 659 (delta 159), reused 220 (delta 34), pack-reused 0
Receiving objects: 100% (659/659), 1.97 MiB | 4.00 MiB/s, done.
Resolving deltas: 100% (159/159), done.
autoconf scripts already exist.
...
libtool: install: /bin/install -c tools/.libs/curve_keygen /home/cbox_dev/git/ZEROMQ/libzmq/builds/android/prefix/x86_64/bin/curve_keygen
 /bin/mkdir -p '/home/cbox_dev/git/ZEROMQ/libzmq/builds/android/prefix/x86_64/include'
 /bin/install -c -m 644 include/zmq.h include/zmq_utils.h '/home/cbox_dev/git/ZEROMQ/libzmq/builds/android/prefix/x86_64/include'
 /bin/mkdir -p '/home/cbox_dev/git/ZEROMQ/libzmq/builds/android/prefix/x86_64/lib/pkgconfig'
 /bin/install -c -m 644 src/libzmq.pc '/home/cbox_dev/git/ZEROMQ/libzmq/builds/android/prefix/x86_64/lib/pkgconfig'
make[2]: Leaving directory `/tmp/android_build/x86_64/libzmq'
make[1]: Leaving directory `/tmp/android_build/x86_64/libzmq'
libzmq android build succeeded
prompt>
```