### PR TITLE
Problem: Default Android NDK version is not aligned with zproject

### DIFF
--- a/builds/android/README.md
+++ b/builds/android/README.md
@@ -5,12 +5,12 @@
 You need the Android Native Development Kit (NDK) installed. See
 [here](https://developer.android.com/ndk) to download it.
 
-This project is tested against Android NDK version r24.
+This project is tested against Android NDK version r25.
 
-If you installed version r24 all you have to do is to expose the NDK root
+If you installed version r25 all you have to do is to expose the NDK root
 directory as environment variable, e.g:
 
-    export ANDROID_NDK_ROOT=$HOME/android-ndk-r24
+    export ANDROID_NDK_ROOT=$HOME/android-ndk-r25
 
 If you installed another version you have to expose the NDK root directory as
 well as the NDK version, e.g:

--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -112,12 +112,12 @@ function android_build_env {
 
     if [ -z "$ANDROID_NDK_ROOT" ]; then
         ANDROID_BUILD_FAIL+=("Please set the ANDROID_NDK_ROOT environment variable")
-        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r24\")")
+        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r25\")")
     fi
 
     if [ -z "$TOOLCHAIN_PATH" ]; then
         ANDROID_BUILD_FAIL+=("Please set the TOOLCHAIN_PATH environment variable")
-        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r24/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin\")")
+        ANDROID_BUILD_FAIL+=("  (eg. \"/home/user/android/android-ndk-r25/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin\")")
     fi
 
     if [ -z "$TOOLCHAIN_HOST" ]; then

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -34,7 +34,7 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
 esac
 
 # Set default values used in ci builds
-export NDK_VERSION=${NDK_VERSION:-android-ndk-r24}
+export NDK_VERSION=${NDK_VERSION:-android-ndk-r25}
 # With NDK r22b, the minimum SDK version range is [16, 31].
 # Since NDK r24, the minimum SDK version range is [19, 31].
 # SDK version 21 is the minimum version for 64-bit builds.

--- a/builds/android/ci_build.sh
+++ b/builds/android/ci_build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export NDK_VERSION=android-ndk-r24
+export NDK_VERSION=android-ndk-r25
 export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
 
 case $(uname | tr '[:upper:]' '[:lower:]') in


### PR DESCRIPTION
Solution: Set NDK r25 as the default. No compatiblity changes required.