### PR TITLE
avoid intermittent timeouts in test (esp. when run w/ASAN etc.)

### DIFF
--- a/tests/test_spec_req.cpp
+++ b/tests/test_spec_req.cpp
@@ -53,7 +53,7 @@ void test_round_robin_out (const char *bind_address_)
     //  We have to give the connects time to finish otherwise the requests
     //  will not properly round-robin. We could alternatively connect the
     //  REQ sockets to the REP sockets.
-    msleep (SETTLE_TIME);
+    msleep (SETTLE_TIME * services);
 
     // Send our peer-replies, and expect every REP it used once in order
     for (size_t peer = 0; peer < services; peer++) {


### PR DESCRIPTION
We're trying to automate running the unit tests, but an intermittent timeout error in `test_spec_req` is causing problems.  This is particularly troublesome when running the tests under sanitizers (e.g., ASAN).

```
        Start  32: test_spec_req
 32/117 Test  #32: test_spec_req ....................***Timeout  10.01 sec
```

Running the test stand-alone is not much more informative:

```
[btorpey@bt-brix7 master]$ ./build/bin/test_spec_req
/home/btorpey/work/libzmq/master/src/tests/test_spec_req.cpp:230:test_round_robin_out_inproc:PASS

Alarm clock
[btorpey@bt-brix7 master]$
```

OTOH, the test succeeds when run under gdb.

In any case, the patch below appears to eliminate the timeout by multiplying `SETTLE_TIME` by the number of peers.

