### PR TITLE
Problem: Android helpers no not validate dependent libraries.

### DIFF
--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -320,8 +320,12 @@ function android_build_verify_so {
         ANDROID_BUILD_FAIL+=("  ${elfoutput}")
     fi
 
-    for dep_soname do
-        if [[ $elfoutput != *"library: [${dep_soname}]"* ]]; then
+    for dep_soname in "$@" ; do
+        local dep_sofile="${ANDROID_BUILD_PREFIX}/lib/${dep_soname}"
+        if [ ! -f "${dep_sofile}" ]; then
+            ANDROID_BUILD_FAIL+=("Found no library named ${dep_soname}")
+            ANDROID_BUILD_FAIL+=("  ${dep_sofile}")
+        elif [[ $elfoutput != *"library: [${dep_soname}]"* ]]; then
             ANDROID_BUILD_FAIL+=("Library ${soname} was expected to be linked to library with soname:")
             ANDROID_BUILD_FAIL+=("  ${dep_soname}")
         fi


### PR DESCRIPTION
Seen in the code:
```
# Parse readelf output to verify the correct linking of libraries.
#   The first argument should be the soname of the newly built library.
#   The rest of the arguments should be the sonames of dependencies.
#   All sonames should be unversioned for android (no trailing numbers).
function android_build_verify_so {
...
    for dep_soname do
        if [[ $elfoutput != *"library: [${dep_soname}]"* ]]; then
            ANDROID_BUILD_FAIL+=("Library ${soname} was expected to be linked to library with soname:")
            ANDROID_BUILD_FAIL+=("  ${dep_soname}")
        fi
    done
```

The `for xxx` syntax is wrong, most probably a typo somewhere.

Solution: Fix & complete the `for xxx` loop.

Tested with & without LIBSODIUM (only available dependent library for LIBZMQ).

Note: The same has to be done in ZPROJECT, for CZMQ & ZYRE.