### PR TITLE
Problem: Android build script may fail silently

### DIFF
--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 function usage {
     echo "Usage ./build.sh [ arm | arm64 | x86 | x86_64 ]"
 }
@@ -86,7 +88,7 @@ LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
 (android_build_verify_so ${VERIFY} &> /dev/null) || {
     rm -rf "${cache}/libzmq"
-    (cp -r ../.. "${cache}/libzmq" && cd "${cache}/libzmq" && make clean)
+    (cp -r ../.. "${cache}/libzmq" && cd "${cache}/libzmq" && ( make clean || : ))
 
     (cd "${cache}/libzmq" && ./autogen.sh \
         && ./configure --quiet "${ANDROID_BUILD_OPTS[@]}" ${CURVE} --without-docs \

--- a/builds/android/ci_build.sh
+++ b/builds/android/ci_build.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
+#
+#   Exit if any step fails
+set -e
 
 export NDK_VERSION=android-ndk-r25
 export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
+
+# Cleanup.
+rm -rf /tmp/tmp-deps
+mkdir -p /tmp/tmp-deps
 
 case $(uname | tr '[:upper:]' '[:lower:]') in
   linux*)


### PR DESCRIPTION
Solution: Use `set -e`

Note:
To be reported in ZPROJECT, when generating the same scripts.

Note:
`make clean` may fail when Makefile is not yet generated (case of 1st call of build.sh after git clone).

Additionnaly, cleaned the dependency folder
(report of CZMQ & ZYRE similar scripts).