### PR TITLE
Problem: Android APP fails to load ZMQ since NDK r25.x

### DIFF
--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -167,7 +167,7 @@ function android_build_env {
         ANDROID_BUILD_FAIL+=("  ${ANDROID_STL_ROOT}")
     fi
 
-    if [ -n "${ANDROID_LIBC_ROOT}" ] && [ ! -d ${ANDROID_LIBC_ROOT} ]; then
+    if [ -n "${ANDROID_LIBC_ROOT}" ] && [ ! -d "${ANDROID_LIBC_ROOT}" ]; then
         ANDROID_BUILD_FAIL+=("The ANDROID_LIBC_ROOT directory does not exist")
         ANDROID_BUILD_FAIL+=("  ${ANDROID_LIBC_ROOT}")
     fi

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -14,7 +14,10 @@ ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-`pwd`}"
 source ./android_build_helper.sh
 
 # Choose a C++ standard library implementation from the ndk
-ANDROID_BUILD_CXXSTL="gnustl_shared_49"
+export ANDROID_BUILD_CXXSTL="gnustl_shared_49"
+
+# Additional flags for LIBTOOL, for LIBZMQ and other dependencies.
+export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
 BUILD_ARCH=$1
 if [ -z $BUILD_ARCH ]; then
@@ -93,8 +96,6 @@ fi
 ##
 # Build libzmq from local source
 
-LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
-
 (android_build_verify_so ${VERIFY} &> /dev/null) || {
     rm -rf "${cache}/libzmq"
     (cp -r ../.. "${cache}/libzmq" && cd "${cache}/libzmq" && ( make clean || : ))
@@ -116,7 +117,12 @@ LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 }
 
 ##
+# Fetch the STL as well.
+
+cp ${ANDROID_STL_ROOT}/${ANDROID_STL} ${ANDROID_BUILD_PREFIX}/lib/.
+
+##
 # Verify shared libraries in prefix
 
-android_build_verify_so ${VERIFY}
+android_build_verify_so ${VERIFY} ${ANDROID_STL}
 echo "libzmq android build succeeded"

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -119,10 +119,10 @@ fi
 ##
 # Fetch the STL as well.
 
-cp ${ANDROID_STL_ROOT}/${ANDROID_STL} ${ANDROID_BUILD_PREFIX}/lib/.
+cp "${ANDROID_STL_ROOT}/${ANDROID_STL}" "${ANDROID_BUILD_PREFIX}/lib/."
 
 ##
 # Verify shared libraries in prefix
 
-android_build_verify_so ${VERIFY} ${ANDROID_STL}
+android_build_verify_so "${VERIFY}" "${ANDROID_STL}"
 echo "libzmq android build succeeded"


### PR DESCRIPTION
With the help of the dump of ./configure options (former PR):
```
LIBZMQ (arm) - ./configure options to build 'LIBZMQ':
  > --quiet
  > TOOLCHAIN=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64
  > CC=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang
  > CXX=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang++
  > LD=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/ld
  > AS=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-as
  > AR=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
  > RANLIB=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ranlib
  > STRIP=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip
  > CFLAGS= -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE
  > CPPFLAGS= -I/home/stephan/git/zproject-android-testing/libzmq/builds/android/prefix/arm/include
  > CXXFLAGS=
  > LDFLAGS=-L/home/stephan/git/zproject-android-testing/libzmq/builds/android/prefix/arm/lib -L/tmp/android-ndk-r25/sour\
ces/cxx-stl/llvm-libc++/libs/armeabi-v7a
  > LIBS=-lc -ldl -lm -llog -lc++_shared
  > PKG_CONFIG_LIBDIR=/tmp/android-ndk-r25/prebuilt/linux-x86_64/lib/pkgconfig
  > PKG_CONFIG_PATH=/home/stephan/git/zproject-android-testing/libzmq/builds/android/prefix/arm/lib/pkgconfig
  > PKG_CONFIG_SYSROOT_DIR=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/sysroot
  > PKG_CONFIG_DIR=
  > --with-sysroot=/tmp/android-ndk-r25/toolchains/llvm/prebuilt/linux-x86_64/sysroot
  > --host=arm-linux-androideabi
  > --prefix=/home/stephan/git/zproject-android-testing/libzmq/builds/android/prefix/arm
  > --disable-curve
  > --without-docs
```

We can observe that LDFLAGS has invalid `-L<path_to_libc++_shared.so>`:
```
-L/tmp/android-ndk-r25/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a

```
This path is no more valid, since NDK r25, where one should use LLVM path.

Ok, once this is fixed, ./configure requires also the path to libc.so. I don't understand why libc.so is now required, actually, but without this, ./configure fails to build its conftest.

Solution: Fix invalid LDFLAGS.

Notes:

- To be reported to CZMQ/ZYRE via ZPROJECT.

- Tested successfully with Android Emulator (x86 & x86_64).

- Still need some more work, as execution still fails with physical devices (observed on arm64).

- Introduced `ANDROID_STL`, `ANDROID_STL_ROOT` & `ANDROID_LIBC_ROOT`. All are initialized in `android_build_helper.sh`.

- New mechanism **MUST** be compatible with former NDK versions.