### PR TITLE
Problem: Android CI build scripts need minor enhancements (traces & cleanup)

### DIFF
--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 function usage {
-    echo "Usage ./build.sh [ arm | arm64 | x86 | x86_64 ]"
+    echo "LIBZMQ (${BUILD_ARCH}) - Usage ./build.sh [ arm | arm64 | x86 | x86_64 ]"
 }
 
 # Use directory of current script as the build directory and working directory
@@ -25,17 +25,11 @@ if [ -z $BUILD_ARCH ]; then
     exit 1
 fi
 
-case $(uname | tr '[:upper:]' '[:lower:]') in
-  linux*)
-    export HOST_PLATFORM=linux-x86_64
-    ;;
-  darwin*)
-    export HOST_PLATFORM=darwin-x86_64
-    ;;
-  *)
-    echo "Unsupported platform"
-    exit 1
-    ;;
+platform="$(uname | tr '[:upper:]' '[:lower:]')"
+case "${platform}" in
+  linux*)  export HOST_PLATFORM=linux-x86_64 ;;
+  darwin*) export HOST_PLATFORM=darwin-x86_64 ;;
+  *)       echo "LIBZMQ (${BUILD_ARCH}) - Unsupported platform ('${platform}')" ; exit 1 ;;
 esac
 
 # Set default values used in ci builds
@@ -57,7 +51,7 @@ mkdir -p "${cache}"
 
 # Check for environment variable to clear the prefix and do a clean build
 if [[ $ANDROID_BUILD_CLEAN ]]; then
-    echo "Doing a clean build (removing previous build and dependencies)..."
+    echo "LIBZMQ (${BUILD_ARCH}) - Doing a clean build (removing previous build and dependencies)..."
     rm -rf "${ANDROID_BUILD_PREFIX}"/*
 fi
 
@@ -125,4 +119,4 @@ cp "${ANDROID_STL_ROOT}/${ANDROID_STL}" "${ANDROID_BUILD_PREFIX}/lib/."
 # Verify shared libraries in prefix
 
 android_build_verify_so "${VERIFY}" "${ANDROID_STL}"
-echo "libzmq android build succeeded"
+echo "LIBZMQ (${BUILD_ARCH}) - Android build successful"

--- a/builds/android/ci_build.sh
+++ b/builds/android/ci_build.sh
@@ -7,6 +7,8 @@ export NDK_VERSION=android-ndk-r25
 export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
 
 # Cleanup.
+rm -rf /tmp/android_build/
+rm -rf prefix/
 rm -rf /tmp/tmp-deps
 mkdir -p /tmp/tmp-deps
 


### PR DESCRIPTION
Cleanup:
Seen when someone has to relaunch `ci_build.sh` manually, for troubleshooting, or experiment(s), ci_build.sh stops as libraries are already built.

Solution: Clean more temporary/build folders before build.

Note:

  To be reported in ZYRE/CZMQ via ZProject.


Traces:
When called from ZYRE/CZMQ, it's difficult to identify which build script is being executed

Solution: Modify each `echo` trace to show the project name and Android architecture in progress.

Note:

  To be reported in ZYRE/CZMQ via ZProject.