### PR TITLE
Problem: Android APP fails to load ZMQ (ARM64 only)

### DIFF
--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -80,9 +80,9 @@ esac
 export NDK_NUMBER="$(( $(echo ${NDK_VERSION}|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
 NDK_VERSION_LETTER="$(echo ${NDK_VERSION}|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[a-z]' '[A-Z]')"
 if [ -n "${NDK_VERSION_LETTER}" ] ; then
-    NDK_NUMBER=$(( $(( ${NDK_NUMBER} + $(printf '%d' \'${NDK_VERSION_LETTER}) )) - 64 ))
+    NDK_NUMBER=$(( $(( $NDK_NUMBER + $(printf '%d' \'${NDK_VERSION_LETTER}) )) - 64 ))
 fi
-echo "LIBZMQ - Configured NDK_VERSION: ${NDK_VERSION} (${NDK_NUMBER})."
+echo "LIBZMQ - Configured NDK_VERSION: ${NDK_VERSION} ($NDK_NUMBER)."
 
 function android_build_check_fail {
     if [ ! ${#ANDROID_BUILD_FAIL[@]} -eq 0 ]; then

--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -58,6 +58,32 @@ fi
 # (Empty string indicates no failure)
 ANDROID_BUILD_FAIL=()
 
+
+########################################################################
+# Sanity checks
+########################################################################
+if [ -z "${NDK_VERSION}" ] ; then
+    echo "NDK_VERSION not set !"
+    exit 1
+fi
+case "${NDK_VERSION}" in
+    "android-ndk-r"[0-9][0-9] ) : ;;
+    "android-ndk-r"[0-9][0-9][a-z] ) : ;;
+    * ) echo "Invalid format for NDK_VERSION ('${NDK_VERSION}')" ; exit 1 ;;
+esac
+
+########################################################################
+# Compute NDK version into a numeric form:
+#   android-ndk-r21e -> 2105
+#   android-ndk-r25  -> 2500
+########################################################################    
+export NDK_NUMBER="$(( $(echo ${NDK_VERSION}|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
+NDK_VERSION_LETTER="$(echo ${NDK_VERSION}|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[a-z]' '[A-Z]')"
+if [ -n "${NDK_VERSION_LETTER}" ] ; then
+    NDK_NUMBER=$(( $(( ${NDK_NUMBER} + `printf '%d' \'${NDK_VERSION_LETTER}` )) - 64 ))
+fi
+echo "LIBZMQ - Configured NDK_VERSION: ${NDK_VERSION} (${NDK_NUMBER})."
+
 function android_build_check_fail {
     if [ ! ${#ANDROID_BUILD_FAIL[@]} -eq 0 ]; then
         echo "Android (${TOOLCHAIN_ARCH}) build failed for the following reasons:"
@@ -286,6 +312,13 @@ function android_build_opts {
     LDFLAGS+=" -L${ANDROID_STL_ROOT}"
     CFLAGS+=" -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE"
     CPPFLAGS+=" -I${ANDROID_BUILD_PREFIX}/include"
+
+    if [ ${NDK_NUMBER} -ge 2400 ] ; then
+	if [ "${BUILD_ARCH}" = "arm64" ] ; then
+            CXXFLAGS+=" -mno-outline-atomics"
+	fi
+    fi
+
 
     ANDROID_BUILD_OPTS+=("CFLAGS=${CFLAGS} ${ANDROID_BUILD_EXTRA_CFLAGS}")
     ANDROID_BUILD_OPTS+=("CPPFLAGS=${CPPFLAGS} ${ANDROID_BUILD_EXTRA_CPPFLAGS}")

--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -80,7 +80,7 @@ esac
 export NDK_NUMBER="$(( $(echo ${NDK_VERSION}|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
 NDK_VERSION_LETTER="$(echo ${NDK_VERSION}|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[a-z]' '[A-Z]')"
 if [ -n "${NDK_VERSION_LETTER}" ] ; then
-    NDK_NUMBER=$(( $(( ${NDK_NUMBER} + `printf '%d' \'${NDK_VERSION_LETTER}` )) - 64 ))
+    NDK_NUMBER=$(( $(( ${NDK_NUMBER} + $(printf '%d' \'${NDK_VERSION_LETTER}) )) - 64 ))
 fi
 echo "LIBZMQ - Configured NDK_VERSION: ${NDK_VERSION} (${NDK_NUMBER})."
 

--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -77,10 +77,10 @@ esac
 #   android-ndk-r21e -> 2105
 #   android-ndk-r25  -> 2500
 ########################################################################    
-export NDK_NUMBER="$(( $(echo ${NDK_VERSION}|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
-NDK_VERSION_LETTER="$(echo ${NDK_VERSION}|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[:lower:]' '[:upper:]')"
+export NDK_NUMBER="$(( $(echo \"${NDK_VERSION}\"|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
+NDK_VERSION_LETTER="$(echo \"${NDK_VERSION}\"|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[:lower:]' '[:upper:]')"
 if [ -n "${NDK_VERSION_LETTER}" ] ; then
-    NDK_NUMBER=$(( $(( $NDK_NUMBER + $(printf '%d' \'${NDK_VERSION_LETTER}) )) - 64 ))
+    NDK_NUMBER=$(( $(( $NDK_NUMBER + $(printf '%d' \'"${NDK_VERSION_LETTER}") )) - 64 ))
 fi
 echo "LIBZMQ - Configured NDK_VERSION: ${NDK_VERSION} ($NDK_NUMBER)."
 

--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -78,7 +78,7 @@ esac
 #   android-ndk-r25  -> 2500
 ########################################################################    
 export NDK_NUMBER="$(( $(echo ${NDK_VERSION}|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
-NDK_VERSION_LETTER="$(echo ${NDK_VERSION}|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[a-z]' '[A-Z]')"
+NDK_VERSION_LETTER="$(echo ${NDK_VERSION}|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[:lower:]' '[:upper:]')"
 if [ -n "${NDK_VERSION_LETTER}" ] ; then
     NDK_NUMBER=$(( $(( $NDK_NUMBER + $(printf '%d' \'${NDK_VERSION_LETTER}) )) - 64 ))
 fi

--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -77,10 +77,10 @@ esac
 #   android-ndk-r21e -> 2105
 #   android-ndk-r25  -> 2500
 ########################################################################    
-export NDK_NUMBER="$(( $(echo \"${NDK_VERSION}\"|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
-NDK_VERSION_LETTER="$(echo \"${NDK_VERSION}\"|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[:lower:]' '[:upper:]')"
+export NDK_NUMBER="$(( $(echo "${NDK_VERSION}"|sed -e 's|android-ndk-r||g' -e 's|[a-z]||g') * 100 ))"
+NDK_VERSION_LETTER="$(echo "${NDK_VERSION}"|sed -e 's|android-ndk-r[0-9][0-9]||g'|tr '[:lower:]' '[:upper:]')"
 if [ -n "${NDK_VERSION_LETTER}" ] ; then
-    NDK_NUMBER=$(( $(( $NDK_NUMBER + $(printf '%d' \'"${NDK_VERSION_LETTER}") )) - 64 ))
+    NDK_NUMBER=$(( $(( NDK_NUMBER + $(printf '%d' \'"${NDK_VERSION_LETTER}") )) - 64 ))
 fi
 echo "LIBZMQ - Configured NDK_VERSION: ${NDK_VERSION} ($NDK_NUMBER)."
 


### PR DESCRIPTION
Seen with physical Android devices running ARM64.
Not seen with ARM, X86 or X86_64.

Any Android APP loading ZMQ fails with:
```
[FATAL] Couldn't load library library zmq from jar. Dependency is required!
```

Unpack zyre-android-2.0.1.jar, find libzmq.so for ARM64 and look for missing symbols:
```
prompt> unzip zyre-android-2.0.1.jar
prompt> cd lib/arm64-v8a
prompt> nm --undefined-only ./libzmq.so | head
                 U __aarch64_ldadd4_acq
                 U __aarch64_ldadd4_acq_rel
                 U __aarch64_ldadd4_rel
                 U __aarch64_ldadd4_relax
                 U __aarch64_ldadd8_acq_rel
                 U __aarch64_ldadd8_relax
                 U __aarch64_swp8_acq
                 U __aarch64_swp8_acq_rel
                 U __aarch64_swp8_rel
                 U __aarch64_swp8_relax
prompt>
```
Some more symbols are missing, but those are relevant for this issue.

OK.
These symbols are present in libc++_shared, but not exported ...:
```
prompt> nm libc++_shared.so | grep aarch64
00000000000ee6d0 t __aarch64_cas1_acq_rel
00000000000ee7a0 t __aarch64_cas8_acq_rel
00000000001028f0 b __aarch64_have_lse_atomics
00000000000ee840 t __aarch64_ldadd4_acq_rel
00000000000ee810 t __aarch64_ldadd4_rel
00000000000ee8a0 t __aarch64_ldadd8_acq_rel
00000000000ee870 t __aarch64_ldadd8_relax
00000000000ee7e0 t __aarch64_swp8_acq_rel
prompt>
```

Issue seen also on the WEB, with GCC & CLANG:
- https://bugzilla.redhat.com/show_bug.cgi?id=1830472
- https://github.com/flutter/buildroot/pull/434/commits/cea175b83895943c30fb3e2c17e3c43bd619a6b9
- ...

Solution: Add `-mno-outline-atomics` to CXXFLAGS (FLUTTER fix).

Additionaly, had to introduce NDK_NUMBER.
This variable is calculated in `android_build_helper.sh`. It represents the numeric form of NDK_VERSION:
```
  NDK_VERSION          --> NDK_NUMBER
  android-ndk-r25      --> 2500
  android-ndk-r23c     --> 2303
  android-ndk-r22      --> 2200
  android-ndk-r21e     --> 2105
  ... and so on
```

This will help a few other things (NDK download ?).