### PR TITLE
Problem: Android build environment variables need clarifications.

### DIFF
--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -101,22 +101,22 @@ function android_build_set_env {
     export TOOLCHAIN_PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/bin"
 
     # Set variables for each architecture
-    if [ $BUILD_ARCH == "arm" ]; then
+    if [ "${BUILD_ARCH}" == "arm" ]; then
         export TOOLCHAIN_HOST="arm-linux-androideabi"
         export TOOLCHAIN_COMP="armv7a-linux-androideabi${MIN_SDK_VERSION}"
         export TOOLCHAIN_ABI="armeabi-v7a"
         export TOOLCHAIN_ARCH="arm"
-    elif [ $BUILD_ARCH == "x86" ]; then
+    elif [ "${BUILD_ARCH}" == "x86" ]; then
         export TOOLCHAIN_HOST="i686-linux-android"
         export TOOLCHAIN_COMP="i686-linux-android${MIN_SDK_VERSION}"
         export TOOLCHAIN_ABI="x86"
         export TOOLCHAIN_ARCH="x86"
-    elif [ $BUILD_ARCH == "arm64" ]; then
+    elif [ "${BUILD_ARCH}" == "arm64" ]; then
         export TOOLCHAIN_HOST="aarch64-linux-android"
         export TOOLCHAIN_COMP="aarch64-linux-android${MIN_SDK_VERSION}"
         export TOOLCHAIN_ABI="arm64-v8a"
         export TOOLCHAIN_ARCH="arm64"
-    elif [ $BUILD_ARCH == "x86_64" ]; then
+    elif [ "${BUILD_ARCH}" == "x86_64" ]; then
         export TOOLCHAIN_HOST="x86_64-linux-android"
         export TOOLCHAIN_COMP="x86_64-linux-android${MIN_SDK_VERSION}"
         export TOOLCHAIN_ABI="x86_64"
@@ -353,7 +353,7 @@ function android_build_verify_so {
     android_build_check_fail
 
     local READELF="${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-readelf"
-    if command -v ${READELF} >/dev/null 2>&1 ; then
+    if command -v "${READELF}" >/dev/null 2>&1 ; then
         local readelf_bin="${READELF}"
     elif command -v readelf >/dev/null 2>&1 ; then
         local readelf_bin="readelf"
@@ -364,7 +364,8 @@ function android_build_verify_so {
     fi
     android_build_check_fail
 
-    local elfoutput=$(LC_ALL=C $readelf_bin -d ${sofile})
+    local elfoutput
+    elfoutput=$(LC_ALL=C $readelf_bin -d "${sofile}")
 
     local soname_regexp='soname: \[([[:alnum:]\.]+)\]'
     if [[ $elfoutput =~ $soname_regexp ]]; then
@@ -401,4 +402,3 @@ function android_show_configure_opts {
     done
     echo ""
 }
-

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Use directory of current script as the working directory
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
 ########################################################################
 # Configuration & tuning options.
 ########################################################################
@@ -19,7 +22,7 @@ export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
 
 # Use directory of current script as the build directory
 # ${ANDROID_BUILD_DIR}/prefix/<build_arch>/lib will contain produced libraries
-export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd)}"
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-${PWD}}"
 
 # Clean before processing
 export ANDROID_BUILD_CLEAN="${ANDROID_BUILD_CLEAN:-}"
@@ -52,9 +55,6 @@ BUILD_ARCH="$1"
 ########################################################################
 # Compilation
 ########################################################################
-# Use directory of current script as the working directory
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-
 # Get access to android_build functions and variables
 source ./android_build_helper.sh
 
@@ -72,7 +72,7 @@ case "${platform}" in
 esac
 
 # Set up android build environment and set ANDROID_BUILD_OPTS array
-android_build_set_env $BUILD_ARCH
+android_build_set_env "${BUILD_ARCH}"
 android_build_env
 android_build_opts
 
@@ -84,16 +84,16 @@ mkdir -p "${cache}"
 # Check for environment variable to clear the prefix and do a clean build
 if [[ $ANDROID_BUILD_CLEAN ]]; then
     echo "LIBZMQ (${BUILD_ARCH}) - Doing a clean build (removing previous build and dependencies)..."
-    rm -rf "${ANDROID_BUILD_PREFIX}"/*
+    rm -rf "${ANDROID_BUILD_PREFIX:-android-build-prefix-not-set}"/*
 
     # Called shells MUST not clean after ourselves !
     export ANDROID_BUILD_CLEAN=""
 fi
 
 VERIFY=("libzmq.so")
-if [ -z $CURVE ]; then
+if [ -z "${CURVE}" ]; then
     CURVE="--disable-curve"
-elif [ $CURVE == "libsodium" ]; then
+elif [ "${CURVE}" == "libsodium" ]; then
     CURVE="--with-libsodium=yes"
     VERIFY+=("libsodium.so")
     ##

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -19,7 +19,7 @@ export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
 
 # Use directory of current script as the build directory
 # ${ANDROID_BUILD_DIR}/prefix/<build_arch>/lib will contain produced libraries
-export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-$(cd $(dirname "${BASH_SOURCE[0]}") ; pwd)}"
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd)}"
 
 # Clean before processing
 export ANDROID_BUILD_CLEAN="${ANDROID_BUILD_CLEAN:-}"

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -2,13 +2,58 @@
 
 set -e
 
+########################################################################
+# Configuration & tuning options.
+########################################################################
+# Set default values used in ci builds
+export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+
+# Set default path to find Android NDK.
+# Must be of the form <path>/${NDK_VERSION} !!
+export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
+
+# With NDK r22b, the minimum SDK version range is [16, 31].
+# Since NDK r24, the minimum SDK version range is [19, 31].
+# SDK version 21 is the minimum version for 64-bit builds.
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+
+# Use directory of current script as the build directory
+# ${ANDROID_BUILD_DIR}/prefix/<build_arch>/lib will contain produced libraries
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-$(cd $(dirname "${BASH_SOURCE[0]}") ; pwd)}"
+
+# Clean before processing
+export ANDROID_BUILD_CLEAN="${ANDROID_BUILD_CLEAN:-}"
+
+# Select CURVE implementation:
+# - ""               # Do not use any CURVE implementation.
+# - "libsodium"      # Use LIBSODIUM implementation.
+# - "tweetnacl"      # Use internal TWEETNACL implementation.
+export CURVE="${CURVE:-}"
+
+########################################################################
+# Utilities
+########################################################################
 function usage {
-    echo "LIBZMQ (${BUILD_ARCH}) - Usage ./build.sh [ arm | arm64 | x86 | x86_64 ]"
+    echo "LIBZMQ - Usage:"
+    echo "  export XXX=yyy"
+    echo "  ./build.sh [ arm | arm64 | x86 | x86_64 ]"
+    echo ""
+    echo "See this file (configuration & tuning options) for details"
+    echo "on variables XXX and their values xxx"
+    exit 1
 }
 
-# Use directory of current script as the build directory and working directory
+########################################################################
+# Sanity checks
+########################################################################
+BUILD_ARCH="$1"
+[ -z "${BUILD_ARCH}" ] && usage
+
+########################################################################
+# Compilation
+########################################################################
+# Use directory of current script as the working directory
 cd "$( dirname "${BASH_SOURCE[0]}" )"
-ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-`pwd`}"
 
 # Get access to android_build functions and variables
 source ./android_build_helper.sh
@@ -19,25 +64,12 @@ export ANDROID_BUILD_CXXSTL="gnustl_shared_49"
 # Additional flags for LIBTOOL, for LIBZMQ and other dependencies.
 export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
-BUILD_ARCH=$1
-if [ -z $BUILD_ARCH ]; then
-    usage
-    exit 1
-fi
-
 platform="$(uname | tr '[:upper:]' '[:lower:]')"
 case "${platform}" in
   linux*)  export HOST_PLATFORM=linux-x86_64 ;;
   darwin*) export HOST_PLATFORM=darwin-x86_64 ;;
   *)       echo "LIBZMQ (${BUILD_ARCH}) - Unsupported platform ('${platform}')" ; exit 1 ;;
 esac
-
-# Set default values used in ci builds
-export NDK_VERSION=${NDK_VERSION:-android-ndk-r25}
-# With NDK r22b, the minimum SDK version range is [16, 31].
-# Since NDK r24, the minimum SDK version range is [19, 31].
-# SDK version 21 is the minimum version for 64-bit builds.
-export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
 
 # Set up android build environment and set ANDROID_BUILD_OPTS array
 android_build_set_env $BUILD_ARCH
@@ -53,6 +85,9 @@ mkdir -p "${cache}"
 if [[ $ANDROID_BUILD_CLEAN ]]; then
     echo "LIBZMQ (${BUILD_ARCH}) - Doing a clean build (removing previous build and dependencies)..."
     rm -rf "${ANDROID_BUILD_PREFIX}"/*
+
+    # Called shells MUST not clean after ourselves !
+    export ANDROID_BUILD_CLEAN=""
 fi
 
 VERIFY=("libzmq.so")
@@ -62,16 +97,22 @@ elif [ $CURVE == "libsodium" ]; then
     CURVE="--with-libsodium=yes"
     VERIFY+=("libsodium.so")
     ##
-    # Build libsodium from latest master branch
+    # Build LIBSODIUM from latest STABLE branch
 
     (android_build_verify_so "libsodium.so" &> /dev/null) || {
         rm -rf "${cache}/libsodium"
-        (cd "${cache}" && git clone -b stable --depth 1 https://github.com/jedisct1/libsodium.git) || exit 1
+        (
+            echo "LIBZMQ (${BUILD_ARCH}) - Cloning 'https://github.com/jedisct1/libsodium.git' (branch 'stable') under '${cache}/libsodium}'." \
+            && cd "${cache}" \
+            && git clone --quiet -b stable --depth 1 https://github.com/jedisct1/libsodium.git \
+            && cd "${cache}/libsodium" \
+            && git log --oneline -n 1
+        ) || exit 1
         (
             CONFIG_OPTS=()
             CONFIG_OPTS+=("--quiet")
             CONFIG_OPTS+=("${ANDROID_BUILD_OPTS[@]}")
-	    CONFIG_OPTS+=("--disable-soname-versions")
+            CONFIG_OPTS+=("--disable-soname-versions")
 
             cd "${cache}/libsodium" \
             && ./autogen.sh \
@@ -99,7 +140,7 @@ fi
         CONFIG_OPTS+=("${ANDROID_BUILD_OPTS[@]}")
         CONFIG_OPTS+=("${CURVE}")
         CONFIG_OPTS+=("--without-docs")
-	
+
         cd "${cache}/libzmq" \
         && ./autogen.sh \
         && android_show_configure_opts "LIBZMQ" "${CONFIG_OPTS[@]}" \

--- a/builds/android/ci_build.sh
+++ b/builds/android/ci_build.sh
@@ -3,12 +3,15 @@
 #   Exit if any step fails
 set -e
 
-export NDK_VERSION=android-ndk-r25
-export ANDROID_NDK_ROOT="/tmp/${NDK_VERSION}"
+# Configuration
+export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
+export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
+export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-$(cd $(dirname "${BASH_SOURCE[0]}") ; pwd)}"
 
 # Cleanup.
 rm -rf /tmp/android_build/
-rm -rf prefix/
+rm -rf $(dirname "${BASH_SOURCE[0]}")/prefix
 rm -rf /tmp/tmp-deps
 mkdir -p /tmp/tmp-deps
 

--- a/builds/android/ci_build.sh
+++ b/builds/android/ci_build.sh
@@ -3,15 +3,18 @@
 #   Exit if any step fails
 set -e
 
+# Use directory of current script as the working directory
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
 # Configuration
 export NDK_VERSION="${NDK_VERSION:-android-ndk-r25}"
 export ANDROID_NDK_ROOT="${ANDROID_NDK_ROOT:-/tmp/${NDK_VERSION}}"
 export MIN_SDK_VERSION=${MIN_SDK_VERSION:-21}
-export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-$(cd $(dirname "${BASH_SOURCE[0]}") ; pwd)}"
+export ANDROID_BUILD_DIR="${ANDROID_BUILD_DIR:-${PWD}}"
 
 # Cleanup.
 rm -rf /tmp/android_build/
-rm -rf $(dirname "${BASH_SOURCE[0]}")/prefix
+rm -rf "${PWD}/prefix"
 rm -rf /tmp/tmp-deps
 mkdir -p /tmp/tmp-deps
 
@@ -32,8 +35,8 @@ if [ ! -d "${ANDROID_NDK_ROOT}" ]; then
     export FILENAME=$NDK_VERSION-$HOST_PLATFORM.zip
 
     (cd '/tmp' \
-        && wget http://dl.google.com/android/repository/$FILENAME -O $FILENAME &> /dev/null \
-        && unzip -q $FILENAME) || exit 1
+        && wget "http://dl.google.com/android/repository/${FILENAME}" -O "${FILENAME}" &> /dev/null \
+        && unzip -q "${FILENAME}") || exit 1
     unset FILENAME
 fi
 


### PR DESCRIPTION
Reason: All are spread and initialized throughout the code.

Solution: Declare, initialize and document environment variables on top of build.sh.

Benefit: This participates to documentation.