### PR TITLE
Problem: Android NDK 22 download broken since support of NDK 23.

### DIFF
--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -371,16 +371,16 @@ function android_build_opts {
     fi
     local LDFLAGS="-L${ANDROID_BUILD_PREFIX}/lib"
     if [ -n "${ANDROID_LIBC_ROOT}" ] ; then
-	LDFLAGS+=" -L${ANDROID_LIBC_ROOT}"
+        LDFLAGS+=" -L${ANDROID_LIBC_ROOT}"
     fi
     LDFLAGS+=" -L${ANDROID_STL_ROOT}"
     CFLAGS+=" -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE"
     CPPFLAGS+=" -I${ANDROID_BUILD_PREFIX}/include"
 
     if [ ${NDK_NUMBER} -ge 2400 ] ; then
-	if [ "${BUILD_ARCH}" = "arm64" ] ; then
+        if [ "${BUILD_ARCH}" = "arm64" ] ; then
             CXXFLAGS+=" -mno-outline-atomics"
-	fi
+        fi
     fi
 
 

--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -48,6 +48,9 @@
 # repository for the benefit of other users.
 #
 
+########################################################################
+# Initialization
+########################################################################
 # Get directory of current script (if not already set)
 # This directory is also the basis for the build directories the get created.
 if [ -z "$ANDROID_BUILD_DIR" ]; then
@@ -72,6 +75,11 @@ case "${NDK_VERSION}" in
     * ) echo "Invalid format for NDK_VERSION ('${NDK_VERSION}')" ; exit 1 ;;
 esac
 
+if [ -z "${ANDROID_NDK_ROOT}" ] ; then
+    echo "ANDROID_NDK_ROOT not set !"
+    exit 1
+fi
+
 ########################################################################
 # Compute NDK version into a numeric form:
 #   android-ndk-r21e -> 2105
@@ -95,10 +103,66 @@ function android_build_check_fail {
     fi
 }
 
+function android_download_ndk {
+    if [ -d "${ANDROID_NDK_ROOT}" ] ; then
+        # NDK folder detected, let's assume it's valid ...
+        echo "LIBZMQ (${BUILD_ARCH}) - Using existing NDK folder '${ANDROID_NDK_ROOT}'."
+        return
+    fi
+    if [ ! -d  "$(dirname "${ANDROID_NDK_ROOT}")" ] ; then
+        ANDROID_BUILD_FAIL+=("Cannot download NDK in a non existing folder")
+        ANDROID_BUILD_FAIL+=("  $(dirname "${ANDROID_NDK_ROOT}/")")
+    fi
+
+    if [ -z "${ANDROID_NDK_FILENAME}" ] ; then
+        ANDROID_BUILD_FAIL+=("Please set the ANDROID_NDK_FILENAME environment variable")
+    fi
+
+    android_build_check_fail
+
+    echo "LIBZMQ (${BUILD_ARCH}) - Downloading NDK '${NDK_VERSION}'..."
+    (
+        cd "$(dirname "${ANDROID_NDK_ROOT}")" \
+        && rm -f "${ANDROID_NDK_FILENAME}" \
+        && wget -q "http://dl.google.com/android/repository/${ANDROID_NDK_FILENAME}" -O "${ANDROID_NDK_FILENAME}" \
+        && echo "LIBZMQ (${BUILD_ARCH}) - Extracting NDK '${ANDROID_NDK_FILENAME}'..." \
+        && unzip -q "${ANDROID_NDK_FILENAME}" \
+        && echo "LIBZMQ (${BUILD_ARCH}) - NDK extracted under '${ANDROID_NDK_ROOT}'."
+    ) || {
+        ANDROID_BUILD_FAIL+=("Failed to install NDK ('${NDK_VERSION}')")
+        ANDROID_BUILD_FAIL+=("  ${ANDROID_NDK_FILENAME}")
+    }
+
+    android_build_check_fail
+}
+
 function android_build_set_env {
     BUILD_ARCH=$1
 
-    export TOOLCHAIN_PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/bin"
+    platform="$(uname | tr '[:upper:]' '[:lower:]')"
+    case "${platform}" in
+        linux*)
+            if [ $NDK_NUMBER -ge 2300 ] ; then
+                # Since NDK 23, NDK archives are renamed.
+                export ANDROID_NDK_FILENAME=${NDK_VERSION}-linux.zip
+            else
+                export ANDROID_NDK_FILENAME=${NDK_VERSION}-linux-x86_64.zip
+            fi
+            export ANDROID_BUILD_PLATFORM=linux-x86_64
+            ;;
+        darwin*)
+            if [ $NDK_NUMBER -ge 2300 ] ; then
+                # Since NDK 23, NDK archives are renamed.
+                export ANDROID_NDK_FILENAME=${NDK_VERSION}-darwin.zip
+            else
+                export ANDROID_NDK_FILENAME=${NDK_VERSION}-darwin-x86_64.zip
+            fi
+            export ANDROID_BUILD_PLATFORM=darwin-x86_64
+            ;;
+        *)    echo "LIBZMQ (${BUILD_ARCH}) - Unsupported platform ('${platform}')" ; exit 1 ;;
+    esac
+
+    export TOOLCHAIN_PATH="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_BUILD_PLATFORM}/bin"
 
     # Set variables for each architecture
     if [ "${BUILD_ARCH}" == "arm" ]; then
@@ -127,7 +191,7 @@ function android_build_set_env {
     if [ -d "${ANDROID_NDK_ROOT}/platforms" ]; then
        export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/platforms/android-${MIN_SDK_VERSION}/arch-${TOOLCHAIN_ARCH}"
     else
-       export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/sysroot"
+       export ANDROID_BUILD_SYSROOT="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_BUILD_PLATFORM}/sysroot"
     fi
     export ANDROID_BUILD_PREFIX="${ANDROID_BUILD_DIR}/prefix/${TOOLCHAIN_ARCH}"
 
@@ -220,7 +284,7 @@ function android_build_env {
 }
 
 function _android_build_opts_process_binaries {
-    local TOOLCHAIN="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${HOST_PLATFORM}"
+    local TOOLCHAIN="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_BUILD_PLATFORM}"
     local CC="${TOOLCHAIN_PATH}/${TOOLCHAIN_COMP}-clang"
     local CXX="${TOOLCHAIN_PATH}/${TOOLCHAIN_COMP}-clang++"
     # Since NDK r22 the "platforms" dir got removed and the default linker is LLD
@@ -326,7 +390,7 @@ function android_build_opts {
     ANDROID_BUILD_OPTS+=("LDFLAGS=${LDFLAGS} ${ANDROID_BUILD_EXTRA_LDFLAGS}")
     ANDROID_BUILD_OPTS+=("LIBS=${LIBS} ${ANDROID_BUILD_EXTRA_LIBS}")
 
-    ANDROID_BUILD_OPTS+=("PKG_CONFIG_LIBDIR=${ANDROID_NDK_ROOT}/prebuilt/${HOST_PLATFORM}/lib/pkgconfig")
+    ANDROID_BUILD_OPTS+=("PKG_CONFIG_LIBDIR=${ANDROID_NDK_ROOT}/prebuilt/${ANDROID_BUILD_PLATFORM}/lib/pkgconfig")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_PATH=${ANDROID_BUILD_PREFIX}/lib/pkgconfig")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_SYSROOT_DIR=${ANDROID_BUILD_SYSROOT}")
     ANDROID_BUILD_OPTS+=("PKG_CONFIG_DIR=")

--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -56,6 +56,7 @@ BUILD_ARCH="$1"
 # Compilation
 ########################################################################
 # Get access to android_build functions and variables
+# Perform some sanity checks and calculate some variables.
 source ./android_build_helper.sh
 
 # Choose a C++ standard library implementation from the ndk
@@ -64,15 +65,9 @@ export ANDROID_BUILD_CXXSTL="gnustl_shared_49"
 # Additional flags for LIBTOOL, for LIBZMQ and other dependencies.
 export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
-platform="$(uname | tr '[:upper:]' '[:lower:]')"
-case "${platform}" in
-  linux*)  export HOST_PLATFORM=linux-x86_64 ;;
-  darwin*) export HOST_PLATFORM=darwin-x86_64 ;;
-  *)       echo "LIBZMQ (${BUILD_ARCH}) - Unsupported platform ('${platform}')" ; exit 1 ;;
-esac
-
 # Set up android build environment and set ANDROID_BUILD_OPTS array
 android_build_set_env "${BUILD_ARCH}"
+android_download_ndk
 android_build_env
 android_build_opts
 

--- a/builds/android/ci_build.sh
+++ b/builds/android/ci_build.sh
@@ -18,28 +18,6 @@ rm -rf "${PWD}/prefix"
 rm -rf /tmp/tmp-deps
 mkdir -p /tmp/tmp-deps
 
-case $(uname | tr '[:upper:]' '[:lower:]') in
-  linux*)
-    HOST_PLATFORM=linux
-    ;;
-  darwin*)
-    HOST_PLATFORM=darwin
-    ;;
-  *)
-    echo "Unsupported platform"
-    exit 1
-    ;;
-esac
-
-if [ ! -d "${ANDROID_NDK_ROOT}" ]; then
-    export FILENAME=$NDK_VERSION-$HOST_PLATFORM.zip
-
-    (cd '/tmp' \
-        && wget "http://dl.google.com/android/repository/${FILENAME}" -O "${FILENAME}" &> /dev/null \
-        && unzip -q "${FILENAME}") || exit 1
-    unset FILENAME
-fi
-
 ./build.sh "arm"
 ./build.sh "arm64"
 ./build.sh "x86"


### PR DESCRIPTION
Due to the PR to support NDK 23.

With NDK 23, the archive file name has changed.
This change is handled by the PR to support NDK23, but now, only 23 and after
are supported.

Also, NDK 23 support introduced a 2nd occurence of the variable
HOST_PLATFORM, with another value. One occurence being exported,
this may confuse next developpers (and it actually confused me).

Solution: Code review

1st occurence is simply dropped, and the algorithm around is changed so that
there is no need of a 'host_platform' kind of stuff.

2nd occurrence is renamed to ANDROID_BUILD_PLATFORM.

Note that 'HOST' is replaced by 'BUILD', as this is the common naming
when talking about the build/compilation machine, when cross compiling.

A dedicated function is created in the helpers, to actually download
the NDK. As this function is made 'public', more checks are performed.

Note:

> To be reported in CZMQ & ZYRE, via ZPROJECT, where NDK is downloaded
> in 2 different files.
