### PR TITLE
Problem: Android helpers have duplicate init code.

### DIFF
--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -501,19 +501,6 @@ fi
 ANDROID_BUILD_FAIL=()
 
 ########################################################################
-# Initialization
-########################################################################
-# Get directory of current script (if not already set)
-# This directory is also the basis for the build directories the get created.
-if [ -z "$ANDROID_BUILD_DIR" ]; then
-    ANDROID_BUILD_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-fi
-
-# Set up a variable to hold the global failure reasons, separated by newlines
-# (Empty string indicates no failure)
-ANDROID_BUILD_FAIL=()
-
-########################################################################
 # Sanity checks
 ########################################################################
 if [ -z "${NDK_VERSION}" ] ; then


### PR DESCRIPTION
Last PRs introduced a duplicate code in Android helper file. Duplicate "Initialisation" sequence can be observed after the helper functions:

    ########################################################################
    # Initialization

...

    # (Empty string indicates no failure)
    ANDROID_BUILD_FAIL=()

Seen when trying to report last LIBZMQ Android PRs to CZMQ & ZYRE.

Solution: Remove the duplicate code.