### PR TITLE
src/secure_allocator.hpp: define missing 'rebind' type

### DIFF
--- a/src/secure_allocator.hpp
+++ b/src/secure_allocator.hpp
@@ -99,6 +99,17 @@ bool operator!= (const secure_allocator_t<T> &, const secure_allocator_t<U> &)
 #else
 template <typename T> struct secure_allocator_t : std::allocator<T>
 {
+    secure_allocator_t () ZMQ_DEFAULT;
+
+    template <class U>
+    secure_allocator_t (const secure_allocator_t<U> &) ZMQ_NOEXCEPT
+    {
+    }
+
+    template <class U> struct rebind
+    {
+        typedef secure_allocator_t<U> other;
+    };
 };
 #endif
 }


### PR DESCRIPTION
`gcc-13` added an assert to standard headers to make sure custom allocators have intended implementation of rebind type instead of inherited rebind. gcc change:
    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=64c986b49558a7

Without the fix build fails on this week's `gcc-13` as:

    [ 92%] Building CXX object tests/CMakeFiles/test_security_curve.dir/test_security_curve.cpp.o
    In file included from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/ext/alloc_traits.h:34,
                     from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_uninitialized.h:64,
                     from /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/memory:69,
                     from tests/../src/secure_allocator.hpp:42,
                     from tests/../src/curve_client_tools.hpp:49,
                     from tests/test_security_curve.cpp:53:
    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h: In instantiation of 'struct std::__allocator_traits_base::__rebind<zmq::secure_allocator_t<unsigned char>, unsigned char, void>':
    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:94:11:   required by substitution of 'template<class _Alloc, class _Up> using std::__alloc_rebind = typename std::__allocator_traits_base::__rebind<_Alloc, _Up>::type [with _Alloc = zmq::secure_allocator_t<unsigned char>; _Up = unsigned char]'
    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:228:8:   required by substitution of 'template<class _Alloc> template<class _Tp> using std::allocator_traits< <template-parameter-1-1> >::rebind_alloc = std::__alloc_rebind<_Alloc, _Tp> [with _Tp = unsigned char; _Alloc = zmq::secure_allocator_t<unsigned char>]'
    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/ext/alloc_traits.h:126:65:   required from 'struct __gnu_cxx::__alloc_traits<zmq::secure_allocator_t<unsigned char>, unsigned char>::rebind<unsigned char>'
    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_vector.h:88:21:   required from 'struct std::_Vector_base<unsigned char, zmq::secure_allocator_t<unsigned char> >'
    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/stl_vector.h:423:11:   required from 'class std::vector<unsigned char, zmq::secure_allocator_t<unsigned char> >'
    tests/../src/curve_client_tools.hpp:64:76:   required from here
    /<<NIX>>/gcc-13.0.0/include/c++/13.0.0/bits/alloc_traits.h:70:31: error: static assertion failed: allocator_traits<A>::rebind_alloc<A::value_type> must be A
       70 |                         _Tp>::value,
          |                               ^~~~~

The change adds trivial `rebind` definition with expected return type.