### PR TITLE
Problem: message can't be received due to signal

### DIFF
--- a/RELICENSE/nfware.md
+++ b/RELICENSE/nfware.md
@@ -1,0 +1,13 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by NFWare Corp. that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "ilkondr", with
+commit author "Ilya Kondrashkin <ikondrashkin@nfware.com>", are copyright of NFWare.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+Ilya Kondrashkin 2023/01/10


### PR DESCRIPTION
Issue caught in Golang runtime, which widely uses signal SIGURG for scheduling. Sometimes messages cannot be received. Technically socket_base_t::process_commands() returns failure even if some commands were processed, but next message from mailbox could not be received during interrupt.

Solution: retry receiving from mailbox with zero timeout after EINTR.

Signed-off-by: Ilya Kondrashkin <ikondrashkin@nfware.com>