### PR TITLE
tests: use NOT APPLE instead of NOT MATCHES Clang

### DIFF
--- a/RELICENSE/sergeyfedorov.md
+++ b/RELICENSE/sergeyfedorov.md
@@ -1,0 +1,16 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Sergey Fedorov
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "barracuda156",
+with commit author "Sergey Fedorov <vital.had@gmail.com>"
+or commit author "barracuda156", are copyright of Sergey Fedorov.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Sergey Fedorov (barracuda156)
+Done in Taipei on the 2023/02/01

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -277,7 +277,7 @@ foreach(test ${tests})
     endif()
   else()
     # per-test directories not generated on OS X / Darwin
-    if(NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang.*")
+    if(NOT APPLE)
       link_directories(${test} PRIVATE "${ZeroMQ_SOURCE_DIR}/../lib")
     endif()
   endif()


### PR DESCRIPTION
GCC can be used on macOS, therefore correct condition is on Apple and not on Clang.
(Sure enough, otherwise building with GCC you get a lot of warnings about non-existent folders after -L.)