### PR TITLE
#4494 added calls to snprintf, but did not take into account that snprintf can truncate

### DIFF
--- a/RELICENSE/daira.md
+++ b/RELICENSE/daira.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Daira Hopwood
+that grants permission to relicense hir copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "daira", with
+commit author "Daira Hopwood <daira@jacaranda.org>", are copyright of Daira Hopwood.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Daira Hopwood
+2023/02/01

--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -129,8 +129,9 @@ static std::string make_address_string (const char *hbuf_,
     pos += hbuf_len;
     memcpy (pos, ipv6_suffix_, sizeof ipv6_suffix_ - 1);
     pos += sizeof ipv6_suffix_ - 1;
-    pos += snprintf (pos, max_port_str_length + 1 * sizeof (char), "%d",
-                     ntohs (port_));
+    int res = snprintf (pos, max_port_str_length + 1, "%d", ntohs (port_));
+    zmq_assert (res > 0 && res < (int) (max_port_str_length + 1));
+    pos += res;
     return std::string (buf, pos - buf);
 }
 

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -367,9 +367,9 @@ void zmq::udp_engine_t::sockaddr_to_msg (zmq::msg_t *msg_,
     const char *const name = inet_ntoa (addr_->sin_addr);
 
     char port[6];
-    const int port_len = snprintf (port, 6 * sizeof (char), "%d",
-                                   static_cast<int> (ntohs (addr_->sin_port)));
-    zmq_assert (port_len > 0);
+    const int port_len =
+      snprintf (port, 6, "%d", static_cast<int> (ntohs (addr_->sin_port)));
+    zmq_assert (port_len > 0 && port_len < 6);
 
     const size_t name_len = strlen (name);
     const int size = static_cast<int> (name_len) + 1 /* colon */


### PR DESCRIPTION
If snprintf truncates, it returns the number of characters that would have been written without truncation. Add assertions to cover this case.

See also https://github.com/zeromq/libzmq/pull/4494/files#r1092829210