### PR TITLE
Problem: infinite loop binding a dgram socket if it fails

### DIFF
--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -195,7 +195,7 @@ void zmq::udp_engine_t::plug (io_thread_t *io_thread_, session_base_t *session_)
 #endif
         if (rc != 0) {
             assert_success_or_recoverable (_fd, rc);
-            error (connection_error);
+            error (protocol_error);
             return;
         }
 


### PR DESCRIPTION
Solution: treat bind errors as a protocol_error instead of connection_error preventing an infinite loop of trying to create the udp socket as through the protocol_error the creation of the socket fails and the engine is terminated

Up for discussion, should we preserve the errno var like done with tcp sockets?

https://github.com/zeromq/libzmq/blob/a666cb1b409d059e9f844994fe2d9d7b6b7e8f91/src/tcp_listener.cpp#L165-L169

This fixes #4504 