### PR TITLE
Switch to CNG instead of the deprecated WinCrypt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,17 +555,20 @@ endif()
 
 if(ZMQ_HAVE_WINDOWS)
   # Cannot use check_library_exists because the symbol is always declared as char(*)(void)
-  set(CMAKE_REQUIRED_LIBRARIES "ws2_32.lib")
+  set(CMAKE_REQUIRED_LIBRARIES "ws2_32.lib" ${CMAKE_REQUIRED_LIBRARIES})
   check_cxx_symbol_exists(WSAStartup "winsock2.h" HAVE_WS2_32)
 
-  set(CMAKE_REQUIRED_LIBRARIES "rpcrt4.lib")
+  set(CMAKE_REQUIRED_LIBRARIES "rpcrt4.lib" ${CMAKE_REQUIRED_LIBRARIES})
   check_cxx_symbol_exists(UuidCreateSequential "rpc.h" HAVE_RPCRT4)
 
-  set(CMAKE_REQUIRED_LIBRARIES "iphlpapi.lib")
+  set(CMAKE_REQUIRED_LIBRARIES "iphlpapi.lib" ${CMAKE_REQUIRED_LIBRARIES})
   check_cxx_symbol_exists(GetAdaptersAddresses "winsock2.h;iphlpapi.h" HAVE_IPHLAPI)
   check_cxx_symbol_exists(if_nametoindex "iphlpapi.h" HAVE_IF_NAMETOINDEX)
 
-  set(CMAKE_REQUIRED_LIBRARIES "")
+  set(CMAKE_REQUIRED_LIBRARIES "bcrypt.lib" ${CMAKE_REQUIRED_LIBRARIES})
+  check_cxx_symbol_exists(BCryptOpenAlgorithmProvider "bcrypt.h" HAVE_BCRYPT)
+
+  # set(CMAKE_REQUIRED_LIBRARIES "")
   # TODO: This not the symbol we're looking for. What is the symbol?
   check_library_exists(ws2 fopen "" HAVE_WS2)
 else()
@@ -1491,6 +1494,10 @@ if(BUILD_SHARED)
     target_link_libraries(libzmq ws2)
   endif()
 
+  if(HAVE_BCRYPT)
+   target_link_libraries(libzmq bcrypt)
+  endif()
+
   if(HAVE_RPCRT4)
     target_link_libraries(libzmq rpcrt4)
   endif()
@@ -1534,6 +1541,10 @@ if(BUILD_STATIC)
     target_link_libraries(libzmq-static ws2_32)
   elseif(HAVE_WS2)
     target_link_libraries(libzmq-static ws2)
+  endif()
+
+  if(HAVE_BCRYPT)
+   target_link_libraries(libzmq-static bcrypt)
   endif()
 
   if(HAVE_RPCRT4)

--- a/RELICENSE/madamantis-leviathan.md
+++ b/RELICENSE/madamantis-leviathan.md
@@ -1,0 +1,18 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license 
+chosen by the current ZeroMQ BDFL
+
+This is a statement by Maksym Adamantis that grants permission to
+relicense its copyrights in the libzmq C++ library (ZeroMQ) under the
+Mozilla Public License v2 (MPLv2) or any other Open Source Initiative
+approved license chosen by the current ZeroMQ BDFL (Benevolent
+Dictator for Life).
+
+A portion of the commits made by the Github handle "madamantis-leviathan", with 
+commit author "Maksym Adamantis <maksym.adamantis@leviathansecurity.com>", are
+copyright of Maksym Adamantis. This document hereby grants the libzmq
+project team to relicense libzmq, including all past, present and
+future contributions of the author listed above.
+
+Maksym Adamantis
+2023/02/27
+

--- a/builds/deprecated-msvc/vs2008/libzmq/libzmq.vcproj
+++ b/builds/deprecated-msvc/vs2008/libzmq/libzmq.vcproj
@@ -15,7 +15,7 @@
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
-      <Tool Name="VCLinkerTool" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib" OutputFile="../../../../lib/libzmq.dll" LinkDLL="true" GenerateDebugInformation="true" TargetMachine="1" />
+      <Tool Name="VCLinkerTool" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib Bcrypt.lib" OutputFile="../../../../lib/libzmq.dll" LinkDLL="true" GenerateDebugInformation="true" TargetMachine="1" />
       <Tool Name="VCALinkTool" />
       <Tool Name="VCManifestTool" />
       <Tool Name="VCXDCMakeTool" />
@@ -34,7 +34,7 @@
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
-      <Tool Name="VCLinkerTool" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib" OutputFile="../../../../lib/libzmq.dll" LinkDLL="true" GenerateDebugInformation="true" OptimizeReferences="2" EnableCOMDATFolding="2" TargetMachine="1" />
+      <Tool Name="VCLinkerTool" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib Bcrypt.lib" OutputFile="../../../../lib/libzmq.dll" LinkDLL="true" GenerateDebugInformation="true" OptimizeReferences="2" EnableCOMDATFolding="2" TargetMachine="1" />
       <Tool Name="VCALinkTool" />
       <Tool Name="VCManifestTool" />
       <Tool Name="VCXDCMakeTool" />
@@ -53,7 +53,7 @@
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
-      <Tool Name="VCLibrarianTool" AdditionalOptions="/ignore:4006" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib" OutputFile="../../../../lib/libzmq_d.lib" />
+      <Tool Name="VCLibrarianTool" AdditionalOptions="/ignore:4006" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib Bcrypt.lib" OutputFile="../../../../lib/libzmq_d.lib" />
       <Tool Name="VCALinkTool" />
       <Tool Name="VCXDCMakeTool" />
       <Tool Name="VCBscMakeTool" />
@@ -70,7 +70,7 @@
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
-      <Tool Name="VCLibrarianTool" AdditionalOptions="/ignore:4006" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib" OutputFile="../../../../lib/libzmq.lib" />
+      <Tool Name="VCLibrarianTool" AdditionalOptions="/ignore:4006" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib Bcrypt.lib" OutputFile="../../../../lib/libzmq.lib" />
       <Tool Name="VCALinkTool" />
       <Tool Name="VCXDCMakeTool" />
       <Tool Name="VCBscMakeTool" />
@@ -87,7 +87,7 @@
       <Tool Name="VCManagedResourceCompilerTool" />
       <Tool Name="VCResourceCompilerTool" />
       <Tool Name="VCPreLinkEventTool" />
-      <Tool Name="VCLinkerTool" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib libpgm.lib" OutputFile="../../../../lib/libzmq.dll" AdditionalLibraryDirectories="../../../../../OpenPGM/lib" LinkDLL="true" GenerateDebugInformation="true" OptimizeReferences="2" EnableCOMDATFolding="2" TargetMachine="1" />
+      <Tool Name="VCLinkerTool" AdditionalDependencies="Ws2_32.lib Rpcrt4.lib Advapi32.lib Iphlpapi.lib libpgm.lib Bcrypt.lib" OutputFile="../../../../lib/libzmq.dll" AdditionalLibraryDirectories="../../../../../OpenPGM/lib" LinkDLL="true" GenerateDebugInformation="true" OptimizeReferences="2" EnableCOMDATFolding="2" TargetMachine="1" />
       <Tool Name="VCALinkTool" />
       <Tool Name="VCManifestTool" />
       <Tool Name="VCXDCMakeTool" />

--- a/builds/deprecated-msvc/vs2010/inproc_lat/inproc_lat.props
+++ b/builds/deprecated-msvc/vs2010/inproc_lat/inproc_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2010/inproc_thr/inproc_thr.props
+++ b/builds/deprecated-msvc/vs2010/inproc_thr/inproc_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2010/libzmq/libzmq.props
+++ b/builds/deprecated-msvc/vs2010/libzmq/libzmq.props
@@ -34,7 +34,7 @@
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Lib Condition="'$(ConfigurationType)'=='StaticLibrary'">
       <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>

--- a/builds/deprecated-msvc/vs2010/local_lat/local_lat.props
+++ b/builds/deprecated-msvc/vs2010/local_lat/local_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2010/local_thr/local_thr.props
+++ b/builds/deprecated-msvc/vs2010/local_thr/local_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2010/remote_lat/remote_lat.props
+++ b/builds/deprecated-msvc/vs2010/remote_lat/remote_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2010/remote_thr/remote_thr.props
+++ b/builds/deprecated-msvc/vs2010/remote_thr/remote_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2012/inproc_lat/inproc_lat.props
+++ b/builds/deprecated-msvc/vs2012/inproc_lat/inproc_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2012/inproc_thr/inproc_thr.props
+++ b/builds/deprecated-msvc/vs2012/inproc_thr/inproc_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2012/libzmq/libzmq.props
+++ b/builds/deprecated-msvc/vs2012/libzmq/libzmq.props
@@ -34,7 +34,7 @@
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Lib Condition="'$(ConfigurationType)'=='StaticLibrary'">
       <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>

--- a/builds/deprecated-msvc/vs2012/local_lat/local_lat.props
+++ b/builds/deprecated-msvc/vs2012/local_lat/local_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2012/local_thr/local_thr.props
+++ b/builds/deprecated-msvc/vs2012/local_thr/local_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2012/remote_lat/remote_lat.props
+++ b/builds/deprecated-msvc/vs2012/remote_lat/remote_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2012/remote_thr/remote_thr.props
+++ b/builds/deprecated-msvc/vs2012/remote_thr/remote_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2013/inproc_lat/inproc_lat.props
+++ b/builds/deprecated-msvc/vs2013/inproc_lat/inproc_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2013/inproc_thr/inproc_thr.props
+++ b/builds/deprecated-msvc/vs2013/inproc_thr/inproc_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2013/libzmq/libzmq.props
+++ b/builds/deprecated-msvc/vs2013/libzmq/libzmq.props
@@ -34,7 +34,7 @@
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Lib Condition="'$(ConfigurationType)'=='StaticLibrary'">
       <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>

--- a/builds/deprecated-msvc/vs2013/local_lat/local_lat.props
+++ b/builds/deprecated-msvc/vs2013/local_lat/local_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2013/local_thr/local_thr.props
+++ b/builds/deprecated-msvc/vs2013/local_thr/local_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2013/remote_lat/remote_lat.props
+++ b/builds/deprecated-msvc/vs2013/remote_lat/remote_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2013/remote_thr/remote_thr.props
+++ b/builds/deprecated-msvc/vs2013/remote_thr/remote_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2015/inproc_lat/inproc_lat.props
+++ b/builds/deprecated-msvc/vs2015/inproc_lat/inproc_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2015/inproc_thr/inproc_thr.props
+++ b/builds/deprecated-msvc/vs2015/inproc_thr/inproc_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2015/libzmq/libzmq.props
+++ b/builds/deprecated-msvc/vs2015/libzmq/libzmq.props
@@ -34,7 +34,7 @@
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Lib Condition="'$(ConfigurationType)'=='StaticLibrary'">
       <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>

--- a/builds/deprecated-msvc/vs2015/local_lat/local_lat.props
+++ b/builds/deprecated-msvc/vs2015/local_lat/local_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2015/local_thr/local_thr.props
+++ b/builds/deprecated-msvc/vs2015/local_thr/local_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2015/remote_lat/remote_lat.props
+++ b/builds/deprecated-msvc/vs2015/remote_lat/remote_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2015/remote_thr/remote_thr.props
+++ b/builds/deprecated-msvc/vs2015/remote_thr/remote_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2015_xp/platform.hpp
+++ b/builds/deprecated-msvc/vs2015_xp/platform.hpp
@@ -11,5 +11,6 @@
 
 #pragma comment(lib,"ws2_32.lib")
 #pragma comment(lib,"Iphlpapi.lib")
+#pragma comment(lib,"Bcrypt.lib")
 
 #endif

--- a/builds/deprecated-msvc/vs2017/inproc_lat/inproc_lat.props
+++ b/builds/deprecated-msvc/vs2017/inproc_lat/inproc_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2017/inproc_thr/inproc_thr.props
+++ b/builds/deprecated-msvc/vs2017/inproc_thr/inproc_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2017/libzmq/libzmq.props
+++ b/builds/deprecated-msvc/vs2017/libzmq/libzmq.props
@@ -34,7 +34,7 @@
       <PreprocessorDefinitions Condition="'$(ConfigurationType)' == 'DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Ws2_32.lib;Rpcrt4.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Lib Condition="'$(ConfigurationType)'=='StaticLibrary'">
       <AdditionalOptions>/ignore:4221 %(AdditionalOptions)</AdditionalOptions>

--- a/builds/deprecated-msvc/vs2017/local_lat/local_lat.props
+++ b/builds/deprecated-msvc/vs2017/local_lat/local_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2017/local_thr/local_thr.props
+++ b/builds/deprecated-msvc/vs2017/local_thr/local_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2017/remote_lat/remote_lat.props
+++ b/builds/deprecated-msvc/vs2017/remote_lat/remote_lat.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 

--- a/builds/deprecated-msvc/vs2017/remote_thr/remote_thr.props
+++ b/builds/deprecated-msvc/vs2017/remote_thr/remote_thr.props
@@ -14,7 +14,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir)..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;Rpcrt4.lib;Ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Since wincrypt.h is [deprecated](https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-cryptgenrandom), I replaced it with [BCryptGenRandom](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom) from Cryptography Next Generation API (CNG). 

I tried to follow the existing code style so as not to break anything. However, the changes that I made to CMakeLists.txt to include the new library (bcrypt.lib) don't appear to have had any effect. Feedback would be really appreciated 