### PR TITLE
Add support for QNX 7.1 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1468,6 +1468,11 @@ endforeach()
 
 if(BUILD_SHARED)
   target_link_libraries(libzmq ${CMAKE_THREAD_LIBS_INIT})
+
+  if(QNX)
+    target_link_libraries(libzmq -lsocket)
+  endif()
+
   if(GNUTLS_FOUND)
     target_link_libraries(libzmq ${GNUTLS_LIBRARIES})
     target_include_directories(libzmq PRIVATE "${GNUTLS_INCLUDE_DIR}")

--- a/RELICENSE/chachoi.md
+++ b/RELICENSE/chachoi.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by James Choi
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other 
+Open Source Initiative approved license chosen by the current ZeroMQ 
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "chachoi", with
+commit author "James Choi <chachoi@blackberry.com>", are copyright of James Choi.
+This document hereby grants the libzmq project team to relicense libzmq, 
+including all past, present and future contributions of the author listed above.
+
+James Choi
+2023/04/11

--- a/build_qnx/Makefile
+++ b/build_qnx/Makefile
@@ -1,0 +1,8 @@
+LIST=OS
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/common.mk
+++ b/build_qnx/common.mk
@@ -1,0 +1,57 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+NAME=libzmq
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+LIBZMQ_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+LIBZMQ_VERSION = .4.3.4
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = libzmq_all
+.PHONY: libzmq_all install check clean
+
+CFLAGS += $(FLAGS)
+LDFLAGS += -Wl,--build-id=md5
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+LIBZMQ_DIR = $(PROJECT_ROOT)/../
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX=$(LIBZMQ_INSTALL_ROOT)/${CPUVARDIR}/usr \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_INSTALL_INCLUDEDIR=$(LIBZMQ_INSTALL_ROOT)/usr/include \
+             -DCMAKE_INSTALL_LIBDIR=$(LIBZMQ_INSTALL_ROOT)/$(CPUVARDIR)/usr/lib \
+             -DCMAKE_INSTALL_BINDIR=$(LIBZMQ_INSTALL_ROOT)/$(CPUVARDIR)/usr/bin \
+             -DCPUVARDIR=$(CPUVARDIR)
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+ifndef NO_TARGET_OVERRIDE
+libzmq_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(LIBZMQ_DIR)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: libzmq_all
+	@cd build && make VERBOSE=1 install
+
+clean iclean spotless:
+	rm -rf build
+
+uninstall:
+endif

--- a/build_qnx/nto/Makefile
+++ b/build_qnx/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/Makefile
+++ b/build_qnx/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/le/Makefile
+++ b/build_qnx/nto/aarch64/le/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64 
+FLAGS      += $(VFLAG_le) $(CCVFLAG_le)
+LDFLAGS    += $(VFLAG_le) $(LDVFLAG_le)

--- a/build_qnx/nto/x86_64/Makefile
+++ b/build_qnx/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/x86_64/o/Makefile
+++ b/build_qnx/nto/x86_64/o/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64
+FLAGS      += $(VFLAG_o) $(CCVFLAG_o)
+LDFLAGS    += $(VFLAG_o) $(LDVFLAG_o)

--- a/build_qnx/qnx.nto.toolchain.cmake
+++ b/build_qnx/qnx.nto.toolchain.cmake
@@ -1,0 +1,34 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} -std=gnu++11 ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -306,6 +306,10 @@ foreach(test ${tests})
 
   set_tests_properties(${test} PROPERTIES TIMEOUT 10)
   set_tests_properties(${test} PROPERTIES SKIP_RETURN_CODE 77)
+
+  if(QNX)
+    install(TARGETS ${test} RUNTIME DESTINATION bin/)
+  endif()
 endforeach()
 
 # override timeout for these tests


### PR DESCRIPTION
I added support for QNX 7.1 build.

All QNX build related files are under build_qnx.

Build instructions for QNX 7.1 on Ubuntu:

```bash
source <path-to-qnxsdp-env.sh>/qnxsdp-env.sh
git clone https://github.com/chachoi/libzmq.git && cd libzmq/build_qnx
make -j 4 install
```