### PR TITLE
Add NORM Transport configuration sockopts

### DIFF
--- a/RELICENSE/weston-nrl.md
+++ b/RELICENSE/weston-nrl.md
@@ -1,0 +1,12 @@
+# Permission to Relicense under MPLv2
+
+This is a statement by Jeffery Weston that grants permission to relicense its
+copyrights in the libzmq C++ library (ZeroMQ) under the Mozilla Public License
+v2 (MPLv2).
+
+A portion of the commits made by the Github handle "weston-nrl", with commit
+author "Jeff Weston" or "Jeffery Weston" are copyright of Jeffery Weston. This
+document hereby grants the libzmq project team to relicense libzmq, including
+all past, present and future contributions of the author listed above.
+
+Jeffery Weston 2023/04/05 s

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -1009,6 +1009,8 @@ TCP-friendly congestion control mode. Fixed rate mode (using datarate set by
 'ZMQ_RATE') offers better performance, but care must be taken to prevent data
 loss.
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: 0, 1, 2, 3, 4
@@ -1024,6 +1026,8 @@ sender using unicast instead of multicast.  NORM transport endpoints specifying
 a unicast address will use unicast NACKs by default (without setting
 'ZMQ_NORM_UNICAST_NACK').
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: boolean
@@ -1034,6 +1038,8 @@ Applicable socket types:: All, when using NORM transport.
 ZMQ_NORM_BUFFER_SIZE: Retrieve NORM buffer size
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Gets NORM buffer size for NORM transport sender, receiver, and stream.
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int
@@ -1049,6 +1055,8 @@ individual NORM messages (ZMQ messages may be split over multiple NORM
 messages).  Ideally, this value should fit within the system/network maximum
 transmission unit (MTU) after accounting for additional NORM message headers
 (up to 48 bytes).
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int
@@ -1066,6 +1074,8 @@ of (255 - 'ZMQ_NORM_BLOCK_SIZE'). Minimum value is ('ZMQ_NORM_NUM_PARITY' + 1).
 Effective value may be different based on the settings of 'ZMQ_NORM_NUM_PARITY'
 and 'ZMQ_NORM_NUM_AUTOPARITY' if invalid settings are provided.
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: >0, <=255
@@ -1082,6 +1092,8 @@ Maximum value is 255, but is further limited to a value of
 Effective value may be different based on the setting of
 'ZMQ_NORM_NUM_AUTOPARITY' if invalid settings are provided.
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: >0, <255
@@ -1096,6 +1108,8 @@ send at the end of each FEC coding block. By default, no proactive parity
 segments will be sent; instead, parity segments will only be sent in response to
 repair requests (NACKs). Maximum value is 255, but is further limited to a 
 maximum value of 'ZMQ_NORM_NUM_PARITY'.
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int
@@ -1113,6 +1127,8 @@ discards the oldest data (which may be pending repair or may never have been
 transmitted) in favor of accepting new data. This may be useful in cases where
 it is more important to quickly deliver new data instead of reliably delivering
 older data.
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int

--- a/doc/zmq_getsockopt.txt
+++ b/doc/zmq_getsockopt.txt
@@ -998,6 +998,129 @@ Default value:: 0
 Applicable socket types:: ZMQ_PUB, ZMQ_XPUB, ZMQ_SUB, ZMQ_XSUB
 
 
+ZMQ_NORM_MODE: Retrieve NORM Sender Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gets the NORM sender mode to control the operation of the NORM transport. NORM
+supports fixed rate operation (0='ZMQ_NORM_FIXED'), congestion control mode 
+(1='ZMQ_NORM_CC'), loss-tolerant congestion control (2='ZMQ_NORM_CCL'), explicit
+congestion notification (ECN)-enabled congestion control (3='ZMQ_NORM_CCE'), and
+ECN-only congestion control (4='ZMQ_NORM_CCE_ECNONLY'). The default value is 
+TCP-friendly congestion control mode. Fixed rate mode (using datarate set by
+'ZMQ_RATE') offers better performance, but care must be taken to prevent data
+loss.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1, 2, 3, 4
+Default value:: 1 ('ZMQ_NORM_CC')
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_UNICAST_NACK: Retrieve NORM Unicast NACK mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Retrieves status of NORM unicast NACK mode setting for multicast receivers. If
+set, NORM receiver will send Negative ACKnowledgements (NACKs) back to the
+sender using unicast instead of multicast.  NORM transport endpoints specifying
+a unicast address will use unicast NACKs by default (without setting
+'ZMQ_NORM_UNICAST_NACK').
+
+[horizontal]
+Option value type:: int
+Option value unit:: boolean
+Default value:: 0 (false)
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_BUFFER_SIZE: Retrieve NORM buffer size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gets NORM buffer size for NORM transport sender, receiver, and stream.
+
+[horizontal]
+Option value type:: int
+Option value unit:: kilobytes
+Default value:: 2048
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_SEGMENT_SIZE: Retrieve NORM segment size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gets NORM sender segment size, which is the maximum message payload size of
+individual NORM messages (ZMQ messages may be split over multiple NORM
+messages).  Ideally, this value should fit within the system/network maximum
+transmission unit (MTU) after accounting for additional NORM message headers
+(up to 48 bytes).
+
+[horizontal]
+Option value type:: int
+Option value unit:: bytes
+Default value:: 1400
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_BLOCK_SIZE: Retrieve NORM block size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gets NORM sender block size, which is the number of segments in a NORM FEC
+coding block. NORM repair operations take place at block boundaries. Maximum
+value is 255, but parity packets ('ZMQ_NORM_NUM_PARITY') are limited to a value
+of (255 - 'ZMQ_NORM_BLOCK_SIZE'). Minimum value is ('ZMQ_NORM_NUM_PARITY' + 1).
+Effective value may be different based on the settings of 'ZMQ_NORM_NUM_PARITY'
+and 'ZMQ_NORM_NUM_AUTOPARITY' if invalid settings are provided.
+
+[horizontal]
+Option value type:: int
+Option value unit:: >0, <=255
+Default value:: 16
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_NUM_PARITY: Retrieve NORM parity segment setting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gets the maximum number of NORM parity symbol segments that the sender is
+willing to calculate per FEC coding block for the purpose of reparing lost data.
+Maximum value is 255, but is further limited to a value of
+(255 - 'ZMQ_NORM_BLOCK_SIZE'). Minimum value is 'ZMQ_NORM_NUM_AUTOPARITY'.
+Effective value may be different based on the setting of
+'ZMQ_NORM_NUM_AUTOPARITY' if invalid settings are provided.
+
+[horizontal]
+Option value type:: int
+Option value unit:: >0, <255
+Default value:: 4
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_NUM_AUTOPARITY: Retrieve proactive NORM parity segment setting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gets the number of NORM parity symbol segments that the sender will proactively
+send at the end of each FEC coding block. By default, no proactive parity
+segments will be sent; instead, parity segments will only be sent in response to
+repair requests (NACKs). Maximum value is 255, but is further limited to a 
+maximum value of 'ZMQ_NORM_NUM_PARITY'.
+
+[horizontal]
+Option value type:: int
+Option value unit:: >=0, <255
+Default value:: 0
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_PUSH: Retrieve NORM push mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gets status of NORM stream push mode, which alters the behavior of the sender
+when enqueueing new data. By default, NORM will stop accepting new messages
+while waiting for old data to be transmitted and/or repaired. Enabling push mode
+discards the oldest data (which may be pending repair or may never have been
+transmitted) in favor of accepting new data. This may be useful in cases where
+it is more important to quickly deliver new data instead of reliably delivering
+older data.
+
+[horizontal]
+Option value type:: int
+Option value unit:: boolean
+Default value:: 0 (false)
+Applicable socket types:: All, when using NORM transport.
+
+
 RETURN VALUE
 ------------
 The _zmq_getsockopt()_ function shall return zero if successful. Otherwise it

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1529,6 +1529,129 @@ Default value:: 8192
 Applicable socket types:: All, when using TCP, IPC, PGM or NORM transport.
 
 
+ZMQ_NORM_MODE: NORM Sender Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the NORM sender mode to control the operation of the NORM transport. NORM
+supports fixed rate operation (0='ZMQ_NORM_FIXED'), congestion control mode 
+(1='ZMQ_NORM_CC'), loss-tolerant congestion control (2='ZMQ_NORM_CCL'), explicit
+congestion notification (ECN)-enabled congestion control (3='ZMQ_NORM_CCE'), and
+ECN-only congestion control (4='ZMQ_NORM_CCE_ECNONLY'). The default value is 
+TCP-friendly congestion control mode. Fixed rate mode (using datarate set by
+'ZMQ_RATE') offers better performance, but care must be taken to prevent data
+loss.  ECN modes will set one of the ECN Capable Transport bits in the given
+'ZMQ_TOS' if it is not set already.
+
+[horizontal]
+Option value type:: int
+Option value unit:: 0, 1, 2, 3, 4
+Default value:: 1 ('ZMQ_NORM_CC')
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_UNICAST_NACK: Set NORM Unicast NACK mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If set, NORM receiver will send Negative ACKnowledgements (NACKs) back to the
+sender using unicast instead of multicast.  NORM transport endpoints specifying
+a unicast address will enable this by default, but it is disabled by default for
+multicast addresses.
+
+[horizontal]
+Option value type:: int
+Option value unit:: boolean
+Default value:: 0 (false)
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_BUFFER_SIZE: Set NORM buffer size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets NORM buffer size for NORM transport sender, receiver, and stream.
+
+[horizontal]
+Option value type:: int
+Option value unit:: kilobytes
+Default value:: 2048
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_SEGMENT_SIZE: Set NORM segment size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets NORM sender segment size, which is the maximum message payload size of
+individual NORM messages (ZMQ messages may be split over multiple NORM
+messages).  Ideally, this value should fit within the system/network maximum
+transmission unit (MTU) after accounting for additional NORM message headers
+(up to 48 bytes).
+
+[horizontal]
+Option value type:: int
+Option value unit:: bytes
+Default value:: 1400
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_BLOCK_SIZE: Set NORM block size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets NORM sender block size, which is the number of segments in a NORM FEC
+coding block. NORM repair operations take place at block boundaries. Maximum
+value is 255, but parity packets ('ZMQ_NORM_NUM_PARITY') are limited to a value
+of (255 - 'ZMQ_NORM_BLOCK_SIZE'). Minimum value is ('ZMQ_NORM_NUM_PARITY' + 1).
+Effective value may be different based on the settings of 'ZMQ_NORM_NUM_PARITY'
+and 'ZMQ_NORM_NUM_AUTOPARITY' if invalid settings are provided.
+
+[horizontal]
+Option value type:: int
+Option value unit:: >0, <=255
+Default value:: 16
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_NUM_PARITY: Set number of NORM parity segments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the maximum number of NORM parity symbol segments that the sender is
+willing to calculate per FEC coding block for the purpose of reparing lost data.
+Maximum value is 255, but is further limited to a value of
+(255 - 'ZMQ_NORM_BLOCK_SIZE'). Minimum value is 'ZMQ_NORM_NUM_AUTOPARITY'.
+Effective value may be different based on the setting of
+'ZMQ_NORM_NUM_AUTOPARITY' if invalid settings are provided.
+
+[horizontal]
+Option value type:: int
+Option value unit:: >0, <255
+Default value:: 4
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_NUM_AUTOPARITY: Set number of proactive NORM parity segments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sets the number of NORM parity symbol segments that the sender will proactively
+send at the end of each FEC coding block. By default, no proactive parity
+segments will be sent; instead, parity segments will only be sent in response to
+repair requests (NACKs). Maximum value is 255, but is further limited to a 
+maximum value of 'ZMQ_NORM_NUM_PARITY'.
+
+[horizontal]
+Option value type:: int
+Option value unit:: >=0, <255
+Default value:: 0
+Applicable socket types:: All, when using NORM transport.
+
+
+ZMQ_NORM_PUSH: Enable NORM push mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Enables NORM stream push mode, which alters the behavior of the sender when
+enqueueing new data. By default, NORM will stop accepting new messages while
+waiting for old data to be transmitted and/or repaired. Enabling push mode
+discards the oldest data (which may be pending repair or may never have been
+transmitted) in favor of accepting new data. This may be useful in cases where
+it is more important to quickly deliver new data instead of reliably delivering
+older data.
+
+[horizontal]
+Option value type:: int
+Option value unit:: boolean
+Default value:: 0 (false)
+Applicable socket types:: All, when using NORM transport.
+
+
 RETURN VALUE
 ------------
 The _zmq_setsockopt()_ function shall return zero if successful. Otherwise it

--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1541,6 +1541,8 @@ TCP-friendly congestion control mode. Fixed rate mode (using datarate set by
 loss.  ECN modes will set one of the ECN Capable Transport bits in the given
 'ZMQ_TOS' if it is not set already.
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: 0, 1, 2, 3, 4
@@ -1555,6 +1557,8 @@ sender using unicast instead of multicast.  NORM transport endpoints specifying
 a unicast address will enable this by default, but it is disabled by default for
 multicast addresses.
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: boolean
@@ -1565,6 +1569,8 @@ Applicable socket types:: All, when using NORM transport.
 ZMQ_NORM_BUFFER_SIZE: Set NORM buffer size
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Sets NORM buffer size for NORM transport sender, receiver, and stream.
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int
@@ -1580,6 +1586,8 @@ individual NORM messages (ZMQ messages may be split over multiple NORM
 messages).  Ideally, this value should fit within the system/network maximum
 transmission unit (MTU) after accounting for additional NORM message headers
 (up to 48 bytes).
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int
@@ -1597,6 +1605,8 @@ of (255 - 'ZMQ_NORM_BLOCK_SIZE'). Minimum value is ('ZMQ_NORM_NUM_PARITY' + 1).
 Effective value may be different based on the settings of 'ZMQ_NORM_NUM_PARITY'
 and 'ZMQ_NORM_NUM_AUTOPARITY' if invalid settings are provided.
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: >0, <=255
@@ -1613,6 +1623,8 @@ Maximum value is 255, but is further limited to a value of
 Effective value may be different based on the setting of
 'ZMQ_NORM_NUM_AUTOPARITY' if invalid settings are provided.
 
+NOTE: in DRAFT state, not yet available in stable releases.
+
 [horizontal]
 Option value type:: int
 Option value unit:: >0, <255
@@ -1627,6 +1639,8 @@ send at the end of each FEC coding block. By default, no proactive parity
 segments will be sent; instead, parity segments will only be sent in response to
 repair requests (NACKs). Maximum value is 255, but is further limited to a 
 maximum value of 'ZMQ_NORM_NUM_PARITY'.
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int
@@ -1644,6 +1658,8 @@ discards the oldest data (which may be pending repair or may never have been
 transmitted) in favor of accepting new data. This may be useful in cases where
 it is more important to quickly deliver new data instead of reliably delivering
 older data.
+
+NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
 Option value type:: int

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -411,6 +411,30 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
 #define ZMQ_SRCFD 2
 
 /******************************************************************************/
+/*  NORM transport configuration options                                      */
+/******************************************************************************/
+#ifdef ZMQ_HAVE_NORM
+
+/*  NORM socket options                                                       */
+#define ZMQ_NORM_MODE 150
+#define ZMQ_NORM_UNICAST_NACK 151
+#define ZMQ_NORM_BUFFER_SIZE 152
+#define ZMQ_NORM_SEGMENT_SIZE 153
+#define ZMQ_NORM_BLOCK_SIZE 154
+#define ZMQ_NORM_NUM_PARITY 155
+#define ZMQ_NORM_NUM_AUTOPARITY 156
+#define ZMQ_NORM_PUSH 157
+
+/*  NORM mode options                                                         */
+#define ZMQ_NORM_FIXED 0
+#define ZMQ_NORM_CC 1
+#define ZMQ_NORM_CCL 2
+#define ZMQ_NORM_CCE 3
+#define ZMQ_NORM_CCE_ECNONLY 4
+
+#endif // ZMQ_HAVE_NORM
+
+/******************************************************************************/
 /*  GSSAPI definitions                                                        */
 /******************************************************************************/
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -411,30 +411,6 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
 #define ZMQ_SRCFD 2
 
 /******************************************************************************/
-/*  NORM transport configuration options                                      */
-/******************************************************************************/
-#ifdef ZMQ_HAVE_NORM
-
-/*  NORM socket options                                                       */
-#define ZMQ_NORM_MODE 150
-#define ZMQ_NORM_UNICAST_NACK 151
-#define ZMQ_NORM_BUFFER_SIZE 152
-#define ZMQ_NORM_SEGMENT_SIZE 153
-#define ZMQ_NORM_BLOCK_SIZE 154
-#define ZMQ_NORM_NUM_PARITY 155
-#define ZMQ_NORM_NUM_AUTOPARITY 156
-#define ZMQ_NORM_PUSH 157
-
-/*  NORM mode options                                                         */
-#define ZMQ_NORM_FIXED 0
-#define ZMQ_NORM_CC 1
-#define ZMQ_NORM_CCL 2
-#define ZMQ_NORM_CCE 3
-#define ZMQ_NORM_CCE_ECNONLY 4
-
-#endif // ZMQ_HAVE_NORM
-
-/******************************************************************************/
 /*  GSSAPI definitions                                                        */
 /******************************************************************************/
 
@@ -705,6 +681,23 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_HICCUP_MSG 114
 #define ZMQ_XSUB_VERBOSE_UNSUBSCRIBE 115
 #define ZMQ_TOPICS_COUNT 116
+
+/*  DRAFT NORM socket options                                                 */
+#define ZMQ_NORM_MODE 150
+#define ZMQ_NORM_UNICAST_NACK 151
+#define ZMQ_NORM_BUFFER_SIZE 152
+#define ZMQ_NORM_SEGMENT_SIZE 153
+#define ZMQ_NORM_BLOCK_SIZE 154
+#define ZMQ_NORM_NUM_PARITY 155
+#define ZMQ_NORM_NUM_AUTOPARITY 156
+#define ZMQ_NORM_PUSH 157
+
+/*  DRAFT ZMQ_NORM_MODE options                                               */
+#define ZMQ_NORM_FIXED 0
+#define ZMQ_NORM_CC 1
+#define ZMQ_NORM_CCL 2
+#define ZMQ_NORM_CCE 3
+#define ZMQ_NORM_CCE_ECNONLY 4
 
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -681,16 +681,14 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_HICCUP_MSG 114
 #define ZMQ_XSUB_VERBOSE_UNSUBSCRIBE 115
 #define ZMQ_TOPICS_COUNT 116
-
-/*  DRAFT NORM socket options                                                 */
-#define ZMQ_NORM_MODE 150
-#define ZMQ_NORM_UNICAST_NACK 151
-#define ZMQ_NORM_BUFFER_SIZE 152
-#define ZMQ_NORM_SEGMENT_SIZE 153
-#define ZMQ_NORM_BLOCK_SIZE 154
-#define ZMQ_NORM_NUM_PARITY 155
-#define ZMQ_NORM_NUM_AUTOPARITY 156
-#define ZMQ_NORM_PUSH 157
+#define ZMQ_NORM_MODE 117
+#define ZMQ_NORM_UNICAST_NACK 118
+#define ZMQ_NORM_BUFFER_SIZE 119
+#define ZMQ_NORM_SEGMENT_SIZE 120
+#define ZMQ_NORM_BLOCK_SIZE 121
+#define ZMQ_NORM_NUM_PARITY 122
+#define ZMQ_NORM_NUM_AUTOPARITY 123
+#define ZMQ_NORM_PUSH 124
 
 /*  DRAFT ZMQ_NORM_MODE options                                               */
 #define ZMQ_NORM_FIXED 0

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -152,14 +152,18 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
         NormSetDefaultUnicastNack (norm_session, true);
     }
     // Set TOS but check TOS ECN bit for CCE modes
-    if ((options.norm_mode == ZMQ_NORM_CCE || options.norm_mode == ZMQ_NORM_CCE_ECNONLY) && (options.tos % 4 == 0)) {
+    if ((options.norm_mode == ZMQ_NORM_CCE
+         || options.norm_mode == ZMQ_NORM_CCE_ECNONLY)
+        && (options.tos % 4 == 0)) {
         // ECN Capable Transport not set, so set it
-        NormSetTOS(norm_session, options.tos + 1);
-    } else if ((options.norm_mode == ZMQ_NORM_CCE || options.norm_mode == ZMQ_NORM_CCE_ECNONLY) && (options.tos % 4 == 3)) {
+        NormSetTOS (norm_session, options.tos + 1);
+    } else if ((options.norm_mode == ZMQ_NORM_CCE
+                || options.norm_mode == ZMQ_NORM_CCE_ECNONLY)
+               && (options.tos % 4 == 3)) {
         // Congestion Experienced is an invalid setting, remove one of the bits
-        NormSetTOS(norm_session, options.tos - 1);
+        NormSetTOS (norm_session, options.tos - 1);
     } else {
-        NormSetTOS(norm_session, options.tos);
+        NormSetTOS (norm_session, options.tos);
     }
 
     if (recv) {
@@ -167,7 +171,8 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
         // receiver sync to the sender's _current_ message transmission.
         // NORM_SYNC_STREAM tries to get everything the sender has cached/buffered
         NormSetDefaultSyncPolicy (norm_session, NORM_SYNC_STREAM);
-        if (!NormStartReceiver (norm_session, (unsigned long)options.norm_buffer_size * 1024)) {
+        if (!NormStartReceiver (
+              norm_session, (unsigned long) options.norm_buffer_size * 1024)) {
             // errno set by whatever failed
             int savedErrno = errno;
             NormDestroyInstance (norm_instance); // session gets closed, too
@@ -181,13 +186,21 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
 
     if (send) {
         // Handle invalid settings -- num_parity must be >= num_autoparity (which has a default of 0)
-        unsigned char numparity = (options.norm_num_parity >= options.norm_num_autoparity ? options.norm_num_parity : options.norm_num_autoparity);
+        unsigned char numparity =
+          (options.norm_num_parity >= options.norm_num_autoparity
+             ? options.norm_num_parity
+             : options.norm_num_autoparity);
         // Handle invalid settings -- block size must be > effective num_parity (which is <255)
-        unsigned char blocksize = (options.norm_block_size > numparity ? options.norm_block_size : numparity + 1);
+        unsigned char blocksize =
+          (options.norm_block_size > numparity ? options.norm_block_size
+                                               : numparity + 1);
         // Pick a random sender instance id (aka norm sender session id)
         NormSessionId instanceId = NormGetRandomSessionId ();
         // TBD - provide "options" for some NORM sender parameters
-        if (!NormStartSender (norm_session, instanceId, (unsigned long)options.norm_buffer_size * 1024, options.norm_segment_size, blocksize, numparity)) {
+        if (!NormStartSender (norm_session, instanceId,
+                              (unsigned long) options.norm_buffer_size * 1024,
+                              options.norm_segment_size, blocksize,
+                              numparity)) {
             // errno set by whatever failed
             int savedErrno = errno;
             NormDestroyInstance (norm_instance); // session gets closed, too
@@ -198,24 +211,27 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
         }
         // Handle NORM mode
         if (options.norm_mode == ZMQ_NORM_FIXED) {
-            NormSetTxRate(norm_session, (double)options.rate * 1000);
+            NormSetTxRate (norm_session, (double) options.rate * 1000);
         } else {
             NormSetCongestionControl (norm_session, true);
             if (options.norm_mode != ZMQ_NORM_CC) {
-                NormSetEcnSupport(norm_session, 
-                                  ((options.norm_mode == ZMQ_NORM_CCE) || (options.norm_mode == ZMQ_NORM_CCE_ECNONLY)), 
-                                  options.norm_mode == ZMQ_NORM_CCE_ECNONLY, 
-                                  options.norm_mode == ZMQ_NORM_CCL);
+                NormSetEcnSupport(
+                  norm_session, 
+                  ((options.norm_mode == ZMQ_NORM_CCE)
+                   || (options.norm_mode == ZMQ_NORM_CCE_ECNONLY)), 
+                  options.norm_mode == ZMQ_NORM_CCE_ECNONLY, 
+                  options.norm_mode == ZMQ_NORM_CCL);
             }
         }
         if (options.norm_num_autoparity > 0) {
-            NormSetAutoParity(norm_session, options.norm_num_autoparity);
+            NormSetAutoParity (norm_session, options.norm_num_autoparity);
         }
         norm_tx_ready = true;
         is_sender = true;
         if (NORM_OBJECT_INVALID
-            == (norm_tx_stream =
-                  NormStreamOpen (norm_session, (unsigned long)options.norm_buffer_size * 1024))) {
+            == (norm_tx_stream = NormStreamOpen (
+                  norm_session,
+                  (unsigned long) options.norm_buffer_size * 1024))) {
             // errno set by whatever failed
             int savedErrno = errno;
             NormDestroyInstance (norm_instance); // session gets closed, too
@@ -225,7 +241,7 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
             return -1;
         }
         // NORM Stream options
-	NormStreamSetPushEnable(norm_tx_stream, options.norm_push_enable);
+	NormStreamSetPushEnable (norm_tx_stream, options.norm_push_enable);
     }
 
     //NormSetMessageTrace(norm_session, true);

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -215,11 +215,11 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
         } else {
             NormSetCongestionControl (norm_session, true);
             if (options.norm_mode != ZMQ_NORM_CC) {
-                NormSetEcnSupport(
-                  norm_session, 
+                NormSetEcnSupport (
+                  norm_session,
                   ((options.norm_mode == ZMQ_NORM_CCE)
-                   || (options.norm_mode == ZMQ_NORM_CCE_ECNONLY)), 
-                  options.norm_mode == ZMQ_NORM_CCE_ECNONLY, 
+                   || (options.norm_mode == ZMQ_NORM_CCE_ECNONLY)),
+                  options.norm_mode == ZMQ_NORM_CCE_ECNONLY,
                   options.norm_mode == ZMQ_NORM_CCL);
             }
         }
@@ -241,7 +241,7 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
             return -1;
         }
         // NORM Stream options
-	NormStreamSetPushEnable (norm_tx_stream, options.norm_push_enable);
+        NormStreamSetPushEnable (norm_tx_stream, options.norm_push_enable);
     }
 
     //NormSetMessageTrace(norm_session, true);

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -131,9 +131,7 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
         return -1;
     }
     // There's many other useful NORM options that could be applied here
-    if (NormIsUnicastAddress (addr)) {
-        NormSetDefaultUnicastNack (norm_session, true);
-    } else {
+    if (!NormIsUnicastAddress (addr)) {
         // These only apply for multicast sessions
         //NormSetTTL(norm_session, options.multicast_hops);  // ZMQ default is 1
         NormSetTTL (
@@ -150,13 +148,26 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
             NormSetMulticastInterface (norm_session, ifacePtr);
         }
     }
+    if (NormIsUnicastAddress (addr) || options.norm_unicast_nacks) {
+        NormSetDefaultUnicastNack (norm_session, true);
+    }
+    // Set TOS but check TOS ECN bit for CCE modes
+    if ((options.norm_mode == ZMQ_NORM_CCE || options.norm_mode == ZMQ_NORM_CCE_ECNONLY) && (options.tos % 4 == 0)) {
+        // ECN Capable Transport not set, so set it
+        NormSetTOS(norm_session, options.tos + 1);
+    } else if ((options.norm_mode == ZMQ_NORM_CCE || options.norm_mode == ZMQ_NORM_CCE_ECNONLY) && (options.tos % 4 == 3)) {
+        // Congestion Experienced is an invalid setting, remove one of the bits
+        NormSetTOS(norm_session, options.tos - 1);
+    } else {
+        NormSetTOS(norm_session, options.tos);
+    }
 
     if (recv) {
         // The alternative NORM_SYNC_CURRENT here would provide "instant"
         // receiver sync to the sender's _current_ message transmission.
         // NORM_SYNC_STREAM tries to get everything the sender has cached/buffered
         NormSetDefaultSyncPolicy (norm_session, NORM_SYNC_STREAM);
-        if (!NormStartReceiver (norm_session, 2 * 1024 * 1024)) {
+        if (!NormStartReceiver (norm_session, (unsigned long)options.norm_buffer_size * 1024)) {
             // errno set by whatever failed
             int savedErrno = errno;
             NormDestroyInstance (norm_instance); // session gets closed, too
@@ -169,11 +180,14 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
     }
 
     if (send) {
+        // Handle invalid settings -- num_parity must be >= num_autoparity (which has a default of 0)
+        unsigned char numparity = (options.norm_num_parity >= options.norm_num_autoparity ? options.norm_num_parity : options.norm_num_autoparity);
+        // Handle invalid settings -- block size must be > effective num_parity (which is <255)
+        unsigned char blocksize = (options.norm_block_size > numparity ? options.norm_block_size : numparity + 1);
         // Pick a random sender instance id (aka norm sender session id)
         NormSessionId instanceId = NormGetRandomSessionId ();
         // TBD - provide "options" for some NORM sender parameters
-        if (!NormStartSender (norm_session, instanceId, 2 * 1024 * 1024, 1400,
-                              16, 4)) {
+        if (!NormStartSender (norm_session, instanceId, (unsigned long)options.norm_buffer_size * 1024, options.norm_segment_size, blocksize, numparity)) {
             // errno set by whatever failed
             int savedErrno = errno;
             NormDestroyInstance (norm_instance); // session gets closed, too
@@ -182,12 +196,26 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
             errno = savedErrno;
             return -1;
         }
-        NormSetCongestionControl (norm_session, true);
+        // Handle NORM mode
+        if (options.norm_mode == ZMQ_NORM_FIXED) {
+            NormSetTxRate(norm_session, (double)options.rate * 1000);
+        } else {
+            NormSetCongestionControl (norm_session, true);
+            if (options.norm_mode != ZMQ_NORM_CC) {
+                NormSetEcnSupport(norm_session, 
+                                  ((options.norm_mode == ZMQ_NORM_CCE) || (options.norm_mode == ZMQ_NORM_CCE_ECNONLY)), 
+                                  options.norm_mode == ZMQ_NORM_CCE_ECNONLY, 
+                                  options.norm_mode == ZMQ_NORM_CCL);
+            }
+        }
+        if (options.norm_num_autoparity > 0) {
+            NormSetAutoParity(norm_session, options.norm_num_autoparity);
+        }
         norm_tx_ready = true;
         is_sender = true;
         if (NORM_OBJECT_INVALID
             == (norm_tx_stream =
-                  NormStreamOpen (norm_session, 2 * 1024 * 1024))) {
+                  NormStreamOpen (norm_session, (unsigned long)options.norm_buffer_size * 1024))) {
             // errno set by whatever failed
             int savedErrno = errno;
             NormDestroyInstance (norm_instance); // session gets closed, too
@@ -196,6 +224,8 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
             errno = savedErrno;
             return -1;
         }
+        // NORM Stream options
+	NormStreamSetPushEnable(norm_tx_stream, options.norm_push_enable);
     }
 
     //NormSetMessageTrace(norm_session, true);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -257,6 +257,16 @@ zmq::options_t::options_t () :
     can_recv_disconnect_msg (false),
     hiccup_msg (),
     can_recv_hiccup_msg (false),
+#ifdef ZMQ_HAVE_NORM
+    norm_mode (ZMQ_NORM_CC),
+    norm_unicast_nacks (false),
+    norm_buffer_size(2048),
+    norm_segment_size (1400),
+    norm_block_size (16),
+    norm_num_parity (4),
+    norm_num_autoparity (0),
+    norm_push_enable (false),
+#endif // ZMQ_HAVE_NORM
     busy_poll (0)
 {
     memset (curve_public_key, 0, CURVE_KEYSIZE);
@@ -790,6 +800,58 @@ int zmq::options_t::setsockopt (int option_,
             return do_setsockopt_int_as_bool_relaxed (optval_, optvallen_,
                                                       &multicast_loop);
 
+#ifdef ZMQ_HAVE_NORM
+        case ZMQ_NORM_MODE:
+            if (is_int && value >= 0 && value <=4) {
+                norm_mode = value;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_UNICAST_NACK:
+            return do_setsockopt_int_as_bool_strict (optval_, optvallen_,
+                                                     &norm_unicast_nacks);
+
+        case ZMQ_NORM_BUFFER_SIZE:
+            if (is_int && value > 0) {
+                norm_buffer_size = value;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_SEGMENT_SIZE:
+            if (is_int && value > 0) {
+                norm_segment_size = value;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_BLOCK_SIZE:
+            if (is_int && value > 0 && value <= 255) {
+                norm_block_size = value;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_NUM_PARITY:
+            if (is_int && value >= 0 && value < 255) {
+                norm_num_parity = value;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_NUM_AUTOPARITY:
+            if (is_int && value >= 0 && value < 255) {
+                norm_num_autoparity = value;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_PUSH:
+            return do_setsockopt_int_as_bool_strict (optval_, optvallen_,
+                                                     &norm_push_enable);
+#endif //ZMQ_HAVE_NORM
+
 #ifdef ZMQ_BUILD_DRAFT_API
         case ZMQ_IN_BATCH_SIZE:
             if (is_int && value > 0) {
@@ -1277,6 +1339,64 @@ int zmq::options_t::getsockopt (int option_,
                 return 0;
             }
             break;
+
+#ifdef ZMQ_HAVE_NORM
+        case ZMQ_NORM_MODE:
+            if (is_int) {
+                *value = norm_mode;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_UNICAST_NACK:
+            if (is_int) {
+                *value = norm_unicast_nacks;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_BUFFER_SIZE:
+            if (is_int) {
+                *value = norm_buffer_size;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_SEGMENT_SIZE:
+            if (is_int) {
+                *value = norm_segment_size;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_BLOCK_SIZE:
+            if (is_int) {
+                *value = norm_block_size;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_NUM_PARITY:
+            if (is_int) {
+                *value = norm_num_parity;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_NUM_AUTOPARITY:
+            if (is_int) {
+                *value = norm_num_autoparity;
+                return 0;
+            }
+            break;
+
+        case ZMQ_NORM_PUSH:
+            if (is_int) {
+                *value = norm_push_enable;
+                return 0;
+            }
+            break;
+#endif //ZMQ_HAVE_NORM
 
 #ifdef ZMQ_BUILD_DRAFT_API
         case ZMQ_ROUTER_NOTIFY:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -259,7 +259,7 @@ zmq::options_t::options_t () :
     can_recv_hiccup_msg (false),
     norm_mode (ZMQ_NORM_CC),
     norm_unicast_nacks (false),
-    norm_buffer_size(2048),
+    norm_buffer_size (2048),
     norm_segment_size (1400),
     norm_block_size (16),
     norm_num_parity (4),
@@ -842,7 +842,7 @@ int zmq::options_t::setsockopt (int option_,
 
 #ifdef ZMQ_HAVE_NORM
         case ZMQ_NORM_MODE:
-            if (is_int && value >= 0 && value <=4) {
+            if (is_int && value >= 0 && value <= 4) {
                 norm_mode = value;
                 return 0;
             }

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -313,6 +313,18 @@ struct options_t
     std::vector<unsigned char> hiccup_msg;
     bool can_recv_hiccup_msg;
 
+#ifdef ZMQ_HAVE_NORM
+    // NORM Options
+    int norm_mode;
+    bool norm_unicast_nacks;
+    int norm_buffer_size;
+    int norm_segment_size;
+    int norm_block_size;
+    int norm_num_parity;
+    int norm_num_autoparity;
+    bool norm_push_enable;
+#endif // ZMQ_HAVE_NORM
+
     //  This option removes several delays caused by scheduling, interrupts and context switching.
     int busy_poll;
 };

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -313,7 +313,6 @@ struct options_t
     std::vector<unsigned char> hiccup_msg;
     bool can_recv_hiccup_msg;
 
-#ifdef ZMQ_HAVE_NORM
     // NORM Options
     int norm_mode;
     bool norm_unicast_nacks;
@@ -323,7 +322,6 @@ struct options_t
     int norm_num_parity;
     int norm_num_autoparity;
     bool norm_push_enable;
-#endif // ZMQ_HAVE_NORM
 
     //  This option removes several delays caused by scheduling, interrupts and context switching.
     int busy_poll;

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -74,6 +74,23 @@
 #define ZMQ_XSUB_VERBOSE_UNSUBSCRIBE 115
 #define ZMQ_TOPICS_COUNT 116
 
+/*  DRAFT NORM socket options                                                 */
+#define ZMQ_NORM_MODE 150
+#define ZMQ_NORM_UNICAST_NACK 151
+#define ZMQ_NORM_BUFFER_SIZE 152
+#define ZMQ_NORM_SEGMENT_SIZE 153
+#define ZMQ_NORM_BLOCK_SIZE 154
+#define ZMQ_NORM_NUM_PARITY 155
+#define ZMQ_NORM_NUM_AUTOPARITY 156
+#define ZMQ_NORM_PUSH 157
+
+/*  DRAFT ZMQ_NORM_MODE options                                               */
+#define ZMQ_NORM_FIXED 0
+#define ZMQ_NORM_CC 1
+#define ZMQ_NORM_CCL 2
+#define ZMQ_NORM_CCE 3
+#define ZMQ_NORM_CCE_ECNONLY 4
+
 /*  DRAFT ZMQ_RECONNECT_STOP options                                          */
 #define ZMQ_RECONNECT_STOP_CONN_REFUSED 0x1
 #define ZMQ_RECONNECT_STOP_HANDSHAKE_FAILED 0x2

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -73,16 +73,14 @@
 #define ZMQ_HICCUP_MSG 114
 #define ZMQ_XSUB_VERBOSE_UNSUBSCRIBE 115
 #define ZMQ_TOPICS_COUNT 116
-
-/*  DRAFT NORM socket options                                                 */
-#define ZMQ_NORM_MODE 150
-#define ZMQ_NORM_UNICAST_NACK 151
-#define ZMQ_NORM_BUFFER_SIZE 152
-#define ZMQ_NORM_SEGMENT_SIZE 153
-#define ZMQ_NORM_BLOCK_SIZE 154
-#define ZMQ_NORM_NUM_PARITY 155
-#define ZMQ_NORM_NUM_AUTOPARITY 156
-#define ZMQ_NORM_PUSH 157
+#define ZMQ_NORM_MODE 117
+#define ZMQ_NORM_UNICAST_NACK 118
+#define ZMQ_NORM_BUFFER_SIZE 119
+#define ZMQ_NORM_SEGMENT_SIZE 120
+#define ZMQ_NORM_BLOCK_SIZE 121
+#define ZMQ_NORM_NUM_PARITY 122
+#define ZMQ_NORM_NUM_AUTOPARITY 123
+#define ZMQ_NORM_PUSH 124
 
 /*  DRAFT ZMQ_NORM_MODE options                                               */
 #define ZMQ_NORM_FIXED 0


### PR DESCRIPTION
NORM transport is currently hard-coded to particular NORM settings and modes.  This pull request adds some NORM configuration parameters as socket options to allow for more flexibility in configuring NORM transport for different use cases.  Default values and modes remain the same.  The pull also makes use of existing socket options ZMQ_RATE (for NORM fixed-rate operation, not used in congestion control modes) and ZMQ_TOS.