### PR TITLE
Add missing pkg_config_defines when built with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ endif()
 # Will be used to add flags to pkg-config useful when apps want to statically link
 set(pkg_config_libs_private "")
 set(pkg_config_names_private "")
+set(pkg_config_defines "")
 
 option(WITH_OPENPGM "Build with support for OpenPGM" OFF)
 option(WITH_NORM "Build with support for NORM" OFF)
@@ -1463,6 +1464,7 @@ foreach(target ${build_targets})
 
   if(ENABLE_DRAFTS)
     target_compile_definitions(${target} PUBLIC ZMQ_BUILD_DRAFT_API)
+    set(pkg_config_defines "-DZMQ_BUILD_DRAFT_API=1")
   endif()
 endforeach()
 

--- a/RELICENSE/panicgh.md
+++ b/RELICENSE/panicgh.md
@@ -1,0 +1,15 @@
+# Permission to Relicense under MPLv2 or any other OSI approved license chosen by the current ZeroMQ BDFL
+
+This is a statement by Nicolas Benes
+that grants permission to relicense its copyrights in the libzmq C++
+library (ZeroMQ) under the Mozilla Public License v2 (MPLv2) or any other
+Open Source Initiative approved license chosen by the current ZeroMQ
+BDFL (Benevolent Dictator for Life).
+
+A portion of the commits made by the Github handle "panicgh", with
+commit author "Nicolas Benes <nbenes.gh@xandea.de>", are copyright of Nicolas Benes.
+This document hereby grants the libzmq project team to relicense libzmq,
+including all past, present and future contributions of the author listed above.
+
+Nicolas Benes
+2023/05/12


### PR DESCRIPTION
The pkg_config_defines variable was only set in configure.ac, but not in CMake. This lead to the `-DZMQ_BUILD_DRAFT_API=1` flag to be omitted from the generated pkg-config file.

configure.ac contains this to set the variable accordingly:

https://github.com/zeromq/libzmq/blob/532b61275e93a8f7e0f2dee4ee1a83f075325926/configure.ac#L1056-L1063

