### PR TITLE
Link to openpgm when building with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1468,6 +1468,10 @@ if(BUILD_SHARED)
   if(norm_FOUND)
       target_link_libraries(libzmq norm::norm)
   endif()
+
+  if(OPENPGM_FOUND)
+	  target_link_libraries(libzmq ${OPENPGM_LIBRARIES})
+  endif()
 endif()
 
 if(BUILD_STATIC)
@@ -1516,6 +1520,10 @@ if(BUILD_STATIC)
 
   if(norm_FOUND)
       target_link_libraries(libzmq-static norm::norm)
+  endif()
+
+  if(OPENPGM_FOUND)
+	  target_link_libraries(libzmq-static ${OPENPGM_LIBRARIES})
   endif()
 endif()
 


### PR DESCRIPTION

I was noticing a problem where libzmq fails to link to openpgm when building with CMake.
