### PR TITLE
Change NORM to set TTL using MULTICAST_HOPS sockopt

### DIFF
--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -133,10 +133,9 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
     // There's many other useful NORM options that could be applied here
     if (!NormIsUnicastAddress (addr)) {
         // These only apply for multicast sessions
-        //NormSetTTL(norm_session, options.multicast_hops);  // ZMQ default is 1
         NormSetTTL (
           norm_session,
-          255); // since the ZMQ_MULTICAST_HOPS socket option isn't well-supported
+          options.multicast_hops);
         NormSetRxPortReuse (
           norm_session,
           true); // port reuse doesn't work for non-connected unicast

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -133,9 +133,7 @@ int zmq::norm_engine_t::init (const char *network_, bool send, bool recv)
     // There's many other useful NORM options that could be applied here
     if (!NormIsUnicastAddress (addr)) {
         // These only apply for multicast sessions
-        NormSetTTL (
-          norm_session,
-          options.multicast_hops);
+        NormSetTTL (norm_session, options.multicast_hops);
         NormSetRxPortReuse (
           norm_session,
           true); // port reuse doesn't work for non-connected unicast


### PR DESCRIPTION
It is unclear to me why the current TTL is hard-coded, but this change makes TTL user-configurable using the existing sockopt to allow for more flexibility.  Effectively changes default NORM TTL from 255 to 1.