### PR TITLE
Problem: relicensing forced to remove support for ZMQ_RECONNECT_IVL_MAX option

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -186,6 +186,7 @@ zmq::options_t::options_t () :
     tcp_maxrt (0),
     reconnect_stop (0),
     reconnect_ivl (100),
+    reconnect_ivl_max (0),
     backlog (100),
     maxmsgsize (-1),
     rcvtimeo (-1),
@@ -400,11 +401,11 @@ int zmq::options_t::setsockopt (int option_,
             break;
 
         case ZMQ_RECONNECT_IVL_MAX:
-#ifdef ZMQ_HAVE_WINDOWS
-            return WSAEOPNOTSUPP;
-#else
-            return -EOPNOTSUPP;
-#endif
+            if (is_int && value >= 0) {
+                reconnect_ivl_max = value;
+                return 0;
+            }
+            break;
 
         case ZMQ_BACKLOG:
             if (is_int && value >= 0) {
@@ -1048,11 +1049,11 @@ int zmq::options_t::getsockopt (int option_,
             break;
 
         case ZMQ_RECONNECT_IVL_MAX:
-#ifdef ZMQ_HAVE_WINDOWS
-            return WSAEOPNOTSUPP;
-#else
-            return -EOPNOTSUPP;
-#endif
+            if (is_int) {
+                *value = reconnect_ivl_max;
+                return 0;
+            }
+            break;
 
         case ZMQ_BACKLOG:
             if (is_int) {

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -99,6 +99,10 @@ struct options_t
     //  Minimum interval between attempts to reconnect, in milliseconds.
     //  Default 100ms
     int reconnect_ivl;
+    
+    //  Maximum interval between attempts to reconnect, in milliseconds.
+    //  Default 0ms (meaning maximum interval is disabled)
+    int reconnect_ivl_max;
 
     //  Maximum backlog for pending connections.
     int backlog;


### PR DESCRIPTION
Solution: reimplement support for ZMQ_RECONNECT_IVL_MAX without knowledge of the previous code.
