### PR TITLE
Setting ZMQ_THREAD_PRIORITY to 0 shouldn't nice the threads. #4512

### DIFF
--- a/doc/zmq_ctx_set.txt
+++ b/doc/zmq_ctx_set.txt
@@ -66,7 +66,8 @@ The 'ZMQ_THREAD_PRIORITY' argument sets scheduling priority for
 internal context's thread pool. This option is not available on windows.
 Supported values for this option depend on chosen scheduling policy.
 On Linux, when the scheduler policy is SCHED_OTHER, SCHED_IDLE or SCHED_BATCH, the OS scheduler
-will not use the thread priority but rather the thread "nice value"; in such cases
+will not use the thread priority but rather the thread "nice value"; in such cases,
+if 'ZMQ_THREAD_PRIORITY' is set to a strictly positive value,
 the system call "nice" will be used to set the nice value to -20 (max priority) instead of
 adjusting the thread priority (which must be zero for those scheduling policies).
 Details can be found in sched.h file, or at http://man7.org/linux/man-pages/man2/sched_setscheduler.2.html.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -292,14 +292,12 @@ void zmq::thread_t::
     bool use_nice_instead_priority =
       (policy != SCHED_FIFO) && (policy != SCHED_RR);
 
-    if (_thread_priority != ZMQ_THREAD_PRIORITY_DFLT) {
-        if (use_nice_instead_priority)
-            param.sched_priority =
-              0; // this is the only supported priority for most scheduling policies
-        else
-            param.sched_priority =
-              _thread_priority; // user should provide a value between 1 and 99
-    }
+    if (use_nice_instead_priority)
+        param.sched_priority =
+          0; // this is the only supported priority for most scheduling policies
+    else if (_thread_priority != ZMQ_THREAD_PRIORITY_DFLT)
+        param.sched_priority =
+          _thread_priority; // user should provide a value between 1 and 99
 
 #ifdef __NetBSD__
     if (policy == SCHED_OTHER)
@@ -318,7 +316,8 @@ void zmq::thread_t::
 
 #if !defined ZMQ_HAVE_VXWORKS
     if (use_nice_instead_priority
-        && _thread_priority != ZMQ_THREAD_PRIORITY_DFLT) {
+        && _thread_priority != ZMQ_THREAD_PRIORITY_DFLT
+        && _thread_priority > 0) {
         // assume the user wants to decrease the thread's nice value
         // i.e., increase the chance of this thread being scheduled: try setting that to
         // maximum priority.


### PR DESCRIPTION
This PR fixes the issue #4512 by checking that the priority set on non-real time threads is strictly positive before doing the `nice` system call. The documentation is updated accordingly.
It also fixes a following remark on errors when a thread is created with the scheduling policy OTHER, but without indicating the priority. The priority must be set to 0, as it cannot inherit the priority of the creator thread if that thread has a real-time priority.