### PR TITLE
Add an option to select how address names are interpreted in zmq_bind #4514

### DIFF
--- a/doc/zmq_setsockopt.txt
+++ b/doc/zmq_setsockopt.txt
@@ -1668,6 +1668,19 @@ Option value unit:: boolean
 Default value:: 0 (false)
 Applicable socket types:: All, when using NORM transport.
 
+ZMQ_BIND_RESOLVE_NIC: Configure name resolution of zmq_bind
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When binding sockets, names are by default resolved as network interface names.
+This option allow to change this behaviour to resolve names as hostname instead.
+
+NOTE: in DRAFT state, not yet available in stable releases.
+
+[horizontal]
+Option value type:: int
+Option value unit:: boolean
+Default value:: 1 (true)
+Applicable socket types:: All, when using TCP transport.
+
 
 RETURN VALUE
 ------------

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -662,6 +662,7 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_NORM_NUM_PARITY 122
 #define ZMQ_NORM_NUM_AUTOPARITY 123
 #define ZMQ_NORM_PUSH 124
+#define ZMQ_BIND_RESOLVE_NIC 125
 
 /*  DRAFT ZMQ_NORM_MODE options                                               */
 #define ZMQ_NORM_FIXED 0

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -238,7 +238,8 @@ zmq::options_t::options_t () :
     norm_num_parity (4),
     norm_num_autoparity (0),
     norm_push_enable (false),
-    busy_poll (0)
+    busy_poll (0),
+    bind_resolve_as_nic(true)
 {
     memset (curve_public_key, 0, CURVE_KEYSIZE);
     memset (curve_secret_key, 0, CURVE_KEYSIZE);
@@ -906,6 +907,9 @@ int zmq::options_t::setsockopt (int option_,
             return 0;
 
 
+        case ZMQ_BIND_RESOLVE_NIC:
+            return do_setsockopt_int_as_bool_relaxed (optval_, optvallen_,
+                                                      &bind_resolve_as_nic);
 #endif
 
         default:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -239,7 +239,7 @@ zmq::options_t::options_t () :
     norm_num_autoparity (0),
     norm_push_enable (false),
     busy_poll (0),
-    bind_resolve_as_nic(true)
+    bind_resolve_as_nic (true)
 {
     memset (curve_public_key, 0, CURVE_KEYSIZE);
     memset (curve_secret_key, 0, CURVE_KEYSIZE);

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -298,6 +298,11 @@ struct options_t
 
     //  This option removes several delays caused by scheduling, interrupts and context switching.
     int busy_poll;
+
+    // Behaviour of name resolution when binding.
+    // If true, names should be resolved as network interfaces.
+    // If false, names should be resolved as host names.
+    bool bind_resolve_as_nic;
 };
 
 inline bool get_effective_conflate_option (const options_t &options)

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1110,7 +1110,9 @@ zmq::socket_base_t::resolve_tcp_addr (std::string endpoint_uri_pair_,
         if (rc == 0) {
             tcp_addr->to_string (endpoint_uri_pair_);
             if (_endpoints.find (endpoint_uri_pair_) == _endpoints.end ()) {
-                rc = tcp_addr->resolve (tcp_address_, options.bind_resolve_as_nic, options.ipv6, true);
+                rc =
+                  tcp_addr->resolve (tcp_address_, options.bind_resolve_as_nic,
+                                     options.ipv6, true);
                 if (rc == 0) {
                     tcp_addr->to_string (endpoint_uri_pair_);
                 }

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -1105,12 +1105,12 @@ zmq::socket_base_t::resolve_tcp_addr (std::string endpoint_uri_pair_,
     if (_endpoints.find (endpoint_uri_pair_) == _endpoints.end ()) {
         tcp_address_t *tcp_addr = new (std::nothrow) tcp_address_t ();
         alloc_assert (tcp_addr);
-        int rc = tcp_addr->resolve (tcp_address_, false, options.ipv6);
+        int rc = tcp_addr->resolve (tcp_address_, false, options.ipv6, false);
 
         if (rc == 0) {
             tcp_addr->to_string (endpoint_uri_pair_);
             if (_endpoints.find (endpoint_uri_pair_) == _endpoints.end ()) {
-                rc = tcp_addr->resolve (tcp_address_, true, options.ipv6);
+                rc = tcp_addr->resolve (tcp_address_, options.bind_resolve_as_nic, options.ipv6, true);
                 if (rc == 0) {
                     tcp_addr->to_string (endpoint_uri_pair_);
                 }

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -331,12 +331,14 @@ void zmq::tune_tcp_busy_poll (fd_t socket_, int busy_poll_)
 
 zmq::fd_t zmq::tcp_open_socket (const char *address_,
                                 const zmq::options_t &options_,
-                                bool local_,
+                                bool bind_,
                                 bool fallback_to_ipv4_,
                                 zmq::tcp_address_t *out_tcp_addr_)
 {
+    //  Address resolved as local interface ?
+    bool local_ = bind_ && options_.bind_resolve_as_nic;
     //  Convert the textual address into address structure.
-    int rc = out_tcp_addr_->resolve (address_, local_, options_.ipv6);
+    int rc = out_tcp_addr_->resolve (address_, local_, options_.ipv6, bind_);
     if (rc != 0)
         return retired_fd;
 
@@ -347,7 +349,7 @@ zmq::fd_t zmq::tcp_open_socket (const char *address_,
     if (s == retired_fd && fallback_to_ipv4_
         && out_tcp_addr_->family () == AF_INET6 && errno == EAFNOSUPPORT
         && options_.ipv6) {
-        rc = out_tcp_addr_->resolve (address_, local_, false);
+        rc = out_tcp_addr_->resolve (address_, local_, false, bind_);
         if (rc != 0) {
             return retired_fd;
         }

--- a/src/tcp.hpp
+++ b/src/tcp.hpp
@@ -50,7 +50,7 @@ void tune_tcp_busy_poll (fd_t socket_, int busy_poll_);
 //  errno is set to an error code describing the cause of the error.
 fd_t tcp_open_socket (const char *address_,
                       const options_t &options_,
-                      bool local_,
+                      bool bind_,
                       bool fallback_to_ipv4_,
                       tcp_address_t *out_tcp_addr_);
 }

--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -43,7 +43,7 @@ zmq::tcp_address_t::tcp_address_t (const sockaddr *sa_, socklen_t sa_len_) :
         memcpy (&_address.ipv6, sa_, sizeof (_address.ipv6));
 }
 
-int zmq::tcp_address_t::resolve (const char *name_, bool local_, bool ipv6_)
+int zmq::tcp_address_t::resolve (const char *name_, bool local_, bool ipv6_, bool bind_)
 {
     // Test the ';' to know if we have a source address in name_
     const char *src_delimiter = strrchr (name_, ';');
@@ -74,7 +74,7 @@ int zmq::tcp_address_t::resolve (const char *name_, bool local_, bool ipv6_)
 
     ip_resolver_options_t resolver_opts;
 
-    resolver_opts.bindable (local_)
+    resolver_opts.bindable (bind_)
       .allow_dns (!local_)
       .allow_nic_name (local_)
       .ipv6 (ipv6_)

--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -43,7 +43,10 @@ zmq::tcp_address_t::tcp_address_t (const sockaddr *sa_, socklen_t sa_len_) :
         memcpy (&_address.ipv6, sa_, sizeof (_address.ipv6));
 }
 
-int zmq::tcp_address_t::resolve (const char *name_, bool local_, bool ipv6_, bool bind_)
+int zmq::tcp_address_t::resolve (const char *name_,
+                                 bool local_,
+                                 bool ipv6_,
+                                 bool bind_)
 {
     // Test the ';' to know if we have a source address in name_
     const char *src_delimiter = strrchr (name_, ';');

--- a/src/tcp_address.hpp
+++ b/src/tcp_address.hpp
@@ -20,9 +20,10 @@ class tcp_address_t
 
     //  This function translates textual TCP address into an address
     //  structure. If 'local' is true, names are resolved as local interface
-    //  names. If it is false, names are resolved as remote hostnames.
+    //  names. If it is false, names are resolved as hostnames.
     //  If 'ipv6' is true, the name may resolve to IPv6 address.
-    int resolve (const char *name_, bool local_, bool ipv6_);
+    //  If 'bind' is true, wildcards in names are allowed.
+    int resolve (const char *name_, bool local_, bool ipv6_, bool bind_);
 
     //  The opposite to resolve()
     int to_string (std::string &addr_) const;

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -54,6 +54,7 @@
 #define ZMQ_NORM_NUM_PARITY 122
 #define ZMQ_NORM_NUM_AUTOPARITY 123
 #define ZMQ_NORM_PUSH 124
+#define ZMQ_BIND_RESOLVE_NIC 125
 
 /*  DRAFT ZMQ_NORM_MODE options                                               */
 #define ZMQ_NORM_FIXED 0


### PR DESCRIPTION
This PR partially fixes the issue #4514. It is currently limited to the the TCP sockets.
This PR introduces a new socket option ZMQ_BIND_RESOLVE_NIC, by default set to true.
When this option is set to true, names in addresses for binding sockets are resolved as network interface names, which is the current behaviour.
When this option is set to false, names in addresses for binding sockets are resolved as hostnames, like non-binding sockets.