### PR TITLE
Fallback to hostname resolution in TCP and UDP.

### DIFF
--- a/src/tcp_address.cpp
+++ b/src/tcp_address.cpp
@@ -75,7 +75,7 @@ int zmq::tcp_address_t::resolve (const char *name_, bool local_, bool ipv6_)
     ip_resolver_options_t resolver_opts;
 
     resolver_opts.bindable (local_)
-      .allow_dns (!local_)
+      .allow_dns (true)
       .allow_nic_name (local_)
       .ipv6 (ipv6_)
       .expect_port (true);

--- a/src/udp_address.cpp
+++ b/src/udp_address.cpp
@@ -92,7 +92,7 @@ int zmq::udp_address_t::resolve (const char *name_, bool bind_, bool ipv6_)
     ip_resolver_options_t resolver_opts;
 
     resolver_opts.bindable (bind_)
-      .allow_dns (!bind_)
+      .allow_dns (true)
       .allow_nic_name (bind_)
       .expect_port (true)
       .ipv6 (ipv6_);


### PR DESCRIPTION
This PR fixes the needs behind the issue #4514 by enabling fallback to hostname resolution if interface resolution fails.

When resolving addresses, there is already a fallback to getaddrinfo when interface resolution fails.
When allow_dns is set to false, the AI_NUMERICHOST flag is added to getaddrinfo to disable hostname resolution.
The fact we are binding is currently used to disable hostname resolution in TCP and UDP. To enable the fallback to hostname resolution, the allow_dns option should be set to true in all cases.