### PR TITLE
Fix NORM Assert Error

### DIFF
--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -557,8 +557,7 @@ void zmq::norm_engine_t::recv_data (NormObjectHandle object)
                 char syncFlag;
                 unsigned int numBytes = 1;
                 if (!NormStreamRead (stream, &syncFlag, &numBytes)) {
-                    // broken stream (shouldn't happen after seek msg start?)
-                    zmq_assert (false);
+                    // broken stream (can happen on late-joining subscriber)
                     continue;
                 }
                 if (0 == numBytes) {


### PR DESCRIPTION
Fix assert error that can happen on a late-joining NORM subscriber.  Assert error can happen once publisher has filled its NORM buffer and begun to discard old data it was caching for potential repairs.