### PR TITLE
Replace `egrep` with `grep -E`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -443,7 +443,7 @@ pipeline {
                     echo "Used:     myDEPLOY_JOB_NAME:${myDEPLOY_JOB_NAME} myDEPLOY_BRANCH_PATTERN:${myDEPLOY_BRANCH_PATTERN} myDEPLOY_REPORT_RESULT:${myDEPLOY_REPORT_RESULT}"
                     if ( (myDEPLOY_JOB_NAME != "") && (myDEPLOY_BRANCH_PATTERN != "") ) {
                         if ( env.BRANCH_NAME =~ myDEPLOY_BRANCH_PATTERN ) {
-                            def GIT_URL = sh(returnStdout: true, script: """git remote -v | egrep '^origin' | awk '{print \$2}' | head -1""").trim()
+                            def GIT_URL = sh(returnStdout: true, script: """git remote -v | grep -E '^origin' | awk '{print \$2}' | head -1""").trim()
                             def GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --verify HEAD').trim()
                             def DIST_ARCHIVE = ""
                             if ( params.DO_DIST_DOCS ) { DIST_ARCHIVE = env.BUILD_URL + "artifact/__dist.tar.gz" }

--- a/builds/zos/runtests
+++ b/builds/zos/runtests
@@ -63,9 +63,9 @@ SKIP_TESTS="test_.*_tipc"
 #
 # Excluding tests we know will fail because of missing functionality
 #
-noinst_PROGRAMS=$(grep "test_" Makefile.am | egrep -v "_SOURCES|XFAIL" |
+noinst_PROGRAMS=$(grep "test_" Makefile.am | grep -E -v "_SOURCES|XFAIL" |
                   sed 's/noinst_PROGRAMS.* test/test/; s/^ *//; s/ *\\ *$//;' |
-                  grep -v "${SKIP_TESTS}" | egrep -v "${XFAIL_TESTS}")
+                  grep -v "${SKIP_TESTS}" | grep -E -v "${XFAIL_TESTS}")
 #echo "Found tetsts: ${noinst_PROGRAMS}"
 
 # Run tests on command line, or all tests we found

--- a/version.sh
+++ b/version.sh
@@ -7,9 +7,9 @@ if [ ! -f include/zmq.h ]; then
     echo "version.sh: error: include/zmq.h does not exist" 1>&2
     exit 1
 fi
-MAJOR=`egrep '^#define +ZMQ_VERSION_MAJOR +[0-9]+$' include/zmq.h`
-MINOR=`egrep '^#define +ZMQ_VERSION_MINOR +[0-9]+$' include/zmq.h`
-PATCH=`egrep '^#define +ZMQ_VERSION_PATCH +[0-9]+$' include/zmq.h`
+MAJOR=`grep -E '^#define +ZMQ_VERSION_MAJOR +[0-9]+$' include/zmq.h`
+MINOR=`grep -E '^#define +ZMQ_VERSION_MINOR +[0-9]+$' include/zmq.h`
+PATCH=`grep -E '^#define +ZMQ_VERSION_PATCH +[0-9]+$' include/zmq.h`
 if [ -z "$MAJOR" -o -z "$MINOR" -o -z "$PATCH" ]; then
     echo "version.sh: error: could not extract version from include/zmq.h" 1>&2
     exit 1


### PR DESCRIPTION
For the GNU Grep package version >= 3.8, the `egrep` command emits:
```
egrep: warning: egrep is obsolescent; using grep -E
```
which makes the `./autogen.sh` script very noisy.