### PR TITLE
Fix zmq_proxy_steerable

### DIFF
--- a/doc/zmq_proxy_steerable.txt
+++ b/doc/zmq_proxy_steerable.txt
@@ -19,21 +19,21 @@ The _zmq_proxy_steerable()_ function is a variant of the _zmq_proxy()_ function.
 It accepts a fourth _control_ socket.  When the _control_ socket is _NULL_ the
 two functions operate identically.
 
-When a _control_ socket of type _REP_ is provided to the proxy function the
+When a _control_ socket of type _REP_ or _PAIR_ is provided to the proxy function the
 application may send commands to the proxy.  The following commands are
 supported.
 
 _PAUSE_::
-    The proxy will cease transferring messages between its endpoints.
+    The proxy will cease transferring messages between its endpoints.  _REP_ control socket will reply with an empty message. No response otherwise.
 
 _RESUME_::
-    The proxy will resume transferring messages between its endpoints.
+    The proxy will resume transferring messages between its endpoints.  _REP_ control socket will reply with an empty message. No response otherwise. 
 
 _TERMINATE_::
-    The proxy function will exit with a return value of 0.
+    The proxy function will exit with a return value of 0.  _REP_ control socket will reply with an empty message. No response otherwise.
 
 _STATISTICS_::
-    The proxy behavior will remain unchanged and reply with a set of simple summary values of the messages that have been sent through the proxy as described next.
+    The proxy state will remain unchanged and reply with a set of simple summary values of the messages that have been sent through the proxy as described next. Control socket must support sending.
 
 There are eight statistics values, each of size _uint64_t_ in the multi-part
 message reply to the _STATISTICS_ command.  These are:
@@ -53,6 +53,8 @@ message reply to the _STATISTICS_ command.  These are:
 - number of messages sent by the backend socket
 
 - number of bytes sent by the backend socket
+
+Message totals count each part in a multipart message individually.
 
 
 RETURN VALUE

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -189,10 +189,10 @@ static int handle_control (class zmq::socket_base_t *control_,
         return 0;
     }
 
-    if (msiz == 5 && memcmp (command, "\x05PAUSE", 6)) {
-        state = active;
-    } else if (msiz == 6 && 0 == memcmp (command, "RESUME", 6)) {
+    if (msiz == 5 && 0 == memcmp (command, "PAUSE", 5)) {
         state = paused;
+    } else if (msiz == 6 && 0 == memcmp (command, "RESUME", 6)) {
+        state = active;
     } else if (msiz == 9 && 0 == memcmp (command, "TERMINATE", 9)) {
         state = terminated;
     }

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -197,11 +197,16 @@ static int handle_control (class zmq::socket_base_t *control_,
         state = terminated;
     }
 
-    // satisfy REP duty and reply no matter what.
-    cmsg.init_size (0);
-    rc = control_->send (&cmsg, 0);
-    if (unlikely (rc < 0)) {
-        return -1;
+    int type;
+    size_t sz = sizeof (type);
+    zmq_getsockopt (control_, ZMQ_TYPE, &type, &sz);
+    if (type == ZMQ_REP) {
+        // satisfy REP duty and reply no matter what.
+        cmsg.init_size (0);
+        rc = control_->send (&cmsg, 0);
+        if (unlikely (rc < 0)) {
+            return -1;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
Continuing Brett's work on zmq_proxy_steerable here: https://github.com/zeromq/libzmq/pull/4598

2 problems addressed (split into 2 commits):
1. PAUSE/RESUME commands were seemingly mixed up and the test didn't cover it.
2. The reimplementation changed behaviour by always replying for the simple commands PAUSE, RESUME, TERMINATE, so ZMQ_PAIR usage would have to change when migrating.

I agree that REP makes the most sense for the control socket type, but prior semantics of the control socket pretty much dictated the use ZMQ_PAIR, so this just restores backwards compatibility.


New test assertions with existing src/proxy.cpp:
```
steer: sending STATISTICS - post-pause                                             
stats: client pkts out: 15 worker pkts out: 32 { 30 345 64 736 64 736 30 345 }     
tests/test_proxy_steerable.cpp:465:test_proxy_steerable:FAIL: Expected 575 Was 1081
```