### PR TITLE
allow the max_vsm_size of data can init as vsm type msg

### DIFF
--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -32,7 +32,7 @@ int zmq::msg_t::init (void *data_,
                       void *hint_,
                       content_t *content_)
 {
-    if (size_ < max_vsm_size) {
+    if (size_ <= max_vsm_size) {
         const int rc = init_size (size_);
 
         if (rc != -1) {


### PR DESCRIPTION
the init message of vsm size should be <= max_vsm_size include equal size.