### PR TITLE
Introduce SAL2 annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ zeromq-*.zip
 core
 
 mybuild
+/.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1176,7 +1176,7 @@ if(MINGW)
   endif()
 endif()
 
-set(public_headers include/zmq.h include/zmq_utils.h)
+set(public_headers include/zmq.h include/zmq_utils.h include/zmq_sal.h)
 
 set(readme-docs AUTHORS LICENSE NEWS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ lib_LTLIBRARIES = src/libzmq.la
 
 include_HEADERS = \
 	include/zmq.h \
+	include/zmq_sal.h \
 	include/zmq_utils.h
 
 src_libzmq_la_SOURCES = \
@@ -275,6 +276,7 @@ src_libzmq_la_SOURCES = \
 	src/zap_client.hpp \
 	src/zmtp_engine.cpp \
 	src/zmtp_engine.hpp \
+	src/zmq_sal.h \
 	src/zmq_draft.h
 
 if USE_WEPOLL

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -33,7 +33,7 @@ extern "C" {
 
 /* Include Microsoft SAL header, or no-nothing macros depending on platform */
 
-#include <zmq_sal.h>
+#include "zmq_sal.h"
 
 /*  Handle DSO symbol visibility                                             */
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -31,7 +31,9 @@ extern "C" {
 #include <stddef.h>
 #include <stdio.h>
 
-#include <zmq_sal.h>
+/* Include Microsoft SAL header, or no-nothing macros depending on platform */
+
+#include "zmq_sal.h"
 
 /*  Handle DSO symbol visibility                                             */
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -31,7 +31,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdio.h>
 
-#include "zmq_sal.h"
+#include <zmq_sal.h>
 
 /*  Handle DSO symbol visibility                                             */
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -33,7 +33,7 @@ extern "C" {
 
 /* Include Microsoft SAL header, or no-nothing macros depending on platform */
 
-#include "zmq_sal.h"
+#include <zmq_sal.h>
 
 /*  Handle DSO symbol visibility                                             */
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -32,7 +32,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdio.h>
 
-/* Include Microsoft SAL header, or no-nothing macros depending on platform */
+/* Include Microsoft SAL header, or no-nothing macros depending on platform  */
 
 #include "zmq_sal.h"
 

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -31,28 +31,65 @@ extern "C" {
 #include <stddef.h>
 #include <stdio.h>
 
+#include "zmq_sal.h"
+
 /*  Handle DSO symbol visibility                                             */
+
 #if defined ZMQ_NO_EXPORT
-#define ZMQ_EXPORT
+#define ZMQ_LINKAGE
 #else
 #if defined _WIN32
 #if defined ZMQ_STATIC
-#define ZMQ_EXPORT
+#define ZMQ_LINKAGE
 #elif defined DLL_EXPORT
-#define ZMQ_EXPORT __declspec(dllexport)
+#define ZMQ_LINKAGE __declspec (dllexport)
 #else
-#define ZMQ_EXPORT __declspec(dllimport)
+#define ZMQ_LINKAGE __declspec (dllimport)
 #endif
 #else
 #if defined __SUNPRO_C || defined __SUNPRO_CC
-#define ZMQ_EXPORT __global
+#define ZMQ_LINKAGE __global
 #elif (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
-#define ZMQ_EXPORT __attribute__ ((visibility ("default")))
+#define ZMQ_LINKAGE __attribute__ ((visibility ("default")))
 #else
-#define ZMQ_EXPORT
+#define ZMQ_LINKAGE
 #endif
 #endif
 #endif
+
+#define ZMQ_EXPORT_IMPL(__returntype__)                                        \
+    _Check_return_ _Success_ (return == 0) __returntype__
+#define ZMQ_EXPORT(__returntype__) ZMQ_LINKAGE ZMQ_EXPORT_IMPL (__returntype__)
+
+#define ZMQ_EXPORT_VOID_IMPL void
+#define ZMQ_EXPORT_VOID ZMQ_LINKAGE ZMQ_EXPORT_VOID_IMPL
+
+#define ZMQ_EXPORT_VOID_PTR_IMPL void*
+#define ZMQ_EXPORT_VOID_PTR ZMQ_LINKAGE ZMQ_EXPORT_VOID_PTR_IMPL
+
+#define ZMQ_EXPORT_PTR_IMPL(__returntype__, __underlyingtype__)                \
+    _Must_inspect_result_ _Success_ (return != NULL)                           \
+      _Ret_writes_bytes_ (sizeof (__underlyingtype__)) __returntype__
+#define ZMQ_EXPORT_PTR(__returntype__, __underlyingtype__)                     \
+    ZMQ_LINKAGE ZMQ_EXPORT_PTR_IMPL (__returntype__, __underlyingtype__)
+
+#define ZMQ_EXPORT_BUF_SIZE_IMPL(__returntype__, __underlyingsize__)           \
+    _Must_inspect_result_ _Success_ (return != NULL)                           \
+      _Ret_writes_bytes_ (__underlyingsize__) __returntype__
+#define ZMQ_EXPORT_BUF_SIZE(__returntype__, __underlyingsize__)                \
+    ZMQ_LINKAGE ZMQ_EXPORT_BUF_SIZE_IMPL (__returntype__, __underlyingsize__)
+
+#define ZMQ_EXPORT_STR_IMPL(__returntype__)                                    \
+    _Must_inspect_result_ _Success_ (return != NULL)                           \
+      _When_ (return != NULL, _Ret_z_) __returntype__
+#define ZMQ_EXPORT_STR(__returntype__)                                         \
+    ZMQ_LINKAGE ZMQ_EXPORT_STR_IMPL (__returntype__)
+
+#define ZMQ_EXPORT_STR_SIZE_IMPL(__returntype__, __underlyingsize__)           \
+    _Must_inspect_result_ _Success_ (return != NULL)                           \
+      _Ret_writes_z_ (__underlyingsize__) __returntype__
+#define ZMQ_EXPORT_STR_SIZE(__returntype__, __underlyingsize__)                \
+    ZMQ_LINKAGE ZMQ_EXPORT_STR_SIZE_IMPL (__returntype__, __underlyingsize__)
 
 /*  Define integer types needed for event interface                          */
 #define ZMQ_DEFINED_STDINT 1
@@ -165,13 +202,14 @@ typedef unsigned __int8 uint8_t;
 /*  of this function is to make the code 100% portable, including where 0MQ   */
 /*  compiled with certain CRT library (on Windows) is linked to an            */
 /*  application that uses different CRT library.                              */
-ZMQ_EXPORT int zmq_errno (void);
+ZMQ_EXPORT (int) zmq_errno (void);
 
 /*  Resolves system errors and 0MQ errors to human-readable string.           */
-ZMQ_EXPORT const char *zmq_strerror (int errnum_);
+ZMQ_EXPORT_STR (const char *) zmq_strerror (int errnum_);
 
 /*  Run-time API version detection                                            */
-ZMQ_EXPORT void zmq_version (int *major_, int *minor_, int *patch_);
+ZMQ_EXPORT_VOID
+zmq_version (_Out_ int *major_, _Out_ int *minor_, _Out_ int *patch_);
 
 /******************************************************************************/
 /*  0MQ infrastructure (a.k.a. context) initialisation & termination.         */
@@ -195,17 +233,17 @@ ZMQ_EXPORT void zmq_version (int *major_, int *minor_, int *patch_);
 #define ZMQ_THREAD_PRIORITY_DFLT -1
 #define ZMQ_THREAD_SCHED_POLICY_DFLT -1
 
-ZMQ_EXPORT void *zmq_ctx_new (void);
-ZMQ_EXPORT int zmq_ctx_term (void *context_);
-ZMQ_EXPORT int zmq_ctx_shutdown (void *context_);
-ZMQ_EXPORT int zmq_ctx_set (void *context_, int option_, int optval_);
-ZMQ_EXPORT int zmq_ctx_get (void *context_, int option_);
+ZMQ_EXPORT_PTR (void *, zmq::ctx_t) zmq_ctx_new (void);
+ZMQ_EXPORT (int) zmq_ctx_term (_In_ _Post_invalid_ void *context_);
+ZMQ_EXPORT (int) zmq_ctx_shutdown (_Inout_ void *context_);
+ZMQ_EXPORT (int) zmq_ctx_set (_Inout_ void *context_, int option_, int optval_);
+ZMQ_EXPORT (int) zmq_ctx_get (_In_ void *context_, int option_);
 
 /*  Old (legacy) API                                                          */
-ZMQ_EXPORT void *zmq_init (int io_threads_);
-ZMQ_EXPORT int zmq_term (void *context_);
-ZMQ_EXPORT int zmq_ctx_destroy (void *context_);
-
+ZMQ_EXPORT_PTR (void *, zmq::ctx_t)
+zmq_init (_In_range_ (0, INT_MAX) int io_threads_);
+ZMQ_EXPORT (int) zmq_term (_In_ _Post_invalid_ void *context_);
+ZMQ_EXPORT (int) zmq_ctx_destroy (_In_ _Post_invalid_ void *context_);
 
 /******************************************************************************/
 /*  0MQ message definition.                                                   */
@@ -231,24 +269,36 @@ typedef struct zmq_msg_t
 #endif
 } zmq_msg_t;
 
-typedef void (zmq_free_fn) (void *data_, void *hint_);
+typedef void (zmq_free_fn) (_Pre_maybenull_ _Post_invalid_ void *data_,
+                            _In_opt_ void *hint_);
 
-ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg_);
-ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_);
-ZMQ_EXPORT int zmq_msg_init_data (
-  zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
-ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_);
-ZMQ_EXPORT int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_);
-ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg_);
-ZMQ_EXPORT int zmq_msg_move (zmq_msg_t *dest_, zmq_msg_t *src_);
-ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest_, zmq_msg_t *src_);
-ZMQ_EXPORT void *zmq_msg_data (zmq_msg_t *msg_);
-ZMQ_EXPORT size_t zmq_msg_size (const zmq_msg_t *msg_);
-ZMQ_EXPORT int zmq_msg_more (const zmq_msg_t *msg_);
-ZMQ_EXPORT int zmq_msg_get (const zmq_msg_t *msg_, int property_);
-ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg_, int property_, int optval_);
-ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
-                                     const char *property_);
+_At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT (int)
+  zmq_msg_init (_Out_ zmq_msg_t *msg_);
+_At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT (int)
+  zmq_msg_init_size (_Out_ zmq_msg_t *msg_, size_t size_);
+ZMQ_EXPORT (int)
+_At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_)
+  zmq_msg_init_data (_Out_ zmq_msg_t *msg_,
+                     _In_reads_bytes_opt_ (size_) void *data_,
+                     size_t size_,
+                     _In_opt_ zmq_free_fn *ffn_,
+                     _In_opt_ void *hint_);
+ZMQ_EXPORT (int) zmq_msg_send (_In_ zmq_msg_t *msg_, _In_ void *s_, int flags_);
+ZMQ_EXPORT (int)
+zmq_msg_recv (_Out_ zmq_msg_t *msg_, _In_ void *s_, int flags_);
+ZMQ_EXPORT (int) zmq_msg_close (_Inout_ zmq_msg_t *msg_);
+ZMQ_EXPORT (int)
+zmq_msg_move (_Inout_ zmq_msg_t *dest_, _Inout_ zmq_msg_t *src_);
+ZMQ_EXPORT (int)
+zmq_msg_copy (_Inout_ zmq_msg_t *dest_, _Inout_ zmq_msg_t *src_);
+ZMQ_EXPORT_VOID_PTR zmq_msg_data (_In_ zmq_msg_t *msg_);
+ZMQ_EXPORT (size_t) zmq_msg_size (_In_ const zmq_msg_t *msg_);
+ZMQ_EXPORT (int) zmq_msg_more (_In_ const zmq_msg_t *msg_);
+ZMQ_EXPORT (int) zmq_msg_get (_In_ const zmq_msg_t *msg_, int property_);
+ZMQ_EXPORT (int)
+zmq_msg_set (_Inout_ zmq_msg_t *msg_, int property_, int optval_);
+ZMQ_EXPORT_STR (const char *)
+zmq_msg_gets (_In_ const zmq_msg_t *msg_, _In_z_ const char *property_);
 
 /******************************************************************************/
 /*  0MQ socket definition.                                                    */
@@ -444,21 +494,40 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
 #define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 #define ZMQ_PROTOCOL_ERROR_WS_UNSPECIFIED 0x30000000
 
-ZMQ_EXPORT void *zmq_socket (void *, int type_);
-ZMQ_EXPORT int zmq_close (void *s_);
-ZMQ_EXPORT int
-zmq_setsockopt (void *s_, int option_, const void *optval_, size_t optvallen_);
-ZMQ_EXPORT int
-zmq_getsockopt (void *s_, int option_, void *optval_, size_t *optvallen_);
-ZMQ_EXPORT int zmq_bind (void *s_, const char *addr_);
-ZMQ_EXPORT int zmq_connect (void *s_, const char *addr_);
-ZMQ_EXPORT int zmq_unbind (void *s_, const char *addr_);
-ZMQ_EXPORT int zmq_disconnect (void *s_, const char *addr_);
-ZMQ_EXPORT int zmq_send (void *s_, const void *buf_, size_t len_, int flags_);
-ZMQ_EXPORT int
-zmq_send_const (void *s_, const void *buf_, size_t len_, int flags_);
-ZMQ_EXPORT int zmq_recv (void *s_, void *buf_, size_t len_, int flags_);
-ZMQ_EXPORT int zmq_socket_monitor (void *s_, const char *addr_, int events_);
+ZMQ_EXPORT_PTR (void *, zmq::socket_base_t)
+zmq_socket (_In_ void *context_, int type_);
+ZMQ_EXPORT (int) zmq_close (_In_ void *s_);
+ZMQ_EXPORT (int)
+zmq_setsockopt (_In_ void *s_,
+                int option_,
+                _In_reads_bytes_ (optvallen_) const void *optval_,
+                size_t optvallen_);
+ZMQ_EXPORT (int)
+zmq_getsockopt (_In_ void *s_,
+                int option_,
+                _Out_writes_bytes_ (*optvallen_) void *optval_,
+                _Inout_ size_t *optvallen_);
+ZMQ_EXPORT (int) zmq_bind (_In_ void *s_, _In_z_ const char *addr_);
+ZMQ_EXPORT (int) zmq_connect (_In_ void *s_, _In_z_ const char *addr_);
+ZMQ_EXPORT (int) zmq_unbind (_In_ void *s_, _In_z_ const char *addr_);
+ZMQ_EXPORT (int) zmq_disconnect (_In_ void *s_, _In_z_ const char *addr_);
+ZMQ_EXPORT (int)
+zmq_send (_In_ void *s_,
+          _In_reads_bytes_ (len_) const void *buf_,
+          size_t len_,
+          int flags_);
+ZMQ_EXPORT (int)
+zmq_send_const (_In_ void *s_,
+                _In_reads_bytes_ (len_) const void *buf_,
+                size_t len_,
+                int flags_);
+ZMQ_EXPORT (int)
+zmq_recv (_In_ void *s_,
+          _Out_writes_bytes_ (len_) void *buf_,
+          size_t len_,
+          int flags_);
+ZMQ_EXPORT (int)
+zmq_socket_monitor (_In_ void *s_, _In_z_ const char *addr_, int events_);
 
 /******************************************************************************/
 /*  Hide socket fd type; this was before zmq_poller_event_t typedef below     */
@@ -494,24 +563,29 @@ typedef struct zmq_pollitem_t
 
 #define ZMQ_POLLITEMS_DFLT 16
 
-ZMQ_EXPORT int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_);
+ZMQ_EXPORT (int)
+zmq_poll (_In_reads_ (nitems_) zmq_pollitem_t *items_,
+          int nitems_,
+          long timeout_);
 
 /******************************************************************************/
 /*  Message proxying                                                          */
 /******************************************************************************/
 
-ZMQ_EXPORT int zmq_proxy (void *frontend_, void *backend_, void *capture_);
-ZMQ_EXPORT int zmq_proxy_steerable (void *frontend_,
-                                    void *backend_,
-                                    void *capture_,
-                                    void *control_);
+ZMQ_EXPORT (int)
+zmq_proxy (_In_ void *frontend_, _In_ void *backend_, _In_opt_ void *capture_);
+ZMQ_EXPORT (int)
+zmq_proxy_steerable (_In_ void *frontend_,
+                     _In_ void *backend_,
+                     _In_opt_ void *capture_,
+                     _In_opt_ void *control_);
 
 /******************************************************************************/
 /*  Probe library capabilities                                                */
 /******************************************************************************/
 
 #define ZMQ_HAS_CAPABILITIES 1
-ZMQ_EXPORT int zmq_has (const char *capability_);
+ZMQ_EXPORT (int) zmq_has (_In_z_ const char *capability_);
 
 /*  Deprecated aliases */
 #define ZMQ_STREAMER 1
@@ -519,45 +593,61 @@ ZMQ_EXPORT int zmq_has (const char *capability_);
 #define ZMQ_QUEUE 3
 
 /*  Deprecated methods */
-ZMQ_EXPORT int zmq_device (int type_, void *frontend_, void *backend_);
-ZMQ_EXPORT int zmq_sendmsg (void *s_, zmq_msg_t *msg_, int flags_);
-ZMQ_EXPORT int zmq_recvmsg (void *s_, zmq_msg_t *msg_, int flags_);
+ZMQ_EXPORT (int)
+zmq_device (int type_, _In_ void *frontend_, _In_ void *backend_);
+ZMQ_EXPORT (int) zmq_sendmsg (_In_ void *s_, _In_ zmq_msg_t *msg_, int flags_);
+ZMQ_EXPORT (int) zmq_recvmsg (_In_ void *s_, _Out_ zmq_msg_t *msg_, int flags_);
 struct iovec;
-ZMQ_EXPORT int
-zmq_sendiov (void *s_, struct iovec *iov_, size_t count_, int flags_);
-ZMQ_EXPORT int
-zmq_recviov (void *s_, struct iovec *iov_, size_t *count_, int flags_);
+ZMQ_EXPORT (int)
+zmq_sendiov (_In_ void *s_,
+             _In_reads_ (count_) struct iovec *iov_,
+             size_t count_,
+             int flags_);
+ZMQ_EXPORT (int)
+zmq_recviov (_In_ void *s_,
+             _In_reads_ (*count_) struct iovec *iov_,
+             _Inout_ size_t *count_,
+             int flags_);
 
 /******************************************************************************/
 /*  Encryption functions                                                      */
 /******************************************************************************/
 
 /*  Encode data with Z85 encoding. Returns encoded data                       */
-ZMQ_EXPORT char *
-zmq_z85_encode (char *dest_, const uint8_t *data_, size_t size_);
+ZMQ_EXPORT_STR_SIZE (char *, size_ * 4 / 5 + 1)
+zmq_z85_encode (_Out_writes_z_ (size_ * 4 / 5 + 1) char *dest_,
+                _In_reads_bytes_ (size_) const uint8_t *data_,
+                size_t size_);
 
 /*  Decode data with Z85 encoding. Returns decoded data                       */
-ZMQ_EXPORT uint8_t *zmq_z85_decode (uint8_t *dest_, const char *string_);
+ZMQ_EXPORT_BUF_SIZE (uint8_t *, _String_length_ (string_) * 4 / 5)
+zmq_z85_decode (_Out_writes_bytes_ (_String_length_ (string_) * 4 / 5)
+                  uint8_t *dest_,
+                _In_z_ const char *string_);
 
 /*  Generate z85-encoded public and private keypair with libsodium. */
 /*  Returns 0 on success.                                                     */
-ZMQ_EXPORT int zmq_curve_keypair (char *z85_public_key_, char *z85_secret_key_);
+ZMQ_EXPORT (int)
+zmq_curve_keypair (_Out_writes_z_ (41) char *z85_public_key_,
+                   _Out_writes_z_ (41) char *z85_secret_key_);
 
 /*  Derive the z85-encoded public key from the z85-encoded secret key.        */
 /*  Returns 0 on success.                                                     */
-ZMQ_EXPORT int zmq_curve_public (char *z85_public_key_,
-                                 const char *z85_secret_key_);
+ZMQ_EXPORT (int)
+zmq_curve_public (_Out_writes_z_ (41) char *z85_public_key_,
+                  _In_reads_z_ (41) const char *z85_secret_key_);
 
 /******************************************************************************/
 /*  Atomic utility methods                                                    */
 /******************************************************************************/
 
-ZMQ_EXPORT void *zmq_atomic_counter_new (void);
-ZMQ_EXPORT void zmq_atomic_counter_set (void *counter_, int value_);
-ZMQ_EXPORT int zmq_atomic_counter_inc (void *counter_);
-ZMQ_EXPORT int zmq_atomic_counter_dec (void *counter_);
-ZMQ_EXPORT int zmq_atomic_counter_value (void *counter_);
-ZMQ_EXPORT void zmq_atomic_counter_destroy (void **counter_p_);
+ZMQ_EXPORT_PTR (void *, zmq::atomic_counter_t) zmq_atomic_counter_new (void);
+ZMQ_EXPORT_VOID zmq_atomic_counter_set (_Inout_ void *counter_, int value_);
+ZMQ_EXPORT (int) zmq_atomic_counter_inc (_Inout_ void *counter_);
+ZMQ_EXPORT (int) zmq_atomic_counter_dec (_Inout_ void *counter_);
+ZMQ_EXPORT (int) zmq_atomic_counter_value (_In_ void *counter_);
+ZMQ_EXPORT_VOID
+zmq_atomic_counter_destroy (_Inout_ _Deref_post_null_ void **counter_p_);
 
 /******************************************************************************/
 /*  Scheduling timers                                                         */
@@ -565,18 +655,22 @@ ZMQ_EXPORT void zmq_atomic_counter_destroy (void **counter_p_);
 
 #define ZMQ_HAVE_TIMERS
 
-typedef void (zmq_timer_fn) (int timer_id, void *arg);
+typedef void (zmq_timer_fn) (int timer_id_, _In_opt_ void *arg_);
 
-ZMQ_EXPORT void *zmq_timers_new (void);
-ZMQ_EXPORT int zmq_timers_destroy (void **timers_p);
-ZMQ_EXPORT int
-zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
-ZMQ_EXPORT int zmq_timers_cancel (void *timers, int timer_id);
-ZMQ_EXPORT int
-zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
-ZMQ_EXPORT int zmq_timers_reset (void *timers, int timer_id);
-ZMQ_EXPORT long zmq_timers_timeout (void *timers);
-ZMQ_EXPORT int zmq_timers_execute (void *timers);
+ZMQ_EXPORT_PTR (void *, zmq::timers_t) zmq_timers_new (void);
+ZMQ_EXPORT (int)
+zmq_timers_destroy (_Inout_ _Deref_post_null_ void **timers_p_);
+ZMQ_EXPORT (int)
+zmq_timers_add (_In_ void *timers_,
+                size_t interval_,
+                _In_ zmq_timer_fn handler_,
+                _In_opt_ void *arg_);
+ZMQ_EXPORT (int) zmq_timers_cancel (_In_ void *timers_, int timer_id_);
+ZMQ_EXPORT (int)
+zmq_timers_set_interval (_In_ void *timers_, int timer_id_, size_t interval_);
+ZMQ_EXPORT (int) zmq_timers_reset (_In_ void *timers_, int timer_id_);
+ZMQ_EXPORT (long) zmq_timers_timeout (_In_ void *timers_);
+ZMQ_EXPORT (int) zmq_timers_execute (_In_ void *timers_);
 
 
 /******************************************************************************/
@@ -589,26 +683,28 @@ ZMQ_EXPORT int zmq_timers_execute (void *timers);
 /*  about minutiae of time-related functions on different OS platforms.       */
 
 /*  Starts the stopwatch. Returns the handle to the watch.                    */
-ZMQ_EXPORT void *zmq_stopwatch_start (void);
+ZMQ_EXPORT_PTR (void *, uint64_t) zmq_stopwatch_start (void);
 
 /*  Returns the number of microseconds elapsed since the stopwatch was        */
 /*  started, but does not stop or deallocate the stopwatch.                   */
-ZMQ_EXPORT unsigned long zmq_stopwatch_intermediate (void *watch_);
+ZMQ_EXPORT (unsigned long) zmq_stopwatch_intermediate (_In_ void *watch_);
 
 /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
 /*  the stopwatch was started, and deallocates that watch.                    */
-ZMQ_EXPORT unsigned long zmq_stopwatch_stop (void *watch_);
+ZMQ_EXPORT (unsigned long)
+zmq_stopwatch_stop (_In_ _Post_invalid_ void *watch_);
 
 /*  Sleeps for specified number of seconds.                                   */
-ZMQ_EXPORT void zmq_sleep (int seconds_);
+ZMQ_EXPORT_VOID zmq_sleep (int seconds_);
 
-typedef void (zmq_thread_fn) (void *);
+typedef void (zmq_thread_fn) (_In_opt_ void *);
 
 /* Start a thread. Returns a handle to the thread.                            */
-ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn *func_, void *arg_);
+ZMQ_EXPORT (void *)
+zmq_threadstart (_In_ zmq_thread_fn *func_, _In_opt_ void *arg_);
 
 /* Wait for thread to complete then free up resources.                        */
-ZMQ_EXPORT void zmq_threadclose (void *thread_);
+ZMQ_EXPORT_VOID zmq_threadclose (_In_ _Post_invalid_ void *thread_);
 
 
 /******************************************************************************/
@@ -679,27 +775,34 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_ZERO_COPY_RECV 10
 
 /*  DRAFT Context methods.                                                    */
-ZMQ_EXPORT int zmq_ctx_set_ext (void *context_,
-                                int option_,
-                                const void *optval_,
-                                size_t optvallen_);
-ZMQ_EXPORT int zmq_ctx_get_ext (void *context_,
-                                int option_,
-                                void *optval_,
-                                size_t *optvallen_);
+ZMQ_EXPORT (int)
+zmq_ctx_set_ext (_In_ void *context_,
+                 int option_,
+                 _In_reads_bytes_ (optvallen_) const void *optval_,
+                 size_t optvallen_);
+ZMQ_EXPORT (int)
+zmq_ctx_get_ext (_In_ void *context_,
+                 int option_,
+                 _Out_writes_bytes_ (*optvallen_) void *optval_,
+                 size_t *optvallen_);
 
 /*  DRAFT Socket methods.                                                     */
-ZMQ_EXPORT int zmq_join (void *s, const char *group);
-ZMQ_EXPORT int zmq_leave (void *s, const char *group);
-ZMQ_EXPORT uint32_t zmq_connect_peer (void *s_, const char *addr_);
+ZMQ_EXPORT (int) zmq_join (_In_ void *s_, _In_z_ const char *group_);
+ZMQ_EXPORT (int) zmq_leave (_In_ void *s_, _In_z_ const char *group_);
+ZMQ_EXPORT (uint32_t)
+zmq_connect_peer (_In_ void *s_, _In_z_ const char *addr_);
 
 /*  DRAFT Msg methods.                                                        */
-ZMQ_EXPORT int zmq_msg_set_routing_id (zmq_msg_t *msg, uint32_t routing_id);
-ZMQ_EXPORT uint32_t zmq_msg_routing_id (zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_set_group (zmq_msg_t *msg, const char *group);
-ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
-ZMQ_EXPORT int
-zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
+ZMQ_EXPORT (int)
+zmq_msg_set_routing_id (_Inout_ zmq_msg_t *msg_, uint32_t routing_id_);
+ZMQ_EXPORT (uint32_t) zmq_msg_routing_id (_Inout_ zmq_msg_t *msg_);
+ZMQ_EXPORT (int)
+zmq_msg_set_group (_Inout_ zmq_msg_t *msg_, _In_z_ const char *group_);
+ZMQ_EXPORT_STR (const char *) zmq_msg_group (_In_ zmq_msg_t *msg_);
+_At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT (int)
+  zmq_msg_init_buffer (_Out_ zmq_msg_t *msg_,
+                       _In_reads_bytes_ (size_) const void *buf_,
+                       size_t size_);
 
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"
@@ -725,29 +828,43 @@ typedef struct zmq_poller_event_t
     short events;
 } zmq_poller_event_t;
 
-ZMQ_EXPORT void *zmq_poller_new (void);
-ZMQ_EXPORT int zmq_poller_destroy (void **poller_p);
-ZMQ_EXPORT int zmq_poller_size (void *poller);
-ZMQ_EXPORT int
-zmq_poller_add (void *poller, void *socket, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify (void *poller, void *socket, short events);
-ZMQ_EXPORT int zmq_poller_remove (void *poller, void *socket);
-ZMQ_EXPORT int
-zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
-ZMQ_EXPORT int zmq_poller_wait_all (void *poller,
-                                    zmq_poller_event_t *events,
-                                    int n_events,
-                                    long timeout);
-ZMQ_EXPORT int zmq_poller_fd (void *poller, zmq_fd_t *fd);
+ZMQ_EXPORT_PTR (void *, zmq::socket_poller_t) zmq_poller_new (void);
+ZMQ_EXPORT (int)
+zmq_poller_destroy (_Inout_ _Deref_post_null_ void **poller_p_);
+ZMQ_EXPORT (int) zmq_poller_size (_In_ void *poller_);
+ZMQ_EXPORT (int)
+zmq_poller_add (_In_ void *poller_,
+                _In_ void *socket_,
+                _In_opt_ void *user_data_,
+                short events_);
+ZMQ_EXPORT (int)
+zmq_poller_modify (_In_ void *poller_, _In_ void *socket_, short events_);
+ZMQ_EXPORT (int) zmq_poller_remove (_In_ void *poller_, _In_ void *socket_);
+ZMQ_EXPORT (int)
+zmq_poller_wait (_In_ void *poller_,
+                 _In_ zmq_poller_event_t *event_,
+                 long timeout_);
+ZMQ_EXPORT (int)
+zmq_poller_wait_all (_In_ void *poller_,
+                     _In_reads_ (n_events_) zmq_poller_event_t *events_,
+                     int n_events_,
+                     long timeout_);
+ZMQ_EXPORT (int) zmq_poller_fd (_In_ void *poller_, _In_ zmq_fd_t *fd_);
 
-ZMQ_EXPORT int
-zmq_poller_add_fd (void *poller, zmq_fd_t fd, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, zmq_fd_t fd, short events);
-ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, zmq_fd_t fd);
+ZMQ_EXPORT (int)
+zmq_poller_add_fd (_In_ void *poller_,
+                   zmq_fd_t fd_,
+                   _In_ void *user_data_,
+                   short events_);
+ZMQ_EXPORT (int)
+zmq_poller_modify_fd (_In_ void *poller_, zmq_fd_t fd_, short events_);
+ZMQ_EXPORT (int) zmq_poller_remove_fd (_In_ void *poller_, zmq_fd_t fd_);
 
-ZMQ_EXPORT int zmq_socket_get_peer_state (void *socket,
-                                          const void *routing_id,
-                                          size_t routing_id_size);
+ZMQ_EXPORT (int)
+zmq_socket_get_peer_state (_In_ void *socket_,
+                           _In_reads_bytes_ (routing_id_size_)
+                             const void *routing_id_,
+                           size_t routing_id_size_);
 
 /*  DRAFT Socket monitoring events                                            */
 #define ZMQ_EVENT_PIPES_STATS 0x10000
@@ -758,21 +875,27 @@ ZMQ_EXPORT int zmq_socket_get_peer_state (void *socket,
 #define ZMQ_EVENT_ALL_V1 ZMQ_EVENT_ALL
 #define ZMQ_EVENT_ALL_V2 ZMQ_EVENT_ALL_V1 | ZMQ_EVENT_PIPES_STATS
 
-ZMQ_EXPORT int zmq_socket_monitor_versioned (
-  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_);
-ZMQ_EXPORT int zmq_socket_monitor_pipes_stats (void *s);
+ZMQ_EXPORT (int)
+zmq_socket_monitor_versioned (_In_ void *s_,
+                              _In_z_ const char *addr_,
+                              uint64_t events_,
+                              int event_version_,
+                              int type_);
+ZMQ_EXPORT (int) zmq_socket_monitor_pipes_stats (_In_ void *s);
 
 #if !defined _WIN32
-ZMQ_EXPORT int zmq_ppoll (zmq_pollitem_t *items_,
-                          int nitems_,
-                          long timeout_,
-                          const sigset_t *sigmask_);
+ZMQ_EXPORT (int)
+zmq_ppoll (zmq_pollitem_t *items_,
+           int nitems_,
+           long timeout_,
+           const sigset_t *sigmask_);
 #else
 // Windows has no sigset_t
-ZMQ_EXPORT int zmq_ppoll (zmq_pollitem_t *items_,
-                          int nitems_,
-                          long timeout_,
-                          const void *sigmask_);
+ZMQ_EXPORT (int)
+zmq_ppoll (_In_reads_ (nitems_) zmq_pollitem_t *items_,
+           int nitems_,
+           long timeout_,
+           _In_ const void *sigmask_);
 #endif
 
 #endif // ZMQ_BUILD_DRAFT_API

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -45,9 +45,9 @@ extern "C" {
 #if defined ZMQ_STATIC
 #define ZMQ_LINKAGE
 #elif defined DLL_EXPORT
-#define ZMQ_LINKAGE __declspec (dllexport)
+#define ZMQ_LINKAGE __declspec(dllexport)
 #else
-#define ZMQ_LINKAGE __declspec (dllimport)
+#define ZMQ_LINKAGE __declspec(dllimport)
 #endif
 #else
 #if defined __SUNPRO_C || defined __SUNPRO_CC
@@ -259,10 +259,10 @@ ZMQ_EXPORT (int) zmq_ctx_destroy (_In_ _Post_invalid_ void *context_);
 typedef struct zmq_msg_t
 {
 #if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
-    __declspec (align (8)) unsigned char _[64];
+    __declspec(align (8)) unsigned char _[64];
 #elif defined(_MSC_VER)                                                        \
   && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
-    __declspec (align (4)) unsigned char _[64];
+    __declspec(align (4)) unsigned char _[64];
 #elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
   || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
   || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
+
 /*  *************************************************************************
     NOTE to contributors. This file comprises the principal public contract
     for ZeroMQ API users. Any change to this file supplied in a stable
@@ -66,7 +67,7 @@ extern "C" {
 #define ZMQ_EXPORT_VOID_IMPL void
 #define ZMQ_EXPORT_VOID ZMQ_LINKAGE ZMQ_EXPORT_VOID_IMPL
 
-#define ZMQ_EXPORT_VOID_PTR_IMPL void*
+#define ZMQ_EXPORT_VOID_PTR_IMPL void *
 #define ZMQ_EXPORT_VOID_PTR ZMQ_LINKAGE ZMQ_EXPORT_VOID_PTR_IMPL
 
 #define ZMQ_EXPORT_PTR_IMPL(__returntype__, __underlyingtype__)                \
@@ -258,10 +259,10 @@ ZMQ_EXPORT (int) zmq_ctx_destroy (_In_ _Post_invalid_ void *context_);
 typedef struct zmq_msg_t
 {
 #if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
-    __declspec(align (8)) unsigned char _[64];
+    __declspec (align (8)) unsigned char _[64];
 #elif defined(_MSC_VER)                                                        \
   && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
-    __declspec(align (4)) unsigned char _[64];
+    __declspec (align (4)) unsigned char _[64];
 #elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
   || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
   || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)

--- a/include/zmq_sal.h
+++ b/include/zmq_sal.h
@@ -1,5 +1,21 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 
+/*  *************************************************************************
+    Provides a set of annotations to describe how a function uses its
+    parameters - the assumptions it makes about them, and the guarantees it
+    makes upon finishing.
+    
+    These annotations are used by the static analysis tools to check for
+    common programming errors, such as null pointer dereferences and buffer
+    overruns.
+    
+    They are also used by the compiler to generate more efficient code,
+    and by the IDE to provide better intellisense.
+
+    Code analysis is enabled by adding /analyze to the compiler command line.
+    *************************************************************************
+*/
+
 #ifndef __ZMQ_SAL_H_INCLUDED__
 #define __ZMQ_SAL_H_INCLUDED__
 

--- a/include/zmq_sal.h
+++ b/include/zmq_sal.h
@@ -32,7 +32,7 @@
 #ifndef __ZMQ_SAL_H_INCLUDED__
 #define __ZMQ_SAL_H_INCLUDED__
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (_MSC_VER >= 1700)
 
 #include <sal.h>
 

--- a/include/zmq_sal.h
+++ b/include/zmq_sal.h
@@ -252,6 +252,10 @@ _Analysis_mode_ (_Analysis_local_leak_checks_)
 #undef _Lock_level_order_
 #endif
 #define _Lock_level_order_(n1, n2)
+#ifdef _Analysis_assume_
+#undef _Analysis_assume_
+#endif
+#define _Analysis_assume_(e)
 #ifdef _Analysis_assume_lock_acquired_
 #undef _Analysis_assume_lock_acquired_
 #endif

--- a/include/zmq_sal.h
+++ b/include/zmq_sal.h
@@ -1,0 +1,1045 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#ifndef __ZMQ_SAL_H_INCLUDED__
+#define __ZMQ_SAL_H_INCLUDED__
+
+#if defined(_MSC_VER)
+
+#include <sal.h>
+
+_Analysis_mode_ (_Analysis_code_type_user_code_)
+_Analysis_mode_ (_Analysis_local_leak_checks_)
+
+#else
+/* Redefine all SAL2 annotation macros to be harmless */
+#ifdef _When_
+#undef _When_
+#endif
+#define _When_(c, a)
+#ifdef _At_
+#undef _At_
+#endif
+#define _At_(t, a)
+#ifdef _At_buffer_
+#undef _At_buffer_
+#endif
+#define _At_buffer_(t, i, c, a)
+#ifdef _Group_
+#undef _Group_
+#endif
+#define _Group_(a)
+#ifdef _Pre_
+#undef _Pre_
+#endif
+#define _Pre_
+#ifdef _Post_
+#undef _Post_
+#endif
+#define _Post_
+#ifdef _Deref_
+#undef _Deref_
+#endif
+#define _Deref_
+#ifdef _Null_
+#undef _Null_
+#endif
+#define _Null_
+#ifdef _Notnull_
+#undef _Notnull_
+#endif
+#define _Notnull_
+#ifdef _Maybenull_
+#undef _Maybenull_
+#endif
+#define _Maybenull_
+#ifdef _Const_
+#undef _Const_
+#endif
+#define _Const_
+#ifdef _Check_return_
+#undef _Check_return_
+#endif
+#define _Check_return_
+#ifdef _Must_inspect_result_
+#undef _Must_inspect_result_
+#endif
+#define _Must_inspect_result_
+#ifdef _Pre_satisfies_
+#undef _Pre_satisfies_
+#endif
+#define _Pre_satisfies_(e)
+#ifdef _Post_satisfies_
+#undef _Post_satisfies_
+#endif
+#define _Post_satisfies_(e)
+#ifdef _Writable_elements_
+#undef _Writable_elements_
+#endif
+#define _Writable_elements_(s)
+#ifdef _Writable_bytes_
+#undef _Writable_bytes_
+#endif
+#define _Writable_bytes_(s)
+#ifdef _Readable_elements_
+#undef _Readable_elements_
+#endif
+#define _Readable_elements_(s)
+#ifdef _Readable_bytes_
+#undef _Readable_bytes_
+#endif
+#define _Readable_bytes_(s)
+#ifdef _Null_terminated_
+#undef _Null_terminated_
+#endif
+#define _Null_terminated_
+#ifdef _NullNull_terminated_
+#undef _NullNull_terminated_
+#endif
+#define _NullNull_terminated_
+#ifdef _Valid_
+#undef _Valid_
+#endif
+#define _Valid_
+#ifdef _Notvalid_
+#undef _Notvalid_
+#endif
+#define _Notvalid_
+#ifdef _Success_
+#undef _Success_
+#endif
+#define _Success_(c)
+#ifdef _Return_type_success_
+#undef _Return_type_success_
+#endif
+#define _Return_type_success_(c)
+#ifdef _On_failure_
+#undef _On_failure_
+#endif
+#define _On_failure_(a)
+#ifdef _Always_
+#undef _Always_
+#endif
+#define _Always_(a)
+#ifdef _Use_decl_annotations_
+#undef _Use_decl_annotations_
+#endif
+#define _Use_decl_annotations_
+#ifdef _Pre_defensive_
+#undef _Pre_defensive_
+#endif
+#define _Pre_defensive_
+#ifdef _Post_defensive_
+#undef _Post_defensive_
+#endif
+#define _Post_defensive_
+#ifdef _Pre_unknown_
+#undef _Pre_unknown_
+#endif
+#define _Pre_unknown_
+#ifdef _Acquires_lock_
+#undef _Acquires_lock_
+#endif
+#define _Acquires_lock_(e)
+#ifdef _Releases_lock_
+#undef _Releases_lock_
+#endif
+#define _Releases_lock_(e)
+#ifdef _Requires_lock_held_
+#undef _Requires_lock_held_
+#endif
+#define _Requires_lock_held_(e)
+#ifdef _Requires_lock_not_held_
+#undef _Requires_lock_not_held_
+#endif
+#define _Requires_lock_not_held_(e)
+#ifdef _Requires_no_locks_held_
+#undef _Requires_no_locks_held_
+#endif
+#define _Requires_no_locks_held_
+#ifdef _Guarded_by_
+#undef _Guarded_by_
+#endif
+#define _Guarded_by_(e)
+#ifdef _Write_guarded_by_
+#undef _Write_guarded_by_
+#endif
+#define _Write_guarded_by_(e)
+#ifdef _Interlocked_
+#undef _Interlocked_
+#endif
+#define _Interlocked_
+#ifdef _Post_same_lock_
+#undef _Post_same_lock_
+#endif
+#define _Post_same_lock_(e1, e2)
+#ifdef _Benign_race_begin_
+#undef _Benign_race_begin_
+#endif
+#define _Benign_race_begin_
+#ifdef _Benign_race_end_
+#undef _Benign_race_end_
+#endif
+#define _Benign_race_end_
+#ifdef _No_competing_thread_
+#undef _No_competing_thread_
+#endif
+#define _No_competing_thread_
+#ifdef _No_competing_thread_begin_
+#undef _No_competing_thread_begin_
+#endif
+#define _No_competing_thread_begin_
+#ifdef _No_competing_thread_end_
+#undef _No_competing_thread_end_
+#endif
+#define _No_competing_thread_end_
+#ifdef _Acquires_shared_lock_
+#undef _Acquires_shared_lock_
+#endif
+#define _Acquires_shared_lock_(e)
+#ifdef _Releases_shared_lock_
+#undef _Releases_shared_lock_
+#endif
+#define _Releases_shared_lock_(e)
+#ifdef _Requires_shared_lock_held_
+#undef _Requires_shared_lock_held_
+#endif
+#define _Requires_shared_lock_held_(e)
+#ifdef _Acquires_exclusive_lock_
+#undef _Acquires_exclusive_lock_
+#endif
+#define _Acquires_exclusive_lock_(e)
+#ifdef _Releases_exclusive_lock_
+#undef _Releases_exclusive_lock_
+#endif
+#define _Releases_exclusive_lock_(e)
+#ifdef _Requires_exclusive_lock_held_
+#undef _Requires_exclusive_lock_held_
+#endif
+#define _Requires_exclusive_lock_held_(e)
+#ifdef _Has_lock_kind_
+#undef _Has_lock_kind_
+#endif
+#define _Has_lock_kind_(n)
+#ifdef _Create_lock_level_
+#undef _Create_lock_level_
+#endif
+#define _Create_lock_level_(n)
+#ifdef _Has_lock_level_
+#undef _Has_lock_level_
+#endif
+#define _Has_lock_level_(n)
+#ifdef _Lock_level_order_
+#undef _Lock_level_order_
+#endif
+#define _Lock_level_order_(n1, n2)
+#ifdef _Analysis_assume_lock_acquired_
+#undef _Analysis_assume_lock_acquired_
+#endif
+#define _Analysis_assume_lock_acquired_(e)
+#ifdef _Analysis_assume_lock_released_
+#undef _Analysis_assume_lock_released_
+#endif
+#define _Analysis_assume_lock_released_(e)
+#ifdef _Analysis_assume_lock_held_
+#undef _Analysis_assume_lock_held_
+#endif
+#define _Analysis_assume_lock_held_(e)
+#ifdef _Analysis_assume_lock_not_held_
+#undef _Analysis_assume_lock_not_held_
+#endif
+#define _Analysis_assume_lock_not_held_(e)
+#ifdef _Analysis_assume_same_lock_
+#undef _Analysis_assume_same_lock_
+#endif
+#define _Analysis_assume_same_lock_(e)
+#ifdef _In_
+#undef _In_
+#endif
+#define _In_
+#ifdef _Out_
+#undef _Out_
+#endif
+#define _Out_
+#ifdef _Inout_
+#undef _Inout_
+#endif
+#define _Inout_
+#ifdef _In_z_
+#undef _In_z_
+#endif
+#define _In_z_
+#ifdef _Inout_z_
+#undef _Inout_z_
+#endif
+#define _Inout_z_
+#ifdef _In_reads_
+#undef _In_reads_
+#endif
+#define _In_reads_(s)
+#ifdef _In_reads_bytes_
+#undef _In_reads_bytes_
+#endif
+#define _In_reads_bytes_(s)
+#ifdef _In_reads_z_
+#undef _In_reads_z_
+#endif
+#define _In_reads_z_(s)
+#ifdef _In_reads_or_z_
+#undef _In_reads_or_z_
+#endif
+#define _In_reads_or_z_(s)
+#ifdef _Out_writes_
+#undef _Out_writes_
+#endif
+#define _Out_writes_(s)
+#ifdef _Out_writes_bytes_
+#undef _Out_writes_bytes_
+#endif
+#define _Out_writes_bytes_(s)
+#ifdef _Out_writes_z_
+#undef _Out_writes_z_
+#endif
+#define _Out_writes_z_(s)
+#ifdef _Inout_updates_
+#undef _Inout_updates_
+#endif
+#define _Inout_updates_(s)
+#ifdef _Inout_updates_bytes_
+#undef _Inout_updates_bytes_
+#endif
+#define _Inout_updates_bytes_(s)
+#ifdef _Inout_updates_z_
+#undef _Inout_updates_z_
+#endif
+#define _Inout_updates_z_(s)
+#ifdef _Out_writes_to_
+#undef _Out_writes_to_
+#endif
+#define _Out_writes_to_(s, c)
+#ifdef _Out_writes_bytes_to_
+#undef _Out_writes_bytes_to_
+#endif
+#define _Out_writes_bytes_to_(s, c)
+#ifdef _Out_writes_all_
+#undef _Out_writes_all_
+#endif
+#define _Out_writes_all_(s)
+#ifdef _Out_writes_bytes_all_
+#undef _Out_writes_bytes_all_
+#endif
+#define _Out_writes_bytes_all_(s)
+#ifdef _Inout_updates_to_
+#undef _Inout_updates_to_
+#endif
+#define _Inout_updates_to_(s, c)
+#ifdef _Inout_updates_bytes_to_
+#undef _Inout_updates_bytes_to_
+#endif
+#define _Inout_updates_bytes_to_(s, c)
+#ifdef _Inout_updates_all_
+#undef _Inout_updates_all_
+#endif
+#define _Inout_updates_all_(s)
+#ifdef _Inout_updates_bytes_all_
+#undef _Inout_updates_bytes_all_
+#endif
+#define _Inout_updates_bytes_all_(s)
+#ifdef _In_reads_to_ptr_
+#undef _In_reads_to_ptr_
+#endif
+#define _In_reads_to_ptr_(p)
+#ifdef _In_reads_to_ptr_z_
+#undef _In_reads_to_ptr_z_
+#endif
+#define _In_reads_to_ptr_z_(p)
+#ifdef _Out_writes_to_ptr_
+#undef _Out_writes_to_ptr_
+#endif
+#define _Out_writes_to_ptr_(p)
+#ifdef _Out_writes_to_ptr_z_
+#undef _Out_writes_to_ptr_z_
+#endif
+#define _Out_writes_to_ptr_z_(p)
+#ifdef _In_opt_
+#undef _In_opt_
+#endif
+#define _In_opt_
+#ifdef _Out_opt_
+#undef _Out_opt_
+#endif
+#define _Out_opt_
+#ifdef _Inout_opt_
+#undef _Inout_opt_
+#endif
+#define _Inout_opt_
+#ifdef _In_opt_z_
+#undef _In_opt_z_
+#endif
+#define _In_opt_z_
+#ifdef _Inout_opt_z_
+#undef _Inout_opt_z_
+#endif
+#define _Inout_opt_z_
+#ifdef _In_reads_opt_
+#undef _In_reads_opt_
+#endif
+#define _In_reads_opt_(s)
+#ifdef _In_reads_opt_z_
+#undef _In_reads_opt_z_
+#endif
+#define _In_reads_opt_z_(s)
+#ifdef _In_reads_bytes_opt_
+#undef _In_reads_bytes_opt_
+#endif
+#define _In_reads_bytes_opt_(s)
+#ifdef _Out_writes_opt_
+#undef _Out_writes_opt_
+#endif
+#define _Out_writes_opt_(s)
+#ifdef _Out_writes_bytes_opt_
+#undef _Out_writes_bytes_opt_
+#endif
+#define _Out_writes_bytes_opt_(s)
+#ifdef _Out_writes_opt_z_
+#undef _Out_writes_opt_z_
+#endif
+#define _Out_writes_opt_z_(s)
+#ifdef _Inout_updates_opt_
+#undef _Inout_updates_opt_
+#endif
+#define _Inout_updates_opt_(s)
+#ifdef _Inout_updates_bytes_opt_
+#undef _Inout_updates_bytes_opt_
+#endif
+#define _Inout_updates_bytes_opt_(s)
+#ifdef _Inout_updates_opt_z_
+#undef _Inout_updates_opt_z_
+#endif
+#define _Inout_updates_opt_z_(s)
+#ifdef _Out_writes_to_opt_
+#undef _Out_writes_to_opt_
+#endif
+#define _Out_writes_to_opt_(s, c)
+#ifdef _Out_writes_bytes_to_opt_
+#undef _Out_writes_bytes_to_opt_
+#endif
+#define _Out_writes_bytes_to_opt_(s, c)
+#ifdef _Out_writes_all_opt_
+#undef _Out_writes_all_opt_
+#endif
+#define _Out_writes_all_opt_(s)
+#ifdef _Out_writes_bytes_all_opt_
+#undef _Out_writes_bytes_all_opt_
+#endif
+#define _Out_writes_bytes_all_opt_(s)
+#ifdef _Inout_updates_to_opt_
+#undef _Inout_updates_to_opt_
+#endif
+#define _Inout_updates_to_opt_(s, c)
+#ifdef _Inout_updates_bytes_to_opt_
+#undef _Inout_updates_bytes_to_opt_
+#endif
+#define _Inout_updates_bytes_to_opt_(s, c)
+#ifdef _Inout_updates_all_opt_
+#undef _Inout_updates_all_opt_
+#endif
+#define _Inout_updates_all_opt_(s)
+#ifdef _Inout_updates_bytes_all_opt_
+#undef _Inout_updates_bytes_all_opt_
+#endif
+#define _Inout_updates_bytes_all_opt_(s)
+#ifdef _In_reads_to_ptr_opt_
+#undef _In_reads_to_ptr_opt_
+#endif
+#define _In_reads_to_ptr_opt_(p)
+#ifdef _In_reads_to_ptr_opt_z_
+#undef _In_reads_to_ptr_opt_z_
+#endif
+#define _In_reads_to_ptr_opt_z_(p)
+#ifdef _Out_writes_to_ptr_opt_
+#undef _Out_writes_to_ptr_opt_
+#endif
+#define _Out_writes_to_ptr_opt_(p)
+#ifdef _Out_writes_to_ptr_opt_z_
+#undef _Out_writes_to_ptr_opt_z_
+#endif
+#define _Out_writes_to_ptr_opt_z_(p)
+#ifdef _Outptr_
+#undef _Outptr_
+#endif
+#define _Outptr_
+#ifdef _Outptr_opt_
+#undef _Outptr_opt_
+#endif
+#define _Outptr_opt_
+#ifdef _Outptr_result_maybenull_
+#undef _Outptr_result_maybenull_
+#endif
+#define _Outptr_result_maybenull_
+#ifdef _Outptr_opt_result_maybenull_
+#undef _Outptr_opt_result_maybenull_
+#endif
+#define _Outptr_opt_result_maybenull_
+#ifdef _Outptr_result_z_
+#undef _Outptr_result_z_
+#endif
+#define _Outptr_result_z_
+#ifdef _Outptr_opt_result_z_
+#undef _Outptr_opt_result_z_
+#endif
+#define _Outptr_opt_result_z_
+#ifdef _Outptr_result_maybenull_z_
+#undef _Outptr_result_maybenull_z_
+#endif
+#define _Outptr_result_maybenull_z_
+#ifdef _Outptr_opt_result_maybenull_z_
+#undef _Outptr_opt_result_maybenull_z_
+#endif
+#define _Outptr_opt_result_maybenull_z_
+#ifdef _COM_Outptr_
+#undef _COM_Outptr_
+#endif
+#define _COM_Outptr_
+#ifdef _COM_Outptr_opt_
+#undef _COM_Outptr_opt_
+#endif
+#define _COM_Outptr_opt_
+#ifdef _COM_Outptr_result_maybenull_
+#undef _COM_Outptr_result_maybenull_
+#endif
+#define _COM_Outptr_result_maybenull_
+#ifdef _COM_Outptr_opt_result_maybenull_
+#undef _COM_Outptr_opt_result_maybenull_
+#endif
+#define _COM_Outptr_opt_result_maybenull_
+#ifdef _Outptr_result_buffer_
+#undef _Outptr_result_buffer_
+#endif
+#define _Outptr_result_buffer_(s)
+#ifdef _Outptr_result_buffer_maybenull_
+#undef _Outptr_result_buffer_maybenull_
+#endif
+#define _Outptr_result_buffer_maybenull_(s)
+#ifdef _Outptr_result_bytebuffer_
+#undef _Outptr_result_bytebuffer_
+#endif
+#define _Outptr_result_bytebuffer_(s)
+#ifdef _Outptr_result_bytebuffer_maybenull_
+#undef _Outptr_result_bytebuffer_maybenull_
+#endif
+#define _Outptr_result_bytebuffer_maybenull_(s)
+#ifdef _Outptr_opt_result_buffer_
+#undef _Outptr_opt_result_buffer_
+#endif
+#define _Outptr_opt_result_buffer_(s)
+#ifdef _Outptr_opt_result_buffer_maybenull_
+#undef _Outptr_opt_result_buffer_maybenull_
+#endif
+#define _Outptr_opt_result_buffer_maybenull_(s)
+#ifdef _Outptr_opt_result_bytebuffer_
+#undef _Outptr_opt_result_bytebuffer_
+#endif
+#define _Outptr_opt_result_bytebuffer_(s)
+#ifdef _Outptr_opt_result_bytebuffer_maybenull_
+#undef _Outptr_opt_result_bytebuffer_maybenull_
+#endif
+#define _Outptr_opt_result_bytebuffer_maybenull_(s)
+#ifdef _Outptr_result_buffer_to_
+#undef _Outptr_result_buffer_to_
+#endif
+#define _Outptr_result_buffer_to_(s, c)
+#ifdef _Outptr_result_bytebuffer_to_
+#undef _Outptr_result_bytebuffer_to_
+#endif
+#define _Outptr_result_bytebuffer_to_(s, c)
+#ifdef _Outptr_opt_result_buffer_to_
+#undef _Outptr_opt_result_buffer_to_
+#endif
+#define _Outptr_opt_result_buffer_to_(s, c)
+#ifdef _Outptr_opt_result_bytebuffer_to_
+#undef _Outptr_opt_result_bytebuffer_to_
+#endif
+#define _Outptr_opt_result_bytebuffer_to_(s, c)
+#ifdef _Ret_
+#undef _Ret_
+#endif
+#define _Ret_
+#ifdef _Ret_valid_
+#undef _Ret_valid_
+#endif
+#define _Ret_valid_
+#ifdef _Ret_z_
+#undef _Ret_z_
+#endif
+#define _Ret_z_
+#ifdef _Ret_writes_
+#undef _Ret_writes_
+#endif
+#define _Ret_writes_(s)
+#ifdef _Ret_writes_bytes_
+#undef _Ret_writes_bytes_
+#endif
+#define _Ret_writes_bytes_(s)
+#ifdef _Ret_writes_z_
+#undef _Ret_writes_z_
+#endif
+#define _Ret_writes_z_(s)
+#ifdef _Ret_writes_to_
+#undef _Ret_writes_to_
+#endif
+#define _Ret_writes_to_(s, c)
+#ifdef _Ret_writes_bytes_to_
+#undef _Ret_writes_bytes_to_
+#endif
+#define _Ret_writes_bytes_to_(s, c)
+#ifdef _Ret_writes_to_ptr_
+#undef _Ret_writes_to_ptr_
+#endif
+#define _Ret_writes_to_ptr_(p)
+#ifdef _Ret_writes_to_ptr_z_
+#undef _Ret_writes_to_ptr_z_
+#endif
+#define _Ret_writes_to_ptr_z_(p)
+#ifdef _Ret_writes_maybenull_
+#undef _Ret_writes_maybenull_
+#endif
+#define _Ret_writes_maybenull_(s)
+#ifdef _Ret_writes_bytes_maybenull_
+#undef _Ret_writes_bytes_maybenull_
+#endif
+#define _Ret_writes_bytes_maybenull_(s)
+#ifdef _Ret_writes_to_maybenull_
+#undef _Ret_writes_to_maybenull_
+#endif
+#define _Ret_writes_to_maybenull_(s, c)
+#ifdef _Ret_writes_bytes_to_maybenull_
+#undef _Ret_writes_bytes_to_maybenull_
+#endif
+#define _Ret_writes_bytes_to_maybenull_(s, c)
+#ifdef _Ret_writes_maybenull_z_
+#undef _Ret_writes_maybenull_z_
+#endif
+#define _Ret_writes_maybenull_z_(s)
+#ifdef _Ret_null_
+#undef _Ret_null_
+#endif
+#define _Ret_null_
+#ifdef _Ret_notnull_
+#undef _Ret_notnull_
+#endif
+#define _Ret_notnull_
+#ifdef _Ret_maybenull_
+#undef _Ret_maybenull_
+#endif
+#define _Ret_maybenull_
+#ifdef _Ret_maybenull_z_
+#undef _Ret_maybenull_z_
+#endif
+#define _Ret_maybenull_z_
+#ifdef _Field_size_
+#undef _Field_size_
+#endif
+#define _Field_size_(s)
+#ifdef _Field_size_opt_
+#undef _Field_size_opt_
+#endif
+#define _Field_size_opt_(s)
+#ifdef _Field_size_bytes_
+#undef _Field_size_bytes_
+#endif
+#define _Field_size_bytes_(s)
+#ifdef _Field_size_bytes_opt_
+#undef _Field_size_bytes_opt_
+#endif
+#define _Field_size_bytes_opt_(s)
+#ifdef _Field_size_part_
+#undef _Field_size_part_
+#endif
+#define _Field_size_part_(s, c)
+#ifdef _Field_size_part_opt_
+#undef _Field_size_part_opt_
+#endif
+#define _Field_size_part_opt_(s, c)
+#ifdef _Field_size_bytes_part_
+#undef _Field_size_bytes_part_
+#endif
+#define _Field_size_bytes_part_(s, c)
+#ifdef _Field_size_bytes_part_opt_
+#undef _Field_size_bytes_part_opt_
+#endif
+#define _Field_size_bytes_part_opt_(s, c)
+#ifdef _Field_size_full_
+#undef _Field_size_full_
+#endif
+#define _Field_size_full_(s)
+#ifdef _Field_size_full_opt_
+#undef _Field_size_full_opt_
+#endif
+#define _Field_size_full_opt_(s)
+#ifdef _Field_size_bytes_full_
+#undef _Field_size_bytes_full_
+#endif
+#define _Field_size_bytes_full_(s)
+#ifdef _Field_size_bytes_full_opt_
+#undef _Field_size_bytes_full_opt_
+#endif
+#define _Field_size_bytes_full_opt_(s)
+#ifdef _Printf_format_string_
+#undef _Printf_format_string_
+#endif
+#define _Printf_format_string_
+#ifdef _Scanf_format_string_
+#undef _Scanf_format_string_
+#endif
+#define _Scanf_format_string_
+#ifdef _Scanf_s_format_string_
+#undef _Scanf_s_format_string_
+#endif
+#define _Scanf_s_format_string_
+#ifdef _Printf_format_string_params_
+#undef _Printf_format_string_params_
+#endif
+#define _Printf_format_string_params_(x)
+#ifdef _Scanf_format_string_params_
+#undef _Scanf_format_string_params_
+#endif
+#define _Scanf_format_string_params_(x)
+#ifdef _Scanf_s_format_string_params_
+#undef _Scanf_s_format_string_params_
+#endif
+#define _Scanf_s_format_string_params_(x)
+#ifdef _In_range_
+#undef _In_range_
+#endif
+#define _In_range_(l, h)
+#ifdef _Out_range_
+#undef _Out_range_
+#endif
+#define _Out_range_(l, h)
+#ifdef _Ret_range_
+#undef _Ret_range_
+#endif
+#define _Ret_range_(l, h)
+#ifdef _Deref_in_range_
+#undef _Deref_in_range_
+#endif
+#define _Deref_in_range_(l, h)
+#ifdef _Deref_out_range_
+#undef _Deref_out_range_
+#endif
+#define _Deref_out_range_(l, h)
+#ifdef _Deref_inout_range_
+#undef _Deref_inout_range_
+#endif
+#define _Deref_inout_range_(l, h)
+#ifdef _Field_range_
+#undef _Field_range_
+#endif
+#define _Field_range_(l, h)
+#ifdef _Pre_equal_to_
+#undef _Pre_equal_to_
+#endif
+#define _Pre_equal_to_(e)
+#ifdef _Post_equal_to_
+#undef _Post_equal_to_
+#endif
+#define _Post_equal_to_(e)
+#ifdef _Struct_size_bytes_
+#undef _Struct_size_bytes_
+#endif
+#define _Struct_size_bytes_(s)
+#ifdef _Analysis_assume_
+#undef _Analysis_assume_
+#endif
+#define _Analysis_assume_
+#ifdef _Analysis_assume_nullterminated_
+#undef _Analysis_assume_nullterminated_
+#endif
+#define _Analysis_assume_nullterminated_(s)
+#ifdef _Analysis_mode_
+#undef _Analysis_mode_
+#endif
+#define _Analysis_mode_(m)
+#ifdef _Analysis_noreturn_
+#undef _Analysis_noreturn_
+#endif
+#define _Analysis_noreturn_
+#ifdef _Raises_SEH_exception_
+#undef _Raises_SEH_exception_
+#endif
+#define _Raises_SEH_exception_
+#ifdef _Maybe_raises_SEH_exception_
+#undef _Maybe_raises_SEH_exception_
+#endif
+#define _Maybe_raises_SEH_exception_
+#ifdef _Function_class_
+#undef _Function_class_
+#endif
+#define _Function_class_(n)
+#ifdef _Literal_
+#undef _Literal_
+#endif
+#define _Literal_
+#ifdef _Notliteral_
+#undef _Notliteral_
+#endif
+#define _Notliteral_
+#ifdef _Enum_is_bitflag_
+#undef _Enum_is_bitflag_
+#endif
+#define _Enum_is_bitflag_
+#ifdef _Strict_type_match_
+#undef _Strict_type_match_
+#endif
+#define _Strict_type_match_
+#ifdef _Points_to_data_
+#undef _Points_to_data_
+#endif
+#define _Points_to_data_
+#ifdef _Interlocked_operand_
+#undef _Interlocked_operand_
+#endif
+#define _Interlocked_operand_
+#ifdef _IRQL_raises_
+#undef _IRQL_raises_
+#endif
+#define _IRQL_raises_(i)
+#ifdef _IRQL_requires_
+#undef _IRQL_requires_
+#endif
+#define _IRQL_requires_(i)
+#ifdef _IRQL_requires_max_
+#undef _IRQL_requires_max_
+#endif
+#define _IRQL_requires_max_(i)
+#ifdef _IRQL_requires_min_
+#undef _IRQL_requires_min_
+#endif
+#define _IRQL_requires_min_(i)
+#ifdef _IRQL_saves_
+#undef _IRQL_saves_
+#endif
+#define _IRQL_saves_
+#ifdef _IRQL_saves_global_
+#undef _IRQL_saves_global_
+#endif
+#define _IRQL_saves_global_(k, s)
+#ifdef _IRQL_restores_
+#undef _IRQL_restores_
+#endif
+#define _IRQL_restores_
+#ifdef _IRQL_restores_global_
+#undef _IRQL_restores_global_
+#endif
+#define _IRQL_restores_global_(k, s)
+#ifdef _IRQL_always_function_min_
+#undef _IRQL_always_function_min_
+#endif
+#define _IRQL_always_function_min_(i)
+#ifdef _IRQL_always_function_max_
+#undef _IRQL_always_function_max_
+#endif
+#define _IRQL_always_function_max_(i)
+#ifdef _IRQL_requires_same_
+#undef _IRQL_requires_same_
+#endif
+#define _IRQL_requires_same_
+#ifdef _IRQL_uses_cancel_
+#undef _IRQL_uses_cancel_
+#endif
+#define _IRQL_uses_cancel_
+#ifdef _IRQL_is_cancel_
+#undef _IRQL_is_cancel_
+#endif
+#define _IRQL_is_cancel_
+#ifdef _Kernel_float_saved_
+#undef _Kernel_float_saved_
+#endif
+#define _Kernel_float_saved_
+#ifdef _Kernel_float_restored_
+#undef _Kernel_float_restored_
+#endif
+#define _Kernel_float_restored_
+#ifdef _Kernel_float_used_
+#undef _Kernel_float_used_
+#endif
+#define _Kernel_float_used_
+#ifdef _Kernel_acquires_resource_
+#undef _Kernel_acquires_resource_
+#endif
+#define _Kernel_acquires_resource_(k)
+#ifdef _Kernel_releases_resource_
+#undef _Kernel_releases_resource_
+#endif
+#define _Kernel_releases_resource_(k)
+#ifdef _Kernel_requires_resource_held_
+#undef _Kernel_requires_resource_held_
+#endif
+#define _Kernel_requires_resource_held_(k)
+#ifdef _Kernel_requires_resource_not_held_
+#undef _Kernel_requires_resource_not_held_
+#endif
+#define _Kernel_requires_resource_not_held_(k)
+#ifdef _Kernel_clear_do_init_
+#undef _Kernel_clear_do_init_
+#endif
+#define _Kernel_clear_do_init_(yn)
+#ifdef _Kernel_IoGetDmaAdapter_
+#undef _Kernel_IoGetDmaAdapter_
+#endif
+#define _Kernel_IoGetDmaAdapter_
+#ifdef _Outref_
+#undef _Outref_
+#endif
+#define _Outref_
+#ifdef _Outref_result_maybenull_
+#undef _Outref_result_maybenull_
+#endif
+#define _Outref_result_maybenull_
+#ifdef _Outref_result_buffer_
+#undef _Outref_result_buffer_
+#endif
+#define _Outref_result_buffer_(s)
+#ifdef _Outref_result_bytebuffer_
+#undef _Outref_result_bytebuffer_
+#endif
+#define _Outref_result_bytebuffer_(s)
+#ifdef _Outref_result_buffer_to_
+#undef _Outref_result_buffer_to_
+#endif
+#define _Outref_result_buffer_to_(s, c)
+#ifdef _Outref_result_bytebuffer_to_
+#undef _Outref_result_bytebuffer_to_
+#endif
+#define _Outref_result_bytebuffer_to_(s, c)
+#ifdef _Outref_result_buffer_all_
+#undef _Outref_result_buffer_all_
+#endif
+#define _Outref_result_buffer_all_(s)
+#ifdef _Outref_result_bytebuffer_all_
+#undef _Outref_result_bytebuffer_all_
+#endif
+#define _Outref_result_bytebuffer_all_(s)
+#ifdef _Outref_result_buffer_maybenull_
+#undef _Outref_result_buffer_maybenull_
+#endif
+#define _Outref_result_buffer_maybenull_(s)
+#ifdef _Outref_result_bytebuffer_maybenull_
+#undef _Outref_result_bytebuffer_maybenull_
+#endif
+#define _Outref_result_bytebuffer_maybenull_(s)
+#ifdef _Outref_result_buffer_to_maybenull_
+#undef _Outref_result_buffer_to_maybenull_
+#endif
+#define _Outref_result_buffer_to_maybenull_(s, c)
+#ifdef _Outref_result_bytebuffer_to_maybenull_
+#undef _Outref_result_bytebuffer_to_maybenull_
+#endif
+#define _Outref_result_bytebuffer_to_maybenull_(s, c)
+#ifdef _Outref_result_buffer_all_maybenull_
+#undef _Outref_result_buffer_all_maybenull_
+#endif
+#define _Outref_result_buffer_all_maybenull_(s)
+#ifdef _Outref_result_bytebuffer_all_maybenull_
+#undef _Outref_result_bytebuffer_all_maybenull_
+#endif
+#define _Outref_result_bytebuffer_all_maybenull_(s)
+#ifdef _In_defensive_
+#undef _In_defensive_
+#endif
+#define _In_defensive_(a)
+#ifdef _Out_defensive_
+#undef _Out_defensive_
+#endif
+#define _Out_defensive_(a)
+#ifdef _Inout_defensive_
+#undef _Inout_defensive_
+#endif
+#define _Inout_defensive_(a)
+#ifdef _Outptr_result_nullonfailure_
+#undef _Outptr_result_nullonfailure_
+#endif
+#define _Outptr_result_nullonfailure_
+#ifdef _Outptr_opt_result_nullonfailure_
+#undef _Outptr_opt_result_nullonfailure_
+#endif
+#define _Outptr_opt_result_nullonfailure_
+#ifdef _Outref_result_nullonfailure_
+#undef _Outref_result_nullonfailure_
+#endif
+#define _Outref_result_nullonfailure_
+#ifdef _Result_nullonfailure_
+#undef _Result_nullonfailure_
+#endif
+#define _Result_nullonfailure_
+#ifdef _Result_zeroonfailure_
+#undef _Result_zeroonfailure_
+#endif
+#define _Result_zeroonfailure_
+#ifdef _Acquires_nonreentrant_lock_
+#undef _Acquires_nonreentrant_lock_
+#endif
+#define _Acquires_nonreentrant_lock_(e)
+#ifdef _Releases_nonreentrant_lock_
+#undef _Releases_nonreentrant_lock_
+#endif
+#define _Releases_nonreentrant_lock_(e)
+#ifdef _Function_ignore_lock_checking_
+#undef _Function_ignore_lock_checking_
+#endif
+#define _Function_ignore_lock_checking_(e)
+#ifdef _Analysis_suppress_lock_checking_
+#undef _Analysis_suppress_lock_checking_
+#endif
+#define _Analysis_suppress_lock_checking_(e)
+#undef _Reserved_
+#define _Reserved_ _Pre_equal_to_ (0) _Pre_ _Null_
+#undef _Pre_z_
+#define _Pre_z_ _Pre_ _Null_terminated_
+#undef _Post_z_
+#define _Post_z_ _Post_ _Null_terminated_
+#undef _Prepost_z_
+#define _Prepost_z_ _Pre_z_ _Post_z_
+#undef _Pre_null_
+#define _Pre_null_ _Pre_ _Null_
+#undef _Pre_maybenull_
+#define _Pre_maybenull_ _Pre_ _Maybenull_
+#undef _Pre_notnull_
+#define _Pre_notnull_ _Pre_ _Notnull_
+#undef _Pre_valid_
+#define _Pre_valid_ _Pre_notnull_ _Pre_ _Valid_
+#undef _Pre_opt_valid_
+#define _Pre_opt_valid_ _Pre_maybenull_ _Pre_ _Valid_
+#undef _Post_valid_
+#define _Post_valid_ _Post_ _Valid_
+#undef _Post_invalid_
+#define _Post_invalid_ _Post_ _Deref_ _Notvalid_
+#undef _Post_ptr_invalid_
+#define _Post_ptr_invalid_ _Post_ _Notvalid_
+#undef _Pre_readable_size_
+#define _Pre_readable_size_(s)                                                 \
+    _Pre_ _Readable_elements_ (s)                                              \
+    _Pre_ _Valid_
+#undef _Pre_writable_size_
+#define _Pre_writable_size_(s) _Pre_ _Writable_elements_ (s)
+#undef _Pre_readable_byte_size_
+#define _Pre_readable_byte_size_(s)                                            \
+    _Pre_ _Readable_bytes_ (s)                                                 \
+    _Pre_ _Valid_
+#undef _Pre_writable_byte_size_
+#define _Pre_writable_byte_size_(s) _Pre_ _Writable_bytes_ (s)
+#undef _Post_readable_size_
+#define _Post_readable_size_(s)                                                \
+    _Post_ _Readable_elements_ (s)                                             \
+    _Post_ _Valid_
+#undef _Post_writable_size_
+#define _Post_writable_size_(s) _Post_ _Writable_elements_ (s)
+#undef _Post_readable_byte_size_
+#define _Post_readable_byte_size_(s)                                           \
+    _Post_ _Readable_bytes_ (s)                                                \
+    _Post_ _Valid_
+#undef _Post_writable_byte_size_
+#define _Post_writable_byte_size_(s) _Post_ _Writable_bytes_ (s)
+#endif // _MSC_VER
+
+#endif // __ZMQ_SAL_H_INCLUDED__

--- a/include/zmq_sal.h
+++ b/include/zmq_sal.h
@@ -13,6 +13,19 @@
     and by the IDE to provide better intellisense.
 
     Code analysis is enabled by adding /analyze to the compiler command line.
+    The compiler will then use the annotations to check for common errors.
+
+    More information:
+
+        Using SAL Annotations to Reduce C/C++ Code Defects
+        https://aka.ms/AAn6qoz
+
+        Understanding SAL
+        https://aka.ms/AAn6jkz
+
+        /analyze (Code analysis)
+        https://aka.ms/AAn6qp6
+
     *************************************************************************
 */
 
@@ -252,10 +265,6 @@ _Analysis_mode_ (_Analysis_local_leak_checks_)
 #undef _Lock_level_order_
 #endif
 #define _Lock_level_order_(n1, n2)
-#ifdef _Analysis_assume_
-#undef _Analysis_assume_
-#endif
-#define _Analysis_assume_(e)
 #ifdef _Analysis_assume_lock_acquired_
 #undef _Analysis_assume_lock_acquired_
 #endif
@@ -775,7 +784,7 @@ _Analysis_mode_ (_Analysis_local_leak_checks_)
 #ifdef _Analysis_assume_
 #undef _Analysis_assume_
 #endif
-#define _Analysis_assume_
+#define _Analysis_assume_(e)
 #ifdef _Analysis_assume_nullterminated_
 #undef _Analysis_assume_nullterminated_
 #endif

--- a/include/zmq_sal.h
+++ b/include/zmq_sal.h
@@ -40,6 +40,10 @@ _Analysis_mode_ (_Analysis_local_leak_checks_)
 #undef _Deref_
 #endif
 #define _Deref_
+#ifdef _Deref_post_null_
+#undef _Deref_post_null_
+#endif
+#define _Deref_post_null_
 #ifdef _Null_
 #undef _Null_
 #endif

--- a/include/zmq_sal.h
+++ b/include/zmq_sal.h
@@ -34,13 +34,17 @@
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1700)
 
+#pragma once
+
 #include <sal.h>
 
 _Analysis_mode_ (_Analysis_code_type_user_code_)
   _Analysis_mode_ (_Analysis_local_leak_checks_)
 
-#else
+#elif !defined(_SAL_VERSION) || (_SAL_VERSION < 20)
+
 /* Redefine all SAL2 annotation macros to be harmless */
+
 #ifdef _When_
 #undef _When_
 #endif
@@ -1073,6 +1077,6 @@ _Analysis_mode_ (_Analysis_code_type_user_code_)
     _Post_ _Valid_
 #undef _Post_writable_byte_size_
 #define _Post_writable_byte_size_(s) _Post_ _Writable_bytes_ (s)
-#endif // _MSC_VER
+#endif
 
 #endif // __ZMQ_SAL_H_INCLUDED__

--- a/include/zmq_sal.h
+++ b/include/zmq_sal.h
@@ -37,7 +37,7 @@
 #include <sal.h>
 
 _Analysis_mode_ (_Analysis_code_type_user_code_)
-_Analysis_mode_ (_Analysis_local_leak_checks_)
+  _Analysis_mode_ (_Analysis_local_leak_checks_)
 
 #else
 /* Redefine all SAL2 annotation macros to be harmless */

--- a/packaging/redhat/zeromq.spec
+++ b/packaging/redhat/zeromq.spec
@@ -214,6 +214,7 @@ autoreconf -fi
 %files devel
 %defattr(-,root,root,-)
 %{_includedir}/zmq.h
+%{_includedir}/zmq_sal.h
 %{_includedir}/zmq_utils.h
 
 %{_libdir}/libzmq.a

--- a/perf/zmq_sal.h
+++ b/perf/zmq_sal.h
@@ -13,6 +13,19 @@
     and by the IDE to provide better intellisense.
 
     Code analysis is enabled by adding /analyze to the compiler command line.
+    The compiler will then use the annotations to check for common errors.
+
+    More information:
+
+        Using SAL Annotations to Reduce C/C++ Code Defects
+        https://aka.ms/AAn6qoz
+
+        Understanding SAL
+        https://aka.ms/AAn6jkz
+
+        /analyze (Code analysis)
+        https://aka.ms/AAn6qp6
+
     *************************************************************************
 */
 

--- a/perf/zmq_sal.h
+++ b/perf/zmq_sal.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+/*  *************************************************************************
+    Provides a set of annotations to describe how a function uses its
+    parameters - the assumptions it makes about them, and the guarantees it
+    makes upon finishing.
+    
+    These annotations are used by the static analysis tools to check for
+    common programming errors, such as null pointer dereferences and buffer
+    overruns.
+    
+    They are also used by the compiler to generate more efficient code,
+    and by the IDE to provide better intellisense.
+
+    Code analysis is enabled by adding /analyze to the compiler command line.
+    *************************************************************************
+*/
+
+#ifndef __ZMQ_SAL_H_INCLUDED__
+#define __ZMQ_SAL_H_INCLUDED__
+
+#include "../include/zmq_sal.h"
+
+#endif

--- a/src/err.cpp
+++ b/src/err.cpp
@@ -4,7 +4,7 @@
 #include "err.hpp"
 #include "macros.hpp"
 
-const char *zmq::errno_to_string (int errno_)
+_Ret_z_ const char *zmq::errno_to_string (int errno_)
 {
     switch (errno_) {
 #if defined ZMQ_HAVE_WINDOWS
@@ -47,7 +47,7 @@ const char *zmq::errno_to_string (int errno_)
     }
 }
 
-void zmq::zmq_abort (const char *errmsg_)
+_Analysis_noreturn_ void zmq::zmq_abort (const char *errmsg_)
 {
 #if defined ZMQ_HAVE_WINDOWS
 
@@ -64,12 +64,13 @@ void zmq::zmq_abort (const char *errmsg_)
 
 #ifdef ZMQ_HAVE_WINDOWS
 
-const char *zmq::wsa_error ()
+_Ret_z_ const char *zmq::wsa_error ()
 {
     return wsa_error_no (WSAGetLastError (), NULL);
 }
 
-const char *zmq::wsa_error_no (int no_, const char *wsae_wouldblock_string_)
+_Ret_z_ const char *zmq::wsa_error_no (int no_,
+                                       _In_ const char *wsae_wouldblock_string_)
 {
     //  TODO:  It seems that list of Windows socket errors is longer than this.
     //         Investigate whether there's a way to convert it into the string
@@ -182,7 +183,8 @@ const char *zmq::wsa_error_no (int no_, const char *wsae_wouldblock_string_)
     }
 }
 
-void zmq::win_error (char *buffer_, size_t buffer_size_)
+void zmq::win_error (_Out_writes_bytes_ (buffer_size_) char *buffer_,
+                     size_t buffer_size_)
 {
     const DWORD errcode = GetLastError ();
 #if defined _WIN32_WCE

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -38,7 +38,7 @@ void zmq_abort (const char *errmsg_) __attribute__ ((analyzer_noreturn));
 void zmq_abort (const char *errmsg_);
 #endif
 #elif defined _MSC_VER
-__declspec (noreturn) _Analysis_noreturn_ void zmq_abort (const char *errmsg_);
+__declspec(noreturn) _Analysis_noreturn_ void zmq_abort (const char *errmsg_);
 #else
 void zmq_abort (const char *errmsg_);
 #endif

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -153,7 +153,7 @@ int wsa_error_to_errno (int errcode_);
             fflush (stderr);                                                   \
             zmq::zmq_abort ("FATAL ERROR: OUT OF MEMORY");                     \
         }                                                                      \
-        _Analysis_assume_ (x != NULL);                                         \
+        _Analysis_assume_ ((x) != NULL);                                       \
     } while (false)
 
 #endif

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -38,7 +38,7 @@ void zmq_abort (const char *errmsg_) __attribute__ ((analyzer_noreturn));
 void zmq_abort (const char *errmsg_);
 #endif
 #elif defined _MSC_VER
-__declspec(noreturn) _Analysis_noreturn_ void zmq_abort (const char *errmsg_);
+__declspec (noreturn) _Analysis_noreturn_ void zmq_abort (const char *errmsg_);
 #else
 void zmq_abort (const char *errmsg_);
 #endif
@@ -50,9 +50,8 @@ void print_backtrace ();
 namespace zmq
 {
 _Ret_z_ const char *wsa_error ();
-_Ret_z_ const char *
-wsa_error_no (int no_,
-              _In_ const char *wsae_wouldblock_string_ = "Operation would block");
+_Ret_z_ const char *wsa_error_no (
+  int no_, _In_ const char *wsae_wouldblock_string_ = "Operation would block");
 void win_error (_Out_writes_bytes_ (buffer_size_) char *buffer_,
                 size_t buffer_size_);
 int wsa_error_to_errno (int errcode_);
@@ -154,7 +153,7 @@ int wsa_error_to_errno (int errcode_);
             fflush (stderr);                                                   \
             zmq::zmq_abort ("FATAL ERROR: OUT OF MEMORY");                     \
         }                                                                      \
-        _Analysis_assume_(x != NULL);                                          \
+        _Analysis_assume_ (x != NULL);                                         \
     } while (false)
 
 #endif

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -28,15 +28,15 @@
 
 namespace zmq
 {
-const char *errno_to_string (int errno_);
+_Ret_z_ const char *errno_to_string (int errno_);
 #if defined __clang__
 #if __has_feature(attribute_analyzer_noreturn)
 void zmq_abort (const char *errmsg_) __attribute__ ((analyzer_noreturn));
 #else
 void zmq_abort (const char *errmsg_);
 #endif
-#elif defined __MSCVER__
-__declspec(noreturn) void zmq_abort (const char *errmsg_);
+#elif defined _MSC_VER
+__declspec(noreturn) _Analysis_noreturn_ void zmq_abort (const char *errmsg_);
 #else
 void zmq_abort (const char *errmsg_);
 #endif
@@ -47,11 +47,12 @@ void print_backtrace ();
 
 namespace zmq
 {
-const char *wsa_error ();
-const char *
+_Ret_z_ const char *wsa_error ();
+_Ret_z_ const char *
 wsa_error_no (int no_,
-              const char *wsae_wouldblock_string_ = "Operation would block");
-void win_error (char *buffer_, size_t buffer_size_);
+              _In_ const char *wsae_wouldblock_string_ = "Operation would block");
+void win_error (_Out_writes_bytes_ (buffer_size_) char *buffer_,
+                size_t buffer_size_);
 int wsa_error_to_errno (int errcode_);
 }
 
@@ -151,6 +152,7 @@ int wsa_error_to_errno (int errcode_);
             fflush (stderr);                                                   \
             zmq::zmq_abort ("FATAL ERROR: OUT OF MEMORY");                     \
         }                                                                      \
+        _Analysis_assume_(x != NULL);                                          \
     } while (false)
 
 #endif

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -3,6 +3,8 @@
 #ifndef __ZMQ_ERR_HPP_INCLUDED__
 #define __ZMQ_ERR_HPP_INCLUDED__
 
+#include "zmq_sal.h"
+
 #include <assert.h>
 #if defined _WIN32_WCE
 #include "..\builds\msvc\errno.hpp"

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -136,9 +136,10 @@ int zmq::msg_t::init_external_storage (_In_ content_t *content_,
 }
 
 int zmq::msg_t::init_data (_In_opt_ void *data_,
-               _When_ (data_ == NULL, _In_range_ (0, 0)) size_t size_,
-               _In_opt_ msg_free_fn *ffn_,
-               _In_opt_ void *hint_)
+                           _When_ (data_ == NULL, _In_range_ (0, 0))
+                             size_t size_,
+                           _In_opt_ msg_free_fn *ffn_,
+                           _In_opt_ void *hint_)
 {
     //  If data is NULL and size is not 0, a segfault
     //  would occur once the data is accessed

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -26,11 +26,11 @@ bool zmq::msg_t::check () const
     return _u.base.type >= type_min && _u.base.type <= type_max;
 }
 
-int zmq::msg_t::init (void *data_,
+int zmq::msg_t::init (_In_reads_bytes_ (size_) void *data_,
                       size_t size_,
-                      msg_free_fn *ffn_,
-                      void *hint_,
-                      content_t *content_)
+                      _In_opt_ msg_free_fn *ffn_,
+                      _In_opt_ void *hint_,
+                      _In_opt_ content_t *content_)
 {
     if (size_ < max_vsm_size) {
         const int rc = init_size (size_);
@@ -94,7 +94,8 @@ int zmq::msg_t::init_size (size_t size_)
     return 0;
 }
 
-int zmq::msg_t::init_buffer (const void *buf_, size_t size_)
+int zmq::msg_t::init_buffer (_In_reads_bytes_ (size_) const void *buf_,
+                             size_t size_)
 {
     const int rc = init_size (size_);
     if (unlikely (rc < 0)) {
@@ -108,11 +109,11 @@ int zmq::msg_t::init_buffer (const void *buf_, size_t size_)
     return 0;
 }
 
-int zmq::msg_t::init_external_storage (content_t *content_,
-                                       void *data_,
+int zmq::msg_t::init_external_storage (_In_ content_t *content_,
+                                       _In_ void *data_,
                                        size_t size_,
-                                       msg_free_fn *ffn_,
-                                       void *hint_)
+                                       _In_opt_ msg_free_fn *ffn_,
+                                       _In_opt_ void *hint_)
 {
     zmq_assert (NULL != data_);
     zmq_assert (NULL != content_);
@@ -134,10 +135,10 @@ int zmq::msg_t::init_external_storage (content_t *content_,
     return 0;
 }
 
-int zmq::msg_t::init_data (void *data_,
-                           size_t size_,
-                           msg_free_fn *ffn_,
-                           void *hint_)
+int zmq::msg_t::init_data (_In_opt_ void *data_,
+               _When_ (data_ == NULL, _In_range_ (0, 0)) size_t size_,
+               _In_opt_ msg_free_fn *ffn_,
+               _In_opt_ void *hint_)
 {
     //  If data is NULL and size is not 0, a segfault
     //  would occur once the data is accessed
@@ -209,7 +210,10 @@ int zmq::msg_t::init_leave ()
     return 0;
 }
 
-int zmq::msg_t::init_subscribe (const size_t size_, const unsigned char *topic_)
+int zmq::msg_t::init_subscribe (_When_ (topic_ == NULL, _In_range_ (0, 0))
+                                  const size_t size_,
+                                _In_reads_bytes_ (size_)
+                                  const unsigned char *topic_)
 {
     int rc = init_size (size_);
     if (rc == 0) {
@@ -224,7 +228,10 @@ int zmq::msg_t::init_subscribe (const size_t size_, const unsigned char *topic_)
     return rc;
 }
 
-int zmq::msg_t::init_cancel (const size_t size_, const unsigned char *topic_)
+int zmq::msg_t::init_cancel (_When_ (topic_ == NULL, _In_range_ (0, 0))
+                               const size_t size_,
+                             _In_reads_bytes_ (size_)
+                               const unsigned char *topic_)
 {
     int rc = init_size (size_);
     if (rc == 0) {
@@ -445,7 +452,7 @@ zmq::metadata_t *zmq::msg_t::metadata () const
     return _u.base.metadata;
 }
 
-void zmq::msg_t::set_metadata (zmq::metadata_t *metadata_)
+void zmq::msg_t::set_metadata (_In_ zmq::metadata_t *metadata_)
 {
     assert (metadata_ != NULL);
     assert (_u.base.metadata == NULL);
@@ -646,21 +653,23 @@ int zmq::msg_t::reset_routing_id ()
     return 0;
 }
 
-const char *zmq::msg_t::group () const
+_Ret_z_ const char *zmq::msg_t::group () const
 {
     if (_u.base.group.type == group_type_long)
         return _u.base.group.lgroup.content->group;
     return _u.base.group.sgroup.group;
 }
 
-int zmq::msg_t::set_group (const char *group_)
+int zmq::msg_t::set_group (_In_z_ const char *group_)
 {
     size_t length = strnlen (group_, ZMQ_GROUP_MAX_LENGTH);
 
     return set_group (group_, length);
 }
 
-int zmq::msg_t::set_group (const char *group_, size_t length_)
+int zmq::msg_t::set_group (_In_reads_ (length_) const char *group_,
+                           _Pre_satisfies_ (length_ <= ZMQ_GROUP_MAX_LENGTH)
+                             size_t length_)
 {
     if (length_ > ZMQ_GROUP_MAX_LENGTH) {
         errno = EINVAL;

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -79,7 +79,7 @@ class msg_t
     int init_size (size_t size_);
     int init_buffer (_In_reads_bytes_ (size_) const void *buf_, size_t size_);
     int init_data (_In_opt_ void *data_,
-                   _When_(data_ == NULL, _In_range_ (0,0)) size_t size_,
+                   _When_ (data_ == NULL, _In_range_ (0, 0)) size_t size_,
                    _In_opt_ msg_free_fn *ffn_,
                    _In_opt_ void *hint_);
     int init_external_storage (_In_ content_t *content_,

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -19,7 +19,8 @@
 //  Note that it has to be declared as "C" so that it is the same as
 //  zmq_free_fn defined in zmq.h.
 extern "C" {
-typedef void (msg_free_fn) (void *data_, void *hint_);
+typedef void (msg_free_fn) (_Pre_maybenull_ _Post_invalid_ void *data_,
+                            _In_opt_ void *hint_);
 }
 
 namespace zmq
@@ -69,25 +70,32 @@ class msg_t
     bool check () const;
     int init ();
 
-    int init (void *data_,
+    int init (_In_reads_bytes_ (size_) void *data_,
               size_t size_,
-              msg_free_fn *ffn_,
-              void *hint_,
-              content_t *content_ = NULL);
+              _In_opt_ msg_free_fn *ffn_,
+              _In_opt_ void *hint_,
+              _In_opt_ content_t *content_);
 
     int init_size (size_t size_);
-    int init_buffer (const void *buf_, size_t size_);
-    int init_data (void *data_, size_t size_, msg_free_fn *ffn_, void *hint_);
-    int init_external_storage (content_t *content_,
-                               void *data_,
+    int init_buffer (_In_reads_bytes_ (size_) const void *buf_, size_t size_);
+    int init_data (_In_opt_ void *data_,
+                   _When_(data_ == NULL, _In_range_ (0,0)) size_t size_,
+                   _In_opt_ msg_free_fn *ffn_,
+                   _In_opt_ void *hint_);
+    int init_external_storage (_In_ content_t *content_,
+                               _In_ void *data_,
                                size_t size_,
-                               msg_free_fn *ffn_,
-                               void *hint_);
+                               _In_opt_ msg_free_fn *ffn_,
+                               _In_opt_ void *hint_);
     int init_delimiter ();
     int init_join ();
     int init_leave ();
-    int init_subscribe (const size_t size_, const unsigned char *topic);
-    int init_cancel (const size_t size_, const unsigned char *topic);
+    int init_subscribe (_When_ (topic_ == NULL, _In_range_ (0, 0))
+                          const size_t size_,
+                        _In_reads_bytes_ (size_) const unsigned char *topic_);
+    int init_cancel (_When_ (topic_ == NULL, _In_range_ (0, 0))
+                       const size_t size_,
+                     _In_reads_bytes_ (size_) const unsigned char *topic_);
     int close ();
     int move (msg_t &src_);
     int copy (msg_t &src_);
@@ -97,7 +105,7 @@ class msg_t
     void set_flags (unsigned char flags_);
     void reset_flags (unsigned char flags_);
     metadata_t *metadata () const;
-    void set_metadata (metadata_t *metadata_);
+    void set_metadata (_In_ metadata_t *metadata_);
     void reset_metadata ();
     bool is_routing_id () const;
     bool is_credential () const;
@@ -129,9 +137,11 @@ class msg_t
     uint32_t get_routing_id () const;
     int set_routing_id (uint32_t routing_id_);
     int reset_routing_id ();
-    const char *group () const;
-    int set_group (const char *group_);
-    int set_group (const char *, size_t length_);
+    _Ret_z_ const char *group () const;
+    int set_group (_In_z_ const char *group_);
+    int set_group (_In_reads_ (length_) const char *group_,
+                   _Pre_satisfies_ (length_ <= ZMQ_GROUP_MAX_LENGTH)
+                     size_t length_);
 
     //  After calling this function you can copy the message in POD-style
     //  refs_ times. No need to call copy.
@@ -297,7 +307,7 @@ class msg_t
     } _u;
 };
 
-inline int close_and_return (zmq::msg_t *msg_, int echo_)
+inline int close_and_return (_Inout_ zmq::msg_t *msg_, int echo_)
 {
     // Since we abort on close failure we preserve errno for success case.
     const int err = errno;
@@ -307,7 +317,9 @@ inline int close_and_return (zmq::msg_t *msg_, int echo_)
     return echo_;
 }
 
-inline int close_and_return (zmq::msg_t msg_[], int count_, int echo_)
+inline int close_and_return (_Inout_updates_all_ (count_) zmq::msg_t msg_[],
+                             int count_,
+                             int echo_)
 {
     for (int i = 0; i < count_; i++)
         close_and_return (&msg_[i], 0);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -390,7 +390,8 @@ static inline int _Check_return_ s_sendmsg (_In_ zmq::socket_base_t *s_,
 }
 
 /*  To be deprecated once zmq_msg_send() is stable                           */
-ZMQ_EXPORT_IMPL (int) zmq_sendmsg (_In_ void *s_, _In_ zmq_msg_t *msg_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_sendmsg (_In_ void *s_, _In_ zmq_msg_t *msg_, int flags_)
 {
     return zmq_msg_send (msg_, s_, flags_);
 }
@@ -499,7 +500,8 @@ zmq_sendiov (_In_ void *s_,
 
 // Receiving functions.
 
-static _Check_return_ int s_recvmsg (_In_ zmq::socket_base_t *s_, _In_ zmq_msg_t *msg_, int flags_)
+static _Check_return_ int
+s_recvmsg (_In_ zmq::socket_base_t *s_, _In_ zmq_msg_t *msg_, int flags_)
 {
     const int rc = s_->recv (reinterpret_cast<zmq::msg_t *> (msg_), flags_);
     if (unlikely (rc < 0))
@@ -511,7 +513,8 @@ static _Check_return_ int s_recvmsg (_In_ zmq::socket_base_t *s_, _In_ zmq_msg_t
 }
 
 /*  To be deprecated once zmq_msg_recv() is stable                           */
-ZMQ_EXPORT_IMPL (int) zmq_recvmsg (_In_ void *s_, _Out_ zmq_msg_t *msg_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_recvmsg (_In_ void *s_, _Out_ zmq_msg_t *msg_, int flags_)
 {
     return zmq_msg_recv (msg_, s_, flags_);
 }
@@ -639,18 +642,18 @@ _At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT_IMPL (int)
 
 _At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT_IMPL (int)
   zmq_msg_init_buffer (_Out_ zmq_msg_t *msg_,
-                     _In_reads_bytes_ (size_) const void *buf_,
-                     size_t size_)
+                       _In_reads_bytes_ (size_) const void *buf_,
+                       size_t size_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->init_buffer (buf_, size_);
 }
 
 _At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT_IMPL (int)
   zmq_msg_init_data (_Out_ zmq_msg_t *msg_,
-                   _In_reads_bytes_opt_ (size_) void *data_,
-                   size_t size_,
-                   _In_opt_ zmq_free_fn *ffn_,
-                   _In_opt_ void *hint_)
+                     _In_reads_bytes_opt_ (size_) void *data_,
+                     size_t size_,
+                     _In_opt_ zmq_free_fn *ffn_,
+                     _In_opt_ void *hint_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))
       ->init_data (data_, size_, ffn_, hint_);
@@ -783,7 +786,8 @@ zmq_msg_gets (_In_ const zmq_msg_t *msg_, _In_z_ const char *property_)
 // Polling.
 
 #if defined ZMQ_HAVE_POLLER
-static _Check_return_ int zmq_poller_poll (_In_ zmq_pollitem_t *items_, int nitems_, long timeout_)
+static _Check_return_ int
+zmq_poller_poll (_In_ zmq_pollitem_t *items_, int nitems_, long timeout_)
 {
     // implement zmq_poll on top of zmq_poller
     int rc;
@@ -1481,7 +1485,7 @@ zmq_ppoll (_In_reads_ (nitems_) zmq_pollitem_t *items_,
 
     return nevents;
 #else
-    (void) nitems_, (void) timeout_, (void) sigmask_; 
+    (void) nitems_, (void) timeout_, (void) sigmask_;
     errno = ENOTSUP;
     return -1;
 #endif // ZMQ_HAVE_PPOLL
@@ -1535,7 +1539,8 @@ static _Check_return_ int check_events (const short events_)
     return 0;
 }
 
-static _Check_return_ int check_poller_registration_args (_In_ void *const poller_, _In_ void *const s_)
+static _Check_return_ int
+check_poller_registration_args (_In_ void *const poller_, _In_ void *const s_)
 {
     if (-1 == check_poller (poller_))
         return -1;
@@ -1550,7 +1555,7 @@ static _Check_return_ int check_poller_registration_args (_In_ void *const polle
 
 static _Check_return_ int
 check_poller_fd_registration_args (_In_ void *const poller_,
-                                              const zmq::fd_t fd_)
+                                   const zmq::fd_t fd_)
 {
     if (-1 == check_poller (poller_))
         return -1;

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -44,7 +44,7 @@
 #else
 struct iovec
 {
-    void *iov_base;
+    _Field_size_bytes_ (iov_len) void *iov_base;
     size_t iov_len;
 };
 #endif
@@ -85,7 +85,8 @@ typedef char
   check_msg_t_size[sizeof (zmq::msg_t) == sizeof (zmq_msg_t) ? 1 : -1];
 
 
-void zmq_version (int *major_, int *minor_, int *patch_)
+ZMQ_EXPORT_VOID_IMPL
+zmq_version (_Out_ int *major_, _Out_ int *minor_, _Out_ int *patch_)
 {
     *major_ = ZMQ_VERSION_MAJOR;
     *minor_ = ZMQ_VERSION_MINOR;
@@ -93,12 +94,12 @@ void zmq_version (int *major_, int *minor_, int *patch_)
 }
 
 
-const char *zmq_strerror (int errnum_)
+ZMQ_EXPORT_STR_IMPL (const char *) zmq_strerror (int errnum_)
 {
     return zmq::errno_to_string (errnum_);
 }
 
-int zmq_errno (void)
+ZMQ_EXPORT_IMPL (int) zmq_errno (void)
 {
     return errno;
 }
@@ -106,7 +107,7 @@ int zmq_errno (void)
 
 //  New context API
 
-void *zmq_ctx_new (void)
+ZMQ_EXPORT_PTR_IMPL (void *, zmq::ctx_t) zmq_ctx_new (void)
 {
     //  We do this before the ctx constructor since its embedded mailbox_t
     //  object needs the network to be up and running (at least on Windows).
@@ -125,14 +126,14 @@ void *zmq_ctx_new (void)
     return ctx;
 }
 
-int zmq_ctx_term (void *ctx_)
+ZMQ_EXPORT_IMPL (int) zmq_ctx_term (_In_ _Post_invalid_ void *context_)
 {
-    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+    if (!context_ || !(static_cast<zmq::ctx_t *> (context_))->check_tag ()) {
         errno = EFAULT;
         return -1;
     }
 
-    const int rc = (static_cast<zmq::ctx_t *> (ctx_))->terminate ();
+    const int rc = (static_cast<zmq::ctx_t *> (context_))->terminate ();
     const int en = errno;
 
     //  Shut down only if termination was not interrupted by a signal.
@@ -144,56 +145,63 @@ int zmq_ctx_term (void *ctx_)
     return rc;
 }
 
-int zmq_ctx_shutdown (void *ctx_)
+ZMQ_EXPORT_IMPL (int) zmq_ctx_shutdown (_Inout_ void *context_)
 {
-    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+    if (!context_ || !(static_cast<zmq::ctx_t *> (context_))->check_tag ()) {
         errno = EFAULT;
         return -1;
     }
-    return (static_cast<zmq::ctx_t *> (ctx_))->shutdown ();
+    return (static_cast<zmq::ctx_t *> (context_))->shutdown ();
 }
 
-int zmq_ctx_set (void *ctx_, int option_, int optval_)
+ZMQ_EXPORT_IMPL (int)
+zmq_ctx_set (_Inout_ void *context_, int option_, int optval_)
 {
-    return zmq_ctx_set_ext (ctx_, option_, &optval_, sizeof (int));
+    return zmq_ctx_set_ext (context_, option_, &optval_, sizeof (int));
 }
 
-int zmq_ctx_set_ext (void *ctx_,
-                     int option_,
-                     const void *optval_,
-                     size_t optvallen_)
+ZMQ_EXPORT_IMPL (int)
+zmq_ctx_set_ext (_In_ void *context_,
+                 int option_,
+                 _In_reads_bytes_ (optvallen_) const void *optval_,
+                 size_t optvallen_)
 {
-    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+    if (!context_ || !(static_cast<zmq::ctx_t *> (context_))->check_tag ()) {
         errno = EFAULT;
         return -1;
     }
-    return (static_cast<zmq::ctx_t *> (ctx_))
+    return (static_cast<zmq::ctx_t *> (context_))
       ->set (option_, optval_, optvallen_);
 }
 
-int zmq_ctx_get (void *ctx_, int option_)
+ZMQ_EXPORT_IMPL (int) zmq_ctx_get (_In_ void *context_, int option_)
 {
-    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+    if (!context_ || !(static_cast<zmq::ctx_t *> (context_))->check_tag ()) {
         errno = EFAULT;
         return -1;
     }
-    return (static_cast<zmq::ctx_t *> (ctx_))->get (option_);
+    return (static_cast<zmq::ctx_t *> (context_))->get (option_);
 }
 
-int zmq_ctx_get_ext (void *ctx_, int option_, void *optval_, size_t *optvallen_)
+ZMQ_EXPORT_IMPL (int)
+zmq_ctx_get_ext (_In_ void *context_,
+                 int option_,
+                 _Out_writes_bytes_ (*optvallen_) void *optval_,
+                 size_t *optvallen_)
 {
-    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+    if (!context_ || !(static_cast<zmq::ctx_t *> (context_))->check_tag ()) {
         errno = EFAULT;
         return -1;
     }
-    return (static_cast<zmq::ctx_t *> (ctx_))
+    return (static_cast<zmq::ctx_t *> (context_))
       ->get (option_, optval_, optvallen_);
 }
 
 
 //  Stable/legacy context API
 
-void *zmq_init (int io_threads_)
+ZMQ_EXPORT_PTR_IMPL (void *, zmq::ctx_t)
+zmq_init (_In_range_ (0, INT_MAX) int io_threads_)
 {
     if (io_threads_ >= 0) {
         void *ctx = zmq_ctx_new ();
@@ -204,20 +212,20 @@ void *zmq_init (int io_threads_)
     return NULL;
 }
 
-int zmq_term (void *ctx_)
+ZMQ_EXPORT_IMPL (int) zmq_term (_In_ _Post_invalid_ void *context_)
 {
-    return zmq_ctx_term (ctx_);
+    return zmq_ctx_term (context_);
 }
 
-int zmq_ctx_destroy (void *ctx_)
+ZMQ_EXPORT_IMPL (int) zmq_ctx_destroy (_In_ _Post_invalid_ void *context_)
 {
-    return zmq_ctx_term (ctx_);
+    return zmq_ctx_term (context_);
 }
 
 
 // Sockets
 
-static zmq::socket_base_t *as_socket_base_t (void *s_)
+static zmq::socket_base_t *as_socket_base_t (_In_ void *s_)
 {
     zmq::socket_base_t *s = static_cast<zmq::socket_base_t *> (s_);
     if (!s_ || !s->check_tag ()) {
@@ -227,18 +235,19 @@ static zmq::socket_base_t *as_socket_base_t (void *s_)
     return s;
 }
 
-void *zmq_socket (void *ctx_, int type_)
+ZMQ_EXPORT_PTR_IMPL (void *, zmq::socket_base_t)
+zmq_socket (_In_ void *context_, int type_)
 {
-    if (!ctx_ || !(static_cast<zmq::ctx_t *> (ctx_))->check_tag ()) {
+    if (!context_ || !(static_cast<zmq::ctx_t *> (context_))->check_tag ()) {
         errno = EFAULT;
         return NULL;
     }
-    zmq::ctx_t *ctx = static_cast<zmq::ctx_t *> (ctx_);
+    zmq::ctx_t *ctx = static_cast<zmq::ctx_t *> (context_);
     zmq::socket_base_t *s = ctx->create_socket (type_);
     return static_cast<void *> (s);
 }
 
-int zmq_close (void *s_)
+ZMQ_EXPORT_IMPL (int) zmq_close (_In_ void *s_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -247,10 +256,11 @@ int zmq_close (void *s_)
     return 0;
 }
 
-int zmq_setsockopt (void *s_,
-                    int option_,
-                    const void *optval_,
-                    size_t optvallen_)
+ZMQ_EXPORT_IMPL (int)
+zmq_setsockopt (_In_ void *s_,
+                int option_,
+                _In_reads_bytes_ (optvallen_) const void *optval_,
+                size_t optvallen_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -258,7 +268,11 @@ int zmq_setsockopt (void *s_,
     return s->setsockopt (option_, optval_, optvallen_);
 }
 
-int zmq_getsockopt (void *s_, int option_, void *optval_, size_t *optvallen_)
+ZMQ_EXPORT_IMPL (int)
+zmq_getsockopt (_In_ void *s_,
+                int option_,
+                _Out_writes_bytes_ (*optvallen_) void *optval_,
+                _Inout_ size_t *optvallen_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -266,8 +280,12 @@ int zmq_getsockopt (void *s_, int option_, void *optval_, size_t *optvallen_)
     return s->getsockopt (option_, optval_, optvallen_);
 }
 
-int zmq_socket_monitor_versioned (
-  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_)
+ZMQ_EXPORT_IMPL (int)
+zmq_socket_monitor_versioned (_In_ void *s_,
+                              _In_z_ const char *addr_,
+                              uint64_t events_,
+                              int event_version_,
+                              int type_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -275,12 +293,13 @@ int zmq_socket_monitor_versioned (
     return s->monitor (addr_, events_, event_version_, type_);
 }
 
-int zmq_socket_monitor (void *s_, const char *addr_, int events_)
+ZMQ_EXPORT_IMPL (int)
+zmq_socket_monitor (_In_ void *s_, _In_z_ const char *addr_, int events_)
 {
     return zmq_socket_monitor_versioned (s_, addr_, events_, 1, ZMQ_PAIR);
 }
 
-int zmq_join (void *s_, const char *group_)
+ZMQ_EXPORT_IMPL (int) zmq_join (_In_ void *s_, _In_z_ const char *group_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -288,7 +307,7 @@ int zmq_join (void *s_, const char *group_)
     return s->join (group_);
 }
 
-int zmq_leave (void *s_, const char *group_)
+ZMQ_EXPORT_IMPL (int) zmq_leave (_In_ void *s_, _In_z_ const char *group_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -296,7 +315,7 @@ int zmq_leave (void *s_, const char *group_)
     return s->leave (group_);
 }
 
-int zmq_bind (void *s_, const char *addr_)
+ZMQ_EXPORT_IMPL (int) zmq_bind (_In_ void *s_, _In_z_ const char *addr_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -304,7 +323,7 @@ int zmq_bind (void *s_, const char *addr_)
     return s->bind (addr_);
 }
 
-int zmq_connect (void *s_, const char *addr_)
+ZMQ_EXPORT_IMPL (int) zmq_connect (_In_ void *s_, _In_z_ const char *addr_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -312,7 +331,8 @@ int zmq_connect (void *s_, const char *addr_)
     return s->connect (addr_);
 }
 
-uint32_t zmq_connect_peer (void *s_, const char *addr_)
+ZMQ_EXPORT_IMPL (uint32_t)
+zmq_connect_peer (_In_ void *s_, _In_z_ const char *addr_)
 {
     zmq::peer_t *s = static_cast<zmq::peer_t *> (s_);
     if (!s_ || !s->check_tag ()) {
@@ -334,7 +354,7 @@ uint32_t zmq_connect_peer (void *s_, const char *addr_)
 }
 
 
-int zmq_unbind (void *s_, const char *addr_)
+ZMQ_EXPORT_IMPL (int) zmq_unbind (_In_ void *s_, _In_z_ const char *addr_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -342,7 +362,7 @@ int zmq_unbind (void *s_, const char *addr_)
     return s->term_endpoint (addr_);
 }
 
-int zmq_disconnect (void *s_, const char *addr_)
+ZMQ_EXPORT_IMPL (int) zmq_disconnect (_In_ void *s_, _In_z_ const char *addr_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -352,8 +372,9 @@ int zmq_disconnect (void *s_, const char *addr_)
 
 // Sending functions.
 
-static inline int
-s_sendmsg (zmq::socket_base_t *s_, zmq_msg_t *msg_, int flags_)
+static inline int _Check_return_ s_sendmsg (_In_ zmq::socket_base_t *s_,
+                                            _In_ zmq_msg_t *msg_,
+                                            int flags_)
 {
     size_t sz = zmq_msg_size (msg_);
     const int rc = s_->send (reinterpret_cast<zmq::msg_t *> (msg_), flags_);
@@ -369,12 +390,16 @@ s_sendmsg (zmq::socket_base_t *s_, zmq_msg_t *msg_, int flags_)
 }
 
 /*  To be deprecated once zmq_msg_send() is stable                           */
-int zmq_sendmsg (void *s_, zmq_msg_t *msg_, int flags_)
+ZMQ_EXPORT_IMPL (int) zmq_sendmsg (_In_ void *s_, _In_ zmq_msg_t *msg_, int flags_)
 {
     return zmq_msg_send (msg_, s_, flags_);
 }
 
-int zmq_send (void *s_, const void *buf_, size_t len_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_send (_In_ void *s_,
+          _In_reads_bytes_ (len_) const void *buf_,
+          size_t len_,
+          int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -397,7 +422,11 @@ int zmq_send (void *s_, const void *buf_, size_t len_, int flags_)
     return rc;
 }
 
-int zmq_send_const (void *s_, const void *buf_, size_t len_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_send_const (_In_ void *s_,
+                _In_reads_bytes_ (len_) const void *buf_,
+                size_t len_,
+                int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -429,12 +458,16 @@ int zmq_send_const (void *s_, const void *buf_, size_t len_, int flags_)
 // a single multi-part message, i.e. the last message has
 // ZMQ_SNDMORE bit switched off.
 //
-int zmq_sendiov (void *s_, iovec *a_, size_t count_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_sendiov (_In_ void *s_,
+             _In_reads_ (count_) struct iovec *iov_,
+             size_t count_,
+             int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
         return -1;
-    if (unlikely (count_ <= 0 || !a_)) {
+    if (unlikely (count_ <= 0 || !iov_)) {
         errno = EINVAL;
         return -1;
     }
@@ -443,12 +476,12 @@ int zmq_sendiov (void *s_, iovec *a_, size_t count_, int flags_)
     zmq_msg_t msg;
 
     for (size_t i = 0; i < count_; ++i) {
-        rc = zmq_msg_init_size (&msg, a_[i].iov_len);
+        rc = zmq_msg_init_size (&msg, iov_[i].iov_len);
         if (rc != 0) {
             rc = -1;
             break;
         }
-        memcpy (zmq_msg_data (&msg), a_[i].iov_base, a_[i].iov_len);
+        memcpy (zmq_msg_data (&msg), iov_[i].iov_base, iov_[i].iov_len);
         if (i == count_ - 1)
             flags_ = flags_ & ~ZMQ_SNDMORE;
         rc = s_sendmsg (s, &msg, flags_);
@@ -466,7 +499,7 @@ int zmq_sendiov (void *s_, iovec *a_, size_t count_, int flags_)
 
 // Receiving functions.
 
-static int s_recvmsg (zmq::socket_base_t *s_, zmq_msg_t *msg_, int flags_)
+static _Check_return_ int s_recvmsg (_In_ zmq::socket_base_t *s_, _In_ zmq_msg_t *msg_, int flags_)
 {
     const int rc = s_->recv (reinterpret_cast<zmq::msg_t *> (msg_), flags_);
     if (unlikely (rc < 0))
@@ -478,13 +511,17 @@ static int s_recvmsg (zmq::socket_base_t *s_, zmq_msg_t *msg_, int flags_)
 }
 
 /*  To be deprecated once zmq_msg_recv() is stable                           */
-int zmq_recvmsg (void *s_, zmq_msg_t *msg_, int flags_)
+ZMQ_EXPORT_IMPL (int) zmq_recvmsg (_In_ void *s_, _Out_ zmq_msg_t *msg_, int flags_)
 {
     return zmq_msg_recv (msg_, s_, flags_);
 }
 
 
-int zmq_recv (void *s_, void *buf_, size_t len_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_recv (_In_ void *s_,
+          _Out_writes_bytes_ (len_) void *buf_,
+          size_t len_,
+          int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -532,12 +569,16 @@ int zmq_recv (void *s_, void *buf_, size_t len_, int flags_)
 // function may be freed using free().
 // TODO: this function has no man page
 //
-int zmq_recviov (void *s_, iovec *a_, size_t *count_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_recviov (_In_ void *s_,
+             _In_reads_ (*count_) struct iovec *iov_,
+             _Inout_ size_t *count_,
+             int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
         return -1;
-    if (unlikely (!count_ || *count_ <= 0 || !a_)) {
+    if (unlikely (!count_ || *count_ <= 0 || !iov_)) {
         errno = EINVAL;
         return -1;
     }
@@ -563,14 +604,14 @@ int zmq_recviov (void *s_, iovec *a_, size_t *count_, int flags_)
             break;
         }
 
-        a_[i].iov_len = zmq_msg_size (&msg);
-        a_[i].iov_base = static_cast<char *> (malloc (a_[i].iov_len));
-        if (unlikely (!a_[i].iov_base)) {
+        iov_[i].iov_len = zmq_msg_size (&msg);
+        iov_[i].iov_base = static_cast<char *> (malloc (iov_[i].iov_len));
+        if (unlikely (!iov_[i].iov_base)) {
             errno = ENOMEM;
             return -1;
         }
-        memcpy (a_[i].iov_base, static_cast<char *> (zmq_msg_data (&msg)),
-                a_[i].iov_len);
+        memcpy (iov_[i].iov_base, static_cast<char *> (zmq_msg_data (&msg)),
+                iov_[i].iov_len);
         // Assume zmq_socket ZMQ_RVCMORE is properly set.
         const zmq::msg_t *p_msg = reinterpret_cast<const zmq::msg_t *> (&msg);
         recvmore = p_msg->flags () & zmq::msg_t::more;
@@ -584,29 +625,39 @@ int zmq_recviov (void *s_, iovec *a_, size_t *count_, int flags_)
 
 // Message manipulators.
 
-int zmq_msg_init (zmq_msg_t *msg_)
+_At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT_IMPL (int)
+  zmq_msg_init (_Out_ zmq_msg_t *msg_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->init ();
 }
 
-int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_)
+_At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT_IMPL (int)
+  zmq_msg_init_size (_Out_ zmq_msg_t *msg_, size_t size_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->init_size (size_);
 }
 
-int zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_)
+_At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT_IMPL (int)
+  zmq_msg_init_buffer (_Out_ zmq_msg_t *msg_,
+                     _In_reads_bytes_ (size_) const void *buf_,
+                     size_t size_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->init_buffer (buf_, size_);
 }
 
-int zmq_msg_init_data (
-  zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_)
+_At_ (msg_, _Pre_invalid_ _Pre_notnull_ _Post_valid_) ZMQ_EXPORT_IMPL (int)
+  zmq_msg_init_data (_Out_ zmq_msg_t *msg_,
+                   _In_reads_bytes_opt_ (size_) void *data_,
+                   size_t size_,
+                   _In_opt_ zmq_free_fn *ffn_,
+                   _In_opt_ void *hint_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))
       ->init_data (data_, size_, ffn_, hint_);
 }
 
-int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_msg_send (_In_ zmq_msg_t *msg_, _In_ void *s_, int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -614,7 +665,8 @@ int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_)
     return s_sendmsg (s, msg_, flags_);
 }
 
-int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_)
+ZMQ_EXPORT_IMPL (int)
+zmq_msg_recv (_Out_ zmq_msg_t *msg_, _In_ void *s_, int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)
@@ -622,39 +674,41 @@ int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_)
     return s_recvmsg (s, msg_, flags_);
 }
 
-int zmq_msg_close (zmq_msg_t *msg_)
+ZMQ_EXPORT_IMPL (int) zmq_msg_close (_Inout_ zmq_msg_t *msg_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->close ();
 }
 
-int zmq_msg_move (zmq_msg_t *dest_, zmq_msg_t *src_)
+ZMQ_EXPORT_IMPL (int)
+zmq_msg_move (_Inout_ zmq_msg_t *dest_, _Inout_ zmq_msg_t *src_)
 {
     return (reinterpret_cast<zmq::msg_t *> (dest_))
       ->move (*reinterpret_cast<zmq::msg_t *> (src_));
 }
 
-int zmq_msg_copy (zmq_msg_t *dest_, zmq_msg_t *src_)
+ZMQ_EXPORT_IMPL (int)
+zmq_msg_copy (_Inout_ zmq_msg_t *dest_, _Inout_ zmq_msg_t *src_)
 {
     return (reinterpret_cast<zmq::msg_t *> (dest_))
       ->copy (*reinterpret_cast<zmq::msg_t *> (src_));
 }
 
-void *zmq_msg_data (zmq_msg_t *msg_)
+ZMQ_EXPORT_VOID_PTR_IMPL zmq_msg_data (_In_ zmq_msg_t *msg_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->data ();
 }
 
-size_t zmq_msg_size (const zmq_msg_t *msg_)
+ZMQ_EXPORT_IMPL (size_t) zmq_msg_size (_In_ const zmq_msg_t *msg_)
 {
     return ((zmq::msg_t *) msg_)->size ();
 }
 
-int zmq_msg_more (const zmq_msg_t *msg_)
+ZMQ_EXPORT_IMPL (int) zmq_msg_more (_In_ const zmq_msg_t *msg_)
 {
     return zmq_msg_get (msg_, ZMQ_MORE);
 }
 
-int zmq_msg_get (const zmq_msg_t *msg_, int property_)
+ZMQ_EXPORT_IMPL (int) zmq_msg_get (_In_ const zmq_msg_t *msg_, int property_)
 {
     const char *fd_string;
 
@@ -678,37 +732,41 @@ int zmq_msg_get (const zmq_msg_t *msg_, int property_)
     }
 }
 
-int zmq_msg_set (zmq_msg_t *, int, int)
+ZMQ_EXPORT_IMPL (int)
+zmq_msg_set (_Inout_ zmq_msg_t *msg_, int property_, int optval_)
 {
     //  No properties supported at present
     errno = EINVAL;
     return -1;
 }
 
-int zmq_msg_set_routing_id (zmq_msg_t *msg_, uint32_t routing_id_)
+ZMQ_EXPORT_IMPL (int)
+zmq_msg_set_routing_id (_Inout_ zmq_msg_t *msg_, uint32_t routing_id_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))
       ->set_routing_id (routing_id_);
 }
 
-uint32_t zmq_msg_routing_id (zmq_msg_t *msg_)
+ZMQ_EXPORT_IMPL (uint32_t) zmq_msg_routing_id (_Inout_ zmq_msg_t *msg_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->get_routing_id ();
 }
 
-int zmq_msg_set_group (zmq_msg_t *msg_, const char *group_)
+ZMQ_EXPORT_IMPL (int)
+zmq_msg_set_group (_Inout_ zmq_msg_t *msg_, _In_z_ const char *group_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->set_group (group_);
 }
 
-const char *zmq_msg_group (zmq_msg_t *msg_)
+ZMQ_EXPORT_STR_IMPL (const char *) zmq_msg_group (_In_ zmq_msg_t *msg_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))->group ();
 }
 
 //  Get message metadata string
 
-const char *zmq_msg_gets (const zmq_msg_t *msg_, const char *property_)
+ZMQ_EXPORT_STR_IMPL (const char *)
+zmq_msg_gets (_In_ const zmq_msg_t *msg_, _In_z_ const char *property_)
 {
     const zmq::metadata_t *metadata =
       reinterpret_cast<const zmq::msg_t *> (msg_)->metadata ();
@@ -725,7 +783,7 @@ const char *zmq_msg_gets (const zmq_msg_t *msg_, const char *property_)
 // Polling.
 
 #if defined ZMQ_HAVE_POLLER
-static int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
+static _Check_return_ int zmq_poller_poll (_In_ zmq_pollitem_t *items_, int nitems_, long timeout_)
 {
     // implement zmq_poll on top of zmq_poller
     int rc;
@@ -824,7 +882,10 @@ static int zmq_poller_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
 }
 #endif // ZMQ_HAVE_POLLER
 
-int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_)
+ZMQ_EXPORT_IMPL (int)
+zmq_poll (_In_reads_ (nitems_) zmq_pollitem_t *items_,
+          int nitems_,
+          long timeout_)
 {
 #if defined ZMQ_HAVE_POLLER
     // if poller is present, use that if there is at least 1 thread-safe socket,
@@ -1358,10 +1419,11 @@ int zmq_ppoll (zmq_pollitem_t *items_,
                const sigset_t *sigmask_)
 #else
 // Windows has no sigset_t
-int zmq_ppoll (zmq_pollitem_t *items_,
-               int nitems_,
-               long timeout_,
-               const void *sigmask_)
+ZMQ_EXPORT_IMPL (int)
+zmq_ppoll (_In_reads_ (nitems_) zmq_pollitem_t *items_,
+           int nitems_,
+           long timeout_,
+           _In_ const void *sigmask_)
 #endif
 {
 #ifdef ZMQ_HAVE_PPOLL
@@ -1419,6 +1481,7 @@ int zmq_ppoll (zmq_pollitem_t *items_,
 
     return nevents;
 #else
+    (void) nitems_, (void) timeout_, (void) sigmask_; 
     errno = ENOTSUP;
     return -1;
 #endif // ZMQ_HAVE_PPOLL
@@ -1426,7 +1489,7 @@ int zmq_ppoll (zmq_pollitem_t *items_,
 
 //  The poller functionality
 
-void *zmq_poller_new (void)
+ZMQ_EXPORT_PTR_IMPL (void *, zmq::socket_poller_t) zmq_poller_new (void)
 {
     zmq::socket_poller_t *poller = new (std::nothrow) zmq::socket_poller_t;
     if (!poller) {
@@ -1435,7 +1498,8 @@ void *zmq_poller_new (void)
     return poller;
 }
 
-int zmq_poller_destroy (void **poller_p_)
+ZMQ_EXPORT_IMPL (int)
+zmq_poller_destroy (_Inout_ _Deref_post_null_ void **poller_p_)
 {
     if (poller_p_) {
         const zmq::socket_poller_t *const poller =
@@ -1451,7 +1515,7 @@ int zmq_poller_destroy (void **poller_p_)
 }
 
 
-static int check_poller (void *const poller_)
+static _Check_return_ int check_poller (_In_ void *const poller_)
 {
     if (!poller_
         || !(static_cast<zmq::socket_poller_t *> (poller_))->check_tag ()) {
@@ -1462,7 +1526,7 @@ static int check_poller (void *const poller_)
     return 0;
 }
 
-static int check_events (const short events_)
+static _Check_return_ int check_events (const short events_)
 {
     if (events_ & ~(ZMQ_POLLIN | ZMQ_POLLOUT | ZMQ_POLLERR | ZMQ_POLLPRI)) {
         errno = EINVAL;
@@ -1471,7 +1535,7 @@ static int check_events (const short events_)
     return 0;
 }
 
-static int check_poller_registration_args (void *const poller_, void *const s_)
+static _Check_return_ int check_poller_registration_args (_In_ void *const poller_, _In_ void *const s_)
 {
     if (-1 == check_poller (poller_))
         return -1;
@@ -1484,7 +1548,8 @@ static int check_poller_registration_args (void *const poller_, void *const s_)
     return 0;
 }
 
-static int check_poller_fd_registration_args (void *const poller_,
+static _Check_return_ int
+check_poller_fd_registration_args (_In_ void *const poller_,
                                               const zmq::fd_t fd_)
 {
     if (-1 == check_poller (poller_))
@@ -1498,7 +1563,7 @@ static int check_poller_fd_registration_args (void *const poller_,
     return 0;
 }
 
-int zmq_poller_size (void *poller_)
+ZMQ_EXPORT_IMPL (int) zmq_poller_size (_In_ void *poller_)
 {
     if (-1 == check_poller (poller_))
         return -1;
@@ -1506,22 +1571,27 @@ int zmq_poller_size (void *poller_)
     return (static_cast<zmq::socket_poller_t *> (poller_))->size ();
 }
 
-int zmq_poller_add (void *poller_, void *s_, void *user_data_, short events_)
+ZMQ_EXPORT_IMPL (int)
+zmq_poller_add (_In_ void *poller_,
+                _In_ void *socket_,
+                _In_opt_ void *user_data_,
+                short events_)
 {
-    if (-1 == check_poller_registration_args (poller_, s_)
+    if (-1 == check_poller_registration_args (poller_, socket_)
         || -1 == check_events (events_))
         return -1;
 
-    zmq::socket_base_t *socket = static_cast<zmq::socket_base_t *> (s_);
+    zmq::socket_base_t *socket = static_cast<zmq::socket_base_t *> (socket_);
 
     return (static_cast<zmq::socket_poller_t *> (poller_))
       ->add (socket, user_data_, events_);
 }
 
-int zmq_poller_add_fd (void *poller_,
-                       zmq::fd_t fd_,
-                       void *user_data_,
-                       short events_)
+ZMQ_EXPORT_IMPL (int)
+zmq_poller_add_fd (_In_ void *poller_,
+                   zmq_fd_t fd_,
+                   _In_ void *user_data_,
+                   short events_)
 {
     if (-1 == check_poller_fd_registration_args (poller_, fd_)
         || -1 == check_events (events_))
@@ -1532,20 +1602,22 @@ int zmq_poller_add_fd (void *poller_,
 }
 
 
-int zmq_poller_modify (void *poller_, void *s_, short events_)
+ZMQ_EXPORT_IMPL (int)
+zmq_poller_modify (_In_ void *poller_, _In_ void *socket_, short events_)
 {
-    if (-1 == check_poller_registration_args (poller_, s_)
+    if (-1 == check_poller_registration_args (poller_, socket_)
         || -1 == check_events (events_))
         return -1;
 
     const zmq::socket_base_t *const socket =
-      static_cast<const zmq::socket_base_t *> (s_);
+      static_cast<const zmq::socket_base_t *> (socket_);
 
     return (static_cast<zmq::socket_poller_t *> (poller_))
       ->modify (socket, events_);
 }
 
-int zmq_poller_modify_fd (void *poller_, zmq::fd_t fd_, short events_)
+ZMQ_EXPORT_IMPL (int)
+zmq_poller_modify_fd (_In_ void *poller_, zmq_fd_t fd_, short events_)
 {
     if (-1 == check_poller_fd_registration_args (poller_, fd_)
         || -1 == check_events (events_))
@@ -1555,17 +1627,17 @@ int zmq_poller_modify_fd (void *poller_, zmq::fd_t fd_, short events_)
       ->modify_fd (fd_, events_);
 }
 
-int zmq_poller_remove (void *poller_, void *s_)
+ZMQ_EXPORT_IMPL (int) zmq_poller_remove (_In_ void *poller_, _In_ void *socket_)
 {
-    if (-1 == check_poller_registration_args (poller_, s_))
+    if (-1 == check_poller_registration_args (poller_, socket_))
         return -1;
 
-    zmq::socket_base_t *socket = static_cast<zmq::socket_base_t *> (s_);
+    zmq::socket_base_t *socket = static_cast<zmq::socket_base_t *> (socket_);
 
     return (static_cast<zmq::socket_poller_t *> (poller_))->remove (socket);
 }
 
-int zmq_poller_remove_fd (void *poller_, zmq::fd_t fd_)
+ZMQ_EXPORT_IMPL (int) zmq_poller_remove_fd (_In_ void *poller_, zmq_fd_t fd_)
 {
     if (-1 == check_poller_fd_registration_args (poller_, fd_))
         return -1;
@@ -1573,7 +1645,10 @@ int zmq_poller_remove_fd (void *poller_, zmq::fd_t fd_)
     return (static_cast<zmq::socket_poller_t *> (poller_))->remove_fd (fd_);
 }
 
-int zmq_poller_wait (void *poller_, zmq_poller_event_t *event_, long timeout_)
+ZMQ_EXPORT_IMPL (int)
+zmq_poller_wait (_In_ void *poller_,
+                 _In_ zmq_poller_event_t *event_,
+                 long timeout_)
 {
     const int rc = zmq_poller_wait_all (poller_, event_, 1, timeout_);
 
@@ -1587,10 +1662,11 @@ int zmq_poller_wait (void *poller_, zmq_poller_event_t *event_, long timeout_)
     return rc >= 0 ? 0 : rc;
 }
 
-int zmq_poller_wait_all (void *poller_,
-                         zmq_poller_event_t *events_,
-                         int n_events_,
-                         long timeout_)
+ZMQ_EXPORT_IMPL (int)
+zmq_poller_wait_all (_In_ void *poller_,
+                     _In_reads_ (n_events_) zmq_poller_event_t *events_,
+                     int n_events_,
+                     long timeout_)
 {
     if (-1 == check_poller (poller_))
         return -1;
@@ -1612,7 +1688,7 @@ int zmq_poller_wait_all (void *poller_,
     return rc;
 }
 
-int zmq_poller_fd (void *poller_, zmq_fd_t *fd_)
+ZMQ_EXPORT_IMPL (int) zmq_poller_fd (_In_ void *poller_, _In_ zmq_fd_t *fd_)
 {
     if (!poller_
         || !(static_cast<zmq::socket_poller_t *> (poller_)->check_tag ())) {
@@ -1624,11 +1700,13 @@ int zmq_poller_fd (void *poller_, zmq_fd_t *fd_)
 
 //  Peer-specific state
 
-int zmq_socket_get_peer_state (void *s_,
-                               const void *routing_id_,
-                               size_t routing_id_size_)
+ZMQ_EXPORT_IMPL (int)
+zmq_socket_get_peer_state (_In_ void *socket_,
+                           _In_reads_bytes_ (routing_id_size_)
+                             const void *routing_id_,
+                           size_t routing_id_size_)
 {
-    const zmq::socket_base_t *const s = as_socket_base_t (s_);
+    const zmq::socket_base_t *const s = as_socket_base_t (socket_);
     if (!s)
         return -1;
 
@@ -1637,14 +1715,15 @@ int zmq_socket_get_peer_state (void *s_,
 
 //  Timers
 
-void *zmq_timers_new (void)
+ZMQ_EXPORT_PTR_IMPL (void *, zmq::timers_t) zmq_timers_new (void)
 {
     zmq::timers_t *timers = new (std::nothrow) zmq::timers_t;
     alloc_assert (timers);
     return timers;
 }
 
-int zmq_timers_destroy (void **timers_p_)
+ZMQ_EXPORT_IMPL (int)
+zmq_timers_destroy (_Inout_ _Deref_post_null_ void **timers_p_)
 {
     void *timers = *timers_p_;
     if (!timers || !(static_cast<zmq::timers_t *> (timers))->check_tag ()) {
@@ -1656,10 +1735,11 @@ int zmq_timers_destroy (void **timers_p_)
     return 0;
 }
 
-int zmq_timers_add (void *timers_,
-                    size_t interval_,
-                    zmq_timer_fn handler_,
-                    void *arg_)
+ZMQ_EXPORT_IMPL (int)
+zmq_timers_add (_In_ void *timers_,
+                size_t interval_,
+                _In_ zmq_timer_fn handler_,
+                _In_opt_ void *arg_)
 {
     if (!timers_ || !(static_cast<zmq::timers_t *> (timers_))->check_tag ()) {
         errno = EFAULT;
@@ -1670,7 +1750,7 @@ int zmq_timers_add (void *timers_,
       ->add (interval_, handler_, arg_);
 }
 
-int zmq_timers_cancel (void *timers_, int timer_id_)
+ZMQ_EXPORT_IMPL (int) zmq_timers_cancel (_In_ void *timers_, int timer_id_)
 {
     if (!timers_ || !(static_cast<zmq::timers_t *> (timers_))->check_tag ()) {
         errno = EFAULT;
@@ -1680,7 +1760,8 @@ int zmq_timers_cancel (void *timers_, int timer_id_)
     return (static_cast<zmq::timers_t *> (timers_))->cancel (timer_id_);
 }
 
-int zmq_timers_set_interval (void *timers_, int timer_id_, size_t interval_)
+ZMQ_EXPORT_IMPL (int)
+zmq_timers_set_interval (_In_ void *timers_, int timer_id_, size_t interval_)
 {
     if (!timers_ || !(static_cast<zmq::timers_t *> (timers_))->check_tag ()) {
         errno = EFAULT;
@@ -1691,7 +1772,7 @@ int zmq_timers_set_interval (void *timers_, int timer_id_, size_t interval_)
       ->set_interval (timer_id_, interval_);
 }
 
-int zmq_timers_reset (void *timers_, int timer_id_)
+ZMQ_EXPORT_IMPL (int) zmq_timers_reset (_In_ void *timers_, int timer_id_)
 {
     if (!timers_ || !(static_cast<zmq::timers_t *> (timers_))->check_tag ()) {
         errno = EFAULT;
@@ -1701,7 +1782,7 @@ int zmq_timers_reset (void *timers_, int timer_id_)
     return (static_cast<zmq::timers_t *> (timers_))->reset (timer_id_);
 }
 
-long zmq_timers_timeout (void *timers_)
+ZMQ_EXPORT_IMPL (long) zmq_timers_timeout (_In_ void *timers_)
 {
     if (!timers_ || !(static_cast<zmq::timers_t *> (timers_))->check_tag ()) {
         errno = EFAULT;
@@ -1711,7 +1792,7 @@ long zmq_timers_timeout (void *timers_)
     return (static_cast<zmq::timers_t *> (timers_))->timeout ();
 }
 
-int zmq_timers_execute (void *timers_)
+ZMQ_EXPORT_IMPL (int) zmq_timers_execute (_In_ void *timers_)
 {
     if (!timers_ || !(static_cast<zmq::timers_t *> (timers_))->check_tag ()) {
         errno = EFAULT;
@@ -1723,7 +1804,8 @@ int zmq_timers_execute (void *timers_)
 
 //  The proxy functionality
 
-int zmq_proxy (void *frontend_, void *backend_, void *capture_)
+ZMQ_EXPORT_IMPL (int)
+zmq_proxy (_In_ void *frontend_, _In_ void *backend_, _In_opt_ void *capture_)
 {
     if (!frontend_ || !backend_) {
         errno = EFAULT;
@@ -1735,10 +1817,11 @@ int zmq_proxy (void *frontend_, void *backend_, void *capture_)
                        static_cast<zmq::socket_base_t *> (capture_));
 }
 
-int zmq_proxy_steerable (void *frontend_,
-                         void *backend_,
-                         void *capture_,
-                         void *control_)
+ZMQ_EXPORT_IMPL (int)
+zmq_proxy_steerable (_In_ void *frontend_,
+                     _In_ void *backend_,
+                     _In_opt_ void *capture_,
+                     _In_opt_ void *control_)
 {
     if (!frontend_ || !backend_) {
         errno = EFAULT;
@@ -1752,7 +1835,8 @@ int zmq_proxy_steerable (void *frontend_,
 
 //  The deprecated device functionality
 
-int zmq_device (int /* type */, void *frontend_, void *backend_)
+ZMQ_EXPORT_IMPL (int)
+zmq_device (int type_, _In_ void *frontend_, _In_ void *backend_)
 {
     return zmq::proxy (static_cast<zmq::socket_base_t *> (frontend_),
                        static_cast<zmq::socket_base_t *> (backend_), NULL);
@@ -1760,7 +1844,7 @@ int zmq_device (int /* type */, void *frontend_, void *backend_)
 
 //  Probe library capabilities; for now, reports on transport and security
 
-int zmq_has (const char *capability_)
+ZMQ_EXPORT_IMPL (int) zmq_has (_In_z_ const char *capability_)
 {
 #if defined(ZMQ_HAVE_IPC)
     if (strcmp (capability_, zmq::protocol_name::ipc) == 0)
@@ -1806,7 +1890,7 @@ int zmq_has (const char *capability_)
     return false;
 }
 
-int zmq_socket_monitor_pipes_stats (void *s_)
+ZMQ_EXPORT_IMPL (int) zmq_socket_monitor_pipes_stats (_In_ void *s_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
     if (!s)

--- a/src/zmq_sal.h
+++ b/src/zmq_sal.h
@@ -13,6 +13,19 @@
     and by the IDE to provide better intellisense.
 
     Code analysis is enabled by adding /analyze to the compiler command line.
+    The compiler will then use the annotations to check for common errors.
+
+    More information:
+
+        Using SAL Annotations to Reduce C/C++ Code Defects
+        https://aka.ms/AAn6qoz
+
+        Understanding SAL
+        https://aka.ms/AAn6jkz
+
+        /analyze (Code analysis)
+        https://aka.ms/AAn6qp6
+
     *************************************************************************
 */
 

--- a/src/zmq_sal.h
+++ b/src/zmq_sal.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+/*  *************************************************************************
+    Provides a set of annotations to describe how a function uses its
+    parameters - the assumptions it makes about them, and the guarantees it
+    makes upon finishing.
+    
+    These annotations are used by the static analysis tools to check for
+    common programming errors, such as null pointer dereferences and buffer
+    overruns.
+    
+    They are also used by the compiler to generate more efficient code,
+    and by the IDE to provide better intellisense.
+
+    Code analysis is enabled by adding /analyze to the compiler command line.
+    *************************************************************************
+*/
+
+#ifndef __ZMQ_SAL_H_INCLUDED__
+#define __ZMQ_SAL_H_INCLUDED__
+
+#include "../include/zmq_sal.h"
+
+#endif

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -264,7 +264,8 @@ zmq_curve_public (_Out_writes_z_ (41) char *z85_public_key_,
 //  --------------------------------------------------------------------------
 //  Initialize a new atomic counter, which is set to zero
 
-ZMQ_EXPORT_PTR_IMPL (void *, zmq::atomic_counter_t) zmq_atomic_counter_new (void)
+ZMQ_EXPORT_PTR_IMPL (void *, zmq::atomic_counter_t)
+zmq_atomic_counter_new (void)
 {
     zmq::atomic_counter_t *counter = new (std::nothrow) zmq::atomic_counter_t;
     alloc_assert (counter);
@@ -302,8 +303,8 @@ ZMQ_EXPORT_IMPL (int) zmq_atomic_counter_value (_In_ void *counter_)
 
 //  Destroy atomic counter, and set reference to NULL
 
-ZMQ_EXPORT_VOID_IMPL zmq_atomic_counter_destroy (
-  _Inout_ _Deref_post_null_ void **counter_p_)
+ZMQ_EXPORT_VOID_IMPL
+zmq_atomic_counter_destroy (_Inout_ _Deref_post_null_ void **counter_p_)
 {
     delete (static_cast<zmq::atomic_counter_t *> (*counter_p_));
     *counter_p_ = NULL;

--- a/src/zmq_utils.cpp
+++ b/src/zmq_utils.cpp
@@ -20,7 +20,7 @@
 #include "sodium.h"
 #endif
 
-void zmq_sleep (int seconds_)
+ZMQ_EXPORT_VOID_IMPL zmq_sleep (int seconds_)
 {
 #if defined ZMQ_HAVE_WINDOWS
     Sleep (seconds_ * 1000);
@@ -29,7 +29,7 @@ void zmq_sleep (int seconds_)
 #endif
 }
 
-void *zmq_stopwatch_start ()
+ZMQ_EXPORT_PTR_IMPL (void *, uint64_t) zmq_stopwatch_start (void)
 {
     uint64_t *watch = static_cast<uint64_t *> (malloc (sizeof (uint64_t)));
     alloc_assert (watch);
@@ -37,21 +37,23 @@ void *zmq_stopwatch_start ()
     return static_cast<void *> (watch);
 }
 
-unsigned long zmq_stopwatch_intermediate (void *watch_)
+ZMQ_EXPORT_IMPL (unsigned long) zmq_stopwatch_intermediate (_In_ void *watch_)
 {
     const uint64_t end = zmq::clock_t::now_us ();
     const uint64_t start = *static_cast<uint64_t *> (watch_);
     return static_cast<unsigned long> (end - start);
 }
 
-unsigned long zmq_stopwatch_stop (void *watch_)
+ZMQ_EXPORT_IMPL (unsigned long)
+zmq_stopwatch_stop (_In_ _Post_invalid_ void *watch_)
 {
     const unsigned long res = zmq_stopwatch_intermediate (watch_);
     free (watch_);
     return res;
 }
 
-void *zmq_threadstart (zmq_thread_fn *func_, void *arg_)
+ZMQ_EXPORT_IMPL (void *)
+zmq_threadstart (_In_ zmq_thread_fn *func_, _In_opt_ void *arg_)
 {
     zmq::thread_t *thread = new (std::nothrow) zmq::thread_t;
     alloc_assert (thread);
@@ -59,7 +61,7 @@ void *zmq_threadstart (zmq_thread_fn *func_, void *arg_)
     return thread;
 }
 
-void zmq_threadclose (void *thread_)
+ZMQ_EXPORT_VOID_IMPL zmq_threadclose (_In_ _Post_invalid_ void *thread_)
 {
     zmq::thread_t *p_thread = static_cast<zmq::thread_t *> (thread_);
     p_thread->stop ();
@@ -98,7 +100,10 @@ static uint8_t decoder[96] = {
 //  dest. Size must be a multiple of 4.
 //  Returns NULL and sets errno = EINVAL for invalid input.
 
-char *zmq_z85_encode (char *dest_, const uint8_t *data_, size_t size_)
+ZMQ_EXPORT_STR_SIZE_IMPL (char *, size_ * 4 / 5 + 1)
+zmq_z85_encode (_Out_writes_z_ (size_ * 4 / 5 + 1) char *dest_,
+                _In_reads_bytes_ (size_) const uint8_t *data_,
+                size_t size_)
 {
     if (size_ % 4 != 0) {
         errno = EINVAL;
@@ -132,7 +137,10 @@ char *zmq_z85_encode (char *dest_, const uint8_t *data_, size_t size_)
 //  must be a multiple of 5.
 //  Returns NULL and sets errno = EINVAL for invalid input.
 
-uint8_t *zmq_z85_decode (uint8_t *dest_, const char *string_)
+ZMQ_EXPORT_BUF_SIZE (uint8_t *, _String_length_ (string_) * 4 / 5)
+zmq_z85_decode (_Out_writes_bytes_ (_String_length_ (string_) * 4 / 5)
+                  uint8_t *dest_,
+                _In_z_ const char *string_)
 {
     unsigned int byte_nbr = 0;
     unsigned int char_nbr = 0;
@@ -187,7 +195,9 @@ error_inval:
 //  Returns 0 on success, -1 on failure, setting errno.
 //  Sets errno = ENOTSUP in the absence of a CURVE library.
 
-int zmq_curve_keypair (char *z85_public_key_, char *z85_secret_key_)
+ZMQ_EXPORT_IMPL (int)
+zmq_curve_keypair (_Out_writes_z_ (41) char *z85_public_key_,
+                   _Out_writes_z_ (41) char *z85_secret_key_)
 {
 #if defined(ZMQ_HAVE_CURVE)
 #if crypto_box_PUBLICKEYBYTES != 32 || crypto_box_SECRETKEYBYTES != 32
@@ -219,7 +229,9 @@ int zmq_curve_keypair (char *z85_public_key_, char *z85_secret_key_)
 //  Returns 0 on success, -1 on failure, setting errno.
 //  Sets errno = ENOTSUP in the absence of a CURVE library.
 
-int zmq_curve_public (char *z85_public_key_, const char *z85_secret_key_)
+ZMQ_EXPORT_IMPL (int)
+zmq_curve_public (_Out_writes_z_ (41) char *z85_public_key_,
+                  _In_reads_z_ (41) const char *z85_secret_key_)
 {
 #if defined(ZMQ_HAVE_CURVE)
 #if crypto_box_PUBLICKEYBYTES != 32 || crypto_box_SECRETKEYBYTES != 32
@@ -252,7 +264,7 @@ int zmq_curve_public (char *z85_public_key_, const char *z85_secret_key_)
 //  --------------------------------------------------------------------------
 //  Initialize a new atomic counter, which is set to zero
 
-void *zmq_atomic_counter_new (void)
+ZMQ_EXPORT_PTR_IMPL (void *, zmq::atomic_counter_t) zmq_atomic_counter_new (void)
 {
     zmq::atomic_counter_t *counter = new (std::nothrow) zmq::atomic_counter_t;
     alloc_assert (counter);
@@ -261,14 +273,14 @@ void *zmq_atomic_counter_new (void)
 
 //  Se the value of the atomic counter
 
-void zmq_atomic_counter_set (void *counter_, int value_)
+ZMQ_EXPORT_VOID_IMPL zmq_atomic_counter_set (_Inout_ void *counter_, int value_)
 {
     (static_cast<zmq::atomic_counter_t *> (counter_))->set (value_);
 }
 
 //  Increment the atomic counter, and return the old value
 
-int zmq_atomic_counter_inc (void *counter_)
+ZMQ_EXPORT_IMPL (int) zmq_atomic_counter_inc (_Inout_ void *counter_)
 {
     return (static_cast<zmq::atomic_counter_t *> (counter_))->add (1);
 }
@@ -276,21 +288,22 @@ int zmq_atomic_counter_inc (void *counter_)
 //  Decrement the atomic counter and return 1 (if counter >= 1), or
 //  0 if counter hit zero.
 
-int zmq_atomic_counter_dec (void *counter_)
+ZMQ_EXPORT_IMPL (int) zmq_atomic_counter_dec (_Inout_ void *counter_)
 {
     return (static_cast<zmq::atomic_counter_t *> (counter_))->sub (1) ? 1 : 0;
 }
 
 //  Return actual value of atomic counter
 
-int zmq_atomic_counter_value (void *counter_)
+ZMQ_EXPORT_IMPL (int) zmq_atomic_counter_value (_In_ void *counter_)
 {
     return (static_cast<zmq::atomic_counter_t *> (counter_))->get ();
 }
 
 //  Destroy atomic counter, and set reference to NULL
 
-void zmq_atomic_counter_destroy (void **counter_p_)
+ZMQ_EXPORT_VOID_IMPL zmq_atomic_counter_destroy (
+  _Inout_ _Deref_post_null_ void **counter_p_)
 {
     delete (static_cast<zmq::atomic_counter_t *> (*counter_p_));
     *counter_p_ = NULL;

--- a/tests/zmq_sal.h
+++ b/tests/zmq_sal.h
@@ -13,6 +13,19 @@
     and by the IDE to provide better intellisense.
 
     Code analysis is enabled by adding /analyze to the compiler command line.
+    The compiler will then use the annotations to check for common errors.
+
+    More information:
+
+        Using SAL Annotations to Reduce C/C++ Code Defects
+        https://aka.ms/AAn6qoz
+
+        Understanding SAL
+        https://aka.ms/AAn6jkz
+
+        /analyze (Code analysis)
+        https://aka.ms/AAn6qp6
+
     *************************************************************************
 */
 

--- a/tests/zmq_sal.h
+++ b/tests/zmq_sal.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+/*  *************************************************************************
+    Provides a set of annotations to describe how a function uses its
+    parameters - the assumptions it makes about them, and the guarantees it
+    makes upon finishing.
+    
+    These annotations are used by the static analysis tools to check for
+    common programming errors, such as null pointer dereferences and buffer
+    overruns.
+    
+    They are also used by the compiler to generate more efficient code,
+    and by the IDE to provide better intellisense.
+
+    Code analysis is enabled by adding /analyze to the compiler command line.
+    *************************************************************************
+*/
+
+#ifndef __ZMQ_SAL_H_INCLUDED__
+#define __ZMQ_SAL_H_INCLUDED__
+
+#include "../include/zmq_sal.h"
+
+#endif


### PR DESCRIPTION
Added new zmq_sal.h header. Modified zmq.h and zmq.cpp to add SAL2 annotations to all public functions. Added SAL2 annotations to some internal classes (msg, ctx, some utils)