### PR TITLE
Fix a random test failure, other minor test fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ zeromq-*.zip
 core
 
 mybuild
+
+# VisualStudio artefacts
+/.vs

--- a/perf/benchmark_radix_tree.cpp
+++ b/perf/benchmark_radix_tree.cpp
@@ -1,8 +1,7 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 
-#include "../include/zmq.h"
-
-#if (defined __cplusplus && __cplusplus >= 201103L) || (defined _MSC_VER && _MSC_VER >= 1900)
+#if (defined __cplusplus && __cplusplus >= 201103L)                            \
+  || (defined _MSC_VER && _MSC_VER >= 1900)
 
 #include "radix_tree.hpp"
 #include "trie.hpp"

--- a/perf/benchmark_radix_tree.cpp
+++ b/perf/benchmark_radix_tree.cpp
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 
-#if __cplusplus >= 201103L
+#include "../include/zmq.h"
+
+#if (defined __cplusplus && __cplusplus >= 201103L) || (defined _MSC_VER && _MSC_VER >= 1900)
 
 #include "radix_tree.hpp"
 #include "trie.hpp"
@@ -73,8 +75,9 @@ int main ()
     //
     // Keeping initialization out of the benchmarking function helps
     // heaptrack detect peak memory consumption of the radix tree.
-    zmq::trie_t trie;
+    zmq::trie_with_size_t trie;
     zmq::radix_tree_t radix_tree;
+
     for (auto &key : input_set) {
         trie.add (key, key_length);
         radix_tree.add (key, key_length);

--- a/tests/test_heartbeats.cpp
+++ b/tests/test_heartbeats.cpp
@@ -370,6 +370,7 @@ void test_setsockopt_heartbeat_ttl_max ()
 
 void test_setsockopt_heartbeat_ttl_more_than_max_fails ()
 {
+#if !defined(ZMQ_ACT_MILITANT)
     void *const socket = test_context_socket (ZMQ_PAIR);
     const int value = heartbeat_ttl_max + 1;
     TEST_ASSERT_FAILURE_ERRNO (
@@ -377,6 +378,11 @@ void test_setsockopt_heartbeat_ttl_more_than_max_fails ()
       zmq_setsockopt (socket, ZMQ_HEARTBEAT_TTL, &value, sizeof (value)));
 
     test_context_socket_close (socket);
+#else
+    TEST_IGNORE_MESSAGE (
+      "libzmq with ZMQ_ACT_MILITANT, ignoring "
+      "test_setsockopt_heartbeat_ttl_more_than_max_fails test");
+#endif
 }
 
 void test_setsockopt_heartbeat_ttl_near_zero ()

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -259,7 +259,7 @@ void test_blocking (const char *bind_endpoint_)
 DEFINE_REGULAR_TEST_CASES (tcp, "tcp://127.0.0.1:*")
 DEFINE_REGULAR_TEST_CASES (inproc, "inproc://a")
 
-#if !defined(ZMQ_HAVE_WINDOWS) && !defined(ZMQ_HAVE_GNU)
+#if !defined(ZMQ_HAVE_GNU)
 DEFINE_REGULAR_TEST_CASES (ipc, "ipc://*")
 #endif
 
@@ -272,7 +272,7 @@ int main ()
     RUN_REGULAR_TEST_CASES (tcp);
     RUN_REGULAR_TEST_CASES (inproc);
 
-#if !defined(ZMQ_HAVE_WINDOWS) && !defined(ZMQ_HAVE_GNU)
+#if !defined(ZMQ_HAVE_GNU)
     RUN_REGULAR_TEST_CASES (ipc);
 #endif
     RUN_TEST (test_reset_hwm);

--- a/tests/test_hwm_pubsub.cpp
+++ b/tests/test_hwm_pubsub.cpp
@@ -259,7 +259,7 @@ void test_blocking (const char *bind_endpoint_)
 DEFINE_REGULAR_TEST_CASES (tcp, "tcp://127.0.0.1:*")
 DEFINE_REGULAR_TEST_CASES (inproc, "inproc://a")
 
-#if !defined(ZMQ_HAVE_GNU)
+#if !defined(ZMQ_HAVE_WINDOWS) && !defined(ZMQ_HAVE_GNU)
 DEFINE_REGULAR_TEST_CASES (ipc, "ipc://*")
 #endif
 
@@ -272,7 +272,7 @@ int main ()
     RUN_REGULAR_TEST_CASES (tcp);
     RUN_REGULAR_TEST_CASES (inproc);
 
-#if !defined(ZMQ_HAVE_GNU)
+#if !defined(ZMQ_HAVE_WINDOWS) && !defined(ZMQ_HAVE_GNU)
     RUN_REGULAR_TEST_CASES (ipc);
 #endif
     RUN_TEST (test_reset_hwm);

--- a/tests/test_req_relaxed.cpp
+++ b/tests/test_req_relaxed.cpp
@@ -169,7 +169,7 @@ void test_case_4 ()
     TEST_ASSERT_SUCCESS_ERRNO (
       zmq_setsockopt (req, ZMQ_REQ_CORRELATE, &enabled, sizeof (int)));
 
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (req, ENDPOINT_0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (req, ENDPOINT_7));
 
     //  Setup ROUTER socket as server but do not bind it just yet
     void *router = test_context_socket (ZMQ_ROUTER);
@@ -179,7 +179,7 @@ void test_case_4 ()
     s_send_seq (req, "TO_BE_ANSWERED", SEQ_END);
 
     //  Bind server allowing it to receive messages
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (router, ENDPOINT_0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (router, ENDPOINT_7));
 
     //  Read the two messages and send them back as is
     bounce (router);

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -574,7 +574,7 @@ int main (void)
 
     void *ctx = zmq_ctx_new ();
     test_curve_security_invalid_keysize (ctx);
-    TEST_ASSERT_SUCCESS_ERRNO(zmq_ctx_term(ctx));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_ctx_term (ctx));
 
     zmq::random_close ();
 

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -477,6 +477,7 @@ void test_curve_security_invalid_initiate_command_encrypted_content ()
 
 void test_curve_security_invalid_keysize (void *ctx_)
 {
+#if !defined(ZMQ_ACT_MILITANT)
     //  Check return codes for invalid buffer sizes
     void *client = zmq_socket (ctx_, ZMQ_DEALER);
     TEST_ASSERT_NOT_NULL (client);
@@ -491,6 +492,10 @@ void test_curve_security_invalid_keysize (void *ctx_)
     rc = zmq_setsockopt (client, ZMQ_CURVE_SECRETKEY, valid_client_secret, 123);
     assert (rc == -1 && errno == EINVAL);
     TEST_ASSERT_SUCCESS_ERRNO (zmq_close (client));
+#else
+    TEST_IGNORE_MESSAGE ("libzmq with ZMQ_ACT_MILITANT, ignoring "
+                         "test_curve_security_invalid_keysize test");
+#endif
 }
 
 // TODO why isn't this const?
@@ -569,7 +574,7 @@ int main (void)
 
     void *ctx = zmq_ctx_new ();
     test_curve_security_invalid_keysize (ctx);
-    TEST_ASSERT_SUCCESS_ERRNO (zmq_ctx_term (ctx));
+    TEST_ASSERT_SUCCESS_ERRNO(zmq_ctx_term(ctx));
 
     zmq::random_close ();
 

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -43,6 +43,7 @@
 #define ENDPOINT_4 "udp://127.0.0.1:5559"
 #define ENDPOINT_5 "udp://127.0.0.1:5560"
 #define PORT_6 5561
+#define ENDPOINT_7 "udp://127.0.0.1:5562"
 
 //  For tests that mock ZMTP
 const uint8_t zmtp_greeting_null[64] = {

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -43,7 +43,7 @@
 #define ENDPOINT_4 "udp://127.0.0.1:5559"
 #define ENDPOINT_5 "udp://127.0.0.1:5560"
 #define PORT_6 5561
-#define ENDPOINT_7 "udp://127.0.0.1:5562"
+#define ENDPOINT_7 "tcp://127.0.0.1:5562"
 
 //  For tests that mock ZMTP
 const uint8_t zmtp_greeting_null[64] = {


### PR DESCRIPTION
- Fix a random test failure in either test_req_relaxed or test_reconnect_options due to a shared endpoint.
- Fix test_heartbeats and test_security_curve so they don't fail with ZMQ_ACT_MILITANT.
- Enable benchmark_radix_tree for Windows, use trie_with_size_t consistently with xsub.hpp.
- Exclude VS artifacts in .gitignore.