### PR TITLE
Fixed the CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,6 @@
 # CMake build script for ZeroMQ
+cmake_minimum_required(VERSION 3.5..3.27)
 project(ZeroMQ)
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
-  cmake_minimum_required(VERSION 3.0.2)
-else()
-  cmake_minimum_required(VERSION 2.8.12)
-endif()
 
 include(CheckIncludeFiles)
 include(CheckCCompilerFlag)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,15 @@
 # CMake build script for ZeroMQ tests
-cmake_minimum_required(VERSION "2.8.1")
+cmake_minimum_required(VERSION 3.5..3.27)
 
 # On Windows: solution file will be called tests.sln
 project(tests)
 
 set(tests
+  test_bind_stream_fuzzer
+  test_bind_ws_fuzzer
+  test_connect_stream_fuzzer
+  test_connect_ws_fuzzer
+  test_socket_options_fuzzer
   test_ancillaries
   test_system
   test_pair_inproc

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake build script for ZeroMQ unit tests
-cmake_minimum_required(VERSION "2.8.1")
+cmake_minimum_required(VERSION 3.5..3.27)
 
 set(unittests
     unittest_ypipe


### PR DESCRIPTION
With the current version of the CMake files, there are a few warning messages. This patch fixes those warning (the project is building without warnings).
Note that there will no longer be support for versions of CMake strictly less than 3.5. All the current Linux distributions, including long term support (LTS) ones, have CMake with a version greater than 3.5.
