### PR TITLE
Feature: improve docs

### DIFF
--- a/doc/zmq.adoc
+++ b/doc/zmq.adoc
@@ -107,7 +107,7 @@ Sockets
 ~~~~~~~
 0MQ sockets present an abstraction of an asynchronous _message queue_, with the
 exact queueing semantics depending on the socket type in use. See
-xref:zmq_socket.adoc[zmq_socket] for the socket types provided.
+* xref:zmq_socket.adoc[zmq_socket] for the socket types provided.
 
 The following functions are provided to work with sockets:
 
@@ -139,7 +139,7 @@ Monitoring socket events::
 0MQ provides a mechanism for applications to multiplex input/output events over
 a set containing both 0MQ sockets and standard sockets. This mechanism mirrors
 the standard _poll()_ system call, and is described in detail in
-xref:zmq_poll.adoc[zmq_poll] This API is deprecated, however.
+* xref:zmq_poll.adoc[zmq_poll] This API is deprecated, however.
 
 There is a new DRAFT API with multiple zmq_poller_* function, which is described
 in xref:zmq_poller.adoc[zmq_poller]

--- a/doc/zmq.adoc
+++ b/doc/zmq.adoc
@@ -107,7 +107,7 @@ Sockets
 ~~~~~~~
 0MQ sockets present an abstraction of an asynchronous _message queue_, with the
 exact queueing semantics depending on the socket type in use. See
-* xref:zmq_socket.adoc[zmq_socket] for the socket types provided.
+xref:zmq_socket.adoc[zmq_socket] for the socket types provided.
 
 The following functions are provided to work with sockets:
 
@@ -139,7 +139,7 @@ Monitoring socket events::
 0MQ provides a mechanism for applications to multiplex input/output events over
 a set containing both 0MQ sockets and standard sockets. This mechanism mirrors
 the standard _poll()_ system call, and is described in detail in
-* xref:zmq_poll.adoc[zmq_poll] This API is deprecated, however.
+xref:zmq_poll.adoc[zmq_poll] This API is deprecated, however.
 
 There is a new DRAFT API with multiple zmq_poller_* function, which is described
 in xref:zmq_poller.adoc[zmq_poller]

--- a/doc/zmq_atomic_counter_dec.adoc
+++ b/doc/zmq_atomic_counter_dec.adoc
@@ -42,11 +42,11 @@ return 0;
 
 
 == SEE ALSO
-xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
-xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
-xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
-xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
-xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
+* xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
+* xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
+* xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
+* xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
+* xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
 
 
 == AUTHORS

--- a/doc/zmq_atomic_counter_destroy.adoc
+++ b/doc/zmq_atomic_counter_destroy.adoc
@@ -42,11 +42,11 @@ return 0;
 
 
 == SEE ALSO
-xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
-xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
-xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
-xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
-xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
+* xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
+* xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
+* xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
+* xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
+* xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
 
 
 == AUTHORS

--- a/doc/zmq_atomic_counter_inc.adoc
+++ b/doc/zmq_atomic_counter_inc.adoc
@@ -41,11 +41,11 @@ return 0;
 
 
 == SEE ALSO
-xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
-xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
-xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
-xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
-xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
+* xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
+* xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
+* xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
+* xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
+* xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
 
 
 == AUTHORS

--- a/doc/zmq_atomic_counter_new.adoc
+++ b/doc/zmq_atomic_counter_new.adoc
@@ -42,11 +42,11 @@ return 0;
 
 
 == SEE ALSO
-xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
-xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
-xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
-xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
-xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
+* xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
+* xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
+* xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
+* xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
+* xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
 
 
 == AUTHORS

--- a/doc/zmq_atomic_counter_set.adoc
+++ b/doc/zmq_atomic_counter_set.adoc
@@ -41,11 +41,11 @@ return 0;
 
 
 == SEE ALSO
-xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
-xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
-xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
-xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
-xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
+* xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
+* xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
+* xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
+* xref:zmq_atomic_counter_value.adoc[zmq_atomic_counter_value]
+* xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
 
 
 == AUTHORS

--- a/doc/zmq_atomic_counter_value.adoc
+++ b/doc/zmq_atomic_counter_value.adoc
@@ -42,11 +42,11 @@ return 0;
 
 
 == SEE ALSO
-xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
-xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
-xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
-xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
-xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
+* xref:zmq_atomic_counter_new.adoc[zmq_atomic_counter_new]
+* xref:zmq_atomic_counter_set.adoc[zmq_atomic_counter_set]
+* xref:zmq_atomic_counter_inc.adoc[zmq_atomic_counter_inc]
+* xref:zmq_atomic_counter_dec.adoc[zmq_atomic_counter_dec]
+* xref:zmq_atomic_counter_destroy.adoc[zmq_atomic_counter_destroy]
 
 
 == AUTHORS

--- a/doc/zmq_bind.adoc
+++ b/doc/zmq_bind.adoc
@@ -28,11 +28,11 @@ The 'endpoint' is a string consisting of a 'transport'`://` followed by an
 
 Every 0MQ socket type except 'ZMQ_PAIR' and 'ZMQ_CHANNEL' supports one-to-many and many-to-one
 semantics. The precise semantics depend on the socket type and are defined in
-xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq_socket.adoc[zmq_socket]
 
 The 'ipc', 'tcp', 'vmci' and 'udp' transports accept wildcard addresses: see
-xref:zmq_ipc.adoc[zmq_ipc], xref:zmq_tcp.adoc[zmq_tcp], xref:zmq_vmci.adoc[zmq_vmci] and
-xref:zmq_udp.adoc[zmq_udp] for details.
+* xref:zmq_ipc.adoc[zmq_ipc], xref:zmq_tcp.adoc[zmq_tcp], xref:zmq_vmci.adoc[zmq_vmci] and
+* xref:zmq_udp.adoc[zmq_udp] for details.
 
 NOTE: the address syntax may be different for _zmq_bind()_ and _zmq_connect()_
 especially for the 'tcp', 'pgm' and 'epgm' transports.
@@ -86,9 +86,9 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_bind.adoc
+++ b/doc/zmq_bind.adoc
@@ -28,11 +28,11 @@ The 'endpoint' is a string consisting of a 'transport'`://` followed by an
 
 Every 0MQ socket type except 'ZMQ_PAIR' and 'ZMQ_CHANNEL' supports one-to-many and many-to-one
 semantics. The precise semantics depend on the socket type and are defined in
-* xref:zmq_socket.adoc[zmq_socket]
+xref:zmq_socket.adoc[zmq_socket]
 
 The 'ipc', 'tcp', 'vmci' and 'udp' transports accept wildcard addresses: see
-* xref:zmq_ipc.adoc[zmq_ipc], xref:zmq_tcp.adoc[zmq_tcp], xref:zmq_vmci.adoc[zmq_vmci] and
-* xref:zmq_udp.adoc[zmq_udp] for details.
+xref:zmq_ipc.adoc[zmq_ipc], xref:zmq_tcp.adoc[zmq_tcp], xref:zmq_vmci.adoc[zmq_vmci] and
+xref:zmq_udp.adoc[zmq_udp] for details.
 
 NOTE: the address syntax may be different for _zmq_bind()_ and _zmq_connect()_
 especially for the 'tcp', 'pgm' and 'epgm' transports.

--- a/doc/zmq_close.adoc
+++ b/doc/zmq_close.adoc
@@ -40,10 +40,10 @@ The provided 'socket' was NULL.
 
 
 == SEE ALSO
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq_ctx_term.adoc[zmq_ctx_term]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq.adoc[zmq]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq_ctx_term.adoc[zmq_ctx_term]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_connect.adoc
+++ b/doc/zmq_connect.adoc
@@ -28,7 +28,7 @@ The 'endpoint' is a string consisting of a 'transport'`://` followed by an
 
 Every 0MQ socket type except 'ZMQ_PAIR' and 'ZMQ_CHANNEL' supports one-to-many and many-to-one
 semantics. The precise semantics depend on the socket type and are defined in
-* xref:zmq_socket.adoc[zmq_socket]
+xref:zmq_socket.adoc[zmq_socket]
 
 NOTE: for most transports and socket types the connection is not performed
 immediately but as needed by 0MQ. Thus a successful call to _zmq_connect()_
@@ -42,7 +42,7 @@ NOTE: following a _zmq_connect()_, for socket types except for ZMQ_ROUTER,
 the socket enters its normal 'ready' state. By contrast, following a
 _zmq_bind()_ alone, the socket enters a 'mute' state in which the socket
 blocks or drops messages according to the socket type, as defined in
-* xref:zmq_socket.adoc[zmq_socket] A ZMQ_ROUTER socket enters its normal 'ready' state
+xref:zmq_socket.adoc[zmq_socket] A ZMQ_ROUTER socket enters its normal 'ready' state
 for a specific peer only when handshaking is complete for that peer, which
 may take an arbitrary time.
 

--- a/doc/zmq_connect.adoc
+++ b/doc/zmq_connect.adoc
@@ -28,7 +28,7 @@ The 'endpoint' is a string consisting of a 'transport'`://` followed by an
 
 Every 0MQ socket type except 'ZMQ_PAIR' and 'ZMQ_CHANNEL' supports one-to-many and many-to-one
 semantics. The precise semantics depend on the socket type and are defined in
-xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq_socket.adoc[zmq_socket]
 
 NOTE: for most transports and socket types the connection is not performed
 immediately but as needed by 0MQ. Thus a successful call to _zmq_connect()_
@@ -42,7 +42,7 @@ NOTE: following a _zmq_connect()_, for socket types except for ZMQ_ROUTER,
 the socket enters its normal 'ready' state. By contrast, following a
 _zmq_bind()_ alone, the socket enters a 'mute' state in which the socket
 blocks or drops messages according to the socket type, as defined in
-xref:zmq_socket.adoc[zmq_socket] A ZMQ_ROUTER socket enters its normal 'ready' state
+* xref:zmq_socket.adoc[zmq_socket] A ZMQ_ROUTER socket enters its normal 'ready' state
 for a specific peer only when handshaking is complete for that peer, which
 may take an arbitrary time.
 
@@ -90,9 +90,9 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_connect_peer.adoc
+++ b/doc/zmq_connect_peer.adoc
@@ -72,10 +72,10 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_ctx_get.adoc
+++ b/doc/zmq_ctx_get.adoc
@@ -45,7 +45,7 @@ NOTE: in DRAFT state, not yet available in stable releases.
 ZMQ_SOCKET_LIMIT: Get largest configurable number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_SOCKET_LIMIT' argument returns the largest number of sockets that
-xref:zmq_ctx_set.adoc[zmq_ctx_set] will accept.
+* xref:zmq_ctx_set.adoc[zmq_ctx_set] will accept.
 
 
 ZMQ_IPV6: Set IPv6 option
@@ -107,8 +107,8 @@ zmq_ctx_set (ctx, ZMQ_BLOCKY, false);
 
 
 == SEE ALSO
-xref:zmq_ctx_set.adoc[zmq_ctx_set]
-xref:zmq.adoc[zmq]
+* xref:zmq_ctx_set.adoc[zmq_ctx_set]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_ctx_get.adoc
+++ b/doc/zmq_ctx_get.adoc
@@ -45,7 +45,7 @@ NOTE: in DRAFT state, not yet available in stable releases.
 ZMQ_SOCKET_LIMIT: Get largest configurable number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_SOCKET_LIMIT' argument returns the largest number of sockets that
-* xref:zmq_ctx_set.adoc[zmq_ctx_set] will accept.
+xref:zmq_ctx_set.adoc[zmq_ctx_set] will accept.
 
 
 ZMQ_IPV6: Set IPv6 option

--- a/doc/zmq_ctx_get_ext.adoc
+++ b/doc/zmq_ctx_get_ext.adoc
@@ -66,8 +66,8 @@ assert (buffLen == prefixLen);
 
 
 == SEE ALSO
-xref:zmq_ctx_get.adoc[zmq_ctx_get]
-xref:zmq.adoc[zmq]
+* xref:zmq_ctx_get.adoc[zmq_ctx_get]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_ctx_new.adoc
+++ b/doc/zmq_ctx_new.adoc
@@ -36,10 +36,10 @@ and it wasn't possible to create a new context.
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
-xref:zmq_ctx_set.adoc[zmq_ctx_set]
-xref:zmq_ctx_get.adoc[zmq_ctx_get]
-xref:zmq_ctx_term.adoc[zmq_ctx_term]
+* xref:zmq.adoc[zmq]
+* xref:zmq_ctx_set.adoc[zmq_ctx_set]
+* xref:zmq_ctx_get.adoc[zmq_ctx_get]
+* xref:zmq_ctx_term.adoc[zmq_ctx_term]
 
 
 == AUTHORS

--- a/doc/zmq_ctx_set.adoc
+++ b/doc/zmq_ctx_set.adoc
@@ -141,7 +141,7 @@ ZMQ_MAX_SOCKETS: Set maximum number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_MAX_SOCKETS' argument sets the maximum number of sockets allowed
 on the context. You can query the maximal allowed value with
-* xref:zmq_ctx_get.adoc[zmq_ctx_get] using the 'ZMQ_SOCKET_LIMIT' option.
+xref:zmq_ctx_get.adoc[zmq_ctx_get] using the 'ZMQ_SOCKET_LIMIT' option.
 
 [horizontal]
 Default value:: 1023

--- a/doc/zmq_ctx_set.adoc
+++ b/doc/zmq_ctx_set.adoc
@@ -130,7 +130,7 @@ The 'ZMQ_ZERO_COPY_RECV' argument specifies whether the message decoder should
 use a zero copy strategy when receiving messages. The zero copy strategy can
 lead to increased memory usage in some cases. This option allows you to use the
 older copying strategy. You can query the value of this option with
-xref:zmq_ctx_get.adoc[zmq_ctx_get] using the 'ZMQ_ZERO_COPY_RECV' option.
+* xref:zmq_ctx_get.adoc[zmq_ctx_get] using the 'ZMQ_ZERO_COPY_RECV' option.
 NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]
@@ -141,7 +141,7 @@ ZMQ_MAX_SOCKETS: Set maximum number of sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'ZMQ_MAX_SOCKETS' argument sets the maximum number of sockets allowed
 on the context. You can query the maximal allowed value with
-xref:zmq_ctx_get.adoc[zmq_ctx_get] using the 'ZMQ_SOCKET_LIMIT' option.
+* xref:zmq_ctx_get.adoc[zmq_ctx_get] using the 'ZMQ_SOCKET_LIMIT' option.
 
 [horizontal]
 Default value:: 1023
@@ -180,8 +180,8 @@ assert (max_sockets == 256);
 
 
 == SEE ALSO
-xref:zmq_ctx_get.adoc[zmq_ctx_get]
-xref:zmq.adoc[zmq]
+* xref:zmq_ctx_get.adoc[zmq_ctx_get]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_ctx_set.adoc
+++ b/doc/zmq_ctx_set.adoc
@@ -130,7 +130,7 @@ The 'ZMQ_ZERO_COPY_RECV' argument specifies whether the message decoder should
 use a zero copy strategy when receiving messages. The zero copy strategy can
 lead to increased memory usage in some cases. This option allows you to use the
 older copying strategy. You can query the value of this option with
-* xref:zmq_ctx_get.adoc[zmq_ctx_get] using the 'ZMQ_ZERO_COPY_RECV' option.
+xref:zmq_ctx_get.adoc[zmq_ctx_get] using the 'ZMQ_ZERO_COPY_RECV' option.
 NOTE: in DRAFT state, not yet available in stable releases.
 
 [horizontal]

--- a/doc/zmq_ctx_set_ext.adoc
+++ b/doc/zmq_ctx_set_ext.adoc
@@ -70,8 +70,8 @@ assert (buffLen == prefixLen);
 
 
 == SEE ALSO
-xref:zmq_ctx_set.adoc[zmq_ctx_set]
-xref:zmq.adoc[zmq]
+* xref:zmq_ctx_set.adoc[zmq_ctx_set]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_ctx_shutdown.adoc
+++ b/doc/zmq_ctx_shutdown.adoc
@@ -34,11 +34,11 @@ The provided 'context' was invalid.
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
-xref:zmq_init.adoc[zmq_init]
-xref:zmq_ctx_term.adoc[zmq_ctx_term]
-xref:zmq_close.adoc[zmq_close]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq.adoc[zmq]
+* xref:zmq_init.adoc[zmq_init]
+* xref:zmq_ctx_term.adoc[zmq_ctx_term]
+* xref:zmq_close.adoc[zmq_close]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
 
 
 == AUTHORS

--- a/doc/zmq_ctx_term.adoc
+++ b/doc/zmq_ctx_term.adoc
@@ -33,7 +33,7 @@ For further details regarding socket linger behaviour refer to the _ZMQ_LINGER_
 option in xref:zmq_setsockopt.adoc[zmq_setsockopt]
 
 This function replaces the deprecated functions xref:zmq_term.adoc[zmq_term] and
-* xref:zmq_ctx_destroy.adoc[zmq_ctx_destroy]
+xref:zmq_ctx_destroy.adoc[zmq_ctx_destroy]
 
 
 == RETURN VALUE

--- a/doc/zmq_ctx_term.adoc
+++ b/doc/zmq_ctx_term.adoc
@@ -33,7 +33,7 @@ For further details regarding socket linger behaviour refer to the _ZMQ_LINGER_
 option in xref:zmq_setsockopt.adoc[zmq_setsockopt]
 
 This function replaces the deprecated functions xref:zmq_term.adoc[zmq_term] and
-xref:zmq_ctx_destroy.adoc[zmq_ctx_destroy]
+* xref:zmq_ctx_destroy.adoc[zmq_ctx_destroy]
 
 
 == RETURN VALUE
@@ -49,10 +49,10 @@ Termination was interrupted by a signal. It can be restarted if needed.
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
-xref:zmq_init.adoc[zmq_init]
-xref:zmq_close.adoc[zmq_close]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq.adoc[zmq]
+* xref:zmq_init.adoc[zmq_init]
+* xref:zmq_close.adoc[zmq_close]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
 
 
 == AUTHORS

--- a/doc/zmq_curve.adoc
+++ b/doc/zmq_curve.adoc
@@ -71,12 +71,12 @@ secret:
 ----
 
 == SEE ALSO
-xref:zmq_z85_encode.adoc[zmq_z85_encode]
-xref:zmq_z85_decode.adoc[zmq_z85_decode]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_null.adoc[zmq_null]
-xref:zmq_plain.adoc[zmq_plain]
-xref:zmq.adoc[zmq]
+* xref:zmq_z85_encode.adoc[zmq_z85_encode]
+* xref:zmq_z85_decode.adoc[zmq_z85_decode]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_null.adoc[zmq_null]
+* xref:zmq_plain.adoc[zmq_plain]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_curve_keypair.adoc
+++ b/doc/zmq_curve_keypair.adoc
@@ -37,9 +37,9 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_z85_encode.adoc[zmq_z85_encode]
-xref:zmq_z85_decode.adoc[zmq_z85_decode]
-xref:zmq_curve.adoc[zmq_curve]
+* xref:zmq_z85_encode.adoc[zmq_z85_encode]
+* xref:zmq_z85_decode.adoc[zmq_z85_decode]
+* xref:zmq_curve.adoc[zmq_curve]
 
 
 == AUTHORS

--- a/doc/zmq_curve_public.adoc
+++ b/doc/zmq_curve_public.adoc
@@ -42,10 +42,10 @@ assert (!strcmp (derived_public, public_key));
 
 
 == SEE ALSO
-xref:zmq_z85_encode.adoc[zmq_z85_encode]
-xref:zmq_z85_decode.adoc[zmq_z85_decode]
-xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
-xref:zmq_curve.adoc[zmq_curve]
+* xref:zmq_z85_encode.adoc[zmq_z85_encode]
+* xref:zmq_z85_decode.adoc[zmq_z85_decode]
+* xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
+* xref:zmq_curve.adoc[zmq_curve]
 
 
 == AUTHORS

--- a/doc/zmq_disconnect.adoc
+++ b/doc/zmq_disconnect.adoc
@@ -57,9 +57,9 @@ assert (rc == 0);
 ----
 
 == SEE ALSO
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_errno.adoc
+++ b/doc/zmq_errno.adoc
@@ -34,7 +34,7 @@ No errors are defined.
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_getsockopt.adoc
+++ b/doc/zmq_getsockopt.adoc
@@ -380,7 +380,7 @@ ZMQ_LINGER: Retrieve linger period for socket shutdown
 The 'ZMQ_LINGER' option shall retrieve the linger period for the specified
 'socket'.  The linger period determines how long pending messages which have
 yet to be sent to a peer shall linger in memory after a socket is closed with
-xref:zmq_close.adoc[zmq_close], and further affects the termination of the socket's
+* xref:zmq_close.adoc[zmq_close], and further affects the termination of the socket's
 context with xref:zmq_ctx_term.adoc[zmq_ctx_term] The following outlines the different
 behaviours:
 
@@ -1164,9 +1164,9 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_getsockopt.adoc
+++ b/doc/zmq_getsockopt.adoc
@@ -380,7 +380,7 @@ ZMQ_LINGER: Retrieve linger period for socket shutdown
 The 'ZMQ_LINGER' option shall retrieve the linger period for the specified
 'socket'.  The linger period determines how long pending messages which have
 yet to be sent to a peer shall linger in memory after a socket is closed with
-* xref:zmq_close.adoc[zmq_close], and further affects the termination of the socket's
+xref:zmq_close.adoc[zmq_close], and further affects the termination of the socket's
 context with xref:zmq_ctx_term.adoc[zmq_ctx_term] The following outlines the different
 behaviours:
 

--- a/doc/zmq_gssapi.adoc
+++ b/doc/zmq_gssapi.adoc
@@ -59,10 +59,10 @@ the krb5 GSSAPI mechanism.
 
 
 == SEE ALSO
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_null.adoc[zmq_null]
-xref:zmq_curve.adoc[zmq_curve]
-xref:zmq.adoc[zmq]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_null.adoc[zmq_null]
+* xref:zmq_curve.adoc[zmq_curve]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_inproc.adoc
+++ b/doc/zmq_inproc.adoc
@@ -12,7 +12,7 @@ sharing a single 0MQ 'context'.
 NOTE: No I/O threads are involved in passing messages using the 'inproc'
 transport. Therefore, if you are using a 0MQ 'context' for in-process messaging
 only you can initialise the 'context' with zero I/O threads. See
-* xref:zmq_init.adoc[zmq_init] for details.
+xref:zmq_init.adoc[zmq_init] for details.
 
 
 == ADDRESSING

--- a/doc/zmq_inproc.adoc
+++ b/doc/zmq_inproc.adoc
@@ -12,7 +12,7 @@ sharing a single 0MQ 'context'.
 NOTE: No I/O threads are involved in passing messages using the 'inproc'
 transport. Therefore, if you are using a 0MQ 'context' for in-process messaging
 only you can initialise the 'context' with zero I/O threads. See
-xref:zmq_init.adoc[zmq_init] for details.
+* xref:zmq_init.adoc[zmq_init] for details.
 
 
 == ADDRESSING
@@ -67,13 +67,13 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_ipc.adoc[zmq_ipc]
-xref:zmq_tcp.adoc[zmq_tcp]
-xref:zmq_pgm.adoc[zmq_pgm]
-xref:zmq_vmci.adoc[zmq_vmci]
-xref:zmq.adoc[zmq]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_ipc.adoc[zmq_ipc]
+* xref:zmq_tcp.adoc[zmq_tcp]
+* xref:zmq_pgm.adoc[zmq_pgm]
+* xref:zmq_vmci.adoc[zmq_vmci]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_ipc.adoc
+++ b/doc/zmq_ipc.adoc
@@ -84,14 +84,14 @@ assert (rc == 0);
 ----
 
 == SEE ALSO
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_inproc.adoc[zmq_inproc]
-xref:zmq_tcp.adoc[zmq_tcp]
-xref:zmq_pgm.adoc[zmq_pgm]
-xref:zmq_vmci.adoc[zmq_vmci]
-xref:zmq_getsockopt.adoc[zmq_getsockopt]
-xref:zmq.adoc[zmq]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_inproc.adoc[zmq_inproc]
+* xref:zmq_tcp.adoc[zmq_tcp]
+* xref:zmq_pgm.adoc[zmq_pgm]
+* xref:zmq_vmci.adoc[zmq_vmci]
+* xref:zmq_getsockopt.adoc[zmq_getsockopt]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_close.adoc
+++ b/doc/zmq_msg_close.adoc
@@ -35,13 +35,13 @@ Invalid message.
 
 
 == SEE ALSO
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
-xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
-xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
-xref:zmq_msg_data.adoc[zmq_msg_data]
-xref:zmq_msg_size.adoc[zmq_msg_size]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
+* xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
+* xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
+* xref:zmq_msg_data.adoc[zmq_msg_data]
+* xref:zmq_msg_size.adoc[zmq_msg_size]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_copy.adoc
+++ b/doc/zmq_msg_copy.adoc
@@ -49,13 +49,13 @@ zmq_msg_close (&msg);
 ----
 
 == SEE ALSO
-xref:zmq_msg_move.adoc[zmq_msg_move]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
-xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
-xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_move.adoc[zmq_msg_move]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
+* xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
+* xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_data.adoc
+++ b/doc/zmq_msg_data.adoc
@@ -27,13 +27,13 @@ No errors are defined.
 
 
 == SEE ALSO
-xref:zmq_msg_size.adoc[zmq_msg_size]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
-xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
-xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_size.adoc[zmq_msg_size]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
+* xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
+* xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_get.adoc
+++ b/doc/zmq_msg_get.adoc
@@ -63,10 +63,10 @@ while (true) {
 
 
 == SEE ALSO
-xref:zmq_msg_set.adoc[zmq_msg_set]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_set.adoc[zmq_msg_set]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_gets.adoc
+++ b/doc/zmq_msg_gets.adoc
@@ -66,8 +66,8 @@ zmq_msg_close (&msg);
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq.adoc[zmq]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please

--- a/doc/zmq_msg_init.adoc
+++ b/doc/zmq_msg_init.adoc
@@ -42,13 +42,13 @@ assert (nbytes != -1);
 
 
 == SEE ALSO
-xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
-xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
-xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq_msg_data.adoc[zmq_msg_data]
-xref:zmq_msg_size.adoc[zmq_msg_size]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
+* xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
+* xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq_msg_data.adoc[zmq_msg_data]
+* xref:zmq_msg_size.adoc[zmq_msg_size]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_init_buffer.adoc
+++ b/doc/zmq_msg_init_buffer.adoc
@@ -37,13 +37,13 @@ Insufficient storage space is available.
 
 
 == SEE ALSO
-xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
-xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq_msg_data.adoc[zmq_msg_data]
-xref:zmq_msg_size.adoc[zmq_msg_size]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
+* xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq_msg_data.adoc[zmq_msg_data]
+* xref:zmq_msg_size.adoc[zmq_msg_size]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_init_data.adoc
+++ b/doc/zmq_msg_init_data.adoc
@@ -67,13 +67,13 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
-xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq_msg_data.adoc[zmq_msg_data]
-xref:zmq_msg_size.adoc[zmq_msg_size]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
+* xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq_msg_data.adoc[zmq_msg_data]
+* xref:zmq_msg_size.adoc[zmq_msg_size]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_init_size.adoc
+++ b/doc/zmq_msg_init_size.adoc
@@ -37,13 +37,13 @@ Insufficient storage space is available.
 
 
 == SEE ALSO
-xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
-xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq_msg_data.adoc[zmq_msg_data]
-xref:zmq_msg_size.adoc[zmq_msg_size]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
+* xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq_msg_data.adoc[zmq_msg_data]
+* xref:zmq_msg_size.adoc[zmq_msg_size]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_more.adoc
+++ b/doc/zmq_msg_more.adoc
@@ -45,11 +45,11 @@ while (true) {
 
 
 == SEE ALSO
-xref:zmq_msg_get.adoc[zmq_msg_get]
-xref:zmq_msg_set.adoc[zmq_msg_set]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_get.adoc[zmq_msg_get]
+* xref:zmq_msg_set.adoc[zmq_msg_set]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_move.adoc
+++ b/doc/zmq_msg_move.adoc
@@ -31,13 +31,13 @@ Invalid message.
 
 
 == SEE ALSO
-xref:zmq_msg_copy.adoc[zmq_msg_copy]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
-xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
-xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_copy.adoc[zmq_msg_copy]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
+* xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
+* xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_recv.adoc
+++ b/doc/zmq_msg_recv.adoc
@@ -36,7 +36,7 @@ message or none at all. The total number of message parts is unlimited except
 by available memory.
 
 An application that processes multi-part messages must use the _ZMQ_RCVMORE_
-* xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_msg_recv()_ to determine if
+xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_msg_recv()_ to determine if
 there are further parts to receive.
 
 

--- a/doc/zmq_msg_recv.adoc
+++ b/doc/zmq_msg_recv.adoc
@@ -36,7 +36,7 @@ message or none at all. The total number of message parts is unlimited except
 by available memory.
 
 An application that processes multi-part messages must use the _ZMQ_RCVMORE_
-xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_msg_recv()_ to determine if
+* xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_msg_recv()_ to determine if
 there are further parts to receive.
 
 
@@ -105,13 +105,13 @@ do {
 
 
 == SEE ALSO
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_msg_send.adoc[zmq_msg_send]
-xref:zmq_getsockopt.adoc[zmq_getsockopt]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_msg_send.adoc[zmq_msg_send]
+* xref:zmq_getsockopt.adoc[zmq_getsockopt]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_routing_id.adoc
+++ b/doc/zmq_msg_routing_id.adoc
@@ -45,7 +45,7 @@ assert (routing_id);
 
 
 == SEE ALSO
-xref:zmq_msg_set_routing_id.adoc[zmq_msg_set_routing_id]
+* xref:zmq_msg_set_routing_id.adoc[zmq_msg_set_routing_id]
 
 
 == AUTHORS

--- a/doc/zmq_msg_send.adoc
+++ b/doc/zmq_msg_send.adoc
@@ -111,11 +111,11 @@ rc = zmq_msg_send (&part3, socket, 0);
 
 
 == SEE ALSO
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_msg_recv.adoc[zmq_msg_recv]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_msg_recv.adoc[zmq_msg_recv]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_set.adoc
+++ b/doc/zmq_msg_set.adoc
@@ -29,8 +29,8 @@ The requested property _property_ is unknown.
 
 
 == SEE ALSO
-xref:zmq_msg_get.adoc[zmq_msg_get]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_get.adoc[zmq_msg_get]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_set_routing_id.adoc
+++ b/doc/zmq_msg_set_routing_id.adoc
@@ -29,8 +29,8 @@ The provided 'routing_id' is zero.
 
 
 == SEE ALSO
-xref:zmq_msg_routing_id.adoc[zmq_msg_routing_id]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_routing_id.adoc[zmq_msg_routing_id]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_msg_size.adoc
+++ b/doc/zmq_msg_size.adoc
@@ -27,13 +27,13 @@ No errors are defined.
 
 
 == SEE ALSO
-xref:zmq_msg_data.adoc[zmq_msg_data]
-xref:zmq_msg_init.adoc[zmq_msg_init]
-xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
-xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
-xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
-xref:zmq_msg_close.adoc[zmq_msg_close]
-xref:zmq.adoc[zmq]
+* xref:zmq_msg_data.adoc[zmq_msg_data]
+* xref:zmq_msg_init.adoc[zmq_msg_init]
+* xref:zmq_msg_init_size.adoc[zmq_msg_init_size]
+* xref:zmq_msg_init_buffer.adoc[zmq_msg_init_buffer]
+* xref:zmq_msg_init_data.adoc[zmq_msg_init_data]
+* xref:zmq_msg_close.adoc[zmq_msg_close]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_null.adoc
+++ b/doc/zmq_null.adoc
@@ -12,9 +12,9 @@ for ZeroMQ sockets.
 
 
 == SEE ALSO
-xref:zmq_plain.adoc[zmq_plain]
-xref:zmq_curve.adoc[zmq_curve]
-xref:zmq.adoc[zmq]
+* xref:zmq_plain.adoc[zmq_plain]
+* xref:zmq_curve.adoc[zmq_curve]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_pgm.adoc
+++ b/doc/zmq_pgm.adoc
@@ -21,7 +21,7 @@ The 'pgm' and 'epgm' transports can only be used with the 'ZMQ_PUB' and
 
 Further, PGM sockets are rate limited by default. For details, refer to the
 'ZMQ_RATE', and 'ZMQ_RECOVERY_IVL' options documented in
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
 
 CAUTION: The 'pgm' transport implementation requires access to raw IP sockets.
 Additional privileges may be required on some operating systems for this
@@ -67,7 +67,7 @@ Consecutive PGM datagrams are interpreted by 0MQ as a single continuous stream
 of data where 0MQ messages are not necessarily aligned with PGM datagram
 boundaries and a single 0MQ message may span several PGM datagrams. This stream
 of data consists of 0MQ messages encapsulated in 'frames' as described in
-xref:zmq_tcp.adoc[zmq_tcp]
+* xref:zmq_tcp.adoc[zmq_tcp]
 
 
 PGM datagram payload
@@ -164,13 +164,13 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_tcp.adoc[zmq_tcp]
-xref:zmq_ipc.adoc[zmq_ipc]
-xref:zmq_inproc.adoc[zmq_inproc]
-xref:zmq_vmci.adoc[zmq_vmci]
-xref:zmq.adoc[zmq]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_tcp.adoc[zmq_tcp]
+* xref:zmq_ipc.adoc[zmq_ipc]
+* xref:zmq_inproc.adoc[zmq_inproc]
+* xref:zmq_vmci.adoc[zmq_vmci]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_pgm.adoc
+++ b/doc/zmq_pgm.adoc
@@ -21,7 +21,7 @@ The 'pgm' and 'epgm' transports can only be used with the 'ZMQ_PUB' and
 
 Further, PGM sockets are rate limited by default. For details, refer to the
 'ZMQ_RATE', and 'ZMQ_RECOVERY_IVL' options documented in
-* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+xref:zmq_setsockopt.adoc[zmq_setsockopt]
 
 CAUTION: The 'pgm' transport implementation requires access to raw IP sockets.
 Additional privileges may be required on some operating systems for this
@@ -67,7 +67,7 @@ Consecutive PGM datagrams are interpreted by 0MQ as a single continuous stream
 of data where 0MQ messages are not necessarily aligned with PGM datagram
 boundaries and a single 0MQ message may span several PGM datagrams. This stream
 of data consists of 0MQ messages encapsulated in 'frames' as described in
-* xref:zmq_tcp.adoc[zmq_tcp]
+xref:zmq_tcp.adoc[zmq_tcp]
 
 
 PGM datagram payload

--- a/doc/zmq_plain.adoc
+++ b/doc/zmq_plain.adoc
@@ -20,10 +20,10 @@ options. Which peer binds, and which connects, is not relevant.
 
 
 == SEE ALSO
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_null.adoc[zmq_null]
-xref:zmq_curve.adoc[zmq_curve]
-xref:zmq.adoc[zmq]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_null.adoc[zmq_null]
+* xref:zmq_curve.adoc[zmq_curve]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_poll.adoc
+++ b/doc/zmq_poll.adoc
@@ -122,10 +122,10 @@ assert (rc >= 0);
 
 
 == SEE ALSO
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq.adoc[zmq]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq.adoc[zmq]
 
 Your operating system documentation for the _poll()_ system call.
 

--- a/doc/zmq_poller.adoc
+++ b/doc/zmq_poller.adoc
@@ -312,10 +312,10 @@ zmq_poller_destroy (&poller);
 
 
 == SEE ALSO
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq.adoc[zmq]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_ppoll.adoc
+++ b/doc/zmq_ppoll.adoc
@@ -116,11 +116,11 @@ if (rc < 0 && errno == EINTR && sigterm_received) {
 
 
 == SEE ALSO
-xref:zmq_poll.adoc[zmq_poll]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq.adoc[zmq]
+* xref:zmq_poll.adoc[zmq_poll]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq.adoc[zmq]
 
 Your operating system documentation for the _poll()_ system call.
 

--- a/doc/zmq_proxy.adoc
+++ b/doc/zmq_proxy.adoc
@@ -79,10 +79,10 @@ zmq_proxy (frontend, backend, NULL);
 
 
 == SEE ALSO
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_proxy_steerable.adoc
+++ b/doc/zmq_proxy_steerable.adoc
@@ -109,11 +109,11 @@ zmq_close(control);
 
 
 == SEE ALSO
-xref:zmq_proxy.adoc[zmq_proxy]
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_proxy.adoc[zmq_proxy]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_recv.adoc
+++ b/doc/zmq_recv.adoc
@@ -32,7 +32,7 @@ message or none at all. The total number of message parts is unlimited except
 by available memory.
 
 An application that processes multi-part messages must use the _ZMQ_RCVMORE_
-xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_recv()_ to determine if
+* xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_recv()_ to determine if
 there are further parts to receive.
 
 == RETURN VALUE
@@ -74,11 +74,11 @@ assert (nbytes != -1);
 
 
 == SEE ALSO
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_getsockopt.adoc[zmq_getsockopt]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_getsockopt.adoc[zmq_getsockopt]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_recv.adoc
+++ b/doc/zmq_recv.adoc
@@ -32,7 +32,7 @@ message or none at all. The total number of message parts is unlimited except
 by available memory.
 
 An application that processes multi-part messages must use the _ZMQ_RCVMORE_
-* xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_recv()_ to determine if
+xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_recv()_ to determine if
 there are further parts to receive.
 
 == RETURN VALUE

--- a/doc/zmq_recvmsg.adoc
+++ b/doc/zmq_recvmsg.adoc
@@ -34,7 +34,7 @@ message or none at all. The total number of message parts is unlimited except
 by available memory.
 
 An application that processes multi-part messages must use the _ZMQ_RCVMORE_
-* xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_recvmsg()_ to determine if
+xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_recvmsg()_ to determine if
 there are further parts to receive.
 
 

--- a/doc/zmq_recvmsg.adoc
+++ b/doc/zmq_recvmsg.adoc
@@ -34,7 +34,7 @@ message or none at all. The total number of message parts is unlimited except
 by available memory.
 
 An application that processes multi-part messages must use the _ZMQ_RCVMORE_
-xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_recvmsg()_ to determine if
+* xref:zmq_getsockopt.adoc[zmq_getsockopt] option after calling _zmq_recvmsg()_ to determine if
 there are further parts to receive.
 
 
@@ -103,12 +103,12 @@ do {
 
 
 == SEE ALSO
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_getsockopt.adoc[zmq_getsockopt]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_getsockopt.adoc[zmq_getsockopt]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_send.adoc
+++ b/doc/zmq_send.adoc
@@ -85,10 +85,10 @@ assert (rc == 2);
 ----
 
 == SEE ALSO
-xref:zmq_send_const.adoc[zmq_send_const]
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_send_const.adoc[zmq_send_const]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_send_const.adoc
+++ b/doc/zmq_send_const.adoc
@@ -84,10 +84,10 @@ assert (rc == 2);
 ----
 
 == SEE ALSO
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_sendmsg.adoc
+++ b/doc/zmq_sendmsg.adoc
@@ -103,9 +103,9 @@ rc = zmq_sendmsg (socket, &part3, 0);
 
 
 == SEE ALSO
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_setsockopt.adoc
+++ b/doc/zmq_setsockopt.adoc
@@ -171,7 +171,7 @@ sockets, see xref:zmq_curve.adoc[zmq_curve] You can provide the key as 32 binary
 bytes, or as a 40-character string encoded in the Z85 encoding format and
 terminated in a null byte. The public key must always be used with the
 matching secret key. To generate a public/secret key pair, use
-* xref:zmq_curve_keypair.adoc[zmq_curve_keypair] To derive the public key from a secret key,
+xref:zmq_curve_keypair.adoc[zmq_curve_keypair] To derive the public key from a secret key,
 use xref:zmq_curve_public.adoc[zmq_curve_public]
 
 NOTE: an option value size of 40 is supported for backwards compatibility,
@@ -206,7 +206,7 @@ Applicable socket types:: all, when using TCP transport
 ZMQ_CURVE_SERVER: Set CURVE server role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Defines whether the socket will act as server for CURVE security, see
-* xref:zmq_curve.adoc[zmq_curve] A value of '1' means the socket will act as
+xref:zmq_curve.adoc[zmq_curve] A value of '1' means the socket will act as
 CURVE server. A value of '0' means the socket will not act as CURVE
 server, and its security role then depends on other option settings.
 Setting this to '0' shall reset the socket security to NULL. When you
@@ -228,7 +228,7 @@ sockets, see xref:zmq_curve.adoc[zmq_curve] You can provide the key as 32 binary
 bytes, or as a 40-character string encoded in the Z85 encoding format and
 terminated in a null byte. This key must have been generated together with
 the server's secret key. To generate a public/secret key pair, use
-* xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
+xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
 
 NOTE: an option value size of 40 is supported for backwards compatibility,
 though is deprecated.
@@ -270,7 +270,7 @@ Applicable socket types:: ZMQ_DEALER, ZMQ_CLIENT and ZMQ_PEER
 ZMQ_GSSAPI_PLAINTEXT: Disable GSSAPI encryption
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Defines whether communications on the socket will be encrypted, see
-* xref:zmq_gssapi.adoc[zmq_gssapi] A value of '1' means  that communications will be
+xref:zmq_gssapi.adoc[zmq_gssapi] A value of '1' means  that communications will be
 plaintext.  A value of '0' means communications will be encrypted.
 
 [horizontal]
@@ -294,7 +294,7 @@ Applicable socket types:: all, when using TCP transport
 ZMQ_GSSAPI_SERVER: Set GSSAPI server role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Defines whether the socket will act as server for GSSAPI security, see
-* xref:zmq_gssapi.adoc[zmq_gssapi] A value of '1' means the socket will act as GSSAPI
+xref:zmq_gssapi.adoc[zmq_gssapi] A value of '1' means the socket will act as GSSAPI
 server. A value of '0' means the socket will act as GSSAPI client.
 
 [horizontal]
@@ -482,7 +482,7 @@ ZMQ_LINGER: Set linger period for socket shutdown
 The 'ZMQ_LINGER' option shall set the linger period for the specified 'socket'.
 The linger period determines how long pending messages which have yet to be
 sent to a peer shall linger in memory after a socket is disconnected with
-* xref:zmq_disconnect.adoc[zmq_disconnect] or closed with xref:zmq_close.adoc[zmq_close], and further
+xref:zmq_disconnect.adoc[zmq_disconnect] or closed with xref:zmq_close.adoc[zmq_close], and further
 affects the termination of the socket's context with xref:zmq_ctx_term.adoc[zmq_ctx_term]
 The following outlines the different behaviours:
 
@@ -585,7 +585,7 @@ Applicable socket types:: all, when using TCP transport
 ZMQ_PLAIN_SERVER: Set PLAIN server role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Defines whether the socket will act as server for PLAIN security, see
-* xref:zmq_plain.adoc[zmq_plain] A value of '1' means the socket will act as
+xref:zmq_plain.adoc[zmq_plain] A value of '1' means the socket will act as
 PLAIN server. A value of '0' means the socket will not act as PLAIN
 server, and its security role then depends on other option settings.
 Setting this to '0' shall reset the socket security to NULL.

--- a/doc/zmq_setsockopt.adoc
+++ b/doc/zmq_setsockopt.adoc
@@ -171,7 +171,7 @@ sockets, see xref:zmq_curve.adoc[zmq_curve] You can provide the key as 32 binary
 bytes, or as a 40-character string encoded in the Z85 encoding format and
 terminated in a null byte. The public key must always be used with the
 matching secret key. To generate a public/secret key pair, use
-xref:zmq_curve_keypair.adoc[zmq_curve_keypair] To derive the public key from a secret key,
+* xref:zmq_curve_keypair.adoc[zmq_curve_keypair] To derive the public key from a secret key,
 use xref:zmq_curve_public.adoc[zmq_curve_public]
 
 NOTE: an option value size of 40 is supported for backwards compatibility,
@@ -206,7 +206,7 @@ Applicable socket types:: all, when using TCP transport
 ZMQ_CURVE_SERVER: Set CURVE server role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Defines whether the socket will act as server for CURVE security, see
-xref:zmq_curve.adoc[zmq_curve] A value of '1' means the socket will act as
+* xref:zmq_curve.adoc[zmq_curve] A value of '1' means the socket will act as
 CURVE server. A value of '0' means the socket will not act as CURVE
 server, and its security role then depends on other option settings.
 Setting this to '0' shall reset the socket security to NULL. When you
@@ -228,7 +228,7 @@ sockets, see xref:zmq_curve.adoc[zmq_curve] You can provide the key as 32 binary
 bytes, or as a 40-character string encoded in the Z85 encoding format and
 terminated in a null byte. This key must have been generated together with
 the server's secret key. To generate a public/secret key pair, use
-xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
+* xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
 
 NOTE: an option value size of 40 is supported for backwards compatibility,
 though is deprecated.
@@ -270,7 +270,7 @@ Applicable socket types:: ZMQ_DEALER, ZMQ_CLIENT and ZMQ_PEER
 ZMQ_GSSAPI_PLAINTEXT: Disable GSSAPI encryption
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Defines whether communications on the socket will be encrypted, see
-xref:zmq_gssapi.adoc[zmq_gssapi] A value of '1' means  that communications will be
+* xref:zmq_gssapi.adoc[zmq_gssapi] A value of '1' means  that communications will be
 plaintext.  A value of '0' means communications will be encrypted.
 
 [horizontal]
@@ -294,7 +294,7 @@ Applicable socket types:: all, when using TCP transport
 ZMQ_GSSAPI_SERVER: Set GSSAPI server role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Defines whether the socket will act as server for GSSAPI security, see
-xref:zmq_gssapi.adoc[zmq_gssapi] A value of '1' means the socket will act as GSSAPI
+* xref:zmq_gssapi.adoc[zmq_gssapi] A value of '1' means the socket will act as GSSAPI
 server. A value of '0' means the socket will act as GSSAPI client.
 
 [horizontal]
@@ -482,7 +482,7 @@ ZMQ_LINGER: Set linger period for socket shutdown
 The 'ZMQ_LINGER' option shall set the linger period for the specified 'socket'.
 The linger period determines how long pending messages which have yet to be
 sent to a peer shall linger in memory after a socket is disconnected with
-xref:zmq_disconnect.adoc[zmq_disconnect] or closed with xref:zmq_close.adoc[zmq_close], and further
+* xref:zmq_disconnect.adoc[zmq_disconnect] or closed with xref:zmq_close.adoc[zmq_close], and further
 affects the termination of the socket's context with xref:zmq_ctx_term.adoc[zmq_ctx_term]
 The following outlines the different behaviours:
 
@@ -585,7 +585,7 @@ Applicable socket types:: all, when using TCP transport
 ZMQ_PLAIN_SERVER: Set PLAIN server role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Defines whether the socket will act as server for PLAIN security, see
-xref:zmq_plain.adoc[zmq_plain] A value of '1' means the socket will act as
+* xref:zmq_plain.adoc[zmq_plain] A value of '1' means the socket will act as
 PLAIN server. A value of '0' means the socket will not act as PLAIN
 server, and its security role then depends on other option settings.
 Setting this to '0' shall reset the socket security to NULL.
@@ -1711,11 +1711,11 @@ assert (rc);
 
 
 == SEE ALSO
-xref:zmq_getsockopt.adoc[zmq_getsockopt]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq_plain.adoc[zmq_plain]
-xref:zmq_curve.adoc[zmq_curve]
-xref:zmq.adoc[zmq]
+* xref:zmq_getsockopt.adoc[zmq_getsockopt]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq_plain.adoc[zmq_plain]
+* xref:zmq_curve.adoc[zmq_curve]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_socket.adoc
+++ b/doc/zmq_socket.adoc
@@ -19,7 +19,7 @@ The newly created socket is initially unbound, and not associated with any
 endpoints. In order to establish a message flow a socket must first be
 connected to at least one endpoint with xref:zmq_connect.adoc[zmq_connect], or at least one
 endpoint must be created for accepting incoming connections with
-* xref:zmq_bind.adoc[zmq_bind]
+xref:zmq_bind.adoc[zmq_bind]
 
 .Key differences to conventional sockets
 Generally speaking, conventional sockets present a _synchronous_ interface to
@@ -85,7 +85,7 @@ will accept messages, queue them, and send them as rapidly as the network
 allows. The outgoing buffer limit is defined by the high water mark for the
 socket. If the outgoing buffer is full, or, for connection-oriented transports,
 if the ZMQ_IMMEDIATE option is set and there is no connected peer,
-* xref:zmq_send.adoc[zmq_send] will block.
+xref:zmq_send.adoc[zmq_send] will block.
 The 'ZMQ_CLIENT' socket will not drop messages.
 
 When a 'ZMQ_CLIENT' socket is connected to multiple 'ZMQ_SERVER' sockets,
@@ -616,7 +616,7 @@ peers, and each message received is fair-queued from all connected peers.
 When a 'ZMQ_DEALER' socket enters the 'mute' state due to having reached the
 high water mark for all peers, or, for connection-oriented transports, if the
 ZMQ_IMMEDIATE option is set and there are no peers at all, then any
-* xref:zmq_send.adoc[zmq_send] operations on the socket shall block until the mute state
+xref:zmq_send.adoc[zmq_send] operations on the socket shall block until the mute state
 ends or at least one peer becomes available for sending; messages are not discarded.
 
 When a 'ZMQ_DEALER' socket is connected to a 'ZMQ_REP' socket each message sent

--- a/doc/zmq_socket.adoc
+++ b/doc/zmq_socket.adoc
@@ -19,7 +19,7 @@ The newly created socket is initially unbound, and not associated with any
 endpoints. In order to establish a message flow a socket must first be
 connected to at least one endpoint with xref:zmq_connect.adoc[zmq_connect], or at least one
 endpoint must be created for accepting incoming connections with
-xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_bind.adoc[zmq_bind]
 
 .Key differences to conventional sockets
 Generally speaking, conventional sockets present a _synchronous_ interface to
@@ -85,7 +85,7 @@ will accept messages, queue them, and send them as rapidly as the network
 allows. The outgoing buffer limit is defined by the high water mark for the
 socket. If the outgoing buffer is full, or, for connection-oriented transports,
 if the ZMQ_IMMEDIATE option is set and there is no connected peer,
-xref:zmq_send.adoc[zmq_send] will block.
+* xref:zmq_send.adoc[zmq_send] will block.
 The 'ZMQ_CLIENT' socket will not drop messages.
 
 When a 'ZMQ_CLIENT' socket is connected to multiple 'ZMQ_SERVER' sockets,
@@ -616,7 +616,7 @@ peers, and each message received is fair-queued from all connected peers.
 When a 'ZMQ_DEALER' socket enters the 'mute' state due to having reached the
 high water mark for all peers, or, for connection-oriented transports, if the
 ZMQ_IMMEDIATE option is set and there are no peers at all, then any
-xref:zmq_send.adoc[zmq_send] operations on the socket shall block until the mute state
+* xref:zmq_send.adoc[zmq_send] operations on the socket shall block until the mute state
 ends or at least one peer becomes available for sending; messages are not discarded.
 
 When a 'ZMQ_DEALER' socket is connected to a 'ZMQ_REP' socket each message sent
@@ -734,14 +734,14 @@ zmq_ctx_destroy (ctx);
 
 
 == SEE ALSO
-xref:zmq_init.adoc[zmq_init]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_send.adoc[zmq_send]
-xref:zmq_recv.adoc[zmq_recv]
-xref:zmq_inproc.adoc[zmq_inproc]
-xref:zmq.adoc[zmq]
+* xref:zmq_init.adoc[zmq_init]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_send.adoc[zmq_send]
+* xref:zmq_recv.adoc[zmq_recv]
+* xref:zmq_inproc.adoc[zmq_inproc]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_socket_monitor.adoc
+++ b/doc/zmq_socket_monitor.adoc
@@ -279,7 +279,7 @@ int main (void)
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_socket_monitor_versioned.adoc
+++ b/doc/zmq_socket_monitor_versioned.adoc
@@ -385,7 +385,7 @@ int main (void)
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_strerror.adoc
+++ b/doc/zmq_strerror.adoc
@@ -38,7 +38,7 @@ if (!ctx) {
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_tcp.adoc
+++ b/doc/zmq_tcp.adoc
@@ -120,13 +120,13 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_pgm.adoc[zmq_pgm]
-xref:zmq_ipc.adoc[zmq_ipc]
-xref:zmq_inproc.adoc[zmq_inproc]
-xref:zmq_vmci.adoc[zmq_vmci]
-xref:zmq.adoc[zmq]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_pgm.adoc[zmq_pgm]
+* xref:zmq_ipc.adoc[zmq_ipc]
+* xref:zmq_inproc.adoc[zmq_inproc]
+* xref:zmq_vmci.adoc[zmq_vmci]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_timers.adoc
+++ b/doc/zmq_timers.adoc
@@ -144,7 +144,7 @@ _timer_id_ did not exist or was already cancelled.
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_tipc.adoc
+++ b/doc/zmq_tipc.adoc
@@ -61,14 +61,14 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_tcp.adoc[zmq_tcp]
-xref:zmq_pgm.adoc[zmq_pgm]
-xref:zmq_ipc.adoc[zmq_ipc]
-xref:zmq_inproc.adoc[zmq_inproc]
-xref:zmq_vmci.adoc[zmq_vmci]
-xref:zmq.adoc[zmq]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_tcp.adoc[zmq_tcp]
+* xref:zmq_pgm.adoc[zmq_pgm]
+* xref:zmq_ipc.adoc[zmq_ipc]
+* xref:zmq_inproc.adoc[zmq_inproc]
+* xref:zmq_vmci.adoc[zmq_vmci]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_udp.adoc
+++ b/doc/zmq_udp.adoc
@@ -94,13 +94,13 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_setsockopt.adoc[zmq_setsockopt]
-xref:zmq_tcp.adoc[zmq_tcp]
-xref:zmq_ipc.adoc[zmq_ipc]
-xref:zmq_inproc.adoc[zmq_inproc]
-xref:zmq_vmci.adoc[zmq_vmci]
-xref:zmq.adoc[zmq]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_setsockopt.adoc[zmq_setsockopt]
+* xref:zmq_tcp.adoc[zmq_tcp]
+* xref:zmq_ipc.adoc[zmq_ipc]
+* xref:zmq_inproc.adoc[zmq_inproc]
+* xref:zmq_vmci.adoc[zmq_vmci]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_unbind.adoc
+++ b/doc/zmq_unbind.adoc
@@ -24,7 +24,7 @@ The 'endpoint' argument is as described in xref:zmq_bind.adoc[zmq_bind]
 Unbinding wild-card address from a socket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When wild-card `*` 'endpoint' (described in xref:zmq_tcp.adoc[zmq_tcp],
-* xref:zmq_ipc.adoc[zmq_ipc], xref:zmq_udp.adoc[zmq_udp] and xref:zmq_vmci.adoc[zmq_vmci]) was used in
+xref:zmq_ipc.adoc[zmq_ipc], xref:zmq_udp.adoc[zmq_udp] and xref:zmq_vmci.adoc[zmq_vmci]) was used in
 _zmq_bind()_, the caller should use real 'endpoint' obtained from the 
 ZMQ_LAST_ENDPOINT socket option to unbind this 'endpoint' from a socket.
 

--- a/doc/zmq_unbind.adoc
+++ b/doc/zmq_unbind.adoc
@@ -24,7 +24,7 @@ The 'endpoint' argument is as described in xref:zmq_bind.adoc[zmq_bind]
 Unbinding wild-card address from a socket
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When wild-card `*` 'endpoint' (described in xref:zmq_tcp.adoc[zmq_tcp],
-xref:zmq_ipc.adoc[zmq_ipc], xref:zmq_udp.adoc[zmq_udp] and xref:zmq_vmci.adoc[zmq_vmci]) was used in
+* xref:zmq_ipc.adoc[zmq_ipc], xref:zmq_udp.adoc[zmq_udp] and xref:zmq_vmci.adoc[zmq_vmci]) was used in
 _zmq_bind()_, the caller should use real 'endpoint' obtained from the 
 ZMQ_LAST_ENDPOINT socket option to unbind this 'endpoint' from a socket.
 
@@ -83,9 +83,9 @@ interchangeably. Bound sockets should be unbound, and connected sockets should
 be disconnected.
 
 == SEE ALSO
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_socket.adoc[zmq_socket]
-xref:zmq.adoc[zmq]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_socket.adoc[zmq_socket]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_version.adoc
+++ b/doc/zmq_version.adoc
@@ -37,7 +37,7 @@ printf ("Current 0MQ version is %d.%d.%d\n", major, minor, patch);
 
 
 == SEE ALSO
-xref:zmq.adoc[zmq]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_vmci.adoc
+++ b/doc/zmq_vmci.adoc
@@ -75,14 +75,14 @@ assert (rc == 0);
 
 
 == SEE ALSO
-xref:zmq_bind.adoc[zmq_bind]
-xref:zmq_connect.adoc[zmq_connect]
-xref:zmq_inproc.adoc[zmq_inproc]
-xref:zmq_tcp.adoc[zmq_tcp]
-xref:zmq_pgm.adoc[zmq_pgm]
-xref:zmq_vmci.adoc[zmq_vmci]
-xref:zmq_getsockopt.adoc[zmq_getsockopt]
-xref:zmq.adoc[zmq]
+* xref:zmq_bind.adoc[zmq_bind]
+* xref:zmq_connect.adoc[zmq_connect]
+* xref:zmq_inproc.adoc[zmq_inproc]
+* xref:zmq_tcp.adoc[zmq_tcp]
+* xref:zmq_pgm.adoc[zmq_pgm]
+* xref:zmq_vmci.adoc[zmq_vmci]
+* xref:zmq_getsockopt.adoc[zmq_getsockopt]
+* xref:zmq.adoc[zmq]
 
 
 == AUTHORS

--- a/doc/zmq_z85_decode.adoc
+++ b/doc/zmq_z85_decode.adoc
@@ -32,10 +32,10 @@ zmq_z85_decode (public_key, decoded);
 
 
 == SEE ALSO
-xref:zmq_z85_encode.adoc[zmq_z85_encode]
-xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
-xref:zmq_curve_public.adoc[zmq_curve_public]
-xref:zmq_curve.adoc[zmq_curve]
+* xref:zmq_z85_encode.adoc[zmq_z85_encode]
+* xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
+* xref:zmq_curve_public.adoc[zmq_curve_public]
+* xref:zmq_curve.adoc[zmq_curve]
 
 
 == AUTHORS

--- a/doc/zmq_z85_encode.adoc
+++ b/doc/zmq_z85_encode.adoc
@@ -39,10 +39,10 @@ puts (encoded);
 
 
 == SEE ALSO
-xref:zmq_z85_decode.adoc[zmq_z85_decode]
-xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
-xref:zmq_curve_public.adoc[zmq_curve_public]
-xref:zmq_curve.adoc[zmq_curve]
+* xref:zmq_z85_decode.adoc[zmq_z85_decode]
+* xref:zmq_curve_keypair.adoc[zmq_curve_keypair]
+* xref:zmq_curve_public.adoc[zmq_curve_public]
+* xref:zmq_curve.adoc[zmq_curve]
 
 
 == AUTHORS


### PR DESCRIPTION
* In all "See also" sections: switch from space-separated list to unordered list representation

Rendering before the change: https://github.com/f18m/libzmq/blob/master/doc/zmq_bind.adoc
Rendering after the change: https://github.com/f18m/libzmq/blob/feature/improve-see-also/doc/zmq_bind.adoc