### PR TITLE
Make failing test not hang

### DIFF
--- a/tests/test_radio_dish.cpp
+++ b/tests/test_radio_dish.cpp
@@ -321,7 +321,7 @@ static bool is_multicast_available (int ipv6_)
         struct sockaddr_in *mcast_ipv4 = &mcast.ipv4;
 
         any_ipv4->sin_family = AF_INET;
-        any_ipv4->sin_port = htons (5555);
+        any_ipv4->sin_port = htons (port);
 
         rc = test_inet_pton (AF_INET, "0.0.0.0", &any_ipv4->sin_addr);
         if (rc == 0) {
@@ -395,15 +395,23 @@ static bool is_multicast_available (int ipv6_)
 
     msleep (SETTLE_TIME);
 
-    rc = sendto (send_sock, msg, static_cast<socklen_t> (strlen (msg)), 0,
+#ifdef ZMQ_HAVE_WINDOWS
+    rc = sendto (send_sock, msg, static_cast<int> (strlen (msg)), 0,
                  &mcast.generic, sl);
+#else
+    rc = sendto (send_sock, msg, strlen (msg), 0, &mcast.generic, sl);
+#endif
     if (rc < 0) {
         goto out;
     }
 
     msleep (SETTLE_TIME);
 
+#ifdef ZMQ_HAVE_WINDOWS
     rc = recvfrom (bind_sock, buf, sizeof (buf) - 1, 0, NULL, 0);
+#else
+    rc = recvfrom (bind_sock, buf, sizeof (buf) - 1, MSG_DONTWAIT, NULL, 0);
+#endif
     if (rc < 0) {
         goto out;
     }


### PR DESCRIPTION
The tests/test_radio_dish test implements is_multicast_available() to verify that multicast is working on the system before running tests that relies on this, or skipping those test otherwise.

In some circumstances this check itself hangs due to the recvfrom() call being blocking waiting for data. The test is eventually killed with a SIGALARM signal.

./config/test-driver: line 112: 1227308 Alarm clock             "$@" >> "$log_file" 2>&1
FAIL: tests/test_radio_dish

FAIL tests/test_radio_dish (exit status: 142)

$ tests/test_radio_dish
tests/test_radio_dish.cpp:511:test_leave_unjoined_fails:PASS
tests/test_radio_dish.cpp:512:test_join_too_long_fails:PASS
tests/test_radio_dish.cpp:513:test_long_group:PASS
tests/test_radio_dish.cpp:514:test_join_twice_fails:PASS
tests/test_radio_dish.cpp:515:test_radio_bind_fails_ipv4:PASS
tests/test_radio_dish.cpp:516:test_radio_bind_fails_ipv6:PASS
tests/test_radio_dish.cpp:517:test_dish_connect_fails_ipv4:PASS
tests/test_radio_dish.cpp:518:test_dish_connect_fails_ipv6:PASS
tests/test_radio_dish.cpp:519:test_radio_dish_tcp_poll_ipv4:PASS
tests/test_radio_dish.cpp:520:test_radio_dish_tcp_poll_ipv6:PASS
tests/test_radio_dish.cpp:521:test_radio_dish_udp_ipv4:PASS
tests/test_radio_dish.cpp:522:test_radio_dish_udp_ipv6:PASS
Alarm clock

With this commit, making the recvfrom() call non-blocking. The test does noy hang, and the non-available multicast is detected and the tests needing it are skipped:

PASS: tests/test_radio_dish

$ tests/test_radio_dish
tests/test_radio_dish.cpp:510:test_leave_unjoined_fails:PASS
tests/test_radio_dish.cpp:511:test_join_too_long_fails:PASS
tests/test_radio_dish.cpp:512:test_long_group:PASS
tests/test_radio_dish.cpp:513:test_join_twice_fails:PASS
tests/test_radio_dish.cpp:514:test_radio_bind_fails_ipv4:PASS
tests/test_radio_dish.cpp:515:test_radio_bind_fails_ipv6:PASS
tests/test_radio_dish.cpp:516:test_dish_connect_fails_ipv4:PASS
tests/test_radio_dish.cpp:517:test_dish_connect_fails_ipv6:PASS
tests/test_radio_dish.cpp:518:test_radio_dish_tcp_poll_ipv4:PASS
tests/test_radio_dish.cpp:519:test_radio_dish_tcp_poll_ipv6:PASS
tests/test_radio_dish.cpp:520:test_radio_dish_udp_ipv4:PASS
tests/test_radio_dish.cpp:521:test_radio_dish_udp_ipv6:PASS
tests/test_radio_dish.cpp:431:test_radio_dish_mcast_ipv4:IGNORE: No multicast available
tests/test_radio_dish.cpp:431:test_radio_dish_no_loop_ipv4:IGNORE: No multicast available
tests/test_radio_dish.cpp:431:test_radio_dish_mcast_ipv6:IGNORE: No multicast available
tests/test_radio_dish.cpp:431:test_radio_dish_no_loop_ipv6:IGNORE: No multicast available

-----------------------
16 Tests 0 Failures 4 Ignored
OK