### PR TITLE
Fix 4629 compile warning in endpoint.hpp

### DIFF
--- a/src/endpoint.hpp
+++ b/src/endpoint.hpp
@@ -29,7 +29,7 @@ struct endpoint_uri_pair_t
         return local_type == endpoint_type_bind ? local : remote;
     }
 
-    const bool clash () const { return local == remote; }
+    bool clash () const { return local == remote; }
 
     std::string local, remote;
     endpoint_type_t local_type;


### PR DESCRIPTION
Removes unused qualifier `const` from function returning a bool.