### PR TITLE
Replace old website contribution page link with the page of the new website

### DIFF
--- a/doc/zmq.adoc
+++ b/doc/zmq.adoc
@@ -254,7 +254,7 @@ members of the 0MQ community and pointers can be found on the 0MQ website.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.
 
 
 == RESOURCES

--- a/doc/zmq_atomic_counter_dec.adoc
+++ b/doc/zmq_atomic_counter_dec.adoc
@@ -51,4 +51,4 @@ return 0;
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_atomic_counter_destroy.adoc
+++ b/doc/zmq_atomic_counter_destroy.adoc
@@ -51,4 +51,4 @@ return 0;
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_atomic_counter_inc.adoc
+++ b/doc/zmq_atomic_counter_inc.adoc
@@ -50,4 +50,4 @@ return 0;
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_atomic_counter_new.adoc
+++ b/doc/zmq_atomic_counter_new.adoc
@@ -51,4 +51,4 @@ return 0;
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_atomic_counter_set.adoc
+++ b/doc/zmq_atomic_counter_set.adoc
@@ -50,4 +50,4 @@ return 0;
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_atomic_counter_value.adoc
+++ b/doc/zmq_atomic_counter_value.adoc
@@ -51,4 +51,4 @@ return 0;
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_bind.adoc
+++ b/doc/zmq_bind.adoc
@@ -93,4 +93,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_close.adoc
+++ b/doc/zmq_close.adoc
@@ -48,4 +48,4 @@ The provided 'socket' was NULL.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_connect.adoc
+++ b/doc/zmq_connect.adoc
@@ -97,4 +97,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_connect_peer.adoc
+++ b/doc/zmq_connect_peer.adoc
@@ -80,4 +80,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ctx_get.adoc
+++ b/doc/zmq_ctx_get.adoc
@@ -113,4 +113,4 @@ zmq_ctx_set (ctx, ZMQ_BLOCKY, false);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ctx_get_ext.adoc
+++ b/doc/zmq_ctx_get_ext.adoc
@@ -72,4 +72,4 @@ assert (buffLen == prefixLen);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ctx_new.adoc
+++ b/doc/zmq_ctx_new.adoc
@@ -44,4 +44,4 @@ and it wasn't possible to create a new context.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ctx_set.adoc
+++ b/doc/zmq_ctx_set.adoc
@@ -186,4 +186,4 @@ assert (max_sockets == 256);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ctx_set_ext.adoc
+++ b/doc/zmq_ctx_set_ext.adoc
@@ -76,4 +76,4 @@ assert (buffLen == prefixLen);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ctx_shutdown.adoc
+++ b/doc/zmq_ctx_shutdown.adoc
@@ -43,4 +43,4 @@ The provided 'context' was invalid.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ctx_term.adoc
+++ b/doc/zmq_ctx_term.adoc
@@ -57,4 +57,4 @@ Termination was interrupted by a signal. It can be restarted if needed.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_curve.adoc
+++ b/doc/zmq_curve.adoc
@@ -81,4 +81,4 @@ secret:
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_curve_keypair.adoc
+++ b/doc/zmq_curve_keypair.adoc
@@ -44,4 +44,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_curve_public.adoc
+++ b/doc/zmq_curve_public.adoc
@@ -50,4 +50,4 @@ assert (!strcmp (derived_public, public_key));
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_disconnect.adoc
+++ b/doc/zmq_disconnect.adoc
@@ -64,4 +64,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_errno.adoc
+++ b/doc/zmq_errno.adoc
@@ -39,4 +39,4 @@ No errors are defined.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_getsockopt.adoc
+++ b/doc/zmq_getsockopt.adoc
@@ -1171,4 +1171,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_gssapi.adoc
+++ b/doc/zmq_gssapi.adoc
@@ -67,4 +67,4 @@ the krb5 GSSAPI mechanism.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_has.adoc
+++ b/doc/zmq_has.adoc
@@ -35,4 +35,4 @@ provided. Otherwise it shall return 0.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_inproc.adoc
+++ b/doc/zmq_inproc.adoc
@@ -78,4 +78,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ipc.adoc
+++ b/doc/zmq_ipc.adoc
@@ -96,4 +96,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_close.adoc
+++ b/doc/zmq_msg_close.adoc
@@ -46,4 +46,4 @@ Invalid message.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_copy.adoc
+++ b/doc/zmq_msg_copy.adoc
@@ -60,4 +60,4 @@ zmq_msg_close (&msg);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_data.adoc
+++ b/doc/zmq_msg_data.adoc
@@ -38,4 +38,4 @@ No errors are defined.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_get.adoc
+++ b/doc/zmq_msg_get.adoc
@@ -71,4 +71,4 @@ while (true) {
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_gets.adoc
+++ b/doc/zmq_msg_gets.adoc
@@ -71,4 +71,4 @@ zmq_msg_close (&msg);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_init.adoc
+++ b/doc/zmq_msg_init.adoc
@@ -53,4 +53,4 @@ assert (nbytes != -1);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_init_buffer.adoc
+++ b/doc/zmq_msg_init_buffer.adoc
@@ -48,4 +48,4 @@ Insufficient storage space is available.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_init_data.adoc
+++ b/doc/zmq_msg_init_data.adoc
@@ -78,4 +78,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_init_size.adoc
+++ b/doc/zmq_msg_init_size.adoc
@@ -48,4 +48,4 @@ Insufficient storage space is available.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_more.adoc
+++ b/doc/zmq_msg_more.adoc
@@ -54,4 +54,4 @@ while (true) {
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_move.adoc
+++ b/doc/zmq_msg_move.adoc
@@ -42,4 +42,4 @@ Invalid message.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_recv.adoc
+++ b/doc/zmq_msg_recv.adoc
@@ -116,4 +116,4 @@ do {
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_routing_id.adoc
+++ b/doc/zmq_msg_routing_id.adoc
@@ -50,4 +50,4 @@ assert (routing_id);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_send.adoc
+++ b/doc/zmq_msg_send.adoc
@@ -120,4 +120,4 @@ rc = zmq_msg_send (&part3, socket, 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_set.adoc
+++ b/doc/zmq_msg_set.adoc
@@ -35,4 +35,4 @@ The requested property _property_ is unknown.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_set_routing_id.adoc
+++ b/doc/zmq_msg_set_routing_id.adoc
@@ -35,4 +35,4 @@ The provided 'routing_id' is zero.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_msg_size.adoc
+++ b/doc/zmq_msg_size.adoc
@@ -38,4 +38,4 @@ No errors are defined.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_null.adoc
+++ b/doc/zmq_null.adoc
@@ -19,4 +19,4 @@ for ZeroMQ sockets.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_pgm.adoc
+++ b/doc/zmq_pgm.adoc
@@ -175,4 +175,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_plain.adoc
+++ b/doc/zmq_plain.adoc
@@ -28,4 +28,4 @@ options. Which peer binds, and which connects, is not relevant.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_poll.adoc
+++ b/doc/zmq_poll.adoc
@@ -132,4 +132,4 @@ Your operating system documentation for the _poll()_ system call.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_poller.adoc
+++ b/doc/zmq_poller.adoc
@@ -320,4 +320,4 @@ zmq_poller_destroy (&poller);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_ppoll.adoc
+++ b/doc/zmq_ppoll.adoc
@@ -127,4 +127,4 @@ Your operating system documentation for the _poll()_ system call.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_proxy.adoc
+++ b/doc/zmq_proxy.adoc
@@ -87,4 +87,4 @@ zmq_proxy (frontend, backend, NULL);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_proxy_steerable.adoc
+++ b/doc/zmq_proxy_steerable.adoc
@@ -118,4 +118,4 @@ zmq_close(control);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_recv.adoc
+++ b/doc/zmq_recv.adoc
@@ -83,4 +83,4 @@ assert (nbytes != -1);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_recvmsg.adoc
+++ b/doc/zmq_recvmsg.adoc
@@ -113,4 +113,4 @@ do {
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_send.adoc
+++ b/doc/zmq_send.adoc
@@ -93,4 +93,4 @@ assert (rc == 2);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_send_const.adoc
+++ b/doc/zmq_send_const.adoc
@@ -92,4 +92,4 @@ assert (rc == 2);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_sendmsg.adoc
+++ b/doc/zmq_sendmsg.adoc
@@ -110,4 +110,4 @@ rc = zmq_sendmsg (socket, &part3, 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_setsockopt.adoc
+++ b/doc/zmq_setsockopt.adoc
@@ -1720,4 +1720,4 @@ assert (rc);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_socket.adoc
+++ b/doc/zmq_socket.adoc
@@ -746,4 +746,4 @@ zmq_ctx_destroy (ctx);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_socket_monitor.adoc
+++ b/doc/zmq_socket_monitor.adoc
@@ -284,4 +284,4 @@ int main (void)
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_socket_monitor_versioned.adoc
+++ b/doc/zmq_socket_monitor_versioned.adoc
@@ -390,4 +390,4 @@ int main (void)
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_strerror.adoc
+++ b/doc/zmq_strerror.adoc
@@ -43,5 +43,5 @@ if (!ctx) {
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.
 

--- a/doc/zmq_tcp.adoc
+++ b/doc/zmq_tcp.adoc
@@ -131,4 +131,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_timers.adoc
+++ b/doc/zmq_timers.adoc
@@ -149,4 +149,4 @@ _timer_id_ did not exist or was already cancelled.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_tipc.adoc
+++ b/doc/zmq_tipc.adoc
@@ -73,4 +73,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_udp.adoc
+++ b/doc/zmq_udp.adoc
@@ -105,4 +105,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_unbind.adoc
+++ b/doc/zmq_unbind.adoc
@@ -90,4 +90,4 @@ be disconnected.
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_version.adoc
+++ b/doc/zmq_version.adoc
@@ -42,4 +42,4 @@ printf ("Current 0MQ version is %d.%d.%d\n", major, minor, patch);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_vmci.adoc
+++ b/doc/zmq_vmci.adoc
@@ -87,4 +87,4 @@ assert (rc == 0);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_z85_decode.adoc
+++ b/doc/zmq_z85_decode.adoc
@@ -40,4 +40,4 @@ zmq_z85_decode (public_key, decoded);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.

--- a/doc/zmq_z85_encode.adoc
+++ b/doc/zmq_z85_encode.adoc
@@ -47,4 +47,4 @@ puts (encoded);
 
 == AUTHORS
 This page was written by the 0MQ community. To make a change please
-read the 0MQ Contribution Policy at <http://www.zeromq.org/docs:contributing>.
+read the 0MQ Contribution Policy at <https://zeromq.org/how-to-contribute/>.


### PR DESCRIPTION
Problem: all doc pages are pointing to the old wiki website "how to contribute"

Solution: mass-replace all docs with the link to the updated page in the new website