### PR TITLE
Non-ASCII characters support in ipc:// socket paths

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -27,8 +27,8 @@
 
 #include <direct.h>
 
-#define rmdir _rmdir
-#define unlink _unlink
+#define rmdir rmdir_utf8
+#define unlink unlink_utf8
 #endif
 
 #if defined ZMQ_HAVE_OPENVMS || defined ZMQ_HAVE_VXWORKS

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -25,8 +25,8 @@
 #include <afunix.h>
 #include <direct.h>
 
-#define rmdir _rmdir
-#define unlink _unlink
+#define rmdir rmdir_utf8
+#define unlink unlink_utf8
 
 #else
 #include <unistd.h>


### PR DESCRIPTION
Problem: Using non-ascii characters in unix domain socket path doesn't work on Windows.

Solution: Convert utf-8 socket paths to utf-16 file names when using filesystem calls to delete files and directories as Windows doesn't have any filesystem calls that take utf-8 path.

rmdir_utf8() and unlink_utf8() static functions were created which substitute rmdir() and unlink() when building on Windows.

Fixes #4641 