### PR TITLE
Fixing SEGV #4524. Pipe should only send to peer when active.

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -539,7 +539,7 @@ bool zmq::pipe_t::check_hwm () const
 
 void zmq::pipe_t::send_hwms_to_peer (int inhwm_, int outhwm_)
 {
-    if(_state == active)
+    if (_state == active)
         send_pipe_hwm (_peer, inhwm_, outhwm_);
 }
 
@@ -555,11 +555,11 @@ const zmq::endpoint_uri_pair_t &zmq::pipe_t::get_endpoint_pair () const
 
 void zmq::pipe_t::send_stats_to_peer (own_t *socket_base_)
 {
-    if(_state == active) {
+    if (_state == active) {
         endpoint_uri_pair_t *ep =
-        new (std::nothrow) endpoint_uri_pair_t (_endpoint_pair);
-        send_pipe_peer_stats (_peer, _msgs_written - _peers_msgs_read, socket_base_,
-                            ep);
+          new (std::nothrow) endpoint_uri_pair_t (_endpoint_pair);
+        send_pipe_peer_stats (_peer, _msgs_written - _peers_msgs_read,
+                              socket_base_, ep);
     }
 }
 

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -539,7 +539,8 @@ bool zmq::pipe_t::check_hwm () const
 
 void zmq::pipe_t::send_hwms_to_peer (int inhwm_, int outhwm_)
 {
-    send_pipe_hwm (_peer, inhwm_, outhwm_);
+    if(_state == active)
+        send_pipe_hwm (_peer, inhwm_, outhwm_);
 }
 
 void zmq::pipe_t::set_endpoint_pair (zmq::endpoint_uri_pair_t endpoint_pair_)
@@ -554,10 +555,12 @@ const zmq::endpoint_uri_pair_t &zmq::pipe_t::get_endpoint_pair () const
 
 void zmq::pipe_t::send_stats_to_peer (own_t *socket_base_)
 {
-    endpoint_uri_pair_t *ep =
-      new (std::nothrow) endpoint_uri_pair_t (_endpoint_pair);
-    send_pipe_peer_stats (_peer, _msgs_written - _peers_msgs_read, socket_base_,
-                          ep);
+    if(_state == active) {
+        endpoint_uri_pair_t *ep =
+        new (std::nothrow) endpoint_uri_pair_t (_endpoint_pair);
+        send_pipe_peer_stats (_peer, _msgs_written - _peers_msgs_read, socket_base_,
+                            ep);
+    }
 }
 
 void zmq::pipe_t::process_pipe_peer_stats (uint64_t queue_count_,


### PR DESCRIPTION
When socket monitoring is active a segmentation fault can occur when the pipepair has entered the mutual termination procedure. When this process is ongoing the pipe should not send or request any stats to or from the pipepair, because the pipepair could already be deleted. The conditions and the occurance of the SEGV are shown and explained in the image. 
![SEGV_diagram](https://github.com/zeromq/libzmq/assets/89665709/f46b9e25-741c-4fc2-9ca2-e268f7ce6fac)

**I'm happy to provide additional explanation.**
