### PR TITLE
Problem: cmake search for kqueue missing headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,7 @@ endif(WIN32)
 
 if(NOT MSVC)
   if(POLLER STREQUAL "")
-    check_cxx_symbol_exists(kqueue sys/event.h HAVE_KQUEUE)
+    check_cxx_symbol_exists(kqueue "sys/types.h;sys/event.h;sys/time.h" HAVE_KQUEUE)
     if(HAVE_KQUEUE)
       set(POLLER "kqueue")
     endif()


### PR DESCRIPTION
Result: on some BSD platforms (at least openbsd 7.4), cmake build will default to POLLER=poll instead of POLLER=kqueue.

Solution: include sys/types.h and sys/time.h as [documented by kqueue](https://man.openbsd.org/kqueue.2) and [used in autotools](https://github.com/zeromq/libzmq/blob/3b264019a24b08246e8a75f5014f893d7b6ffef9/acinclude.m4#L930-L932)

fixes kqueue detection on openbsd. This _avoids_ the error in #3957, but the error remains when building with explicit -DPOLLER=poll, or `./configure --with-poller=poll` .