### PR TITLE
halt build if CURVE requested but not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,12 +258,13 @@ endif()
 # Select curve encryption library, defaults to disabled To use libsodium instead, use --with-libsodium(must be
 # installed) To disable curve, use --disable-curve
 
-option(WITH_LIBSODIUM "Use libsodium" OFF)
+option(WITH_LIBSODIUM "Use libsodium (required with ENABLE_CURVE)" OFF)
 option(WITH_LIBSODIUM_STATIC "Use static libsodium library" OFF)
 option(ENABLE_LIBSODIUM_RANDOMBYTES_CLOSE "Automatically close libsodium randombytes. Not threadsafe without getrandom()" ON)
 option(ENABLE_CURVE "Enable CURVE security" OFF)
 
 if(ENABLE_CURVE)
+  # libsodium is currently the only CURVE provider
   if(WITH_LIBSODIUM)
     find_package("sodium")
     if(SODIUM_FOUND)
@@ -280,12 +281,17 @@ if(ENABLE_CURVE)
       endif()
     else()
       message(
-        ERROR
-          "libsodium not installed, you may want to install libsodium and run cmake again"
+        FATAL_ERROR
+          "libsodium requested but not found, you may want to install libsodium and run cmake again"
       )
     endif()
+  else() # WITH_LIBSODIUM
+    message(
+      FATAL_ERROR
+      "ENABLE_CURVE set, but not WITH_LIBSODIUM. No CURVE provider found."
+      )
   endif()
-else()
+else() # ENABLE_CURVE
   message(STATUS "CURVE security is disabled")
 endif()
 


### PR DESCRIPTION
Problem: It's frustrating to attempt to build libzmq with curve, only to find out _after build has completed_ that it wasn't found and the request was ignored.

Solution: respect user input and fail if their choice cannot be satisfied instead of ignoring it.

now builds where requested configuration is not found fail rather than proceeding without requested features

changes:

Previously, to enable curve, you needed the redundant config:

```
-DENABLE_CURVE=ON -DWITH_LIBSODIUM=ON
```

Whereas the following would not attempt to enable CURVE:

```
-DENABLE_CURVE=ON
```

and the required configuration would also proceed to build without CURVE, ignoring user request with a message.

Since ENABLE_CURVE and WITH_LIBSODIUM really represent the same thing now (there is no CURVE without sodium), we could also deprecate one or default it to True. But this is the smallest change.
