### PR TITLE
Fix the bug that the router may block forever when the sending queue is full

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -537,6 +537,11 @@ bool zmq::pipe_t::check_hwm () const
     return !full;
 }
 
+bool zmq::pipe_t::is_active() const
+{
+    return active == _state;
+}
+
 void zmq::pipe_t::send_hwms_to_peer (int inhwm_, int outhwm_)
 {
     if (_state == active)

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -537,7 +537,7 @@ bool zmq::pipe_t::check_hwm () const
     return !full;
 }
 
-bool zmq::pipe_t::is_active() const
+bool zmq::pipe_t::is_active () const
 {
     return active == _state;
 }

--- a/src/pipe.hpp
+++ b/src/pipe.hpp
@@ -115,6 +115,8 @@ class pipe_t ZMQ_FINAL : public object_t,
     //  Returns true if HWM is not reached
     bool check_hwm () const;
 
+    bool is_active () const;
+
     void set_endpoint_pair (endpoint_uri_pair_t endpoint_pair_);
     const endpoint_uri_pair_t &get_endpoint_pair () const;
 

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -185,7 +185,7 @@ int zmq::router_t::xsend (msg_t *msg_)
                 if (!_current_out->check_write ()) {
                     // Check whether pipe is full or not
                     const bool pipe_full = !_current_out->check_hwm ();
-                    const bool pipe_active = _current_out->is_active();
+                    const bool pipe_active = _current_out->is_active ();
                     out_pipe->active = false;
                     _current_out = NULL;
 

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -185,12 +185,13 @@ int zmq::router_t::xsend (msg_t *msg_)
                 if (!_current_out->check_write ()) {
                     // Check whether pipe is full or not
                     const bool pipe_full = !_current_out->check_hwm ();
+                    const bool pipe_active = _current_out->is_active();
                     out_pipe->active = false;
                     _current_out = NULL;
 
                     if (_mandatory) {
                         _more_out = false;
-                        if (pipe_full)
+                        if (pipe_full && pipe_active)
                             errno = EAGAIN;
                         else
                             errno = EHOSTUNREACH;


### PR DESCRIPTION
If we create a router, and ZMQ_ROUTER_MANDATORY is set to `1`, ZMQ_SNDTIMEO is set to `-1`(default value is -1, infinite)，when a peer SNDHWM is reached, we send a message to this peer, at this time the peer disconnected, We will observe that this situation will cause the function to be blocked forever.

We can find this bug through the following code:
```
static void test_dealer(void* const context)
{   
    void* const dealer = zmq_socket(context, ZMQ_DEALER);
    //
    int rc = zmq_setsockopt(dealer, ZMQ_ROUTING_ID, "X", 1);
    assert(0 == rc);
    rc = zmq_connect(dealer, "inproc://a");
    assert(0 == rc);
    //
    ::std::this_thread::sleep_for(::std::chrono::seconds(5));
    zmq_close(dealer);
    //
    printf("close dealer\n");
}
int main(void)
{
    void* const context = zmq_ctx_new();
    //  
    void* const router = zmq_socket(context, ZMQ_ROUTER);
    //  
    const int on = 1;
    int rc = zmq_setsockopt(router, ZMQ_ROUTER_MANDATORY, &on, sizeof(on));
    assert(0 == rc);
    //  
    rc = zmq_bind(router, "inproc://a");
    assert(0 == rc);
    //  
    ::std::thread thread0(test_dealer, context);
    thread0.detach();
    ::std::this_thread::sleep_for(::std::chrono::seconds(1));
    //  
    while (1) {
        rc = zmq_send(router, "X", 1, ZMQ_SNDMORE);
        if (1 != rc) {
            break;
        }
        rc = zmq_send(router, "hello", 5, 0);
        if (5 != rc) {
            break;
        }
    }
    return 0;
}
```