### PR TITLE
Fix Autotools-generated `libzmq.pc` file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,7 +362,7 @@ case "${host_os}" in
 
         if test "x$enable_static" = "xyes"; then
             CPPFLAGS="-DZMQ_STATIC $CPPFLAGS"
-            PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -liphlpapi"
+            PKGCFG_LIBS_PRIVATE="$PKGCFG_LIBS_PRIVATE -liphlpapi -lws2_32"
         fi
 	# Set FD_SETSIZE to 16384
 	CPPFLAGS=" -DFD_SETSIZE=16384 $CPPFLAGS"


### PR DESCRIPTION
On the master branch @ 481cc3fa2c4414e407d863b4428f1efd5441e97d, cross-compiling for Windows with static linking fails when relying on the `libzmq.pc` file.

Consider the minimum reproducible `zmq_win_demo.cpp` source file:
```
$ cat zmq_win_demo.cpp 
#include <zmq.h>

int main()
{
	auto ctx = zmq_ctx_new();
	zmq_ctx_term(ctx);
}
```

and steps to reproduce the bug as follows:
```
$ ZMQ_INSTALL_PATH=<set_any_path_at_your_choice>
$ ./autogen.sh
$ ./configure --host=x86_64-w64-mingw32 --prefix="$ZMQ_INSTALL_PATH" --disable-shared --disable-drafts --disable-libbsd --disable-perf --disable-Werror
$ make install
$ x86_64-w64-mingw32-g++-posix -static zmq_win_demo.cpp -DZMQ_STATIC $(env PKG_CONFIG_PATH="${ZMQ_INSTALL_PATH}/lib/pkgconfig pkg-config --static --cflags --libs libzmq) -o zmq_win_demo.exe
/usr/bin/x86_64-w64-mingw32-ld: /home/hebasto/TEST_INSTALL_ZMQ/lib/libzmq.a(libzmq_la-zmq.o):/home/hebasto/git/libzmq/src/zmq.cpp:1033: undefined reference to `__imp_select'
/usr/bin/x86_64-w64-mingw32-ld: /home/hebasto/TEST_INSTALL_ZMQ/lib/libzmq.a(libzmq_la-zmq.o): in function `zmq_poll':
/home/hebasto/git/libzmq/src/zmq.cpp:1073: undefined reference to `__WSAFDIsSet'
...
```

This PR fixes this bug.

---

Please note that CMake-generated `libzmq.pc` file is also broken as its "Libs.private" section contains only `-lstdc++` when cross-compiling for Windows. I leave this problem out of this PR scope.