### PR TITLE
cmake: don't use builtin sha1 if not using ws

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ if(NOT ZMQ_USE_GNUTLS)
       endif()
     endif()
   endif()
-  if(NOT ZMQ_USE_NSS)
+  if(ENABLE_WS AND NOT ZMQ_USE_NSS)
     list(APPEND sources ${CMAKE_CURRENT_SOURCE_DIR}/external/sha1/sha1.c
          ${CMAKE_CURRENT_SOURCE_DIR}/external/sha1/sha1.h)
     message(STATUS "Using builtin sha1")


### PR DESCRIPTION
The builtin SHA1 (`ZMQ_USE_BUILTIN_SHA1`) is only used in the websocket engine (`ws_engine.cpp`), so if websockets are disabled, i.e `-DENABLE_DRAFTS=OFF`, don't add `sha1.c` to the sources list.