### PR TITLE
build: fix mingw-w64 compilation with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,9 +313,9 @@ set(POLLER
   kqueue, epoll, devpoll, pollset, poll or select [default=autodetect]")
 
 if(WIN32)
+  set(ZMQ_HAVE_IPC OFF)
   if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore" AND CMAKE_SYSTEM_VERSION MATCHES "^10.0")
     set(ZMQ_HAVE_WINDOWS_UWP ON)
-    set(ZMQ_HAVE_IPC OFF)
     # to remove compile warninging "D9002 ignoring unknown option"
     string(REPLACE "/Zi" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
     set(CMAKE_CXX_FLAGS_DEBUG


### PR DESCRIPTION
Set `ZMQ_HAVE_IPC OFF` for all Windows builds, rather than just `WindowsStore` builds.

This fixes compiling with mingw-w64, and mirrors the autotools builds system:

https://github.com/zeromq/libzmq/blob/2a75ef07be0ba76f86592e10b999331cd6124d52/configure.ac#L145-L152