### PR TITLE
Problem: libzmq uses API not documented on learn.microsoft.com

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -565,6 +565,9 @@ if(ZMQ_HAVE_WINDOWS)
   check_cxx_symbol_exists(GetAdaptersAddresses "winsock2.h;iphlpapi.h" HAVE_IPHLAPI)
   check_cxx_symbol_exists(if_nametoindex "iphlpapi.h" HAVE_IF_NAMETOINDEX)
 
+  set(CMAKE_REQUIRED_LIBRARIES "synchronization.lib")
+  check_cxx_symbol_exists(WaitOnAddress "windows.h" HAVE_WAITONADDRESS)
+
   set(CMAKE_REQUIRED_LIBRARIES "")
   # TODO: This not the symbol we're looking for. What is the symbol?
   check_library_exists(ws2 fopen "" HAVE_WS2)
@@ -595,6 +598,10 @@ if(WIN32 AND NOT CYGWIN)
 
   if(NOT HAVE_IPHLAPI)
     message(FATAL_ERROR "Cannot link to iphlapi")
+  endif()
+  
+  if(NOT HAVE_WAITONADDRESS)
+    message(FATAL_ERROR "Cannot link to Synchronization")
   endif()
 endif()
 
@@ -1505,6 +1512,10 @@ if(BUILD_SHARED)
     target_link_libraries(libzmq iphlpapi)
   endif()
 
+  if(HAVE_WAITONADDRESS)
+    target_link_libraries(libzmq synchronization)
+  endif()
+
   if(RT_LIBRARY)
     target_link_libraries(libzmq -lrt)
   endif()
@@ -1553,6 +1564,10 @@ if(BUILD_STATIC)
 
   if(HAVE_IPHLAPI)
     target_link_libraries(libzmq-static iphlpapi)
+  endif()
+
+  if(HAVE_WAITONADDRESS)
+    target_link_libraries(libzmq-static synchronization)
   endif()
 
   if(RT_LIBRARY)

--- a/external/wepoll/wepoll.c
+++ b/external/wepoll/wepoll.c
@@ -483,8 +483,6 @@ typedef struct reflock {
   volatile long state; /* 32-bit Interlocked APIs operate on `long` values. */
 } reflock_t;
 
-WEPOLL_INTERNAL int reflock_global_init(void);
-
 WEPOLL_INTERNAL void reflock_init(reflock_t* reflock);
 WEPOLL_INTERNAL void reflock_ref(reflock_t* reflock);
 WEPOLL_INTERNAL void reflock_unref(reflock_t* reflock);
@@ -848,7 +846,7 @@ static BOOL CALLBACK init__once_callback(INIT_ONCE* once,
 
   /* N.b. that initialization order matters here. */
   if (ws_global_init() < 0 || nt_global_init() < 0 ||
-      reflock_global_init() < 0 || epoll_global_init() < 0)
+      epoll_global_init() < 0)
     return FALSE;
 
   init__done = true;
@@ -1523,31 +1521,17 @@ bool queue_is_enqueued(const queue_node_t* node) {
 #define REFLOCK__DESTROY_MASK ((long) 0xf0000000UL)
 #define REFLOCK__POISON       ((long) 0x300dead0UL)
 
-static HANDLE reflock__keyed_event = NULL;
-
-int reflock_global_init(void) {
-  NTSTATUS status = NtCreateKeyedEvent(
-      &reflock__keyed_event, KEYEDEVENT_ALL_ACCESS, NULL, 0);
-  if (status != STATUS_SUCCESS)
-    return_set_error(-1, RtlNtStatusToDosError(status));
-  return 0;
-}
-
 void reflock_init(reflock_t* reflock) {
   reflock->state = 0;
 }
 
 static void reflock__signal_event(void* address) {
-  NTSTATUS status =
-      NtReleaseKeyedEvent(reflock__keyed_event, address, FALSE, NULL);
-  if (status != STATUS_SUCCESS)
-    abort();
+  WakeByAddressSingle(address);
 }
 
 static void reflock__await_event(void* address) {
-  NTSTATUS status =
-      NtWaitForKeyedEvent(reflock__keyed_event, address, FALSE, NULL);
-  if (status != STATUS_SUCCESS)
+  BOOL status = WaitOnAddress(address, address, sizeof (void *), INFINITE);
+  if (status != TRUE)
     abort();
 }
 


### PR DESCRIPTION
Solution: Use WaitOnAddress instead of KeyedEvents APIs

This PR would help Microsoft repositories consuming libzmq and zeromq.js (such as microsoft/zeromq-prebuilt) to get into compliance with internal policies. I have created a PR here to request feedback on my changes and start a discussion on whether these changes could be integrated into this repository.