### PR TITLE
Do not bundle zmq.hpp in Debian packages anymore

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -54,12 +54,6 @@ else
 endif
 endif
 
-override_dh_auto_install:
-	dh_auto_install
-ifneq ("$(wildcard debian/zmq.hpp)","")
-	cp $(CURDIR)/debian/zmq.hpp $(CURDIR)/debian/tmp/usr/include/
-endif
-
 override_dh_strip:
 	dh_strip --dbg-package=libzmq5-dbg
 

--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -11,18 +11,6 @@
     <param name="filename">zeromq</param>
   </service>
 
-  <!-- embed zmq.hpp like Debian and Ubuntu do -->
-  <service name="download_url">
-    <param name="protocol">https</param>
-    <param name="host">github.com</param>
-    <param name="path">zeromq/cppzmq/archive/master.zip</param>
-  </service>
-  <service name="extract_file">
-    <param name="archive">*master.zip</param>
-    <param name="files">*/zmq.hpp</param>
-    <param name="outfilename">debian.zmq.hpp</param>
-  </service>
-
   <!-- extract redhat packaging -->
   <service name="extract_file">
     <param name="archive">*.tar</param>


### PR DESCRIPTION
This reverts commit 83c042ccda60cc94a6ad07a38fd8eb0e6dc12375 from https://github.com/zeromq/libzmq/pull/2852.

Starting with Debian 12 and Ubuntu 23.04, zmq.hpp is now included in the cppzmq-dev package. Thus, zmq.hpp should be removed from the OBS packages to prevent a conflict with the system cppzmq pacakge.