### PR TITLE
Problem: macos-latest CIs both failing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -112,11 +112,11 @@ jobs:
             CXX: clang++
           - os: macos-latest
             BUILD_TYPE: default
-            PACKAGES: automake autoconf
+            PACKAGES: automake autoconf libtool
             DRAFT: enabled
           - os: macos-latest
             BUILD_TYPE: default
-            PACKAGES: automake autoconf libsodium
+            PACKAGES: automake autoconf libtool libsodium
             CURVE: libsodium
             DRAFT: disabled
     env:


### PR DESCRIPTION
Solution: Install `libtool`. This seems to be the issue, given the CI output of a recent run, i.e:
```bash
 configure.ac:1023: the top level
configure.ac:80: error: possibly undefined macro: AC_LIBTOOL_WIN32_DLL
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:81: error: possibly undefined macro: AC_PROG_LIBTOOL
configure:7350: error: possibly undefined macro: AC_DISABLE_STATIC
configure:7354: error: possibly undefined macro: AC_ENABLE_STATIC
autoreconf: error: /opt/homebrew/Cellar/autoconf/2.72/bin/autoconf failed with exit status: 1
autogen.sh: error: autoreconf exited with status 1
+ exit 1
```
For example, a CI run from the recent opened #4699: https://github.com/zeromq/libzmq/actions/runs/9841129190/job/27167025854?pr=4699#step:12:200.