### PR TITLE
problem: trying to link against librt on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,6 +589,12 @@ if(NOT MINGW)
   find_library(RT_LIBRARY rt)
   if(RT_LIBRARY)
     set(pkg_config_libs_private "${pkg_config_libs_private} -lrt")
+
+    set(CMAKE_REQUIRED_LIBRARIES rt)
+    check_cxx_symbol_exists(clock_gettime time.h HAVE_CLOCK_GETTIME)
+    set(CMAKE_REQUIRED_LIBRARIES)
+  else()
+    check_cxx_symbol_exists(clock_gettime time.h HAVE_CLOCK_GETTIME)
   endif()
 endif()
 
@@ -609,10 +615,6 @@ if(WIN32 AND NOT CYGWIN)
 endif()
 
 if(NOT MSVC)
-  set(CMAKE_REQUIRED_LIBRARIES rt)
-  check_cxx_symbol_exists(clock_gettime time.h HAVE_CLOCK_GETTIME)
-  set(CMAKE_REQUIRED_LIBRARIES)
-
   check_cxx_symbol_exists(fork unistd.h HAVE_FORK)
   check_cxx_symbol_exists(gethrtime sys/time.h HAVE_GETHRTIME)
   check_cxx_symbol_exists(mkdtemp "stdlib.h;unistd.h" HAVE_MKDTEMP)


### PR DESCRIPTION
Solution: don't use `rt` if not `RT_LIBRARY`

This currently causes the check to fail on macOS:
```bash
/Library/Developer/CommandLineTools/usr/bin/c++  -std=c++11 -Wno-tautological-constant-compare  -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names CMakeFiles/cmTC_8466b.dir/CheckSymbolExists.cxx.o -o cmTC_8466b  -lrt
ld: library 'rt' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
even though `clock_gettime` is available.

Move the `clock_gettime` check up with the other librt related checks, and don't set `CMAKE_REQUIRED_LIBRARIES` if not `RT_LIBRARY`.