### PR TITLE
Replace insert with emplace

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6,6 +6,7 @@
 #include <set>
 
 #include "options.hpp"
+#include "blob.hpp"
 #include "err.hpp"
 #include "macros.hpp"
 
@@ -758,8 +759,7 @@ int zmq::options_t::setsockopt (int option_,
                     if (key.compare (0, 2, "X-") == 0
                         && key.length () <= UCHAR_MAX) {
                         std::string val = s.substr (pos + 1, s.length ());
-                        app_metadata.insert (
-                          std::pair<std::string, std::string> (key, val));
+                        app_metadata.ZMQ_MAP_INSERT_OR_EMPLACE (key, val);
                         return 0;
                     }
                 }

--- a/src/poller_base.cpp
+++ b/src/poller_base.cpp
@@ -3,6 +3,7 @@
 #include "precompiled.hpp"
 #include "poller_base.hpp"
 #include "i_poll_events.hpp"
+#include "blob.hpp"
 #include "err.hpp"
 
 zmq::poller_base_t::~poller_base_t ()
@@ -28,7 +29,7 @@ void zmq::poller_base_t::add_timer (int timeout_, i_poll_events *sink_, int id_)
 {
     uint64_t expiration = _clock.now_ms () + timeout_;
     timer_info_t info = {sink_, id_};
-    _timers.insert (timers_t::value_type (expiration, info));
+    _timers.ZMQ_MAP_INSERT_OR_EMPLACE (expiration, info);
 }
 
 void zmq::poller_base_t::cancel_timer (i_poll_events *sink_, int id_)

--- a/src/timers.cpp
+++ b/src/timers.cpp
@@ -2,6 +2,7 @@
 
 #include "precompiled.hpp"
 #include "timers.hpp"
+#include "blob.hpp"
 #include "err.hpp"
 
 #include <algorithm>
@@ -30,7 +31,7 @@ int zmq::timers_t::add (size_t interval_, timers_timer_fn handler_, void *arg_)
 
     uint64_t when = _clock.now_ms () + interval_;
     timer_t timer = {++_next_timer_id, interval_, handler_, arg_};
-    _timers.insert (timersmap_t::value_type (when, timer));
+    _timers.ZMQ_MAP_INSERT_OR_EMPLACE (when, timer);
 
     return timer.timer_id;
 }
@@ -79,7 +80,7 @@ int zmq::timers_t::set_interval (int timer_id_, size_t interval_)
         timer.interval = interval_;
         uint64_t when = _clock.now_ms () + interval_;
         _timers.erase (it);
-        _timers.insert (timersmap_t::value_type (when, timer));
+        _timers.ZMQ_MAP_INSERT_OR_EMPLACE (when, timer);
 
         return 0;
     }
@@ -97,7 +98,7 @@ int zmq::timers_t::reset (int timer_id_)
         timer_t timer = it->second;
         uint64_t when = _clock.now_ms () + timer.interval;
         _timers.erase (it);
-        _timers.insert (timersmap_t::value_type (when, timer));
+        _timers.ZMQ_MAP_INSERT_OR_EMPLACE (when, timer);
 
         return 0;
     }
@@ -147,8 +148,7 @@ int zmq::timers_t::execute ()
 
             timer.handler (timer.timer_id, timer.arg);
 
-            _timers.insert (
-              timersmap_t::value_type (now + timer.interval, timer));
+            _timers.ZMQ_MAP_INSERT_OR_EMPLACE (now + timer.interval, timer);
         }
     }
     _timers.erase (begin, it);


### PR DESCRIPTION
Perhaps some compilers can optimize insert at compile time, but replacing insert with emplace can avoid unnecessary copy construction or move construction at the C++ syntax level.