### PR TITLE
Fix reading cycle count on non-msvc win-on-aarch64

### DIFF
--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -223,6 +223,10 @@ uint64_t zmq::clock_t::rdtsc ()
                                  ((13 & 15) << 3) | // crm
                                  ((0 & 7) << 0));   // op2
     return _ReadStatusReg (pmccntr_el0);
+#elif (defined(_WIN32) && defined(__GNUC__) && defined(__aarch64__))
+    uint64_t val;
+    __asm__ volatile("mrs %0, pmccntr_el0" : "=r"(val));
+    return val;
 #elif (defined __GNUC__ && (defined __i386__ || defined __x86_64__))
     uint32_t low, high;
     __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));


### PR DESCRIPTION
This closes #4723

This seems fairly portable across all aarch64 systems, be it Windows or Linux.
The arm 32bit intrinsic seems to be Microsoft-Specific, so I don't know how to implement this for arm32.

I don't think either gcc or clang support 32bit arm Windows though, so at least the issue with the undefined variable is solved.