### PR TITLE
cmake_minimum_required() before project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 # CMake build script for ZeroMQ
-project(ZeroMQ)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
+if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Darwin)
   cmake_minimum_required(VERSION 3.0.2)
 else()
   cmake_minimum_required(VERSION 2.8.12)
 endif()
+
+project(ZeroMQ)
 
 include(CheckIncludeFiles)
 include(CheckCCompilerFlag)


### PR DESCRIPTION
 * Without this CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded (MT) Windows builds still produced incompatible MultiThreadedDLL (MD) output.

 * Resolves following warning:

CMake Warning (dev) at CMakeLists.txt:2 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.

 * Use ${CMAKE_HOST_SYSTEM_NAME} as ${CMAKE_SYSTEM_NAME} not set before project().