### PR TITLE
set upper bound in cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # CMake build script for ZeroMQ
 
 if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Darwin)
-  cmake_minimum_required(VERSION 3.0.2)
+  cmake_minimum_required(VERSION 3.0.2...3.31)
 else()
-  cmake_minimum_required(VERSION 2.8.12)
+  cmake_minimum_required(VERSION 2.8.12...3.31)
 endif()
 
 project(ZeroMQ)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake build script for ZeroMQ tests
-cmake_minimum_required(VERSION "2.8.1")
+cmake_minimum_required(VERSION 2.8.1...3.31)
 
 # On Windows: solution file will be called tests.sln
 project(tests)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake build script for ZeroMQ unit tests
-cmake_minimum_required(VERSION "2.8.1")
+cmake_minimum_required(VERSION 2.8.1...3.31)
 
 set(unittests
     unittest_ypipe


### PR DESCRIPTION
setting an upper bound improves forward-compatibility as legacy version support is dropped. Without an upper bound, the minimum version is used as the policy version, which means that setting a version lower than 3.5 will result in warnings starting with cmake 3.27 and errors starting in 4.0 (release candidate out now). This change allows zeromq to build with cmake 4.

- 3.5 compat is deprecated in 3.27 (2023), removed in 4.0 (2025)
- 3.10 compat is deprecated in 3.31 (2024)