### PR TITLE
Rename RemoveSection macro to avoid duplicate conflict with NSIS3

### DIFF
--- a/builds/cmake/NSIS.template32.in
+++ b/builds/cmake/NSIS.template32.in
@@ -120,7 +120,7 @@ Var AR_RegFlags
  "exit_${SecName}:"
 !macroend
  
-!macro RemoveSection SecName
+!macro RemoveSection_CPack SecName
   ;  This macro is used to call section's Remove_... macro
   ;from the uninstaller.
   ;Input: section index constant name specified in Section command.
@@ -843,7 +843,7 @@ Section "Uninstall"
   DeleteRegKey SHCTX "Software\@CPACK_PACKAGE_VENDOR@\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@"
 
   ; Removes all optional components
-  !insertmacro SectionList "RemoveSection"
+  !insertmacro SectionList "RemoveSection_CPack"
   
   !insertmacro MUI_STARTMENU_GETFOLDER Application $MUI_TEMP
     

--- a/builds/cmake/NSIS.template64.in
+++ b/builds/cmake/NSIS.template64.in
@@ -120,7 +120,7 @@ Var AR_RegFlags
  "exit_${SecName}:"
 !macroend
  
-!macro RemoveSection SecName
+!macro RemoveSection_CPack SecName
   ;  This macro is used to call section's Remove_... macro
   ;from the uninstaller.
   ;Input: section index constant name specified in Section command.
@@ -846,7 +846,7 @@ Section "Uninstall"
   DeleteRegKey SHCTX "Software\@CPACK_PACKAGE_VENDOR@\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@"
 
   ; Removes all optional components
-  !insertmacro SectionList "RemoveSection"
+  !insertmacro SectionList "RemoveSection_CPack"
   
   !insertmacro MUI_STARTMENU_GETFOLDER Application $MUI_TEMP
     


### PR DESCRIPTION
The latest version of NSIS (3.11) gives an error with the included NSIS templates. Renaming the RemoveSection macro seems to solve this issue. 