### PR TITLE
Fix up broken CI checks

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -66,7 +66,7 @@ jobs:
           - os: ubuntu-latest
             BUILD_TYPE: cmake
             DRAFT: enabled
-            PACKAGES: cmake clang-format-11
+            PACKAGES: cmake clang-format-18
             DO_CLANG_FORMAT_CHECK: 1
           - os: ubuntu-latest
             BUILD_TYPE: default
@@ -223,7 +223,7 @@ jobs:
       CLANG_TIDY: clang-tidy
     steps:
     - name: Add debian packages
-      run: apt-get install --yes clang-tidy clang-tools
+      run: sudo apt-get install --yes clang-tidy clang-tools
     - name: build
       shell: bash
       working-directory: libzmq

--- a/builds/cmake/ci_build.sh
+++ b/builds/cmake/ci_build.sh
@@ -90,6 +90,7 @@ mkdir build_cmake
 cd build_cmake
 if [ "$DO_CLANG_FORMAT_CHECK" = "1" ] ; then
     if ! ( PKG_CONFIG_PATH=${BUILD_PREFIX}/lib/pkgconfig cmake "${CMAKE_OPTS[@]}" .. && make clang-format-check) ; then
+        echo "clang-format version is: $(clang-format --version)"
         make clang-format-diff
         exit 1
     fi

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -17,7 +17,7 @@
 #define ZMQ_VERSION_PATCH 6
 
 #define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
-    ((major) *10000 + (minor) *100 + (patch))
+    ((major) * 10000 + (minor) * 100 + (patch))
 #define ZMQ_VERSION                                                            \
     ZMQ_MAKE_VERSION (ZMQ_VERSION_MAJOR, ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)
 
@@ -39,9 +39,9 @@ extern "C" {
 #if defined ZMQ_STATIC
 #define ZMQ_EXPORT
 #elif defined DLL_EXPORT
-#define ZMQ_EXPORT __declspec(dllexport)
+#define ZMQ_EXPORT __declspec (dllexport)
 #else
-#define ZMQ_EXPORT __declspec(dllimport)
+#define ZMQ_EXPORT __declspec (dllimport)
 #endif
 #else
 #if defined __SUNPRO_C || defined __SUNPRO_CC
@@ -218,10 +218,10 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context_);
 typedef struct zmq_msg_t
 {
 #if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
-    __declspec(align (8)) unsigned char _[64];
+    __declspec (align (8)) unsigned char _[64];
 #elif defined(_MSC_VER)                                                        \
   && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
-    __declspec(align (4)) unsigned char _[64];
+    __declspec (align (4)) unsigned char _[64];
 #elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
   || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
   || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)

--- a/src/atomic_counter.hpp
+++ b/src/atomic_counter.hpp
@@ -54,9 +54,9 @@ namespace zmq
 //  mutexes).
 
 #if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
-class __declspec(align (8)) atomic_counter_t
+class __declspec (align (8)) atomic_counter_t
 #elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE))
-class __declspec(align (4)) atomic_counter_t
+class __declspec (align (4)) atomic_counter_t
 #else
 class atomic_counter_t
 #endif
@@ -86,23 +86,23 @@ class atomic_counter_t
 #elif defined ZMQ_ATOMIC_COUNTER_TILE
         old_value = arch_atomic_add (&_value, increment_);
 #elif defined ZMQ_ATOMIC_COUNTER_X86
-        __asm__ volatile("lock; xadd %0, %1 \n\t"
-                         : "=r"(old_value), "=m"(_value)
-                         : "0"(increment_), "m"(_value)
-                         : "cc", "memory");
+        __asm__ volatile ("lock; xadd %0, %1 \n\t"
+                          : "=r"(old_value), "=m"(_value)
+                          : "0"(increment_), "m"(_value)
+                          : "cc", "memory");
 #elif defined ZMQ_ATOMIC_COUNTER_ARM
         integer_t flag, tmp;
-        __asm__ volatile("       dmb     sy\n\t"
-                         "1:     ldrex   %0, [%5]\n\t"
-                         "       add     %2, %0, %4\n\t"
-                         "       strex   %1, %2, [%5]\n\t"
-                         "       teq     %1, #0\n\t"
-                         "       bne     1b\n\t"
-                         "       dmb     sy\n\t"
-                         : "=&r"(old_value), "=&r"(flag), "=&r"(tmp),
-                           "+Qo"(_value)
-                         : "Ir"(increment_), "r"(&_value)
-                         : "cc");
+        __asm__ volatile ("       dmb     sy\n\t"
+                          "1:     ldrex   %0, [%5]\n\t"
+                          "       add     %2, %0, %4\n\t"
+                          "       strex   %1, %2, [%5]\n\t"
+                          "       teq     %1, #0\n\t"
+                          "       bne     1b\n\t"
+                          "       dmb     sy\n\t"
+                          : "=&r"(old_value), "=&r"(flag), "=&r"(tmp),
+                            "+Qo"(_value)
+                          : "Ir"(increment_), "r"(&_value)
+                          : "cc");
 #elif defined ZMQ_ATOMIC_COUNTER_MUTEX
         sync.lock ();
         old_value = _value;
@@ -140,24 +140,24 @@ class atomic_counter_t
 #elif defined ZMQ_ATOMIC_COUNTER_X86
         integer_t oldval = -decrement_;
         volatile integer_t *val = &_value;
-        __asm__ volatile("lock; xaddl %0,%1"
-                         : "=r"(oldval), "=m"(*val)
-                         : "0"(oldval), "m"(*val)
-                         : "cc", "memory");
+        __asm__ volatile ("lock; xaddl %0,%1"
+                          : "=r"(oldval), "=m"(*val)
+                          : "0"(oldval), "m"(*val)
+                          : "cc", "memory");
         return oldval != decrement_;
 #elif defined ZMQ_ATOMIC_COUNTER_ARM
         integer_t old_value, flag, tmp;
-        __asm__ volatile("       dmb     sy\n\t"
-                         "1:     ldrex   %0, [%5]\n\t"
-                         "       sub     %2, %0, %4\n\t"
-                         "       strex   %1, %2, [%5]\n\t"
-                         "       teq     %1, #0\n\t"
-                         "       bne     1b\n\t"
-                         "       dmb     sy\n\t"
-                         : "=&r"(old_value), "=&r"(flag), "=&r"(tmp),
-                           "+Qo"(_value)
-                         : "Ir"(decrement_), "r"(&_value)
-                         : "cc");
+        __asm__ volatile ("       dmb     sy\n\t"
+                          "1:     ldrex   %0, [%5]\n\t"
+                          "       sub     %2, %0, %4\n\t"
+                          "       strex   %1, %2, [%5]\n\t"
+                          "       teq     %1, #0\n\t"
+                          "       bne     1b\n\t"
+                          "       dmb     sy\n\t"
+                          : "=&r"(old_value), "=&r"(flag), "=&r"(tmp),
+                            "+Qo"(_value)
+                          : "Ir"(decrement_), "r"(&_value)
+                          : "cc");
         return old_value - decrement_ != 0;
 #elif defined ZMQ_ATOMIC_COUNTER_MUTEX
         sync.lock ();
@@ -170,10 +170,7 @@ class atomic_counter_t
 #endif
     }
 
-    integer_t get () const ZMQ_NOEXCEPT
-    {
-        return _value;
-    }
+    integer_t get () const ZMQ_NOEXCEPT { return _value; }
 
   private:
 #if defined ZMQ_ATOMIC_COUNTER_CXX11

--- a/src/atomic_ptr.hpp
+++ b/src/atomic_ptr.hpp
@@ -60,22 +60,22 @@ inline void *atomic_xchg_ptr (void **ptr_,
     return arch_atomic_exchange (ptr_, val_);
 #elif defined ZMQ_ATOMIC_PTR_X86
     void *old;
-    __asm__ volatile("lock; xchg %0, %2"
-                     : "=r"(old), "=m"(*ptr_)
-                     : "m"(*ptr_), "0"(val_));
+    __asm__ volatile ("lock; xchg %0, %2"
+                      : "=r"(old), "=m"(*ptr_)
+                      : "m"(*ptr_), "0"(val_));
     return old;
 #elif defined ZMQ_ATOMIC_PTR_ARM
     void *old;
     unsigned int flag;
-    __asm__ volatile("       dmb     sy\n\t"
-                     "1:     ldrex   %1, [%3]\n\t"
-                     "       strex   %0, %4, [%3]\n\t"
-                     "       teq     %0, #0\n\t"
-                     "       bne     1b\n\t"
-                     "       dmb     sy\n\t"
-                     : "=&r"(flag), "=&r"(old), "+Qo"(*ptr_)
-                     : "r"(ptr_), "r"(val_)
-                     : "cc");
+    __asm__ volatile ("       dmb     sy\n\t"
+                      "1:     ldrex   %1, [%3]\n\t"
+                      "       strex   %0, %4, [%3]\n\t"
+                      "       teq     %0, #0\n\t"
+                      "       bne     1b\n\t"
+                      "       dmb     sy\n\t"
+                      : "=&r"(flag), "=&r"(old), "+Qo"(*ptr_)
+                      : "r"(ptr_), "r"(val_)
+                      : "cc");
     return old;
 #elif defined ZMQ_ATOMIC_PTR_MUTEX
     _sync.lock ();
@@ -111,26 +111,26 @@ inline void *atomic_cas (void *volatile *ptr_,
     return arch_atomic_val_compare_and_exchange (ptr_, cmp_, val_);
 #elif defined ZMQ_ATOMIC_PTR_X86
     void *old;
-    __asm__ volatile("lock; cmpxchg %2, %3"
-                     : "=a"(old), "=m"(*ptr_)
-                     : "r"(val_), "m"(*ptr_), "0"(cmp_)
-                     : "cc");
+    __asm__ volatile ("lock; cmpxchg %2, %3"
+                      : "=a"(old), "=m"(*ptr_)
+                      : "r"(val_), "m"(*ptr_), "0"(cmp_)
+                      : "cc");
     return old;
 #elif defined ZMQ_ATOMIC_PTR_ARM
     void *old;
     unsigned int flag;
-    __asm__ volatile("       dmb     sy\n\t"
-                     "1:     ldrex   %1, [%3]\n\t"
-                     "       mov     %0, #0\n\t"
-                     "       teq     %1, %4\n\t"
-                     "       it      eq\n\t"
-                     "       strexeq %0, %5, [%3]\n\t"
-                     "       teq     %0, #0\n\t"
-                     "       bne     1b\n\t"
-                     "       dmb     sy\n\t"
-                     : "=&r"(flag), "=&r"(old), "+Qo"(*ptr_)
-                     : "r"(ptr_), "r"(cmp_), "r"(val_)
-                     : "cc");
+    __asm__ volatile ("       dmb     sy\n\t"
+                      "1:     ldrex   %1, [%3]\n\t"
+                      "       mov     %0, #0\n\t"
+                      "       teq     %1, %4\n\t"
+                      "       it      eq\n\t"
+                      "       strexeq %0, %5, [%3]\n\t"
+                      "       teq     %0, #0\n\t"
+                      "       bne     1b\n\t"
+                      "       dmb     sy\n\t"
+                      : "=&r"(flag), "=&r"(old), "+Qo"(*ptr_)
+                      : "r"(ptr_), "r"(cmp_), "r"(val_)
+                      : "cc");
     return old;
 #elif defined ZMQ_ATOMIC_PTR_MUTEX
     _sync.lock ();

--- a/src/blob.hpp
+++ b/src/blob.hpp
@@ -89,7 +89,7 @@ struct blob_t
     unsigned char *data () { return _data; }
 
     //  Defines an order relationship on blob_t.
-    bool operator<(blob_t const &other_) const
+    bool operator< (blob_t const &other_) const
     {
         const int cmpres =
           memcmp (_data, other_._data, std::min (_size, other_._size));
@@ -161,10 +161,7 @@ struct blob_t
         return *this;
     }
 #else
-    blob_t (const blob_t &other) : _owned (false)
-    {
-        set_deep_copy (other);
-    }
+    blob_t (const blob_t &other) : _owned (false) { set_deep_copy (other); }
     blob_t &operator= (const blob_t &other)
     {
         if (this != &other) {

--- a/src/clock.cpp
+++ b/src/clock.cpp
@@ -225,11 +225,11 @@ uint64_t zmq::clock_t::rdtsc ()
     return _ReadStatusReg (pmccntr_el0);
 #elif (defined(_WIN32) && defined(__GNUC__) && defined(__aarch64__))
     uint64_t val;
-    __asm__ volatile("mrs %0, pmccntr_el0" : "=r"(val));
+    __asm__ volatile ("mrs %0, pmccntr_el0" : "=r"(val));
     return val;
 #elif (defined __GNUC__ && (defined __i386__ || defined __x86_64__))
     uint32_t low, high;
-    __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
+    __asm__ volatile ("rdtsc" : "=a"(low), "=d"(high));
     return static_cast<uint64_t> (high) << 32 | low;
 #elif (defined __SUNPRO_CC && (__SUNPRO_CC >= 0x5100)                          \
        && (defined __i386 || defined __amd64 || defined __x86_64))
@@ -238,11 +238,11 @@ uint64_t zmq::clock_t::rdtsc ()
         uint64_t u64val;
         uint32_t u32val[2];
     } tsc;
-    asm("rdtsc" : "=a"(tsc.u32val[0]), "=d"(tsc.u32val[1]));
+    asm ("rdtsc" : "=a"(tsc.u32val[0]), "=d"(tsc.u32val[1]));
     return tsc.u64val;
 #elif defined(__s390__)
     uint64_t tsc;
-    asm("\tstck\t%0\n" : "=Q"(tsc) : : "cc");
+    asm ("\tstck\t%0\n" : "=Q"(tsc) : : "cc");
     return tsc;
 #else
     struct timespec ts;

--- a/src/err.hpp
+++ b/src/err.hpp
@@ -36,7 +36,7 @@ void zmq_abort (const char *errmsg_) __attribute__ ((analyzer_noreturn));
 void zmq_abort (const char *errmsg_);
 #endif
 #elif defined __MSCVER__
-__declspec(noreturn) void zmq_abort (const char *errmsg_);
+__declspec (noreturn) void zmq_abort (const char *errmsg_);
 #else
 void zmq_abort (const char *errmsg_);
 #endif

--- a/src/mailbox.hpp
+++ b/src/mailbox.hpp
@@ -31,10 +31,7 @@ class mailbox_t ZMQ_FINAL : public i_mailbox
     // close the file descriptors in the signaller. This is used in a forked
     // child process to close the file descriptors so that they do not interfere
     // with the context in the parent process.
-    void forked () ZMQ_FINAL
-    {
-        _signaler.forked ();
-    }
+    void forked () ZMQ_FINAL { _signaler.forked (); }
 #endif
 
   private:

--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -629,7 +629,7 @@ void zmq::norm_engine_t::recv_data (NormObjectHandle object)
                 else // Move back to "rx_pending" list until NORM_RX_OBJECT_UPDATED
                     msg_ready_list.Append (*rxState);
             } // end while(NULL != (rxState = iterator.GetNextItem()))
-        }     // end if (zmq_input_ready)
+        } // end if (zmq_input_ready)
     } // end while ((!rx_ready_list.empty() || (zmq_input_ready && !msg_ready_list.empty()))
 
     // Alert zmq of the messages we have pushed up

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -110,14 +110,10 @@ int zmq::socket_poller_t::add (socket_base_t *socket_,
         socket_->add_signaler (_signaler);
     }
 
-    const item_t item = {
-        socket_,
-        0,
-        user_data_,
-        events_
+    const item_t item = {socket_, 0, user_data_, events_
 #if defined ZMQ_POLL_BASED_ON_POLL
-        ,
-        -1
+                         ,
+                         -1
 #endif
     };
     try {
@@ -140,14 +136,10 @@ int zmq::socket_poller_t::add_fd (fd_t fd_, void *user_data_, short events_)
         return -1;
     }
 
-    const item_t item = {
-        NULL,
-        fd_,
-        user_data_,
-        events_
+    const item_t item = {NULL, fd_, user_data_, events_
 #if defined ZMQ_POLL_BASED_ON_POLL
-        ,
-        -1
+                         ,
+                         -1
 #endif
     };
     try {

--- a/src/stream_engine_base.hpp
+++ b/src/stream_engine_base.hpp
@@ -69,7 +69,7 @@ class stream_engine_base_t : public io_object_t, public i_engine
     void set_handshake_timer ();
 
     virtual bool handshake () { return true; };
-    virtual void plug_internal (){};
+    virtual void plug_internal () {};
 
     virtual int process_command_message (msg_t *msg_)
     {

--- a/src/tipc_address.cpp
+++ b/src/tipc_address.cpp
@@ -113,14 +113,12 @@ int zmq::tipc_address_t::to_string (std::string &addr_) const
     std::stringstream s;
     if (address.addrtype == TIPC_ADDR_NAMESEQ
         || address.addrtype == TIPC_ADDR_NAME) {
-        s << "tipc://"
-          << "{" << address.addr.nameseq.type;
+        s << "tipc://" << "{" << address.addr.nameseq.type;
         s << ", " << address.addr.nameseq.lower;
         s << ", " << address.addr.nameseq.upper << "}";
         addr_ = s.str ();
     } else if (address.addrtype == TIPC_ADDR_ID || is_random ()) {
-        s << "tipc://"
-          << "<" << tipc_zone (address.addr.id.node);
+        s << "tipc://" << "<" << tipc_zone (address.addr.id.node);
         s << "." << tipc_cluster (address.addr.id.node);
         s << "." << tipc_node (address.addr.id.node);
         s << ":" << address.addr.id.ref << ">";

--- a/src/udp_engine.hpp
+++ b/src/udp_engine.hpp
@@ -40,7 +40,7 @@ class udp_engine_t ZMQ_FINAL : public io_object_t, public i_engine
     //  are messages to send available.
     void restart_output ();
 
-    void zap_msg_available (){};
+    void zap_msg_available () {};
 
     void in_event ();
     void out_event ();

--- a/src/ypipe_conflate.hpp
+++ b/src/ypipe_conflate.hpp
@@ -42,19 +42,13 @@ template <typename T> class ypipe_conflate_t ZMQ_FINAL : public ypipe_base_t<T>
 #endif
 
     // There are no incomplete items for conflate ypipe
-    bool unwrite (T *)
-    {
-        return false;
-    }
+    bool unwrite (T *) { return false; }
 
     //  Flush is no-op for conflate ypipe. Reader asleep behaviour
     //  is as of the usual ypipe.
     //  Returns false if the reader thread is sleeping. In that case,
     //  caller is obliged to wake the reader up before using the pipe again.
-    bool flush ()
-    {
-        return reader_awake;
-    }
+    bool flush () { return reader_awake; }
 
     //  Check whether item is available for reading.
     bool check_read ()
@@ -79,10 +73,7 @@ template <typename T> class ypipe_conflate_t ZMQ_FINAL : public ypipe_base_t<T>
     //  Applies the function fn to the first element in the pipe
     //  and returns the value returned by the fn.
     //  The pipe mustn't be empty or the function crashes.
-    bool probe (bool (*fn_) (const T &))
-    {
-        return dbuffer.probe (fn_);
-    }
+    bool probe (bool (*fn_) (const T &)) { return dbuffer.probe (fn_); }
 
   protected:
     dbuffer_t<T> dbuffer;

--- a/tests/test_tcp_accept_filter.cpp
+++ b/tests/test_tcp_accept_filter.cpp
@@ -56,10 +56,7 @@ void test_bad_filter_string (const char *const filter_)
 }
 
 #define TEST_BAD_FILTER_STRING(case, filter)                                   \
-    void test_bad_filter_string_##case ()                                      \
-    {                                                                          \
-        test_bad_filter_string (filter);                                       \
-    }
+    void test_bad_filter_string_##case (){test_bad_filter_string (filter);}
 
 TEST_BAD_FILTER_STRING (foo, "foo")
 TEST_BAD_FILTER_STRING (zeros_foo, "0.0.0.0foo")


### PR DESCRIPTION
- Updated clang format to a version that is available in the recent Github Actions environments
- Run clang-format on the codebase to get the ci check passing

Testing: 
- Relying on CI