### PR TITLE
Problem: code coverage build fails

### DIFF
--- a/m4/ax_code_coverage.m4
+++ b/m4/ax_code_coverage.m4
@@ -125,8 +125,8 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 		dnl Build the code coverage flags
 		dnl Define CODE_COVERAGE_LDFLAGS for backwards compatibility
 		CODE_COVERAGE_CPPFLAGS="-DNDEBUG"
-		CODE_COVERAGE_CFLAGS="-O0 -g -fprofile-arcs -ftest-coverage"
-		CODE_COVERAGE_CXXFLAGS="-O0 -g -fprofile-arcs -ftest-coverage"
+		CODE_COVERAGE_CFLAGS="-O0 -g -fprofile-arcs -fprofile-update=atomic -ftest-coverage"
+		CODE_COVERAGE_CXXFLAGS="-O0 -g -fprofile-arcs -fprofile-update=atomic -ftest-coverage"
 		CODE_COVERAGE_LIBS="-lgcov"
 		CODE_COVERAGE_LDFLAGS="$CODE_COVERAGE_LIBS"
 
@@ -142,7 +142,7 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 ']
 		[CODE_COVERAGE_RULES_CAPTURE='
 	$(code_coverage_v_lcov_cap)$(LCOV) $(code_coverage_quiet) $(addprefix --directory ,$(CODE_COVERAGE_DIRECTORY)) --capture --output-file "$(CODE_COVERAGE_OUTPUT_FILE).tmp" --test-name "$(call code_coverage_sanitize,$(PACKAGE_NAME)-$(PACKAGE_VERSION))" --no-checksum --compat-libtool $(CODE_COVERAGE_LCOV_SHOPTS) $(CODE_COVERAGE_LCOV_OPTIONS)
-	$(code_coverage_v_lcov_ign)$(LCOV) $(code_coverage_quiet) $(addprefix --directory ,$(CODE_COVERAGE_DIRECTORY)) --remove "$(CODE_COVERAGE_OUTPUT_FILE).tmp" "/tmp/*" $(CODE_COVERAGE_IGNORE_PATTERN) --output-file "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_LCOV_SHOPTS) $(CODE_COVERAGE_LCOV_RMOPTS)
+	$(code_coverage_v_lcov_ign)$(LCOV) $(code_coverage_quiet) $(addprefix --directory ,$(CODE_COVERAGE_DIRECTORY)) --ignore-errors unused --remove "$(CODE_COVERAGE_OUTPUT_FILE).tmp" "/tmp/*" $(CODE_COVERAGE_IGNORE_PATTERN) --output-file "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_LCOV_SHOPTS) $(CODE_COVERAGE_LCOV_RMOPTS)
 	-@rm -f $(CODE_COVERAGE_OUTPUT_FILE).tmp
 	$(code_coverage_v_genhtml)LANG=C $(GENHTML) $(code_coverage_quiet) $(addprefix --prefix ,$(CODE_COVERAGE_DIRECTORY)) --output-directory "$(CODE_COVERAGE_OUTPUT_DIRECTORY)" --title "$(PACKAGE_NAME)-$(PACKAGE_VERSION) Code Coverage" --legend --show-details "$(CODE_COVERAGE_OUTPUT_FILE)" $(CODE_COVERAGE_GENHTML_OPTIONS)
 	@echo "file://$(abs_builddir)/$(CODE_COVERAGE_OUTPUT_DIRECTORY)/index.html"


### PR DESCRIPTION
Solution: add -fprofile-update=atomic and --ignore-errors unused as indicated by log message

```
geninfo: ERROR: Unexpected negative count '-1' for /usr/include/c++/13/bits/stl_tree.h:2466.
	Perhaps you need to compile with '-fprofile-update=atomic

LCOV   --remove /tmp/*
lcov: ERROR: 'exclude' pattern '/tmp/*' is unused.
	(use "lcov --ignore-errors unused ..." to bypass this error)
```