### PR TITLE
Expose the ability to have zero allocation sends.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1067,7 +1067,8 @@ test_apps += tests/test_poller \
 	tests/test_hiccup_msg \
 	tests/test_zmq_ppoll_fd \
 	tests/test_xsub_verbose \
-	tests/test_pubsub_topics_count
+	tests/test_pubsub_topics_count \
+	tests/test_msg_ffn_external_storage
 
 tests_test_poller_SOURCES = tests/test_poller.cpp
 tests_test_poller_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
@@ -1148,6 +1149,10 @@ tests_test_xsub_verbose_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 tests_test_pubsub_topics_count_SOURCES = tests/test_pubsub_topics_count.cpp
 tests_test_pubsub_topics_count_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
 tests_test_pubsub_topics_count_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+
+tests_test_msg_ffn_external_storage_SOURCES = tests/test_msg_ffn_external_storage.cpp
+tests_test_msg_ffn_external_storage_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
+tests_test_msg_ffn_external_storage_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 
 if HAVE_FORK
 test_apps += tests/test_zmq_ppoll_signals

--- a/builds/gyp/project-tests.gypi
+++ b/builds/gyp/project-tests.gypi
@@ -133,6 +133,17 @@
       ],
     },
     {
+      'target_name': 'test_msg_ffn_external_storage',
+      'type': 'executable',
+      'sources': [
+        '../../tests/test_msg_ffn_external_storage.cpp',
+        '../../tests/testutil.hpp'
+      ],
+      'dependencies': [
+        'libzmq'
+      ],
+    },
+    {
       'target_name': 'test_msg_init',
       'type': 'executable',
       'sources': [

--- a/builds/gyp/project-tests.xml
+++ b/builds/gyp/project-tests.xml
@@ -11,6 +11,7 @@
     <test name = "test_invalid_rep" />
     <test name = "test_msg_flags" />
     <test name = "test_msg_ffn" />
+    <test name = "test_msg_ffn_external_storage" />
     <test name = "test_msg_init" />
     <test name = "test_connect_resolve" />
     <test name = "test_immediate" />

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -701,22 +701,8 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 ZMQ_EXPORT int
 zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
 
-/*  Draft Msg control block type for init_external_storage.                   */
-typedef struct zmq_msg_content_t
-{
-#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
-    __declspec (align (8)) unsigned char _[64];
-#elif defined(_MSC_VER)                                                        \
-  && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
-    __declspec (align (4)) unsigned char _[64];
-#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
-  || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
-  || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
-    unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
-#else
-    unsigned char _[64];
-#endif
-} zmq_msg_content_t;
+/*  Draft Msg control block type for init_external_storage. (64 bytes)        */
+typedef zmq_msg_t zmq_msg_content_t;
 
 ZMQ_EXPORT int zmq_msg_init_external_storage (zmq_msg_t *msg_,
                                               zmq_msg_content_t *content_,

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -233,27 +233,10 @@ typedef struct zmq_msg_t
 
 typedef void (zmq_free_fn) (void *data_, void *hint_);
 
-typedef struct zmq_msg_content_t{
-#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
-  __declspec (align (8)) unsigned char _[64];
-#elif defined(_MSC_VER)                                                        \
-&& (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
-  __declspec (align (4)) unsigned char _[64];
-#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
-|| (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
-|| (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
-  unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
-#else
-  unsigned char _[64];
-#endif
-} zmq_msg_content_t;
-
 ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg_);
 ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_);
 ZMQ_EXPORT int zmq_msg_init_data (
   zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
-ZMQ_EXPORT int zmq_msg_init_external_storage (
-  zmq_msg_t *msg_, zmq_msg_content_t *content_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
 ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_);
 ZMQ_EXPORT int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_);
 ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg_);
@@ -717,6 +700,30 @@ ZMQ_EXPORT int zmq_msg_set_group (zmq_msg_t *msg, const char *group);
 ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 ZMQ_EXPORT int
 zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
+
+/*  Draft Msg control block type for init_external_storage.                   */
+typedef struct zmq_msg_content_t
+{
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
+    __declspec (align (8)) unsigned char _[64];
+#elif defined(_MSC_VER)                                                        \
+  && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
+    __declspec (align (4)) unsigned char _[64];
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
+  || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
+  || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
+    unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
+#else
+    unsigned char _[64];
+#endif
+} zmq_msg_content_t;
+
+ZMQ_EXPORT int zmq_msg_init_external_storage (zmq_msg_t *msg_,
+                                              zmq_msg_content_t *content_,
+                                              void *data_,
+                                              size_t size_,
+                                              zmq_free_fn *ffn_,
+                                              void *hint_);
 
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -233,10 +233,27 @@ typedef struct zmq_msg_t
 
 typedef void (zmq_free_fn) (void *data_, void *hint_);
 
+typedef struct zmq_msg_content_t{
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
+  __declspec (align (8)) unsigned char _[64];
+#elif defined(_MSC_VER)                                                        \
+&& (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
+  __declspec (align (4)) unsigned char _[64];
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
+|| (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
+|| (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
+  unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
+#else
+  unsigned char _[64];
+#endif
+} zmq_msg_content_t;
+
 ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg_);
 ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_);
 ZMQ_EXPORT int zmq_msg_init_data (
   zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
+ZMQ_EXPORT int zmq_msg_init_external_storage (
+  zmq_msg_t *msg_, zmq_msg_content_t *content_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
 ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_);
 ZMQ_EXPORT int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_);
 ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg_);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -610,7 +610,7 @@ int zmq_msg_init_external_storage (
 zmq_msg_t *msg_, zmq_msg_content_t *content_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))
-    ->init_external_storage (msg_, content_, data_, size_, ffn_, hint_);
+    ->init_external_storage (reinterpret_cast<zmq::msg_t::content_t*>(content_), data_, size_, ffn_, hint_);
 }
 
 

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -86,8 +86,8 @@ typedef char
 
 // Compile time check whether msg_t::content_t fits into zmq_msg_content_t.
 // It is expected to be larger.
-typedef char
-  check_msg_content_size[sizeof (zmq::msg_t::content_t) <= sizeof (zmq_msg_content_t) ? 1 : -1];
+typedef char check_msg_content_size
+  [sizeof (zmq::msg_t::content_t) <= sizeof (zmq_msg_content_t) ? 1 : -1];
 
 void zmq_version (int *major_, int *minor_, int *patch_)
 {

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -606,6 +606,14 @@ int zmq_msg_init_data (
       ->init_data (data_, size_, ffn_, hint_);
 }
 
+int zmq_msg_init_external_storage (
+zmq_msg_t *msg_, zmq_msg_content_t *content_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_)
+{
+    return (reinterpret_cast<zmq::msg_t *> (msg_))
+    ->init_external_storage (msg_, content_, data_, size_, ffn_, hint_);
+}
+
+
 int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -84,6 +84,10 @@ struct iovec
 typedef char
   check_msg_t_size[sizeof (zmq::msg_t) == sizeof (zmq_msg_t) ? 1 : -1];
 
+// Compile time check whether msg_t::content_t fits into zmq_msg_content_t.
+// It is expected to be larger.
+typedef char
+  check_msg_content_size[sizeof (zmq::msg_t::content_t) <= sizeof (zmq_msg_content_t) ? 1 : -1];
 
 void zmq_version (int *major_, int *minor_, int *patch_)
 {
@@ -606,11 +610,17 @@ int zmq_msg_init_data (
       ->init_data (data_, size_, ffn_, hint_);
 }
 
-int zmq_msg_init_external_storage (
-zmq_msg_t *msg_, zmq_msg_content_t *content_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_)
+int zmq_msg_init_external_storage (zmq_msg_t *msg_,
+                                   zmq_msg_content_t *content_,
+                                   void *data_,
+                                   size_t size_,
+                                   zmq_free_fn *ffn_,
+                                   void *hint_)
 {
     return (reinterpret_cast<zmq::msg_t *> (msg_))
-    ->init_external_storage (reinterpret_cast<zmq::msg_t::content_t*>(content_), data_, size_, ffn_, hint_);
+      ->init_external_storage (
+        reinterpret_cast<zmq::msg_t::content_t *> (content_), data_, size_,
+        ffn_, hint_);
 }
 
 

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -91,22 +91,8 @@ int zmq_msg_set_group (zmq_msg_t *msg_, const char *group_);
 const char *zmq_msg_group (zmq_msg_t *msg_);
 int zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
 
-/*  Draft Msg control block type for init_external_storage.                   */
-typedef struct zmq_msg_content_t
-{
-#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
-    __declspec (align (8)) unsigned char _[64];
-#elif defined(_MSC_VER)                                                        \
-  && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
-    __declspec (align (4)) unsigned char _[64];
-#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
-  || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
-  || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
-    unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
-#else
-    unsigned char _[64];
-#endif
-} zmq_msg_content_t;
+/*  Draft Msg control block type for init_external_storage. (64 bytes)        */
+typedef zmq_msg_t zmq_msg_content_t;
 
 int zmq_msg_init_external_storage (zmq_msg_t *msg_,
                                    zmq_msg_content_t *content_,

--- a/src/zmq_draft.h
+++ b/src/zmq_draft.h
@@ -91,6 +91,30 @@ int zmq_msg_set_group (zmq_msg_t *msg_, const char *group_);
 const char *zmq_msg_group (zmq_msg_t *msg_);
 int zmq_msg_init_buffer (zmq_msg_t *msg_, const void *buf_, size_t size_);
 
+/*  Draft Msg control block type for init_external_storage.                   */
+typedef struct zmq_msg_content_t
+{
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
+    __declspec (align (8)) unsigned char _[64];
+#elif defined(_MSC_VER)                                                        \
+  && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
+    __declspec (align (4)) unsigned char _[64];
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
+  || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
+  || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
+    unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
+#else
+    unsigned char _[64];
+#endif
+} zmq_msg_content_t;
+
+int zmq_msg_init_external_storage (zmq_msg_t *msg_,
+                                   zmq_msg_content_t *content_,
+                                   void *data_,
+                                   size_t size_,
+                                   zmq_free_fn *ffn_,
+                                   void *hint_);
+
 /*  DRAFT Msg property names.                                                 */
 #define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"
 #define ZMQ_MSG_PROPERTY_SOCKET_TYPE "Socket-Type"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -175,6 +175,7 @@ if(ENABLE_DRAFTS)
     test_zmq_ppoll_fd
     test_xsub_verbose
     test_pubsub_topics_count
+    test_msg_ffn_external_storage
   )
 
   if(HAVE_FORK)

--- a/tests/test_msg_ffn.cpp
+++ b/tests/test_msg_ffn.cpp
@@ -89,7 +89,7 @@ void test_msg_init_ffn ()
     test_context_socket_close (dealer);
 }
 
-void test_msg_init_external_storage ()
+void test_msg_init_ffn_external_storage ()
 {
     //  Create the infrastructure
     char my_endpoint[MAX_SOCKET_STRING];
@@ -101,6 +101,7 @@ void test_msg_init_external_storage ()
     TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (dealer, my_endpoint));
 
     // Test that creating and closing a message triggers ffn
+    zmq_msg_content_t content;
     zmq_msg_t msg;
     char hint[5];
     char data[255];
@@ -108,7 +109,7 @@ void test_msg_init_external_storage ()
     memcpy (data, (void *) "data", 4);
     memcpy (hint, (void *) "hint", 4);
     TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+      zmq_msg_init_external_storage(&msg, &content, (void *) data, 255, ffn, (void *) hint));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
 
     msleep (SETTLE_TIME);
@@ -119,7 +120,7 @@ void test_msg_init_external_storage ()
     zmq_msg_t msg2;
     zmq_msg_init (&msg2);
     TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+      zmq_msg_init_external_storage(&msg2, &content, (void *) data, 255, ffn, (void *) hint));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&msg2, &msg));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
@@ -130,7 +131,7 @@ void test_msg_init_external_storage ()
 
     // Test that sending a message triggers ffn
     TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+      zmq_msg_init_external_storage(&msg, &content, (void *) data, 255, ffn, (void *) hint));
 
     zmq_msg_send (&msg, dealer, 0);
     char buf[255];
@@ -146,7 +147,7 @@ void test_msg_init_external_storage ()
     // Sending a copy of a message triggers ffn
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&msg2));
     TEST_ASSERT_SUCCESS_ERRNO (
-      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+      zmq_msg_init_external_storage (&msg2, &content, (void *) data, 255, ffn, (void *) hint));
     TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&msg2, &msg));
 
     zmq_msg_send (&msg, dealer, 0);

--- a/tests/test_msg_ffn.cpp
+++ b/tests/test_msg_ffn.cpp
@@ -89,6 +89,81 @@ void test_msg_init_ffn ()
     test_context_socket_close (dealer);
 }
 
+void test_msg_init_external_storage ()
+{
+    //  Create the infrastructure
+    char my_endpoint[MAX_SOCKET_STRING];
+
+    void *router = test_context_socket (ZMQ_ROUTER);
+    bind_loopback_ipv4 (router, my_endpoint, sizeof my_endpoint);
+
+    void *dealer = test_context_socket (ZMQ_DEALER);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (dealer, my_endpoint));
+
+    // Test that creating and closing a message triggers ffn
+    zmq_msg_t msg;
+    char hint[5];
+    char data[255];
+    memset (data, 0, 255);
+    memcpy (data, (void *) "data", 4);
+    memcpy (hint, (void *) "hint", 4);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    msleep (SETTLE_TIME);
+    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
+    memcpy (hint, (void *) "hint", 4);
+
+    // Making and closing a copy triggers ffn
+    zmq_msg_t msg2;
+    zmq_msg_init (&msg2);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&msg2, &msg));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    msleep (SETTLE_TIME);
+    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
+    memcpy (hint, (void *) "hint", 4);
+
+    // Test that sending a message triggers ffn
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+
+    zmq_msg_send (&msg, dealer, 0);
+    char buf[255];
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_recv (router, buf, 255, 0));
+    TEST_ASSERT_EQUAL_INT (255, zmq_recv (router, buf, 255, 0));
+    TEST_ASSERT_EQUAL_STRING_LEN (data, buf, 4);
+
+    msleep (SETTLE_TIME);
+    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
+    memcpy (hint, (void *) "hint", 4);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    // Sending a copy of a message triggers ffn
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&msg2));
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_msg_init_data (&msg, (void *) data, 255, ffn, (void *) hint));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&msg2, &msg));
+
+    zmq_msg_send (&msg, dealer, 0);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_recv (router, buf, 255, 0));
+    TEST_ASSERT_EQUAL_INT (255, zmq_recv (router, buf, 255, 0));
+    TEST_ASSERT_EQUAL_STRING_LEN (data, buf, 4);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg2));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&msg));
+
+    msleep (SETTLE_TIME);
+    TEST_ASSERT_EQUAL_STRING_LEN ("freed", hint, 5);
+
+    //  Deallocate the infrastructure.
+    test_context_socket_close (router);
+    test_context_socket_close (dealer);
+}
+
 int main (void)
 {
     setup_test_environment ();


### PR DESCRIPTION
# The Objective:

At a high level I want use zeromq messages to send data as fast as possible from a sending thread. However, as as I have started going through the optimization process, via perf on x64 linux, about 25% of my steady-state time is spent in malloc calls allocating the control blocks for the reference counted long messages. 

This pull request is an request to expose a public api to the zero-copy long message type `type_zclmsg` used internally on the receive side.

## References:

As part of this process I have looked at previous issues that reference this topic, trying to not stomp on things, and get a better understanding of the concerns (If I have missed some it would be great to know):

The most discussion of this seems to be in:
#2795

Though this PR also solves the issue here:
#4343 

## Changes:

The primary change in this is to expose the internal function `init_external_storage` and allow users to pass in a pointer to a preallocated memory block for the init function to construct the content_t control block in. The method/struct we want to expose is below:

```cpp
// src/msg.hpp

    struct content_t
    {
        void *data;
        size_t size;
        msg_free_fn *ffn;
        void *hint;
        zmq::atomic_counter_t refcnt;
    };

// The above control block is 40 bytes, with 8 byte alignment on x64.

    int init_external_storage (content_t *content_,
                               void *data_,
                               size_t size_,
                               msg_free_fn *ffn_,
                               void *hint_);
```

In order to not expose private implementation details, and allow for future modification of the internals, we round up the control block size from ~40 to 64 bytes, and expose the larger structure to the users in the draft api. 

```cpp
// include/zmq.h -- In the Draft API:

typedef struct zmq_msg_content_t{
#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
  __declspec (align (8)) unsigned char _[64];
#elif defined(_MSC_VER)                                                        \
&& (defined(_M_IX86) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM))
  __declspec (align (4)) unsigned char _[64];
#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
|| (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
|| (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
  unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
#else
  unsigned char _[64];
#endif
} zmq_msg_content_t;

// above is lifted from the definition of zmq_msg_t, it has 8 byte alignment.

ZMQ_EXPORT int zmq_msg_init_external_storage (
  zmq_msg_t *msg_, zmq_msg_content_t *content_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
``` 

Thus, users just allocate a 64 byte control block, and pass it to zmq. They are then responsible for the lifetime of the block (In most use cases, it will probably be handled in the zmq_free_fn * ). 

Internally all objects in the control data block are manually destructed as part of zmq_close (any nontrivial types are constructed with placement new):

```cpp
// src/msg.cpp -- zmq::msg_t::close ()

    if (is_zcmsg ()) {
        zmq_assert (_u.zclmsg.content->ffn);

        //  If the content is not shared, or if it is shared and the reference
        //  count has dropped to zero, deallocate it.
        if (!(_u.zclmsg.flags & msg_t::shared)
            || !_u.zclmsg.content->refcnt.sub (1)) {
            //  We used "placement new" operator to initialize the reference
            //  counter so we call the destructor explicitly now.
            _u.zclmsg.content->refcnt.~atomic_counter_t ();

            _u.zclmsg.content->ffn (_u.zclmsg.content->data,
                                    _u.zclmsg.content->hint);
        }
    }
```

## My Use-case:

So for my sending thread, I have a slab allocator, which pulls memory from a lock-free object pool. Under the hood this uses freelist that batches memory allocations. This is fast, though to reduce thread contention of the CAS loop, I generally pull larger chunks and construct multiple smaller messages within this allocated buffer. 

The messages I am using are not huge, but not tiny, at around 1Kb, so I am currently using the `zmq_msg_init_data`, this works, and there is a inline reference counted control block at the beginning of the allocation that is decremented in the zmq's `free_fn`. 

At this point, the `malloc` time from control block allocation starts to add up.

I realize I could send larger messages, and I will be doing that, but it involves rewriting a lot of the code and message logic, on both the send and receive. Just allowing me to point to a preallocated control block at the beginning of the message gives me an easy ~25% speedup.

Additionally I am generally wary of non-deterministic nature of new/delete, especially in the hot path loop.

## Gotchas? / random thoughts?

So trying to think of issues with this, it seems pretty safe, obviously it involves properly managing/releasing the control block memory, but that seems pretty easy for people already using free function. It is not a solution for all issues, but the requirement of zmq to have new/delete for any messages above ~33 bytes seems like a less than ideal scenario.

It also seems like the content object, as a internal API is very stable (last touched 9 years ago?).

One question I was thinking of might be the alignment, 8 bytes on x64 is the minimum, and was easy to copy paste the msg_t alignment, but it may be better to up that to a larger 16 byte, if there is the potential of needing to use 128 bit cas type instructions... That being said, people who use the library should probably respect the the alignment of the types they are given and not assume.

Finally, as a gripe, I personally am not a fan of the name of content_t, since it is not actually the message content but the control block for the message content, it keeps confusing me (why I use control block when I refer to it in this PR)
