### PR TITLE
Problem: zmq_abort() may be called on Windows if polling fails

### DIFF
--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -24,6 +24,7 @@
 #endif
 #endif
 
+#include "err.hpp"
 #include <winsock2.h>
 #include <windows.h>
 #include <mswsock.h>
@@ -57,7 +58,24 @@ struct tcp_keepalive
 #if defined ZMQ_IOTHREAD_POLLER_USE_POLL || defined ZMQ_POLL_BASED_ON_POLL
 static inline int poll (struct pollfd *pfd, unsigned long nfds, int timeout)
 {
-    return WSAPoll (pfd, nfds, timeout);
+    int rc = WSAPoll (pfd, nfds, timeout);
+    if (rc == -1) {
+        int wsaError = WSAGetLastError ();
+        switch (wsaError) {
+            // let these conditions appear as an interrupted call to
+            // simplify downstream error processing.
+            case WSAENETDOWN:
+            case WSAENOBUFS:
+                errno = EINTR;
+                break;
+
+            default:
+                errno = zmq::wsa_error_to_errno (wsaError);
+                break;
+        }
+    }
+
+    return rc;
 }
 #endif
 


### PR DESCRIPTION
### Summary
Fixes occasional `abort()`s on Windows platform caused by unhandled errors returned by `WSAPoll()`, causing occasional crashes.

### Problem
Error handling for the `poll()` function is left to the caller, that should remember to use `WSAGetLastError()` instead of using `errno` to find out the error reason. This requires `#ifdef ZMQ_HAVE_WINDOWS ... #endif` and Windows-specific code to be done for each `poll()` invocation.

### Solution 
On Windows platform, implement custom WSA error to errno translation in the poll() function itself. The goal is to make Windows-specific poll() to appear more Unixy to the callers.

### Changes
* Windows-specific `poll()` function implementation in `windows.hpp`

### Platforms affected
* Windows

### Checklist

- [x]  Code compiles correctly
- [x]  No new compiler warnings
- [x]  No breaking API changes
- [x]  Comments added where needed
- [x]  Change is scoped to Windows-specific logic
