### PR TITLE
CMake: fix installation of config files on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1756,7 +1756,7 @@ if(WITH_DOC)
   endif()
 endif()
 
-if(WIN32)
+if(WIN32 AND NOT MINGW)
   set(ZEROMQ_CMAKECONFIG_INSTALL_DIR
       "CMake"
       CACHE STRING "install path for ZeroMQConfig.cmake")


### PR DESCRIPTION
You have configured zeromq with CMake.
Build environment is MinGW.
When you install the the package config files, they are copied into a "CMake" directory into the sysroot, but this is a nonsense. 

<img width="622" height="220" alt="immagine" src="https://github.com/user-attachments/assets/e20b217d-5a33-4b05-8de5-06344e116b67" />

Instead, they should be copied under ${LIBDIR}/cmake, as GNU tools require.
Hopefully, the solution is very easy.
This tiny PR fixes this error.