### PR TITLE
problem: session restarts input on an engine that never stalled

### DIFF
--- a/src/i_engine.hpp
+++ b/src/i_engine.hpp
@@ -35,8 +35,18 @@ struct i_engine
     //  events are not fired on termination.
     virtual void terminate () = 0;
 
+    //  Indicates whether the engine has stopped reading input because
+    //  it could not push more messages to the session (e.g. the pipe
+    //  is full). Only if this is the case may restart_input () be called.
+    //  The session must check this before calling restart_input (),
+    //  since the pipe and its flow-control state outlive the engine:
+    //  a pipe writability notification may be delivered after the engine
+    //  that stalled on the full pipe has been replaced by a new one.
+    virtual bool input_stopped () const = 0;
+
     //  This method is called by the session to signalise that more
     //  messages can be written to the pipe.
+    //  May only be called if input_stopped () returns true.
     //  Returns false if the engine was deleted due to an error.
     //  TODO it is probably better to change the design such that the engine
     //  does not delete itself

--- a/src/norm_engine.hpp
+++ b/src/norm_engine.hpp
@@ -44,6 +44,8 @@ class norm_engine_t ZMQ_FINAL : public io_object_t, public i_engine
     //  events are not fired on termination.
     void terminate () ZMQ_FINAL;
 
+    bool input_stopped () const ZMQ_FINAL { return !zmq_input_ready; }
+
     //  This method is called by the session to signalise that more
     //  messages can be written to the pipe.
     bool restart_input () ZMQ_FINAL;

--- a/src/pgm_receiver.hpp
+++ b/src/pgm_receiver.hpp
@@ -31,6 +31,7 @@ class pgm_receiver_t ZMQ_FINAL : public io_object_t, public i_engine
     bool has_handshake_stage () { return false; };
     void plug (zmq::io_thread_t *io_thread_, zmq::session_base_t *session_);
     void terminate ();
+    bool input_stopped () const { return active_tsi != NULL; }
     bool restart_input ();
     void restart_output ();
     void zap_msg_available () {}

--- a/src/pgm_sender.hpp
+++ b/src/pgm_sender.hpp
@@ -30,6 +30,9 @@ class pgm_sender_t ZMQ_FINAL : public io_object_t, public i_engine
     bool has_handshake_stage () { return false; };
     void plug (zmq::io_thread_t *io_thread_, zmq::session_base_t *session_);
     void terminate ();
+    //  The sender never reads messages from the wire into the session's
+    //  pipe, so its input can never be stopped nor restarted.
+    bool input_stopped () const { return false; }
     bool restart_input ();
     void restart_output ();
     void zap_msg_available () {}

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -303,7 +303,12 @@ void zmq::session_base_t::write_activated (pipe_t *pipe_)
         return;
     }
 
-    if (_engine)
+    //  The pipe and its flow-control state outlive the engine: the engine
+    //  that stopped reading input because this pipe was full may have been
+    //  destroyed (e.g. on reconnect after a heartbeat timeout) before the
+    //  peer's activation reaches us. Restart input only if the current
+    //  engine is actually stalled; a stale notification must be ignored.
+    if (_engine && _engine->input_stopped ())
         _engine->restart_input ();
 }
 

--- a/src/stream_engine_base.hpp
+++ b/src/stream_engine_base.hpp
@@ -39,6 +39,7 @@ class stream_engine_base_t : public io_object_t, public i_engine
     void plug (zmq::io_thread_t *io_thread_,
                zmq::session_base_t *session_) ZMQ_FINAL;
     void terminate () ZMQ_FINAL;
+    bool input_stopped () const ZMQ_FINAL { return _input_stopped; }
     bool restart_input () ZMQ_FINAL;
     void restart_output () ZMQ_FINAL;
     void zap_msg_available () ZMQ_FINAL;

--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -36,7 +36,8 @@ zmq::udp_engine_t::udp_engine_t (const options_t &options_) :
     _address (NULL),
     _options (options_),
     _send_enabled (false),
-    _recv_enabled (false)
+    _recv_enabled (false),
+    _input_stopped (false)
 {
 }
 
@@ -574,6 +575,7 @@ void zmq::udp_engine_t::in_event ()
         rc = msg.close ();
         errno_assert (rc == 0);
 
+        _input_stopped = true;
         reset_pollin (_handle);
         return;
     }
@@ -592,6 +594,7 @@ void zmq::udp_engine_t::in_event ()
         errno_assert (rc == 0);
 
         _session->reset ();
+        _input_stopped = true;
         reset_pollin (_handle);
         return;
     }
@@ -603,6 +606,9 @@ void zmq::udp_engine_t::in_event ()
 
 bool zmq::udp_engine_t::restart_input ()
 {
+    zmq_assert (_input_stopped);
+
+    _input_stopped = false;
     if (_recv_enabled) {
         set_pollin (_handle);
         in_event ();

--- a/src/udp_engine.hpp
+++ b/src/udp_engine.hpp
@@ -32,6 +32,10 @@ class udp_engine_t ZMQ_FINAL : public io_object_t, public i_engine
     //  events are not fired on termination.
     void terminate ();
 
+    //  Indicates whether the engine stopped polling for input because
+    //  a message did not fit into the session's pipe.
+    bool input_stopped () const { return _input_stopped; }
+
     //  This method is called by the session to signalise that more
     //  messages can be written to the pipe.
     bool restart_input ();
@@ -86,6 +90,7 @@ class udp_engine_t ZMQ_FINAL : public io_object_t, public i_engine
     char _in_buffer[MAX_UDP_MSG];
     bool _send_enabled;
     bool _recv_enabled;
+    bool _input_stopped;
 };
 }
 

--- a/tests/test_heartbeats.cpp
+++ b/tests/test_heartbeats.cpp
@@ -384,6 +384,108 @@ void test_setsockopt_heartbeat_ttl_near_zero ()
     test_setsockopt_heartbeat_success (deciseconds_per_millisecond - 1);
 }
 
+// Test for issue #3937, #4767, #4229, #3596, #4364
+// Reproduces assertion failure: _input_stopped (src/stream_engine_base.cpp)
+//
+// Root cause: After heartbeat-triggered engine replacement, write_activated()
+// calls restart_input() on the new engine which has _input_stopped=false,
+// triggering the assertion.
+//
+// Trigger sequence:
+// 1. SUB with ZMQ_RCVHWM=1 and heartbeat connects to PUB
+// 2. Application stops receiving - pipe fills immediately
+// 3. Engine sets _input_stopped=true and disables POLLIN (backpressure)
+// 4. Engine can't observe incoming heartbeats (they're in kernel buffer)
+// 5. Heartbeat timeout fires -> engine_error() -> engine destroyed/reconnected
+// 6. New engine created with _input_stopped=false
+// 7. Application resumes recv(), draining the pipe
+// 8. Pipe becomes writable -> write_activated() -> restart_input()
+// 9. Assertion fails: restart_input() expects _input_stopped=true
+void test_heartbeat_timeout_slow_subscriber ()
+{
+    char pub_endpoint[MAX_SOCKET_STRING];
+
+    // Create PUB socket
+    void *pub = test_context_socket (ZMQ_PUB);
+    int linger = 0;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (pub, ZMQ_LINGER, &linger, sizeof (linger)));
+    bind_loopback_ipv4 (pub, pub_endpoint, sizeof (pub_endpoint));
+
+    // Create SUB socket with small HWM and short heartbeat
+    void *sub = test_context_socket (ZMQ_SUB);
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (sub, ZMQ_LINGER, &linger, sizeof (linger)));
+
+    int rcvhwm = 1;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (sub, ZMQ_RCVHWM, &rcvhwm, sizeof (rcvhwm)));
+
+    int heartbeat_ivl = 100; // 100ms heartbeat interval
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (
+      sub, ZMQ_HEARTBEAT_IVL, &heartbeat_ivl, sizeof (heartbeat_ivl)));
+
+    int heartbeat_timeout = 200; // 200ms timeout
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (sub, ZMQ_HEARTBEAT_TIMEOUT,
+                                               &heartbeat_timeout,
+                                               sizeof (heartbeat_timeout)));
+
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_setsockopt (sub, ZMQ_SUBSCRIBE, "", 0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (sub, pub_endpoint));
+
+    // Give time for connection to establish
+    msleep (SETTLE_TIME);
+
+    // Send messages continuously from PUB to fill the pipe
+    // PUB will drop messages when SUB's pipe is full, which is fine
+    char msg[64];
+    for (int i = 0; i < 100; i++) {
+        snprintf (msg, sizeof (msg), "Message %d", i);
+        zmq_send (pub, msg, strlen (msg), ZMQ_DONTWAIT);
+        msleep (10);
+    }
+
+    // Receive a few messages to establish flow
+    char buf[256];
+    int rcvtimeo = 1000;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (sub, ZMQ_RCVTIMEO, &rcvtimeo, sizeof (rcvtimeo)));
+
+    for (int i = 0; i < 5; i++) {
+        int rc = zmq_recv (sub, buf, sizeof (buf), 0);
+        if (rc == -1)
+            break;
+    }
+
+    // Keep sending while we pause receiving
+    // This fills the pipe and triggers backpressure (_input_stopped=true)
+    for (int i = 0; i < 50; i++) {
+        snprintf (msg, sizeof (msg), "Fill %d", i);
+        zmq_send (pub, msg, strlen (msg), ZMQ_DONTWAIT);
+        msleep (10);
+    }
+
+    // Now pause receiving for longer than heartbeat timeout
+    // This causes:
+    // 1. Engine stops reading (backpressure) so can't see heartbeats
+    // 2. Heartbeat timeout fires
+    // 3. Engine is replaced with new one (_input_stopped=false)
+    msleep (1000); // 1 second pause - well over heartbeat timeout
+
+    // Resume receiving - this triggers the bug
+    // write_activated() calls restart_input() on engine with _input_stopped=false
+    // --> Assertion failed: _input_stopped
+    for (int i = 0; i < 20; i++) {
+        int rc = zmq_recv (sub, buf, sizeof (buf), 0);
+        if (rc == -1 && zmq_errno () == EAGAIN)
+            break;
+    }
+
+    // If we get here, the bug is fixed
+    test_context_socket_close (sub);
+    test_context_socket_close (pub);
+}
+
 int main (void)
 {
     //  The test cases are very long-running. The default timeout of 60 seconds
@@ -427,6 +529,9 @@ int main (void)
     RUN_TEST (test_heartbeat_notimeout_client_server_with_curve);
     RUN_TEST (test_heartbeat_notimeout_gather_scatter_with_curve);
 #endif
+
+    // Test for issue #3937 - heartbeat timeout with slow subscriber
+    RUN_TEST (test_heartbeat_timeout_slow_subscriber);
 
     return UNITY_END ();
 }


### PR DESCRIPTION
This PR reproduces and fixes the `_input_stopped` assertion crash from https://github.com/zeromq/libzmq/issues/3937

This PR originally made `restart_input ()` ignore the stale call, which was deemed a wrong approach. I investigated the root cause and the PR is now rewritten so that the assert stays in place and the actual bug is addressed

## Root cause

The pipe between session and socket, outlives the engine. `activate_write` is an asynchronous cross-thread command from the reader. It can still be in flight while the stalled engine is replaced. Instrumented trace from the reproducer:

    input stopped    engine=A            (pipe full, A stops reading TCP)
    engine_error     engine=A            (heartbeat timeout)
    process_attach   engine=B            (reconnect)
    write_activated  engine=B            (stale activation from A's stall)
    restart_input    engine=B  -> Assertion failed: _input_stopped

The "input stalled on the full pipe" state lives in the engine and dies with it,
but `session_base_t::write_activated ()` unconditionally called `restart_input ()` on the new engine

## Related observations (not addressed here)

- Heartbeats can kill a healthy connection whenever input is stopped by
  backpressure, because the engine cannot observe incoming PINGs it is not
  reading. That is what triggers the reconnect in this reproducer, but the
  stale-activation race exists for any reconnect-while-stalled.
- `mechanism_ready ()` bails out of routing-id delivery on `EAGAIN` assuming the
  pipe is shutting down, which is also reachable when the pipe is merely still
  full after a reconnect.

Fixes:
https://github.com/zeromq/libzmq/issues/3937

Possibly fixes:
https://github.com/zeromq/libzmq/issues/4767 (Slow subscriber, RX queue full, heartbeat triggers reset)
https://github.com/zeromq/libzmq/issues/4229 (HWM configured (especially rcvhwm), random crashes)
https://github.com/zeromq/libzmq/issues/3596 (CLIENT/SERVER, heartbeat=1s, rcvhwm=1, slow consumer)
https://github.com/zeromq/libzmq/issues/4364 (PUB/SUB, heartbeat with small timeouts)