### PR TITLE
cmake: Don't hardcode include directories for installed targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1487,7 +1487,7 @@ endif()
 foreach(target ${build_targets})
   target_include_directories(
     ${target} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
+                     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
   if(ENABLE_DRAFTS)
     target_compile_definitions(${target} PUBLIC ZMQ_BUILD_DRAFT_API)


### PR DESCRIPTION
This fixes scenarios where user specifies `CMAKE_INSTALL_INCLUDEDIR`.