### PR TITLE
fix: replace assert with early return in out_event when _io_error is set

### DIFF
--- a/src/stream_engine_base.cpp
+++ b/src/stream_engine_base.cpp
@@ -313,7 +313,8 @@ bool zmq::stream_engine_base_t::in_event_internal ()
 
 void zmq::stream_engine_base_t::out_event ()
 {
-    zmq_assert (!_io_error);
+    if (_io_error)
+        return;
 
     //  If write buffer is empty, try to read new data from the encoder.
     if (!_outsize) {


### PR DESCRIPTION
When the I/O thread collects both POLLIN and POLLOUT from the same epoll_wait batch, processing the POLLIN can set _io_error via in_event_internal(), and the already-queued POLLOUT still gets dispatched to out_event() — hitting the assert and crashing. Replacing the assert with an early return handles this gracefully, consistent with the same guard already present in restart_output(). Fixes #4841.