### PR TITLE
Fix double free in pipe_t::process_pipe_term_ack

### DIFF
--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -359,16 +359,18 @@ void zmq::pipe_t::process_pipe_term_ack ()
     //  First, delete all the unread messages in the pipe. We have to do it by
     //  hand because msg_t doesn't have automatic destructor. Then deallocate
     //  the ypipe itself.
+    upipe_t *const in_pipe = _in_pipe;
+    _in_pipe = NULL;
 
-    if (!_conflate) {
+    if (!_conflate && in_pipe) {
         msg_t msg;
-        while (_in_pipe->read (&msg)) {
+        while (in_pipe->read (&msg)) {
             const int rc = msg.close ();
             errno_assert (rc == 0);
         }
     }
 
-    LIBZMQ_DELETE (_in_pipe);
+    delete in_pipe;
 
     //  Deallocate the pipe object
     delete this;

--- a/src/pipe.cpp
+++ b/src/pipe.cpp
@@ -359,16 +359,18 @@ void zmq::pipe_t::process_pipe_term_ack ()
     //  First, delete all the unread messages in the pipe. We have to do it by
     //  hand because msg_t doesn't have automatic destructor. Then deallocate
     //  the ypipe itself.
+    upipe_t *in_pipe = _in_pipe;
+    _in_pipe = NULL;
 
-    if (!_conflate) {
+    if (!_conflate && in_pipe) {
         msg_t msg;
-        while (_in_pipe->read (&msg)) {
+        while (in_pipe->read (&msg)) {
             const int rc = msg.close ();
             errno_assert (rc == 0);
         }
     }
 
-    LIBZMQ_DELETE (_in_pipe);
+    LIBZMQ_DELETE (in_pipe);
 
     //  Deallocate the pipe object
     delete this;


### PR DESCRIPTION
The `_in_pipe` pointer was being used to drain messages and then deleted via `LIBZMQ_DELETE`, but the command dispatch loop in `io_thread_t::in_event` processes all mailbox commands in a single pass. If a second command arrives for the same `pipe_t` after `delete this` is executed, the object's memory has already been freed and `_in_pipe` becomes a dangling pointer, leading to a double free.

This fix saves `_in_pipe` to a local and nulls out the member before draining, so any stale access to the deleted object sees NULL rather than a freed ypipe pointer. Fixes #4806.