### PR TITLE
fix(cmake): register missing fuzzer tests to avoid CTest warnings

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,7 +78,7 @@ set(tests
   test_mock_pub_sub)
 
 if(NOT WIN32)
-  list(APPEND tests test_security_gssapi test_socks test_connect_null_fuzzer test_bind_null_fuzzer test_connect_fuzzer test_bind_fuzzer)
+  list(APPEND tests test_security_gssapi test_socks test_connect_null_fuzzer test_bind_null_fuzzer test_connect_fuzzer test_bind_fuzzer test_connect_stream_fuzzer test_bind_stream_fuzzer test_socket_options_fuzzer)
 endif()
 
 if(ZMQ_HAVE_CURVE)
@@ -193,6 +193,10 @@ endif()
 
 if(ZMQ_HAVE_WS)
   list(APPEND tests test_ws_transport)
+
+  if(NOT WIN32)
+    list(APPEND tests test_connect_ws_fuzzer test_bind_ws_fuzzer)
+  endif()
 
   if(ZMQ_HAVE_WSS)
     list(APPEND tests test_wss_transport)


### PR DESCRIPTION
- add stream fuzzers: test_connect_stream_fuzzer, test_bind_stream_fuzzer
- add socket-options fuzzer: test_socket_options_fuzzer
- add ws fuzzers behind ZMQ_HAVE_WS + NOT WIN32: test_connect_ws_fuzzer, test_bind_ws_fuzzer