### PR TITLE
Fix signed char sign extension in UDP engine in_event()

### DIFF
--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -547,10 +547,8 @@ void zmq::udp_engine_t::in_event ()
         body_size = nbytes;
         body_offset = 0;
     } else {
-        // TODO in out_event, the group size is an *unsigned* char. what is
-        // the maximum value?
         const char *group_buffer = _in_buffer + 1;
-        const int group_size = _in_buffer[0];
+        const int group_size = static_cast<unsigned char> (_in_buffer[0]);
 
         rc = msg.init_size (group_size);
         errno_assert (rc == 0);


### PR DESCRIPTION
On platforms where `char` is signed (Linux x86-64, MSVC, ARM with `-fsigned-char`), `_in_buffer[0]` with a byte value >= 0x80 undergoes sign extension when assigned to `int group_size`. For example, byte 0x80 becomes -128. This negative value is then implicitly cast to `size_t` in `msg.init_size()`, producing a value near `SIZE_MAX`. The allocation fails and `errno_assert` terminates the process.

The `out_event()` send path already correctly uses `static_cast<unsigned char>` for the group size byte (line 448). This patch applies the same cast on the receive path for consistency.

The existing TODO comment at line 541 acknowledges the signedness discrepancy.