### PR TITLE
Fix memory leak in UDP engine on truncated group size

### DIFF
--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -549,8 +549,11 @@ void zmq::udp_engine_t::in_event ()
         memcpy (msg.data (), group_buffer, group_size);
 
         //  This doesn't fit, just ignore
-        if (nbytes - 1 < group_size)
+        if (nbytes - 1 < group_size) {
+            rc = msg.close ();
+            errno_assert (rc == 0);
             return;
+        }
 
         body_size = nbytes - 1 - group_size;
         body_offset = 1 + group_size;


### PR DESCRIPTION
When the `group_size` byte in a received UDP packet exceeds the actual payload length, `in_event()` returns early without calling `msg.close()`. Since `msg_t` has no destructor, the allocated message memory is permanently leaked. Repeated packets exhaust process memory.

This adds `msg.close()` before the early return, matching the cleanup pattern used elsewhere in the same function (e.g., line 564).