### PR TITLE
Fix heap buffer overflow in UDP engine out_event()

### DIFF
--- a/src/udp_engine.cpp
+++ b/src/udp_engine.cpp
@@ -444,7 +444,16 @@ void zmq::udp_engine_t::out_event ()
         } else {
             size = group_size + body_size + 1;
 
-            // TODO: check if larger than maximum size
+            if (size > MAX_UDP_MSG) {
+                rc = group_msg.close ();
+                errno_assert (rc == 0);
+
+                rc = body_msg.close ();
+                errno_assert (rc == 0);
+
+                return;
+            }
+
             _out_buffer[0] = static_cast<unsigned char> (group_size);
             memcpy (_out_buffer + 1, group_msg.data (), group_size);
             memcpy (_out_buffer + 1 + group_size, body_msg.data (), body_size);


### PR DESCRIPTION
The `out_event()` send path copies `group_size + body_size + 1` bytes into the fixed `MAX_UDP_MSG` (8192) byte `_out_buffer` without checking if the total exceeds the buffer capacity. Messages with body larger than approximately 7936 bytes overflow the buffer and corrupt adjacent heap memory.

This adds a bounds check before the `memcpy` calls, discarding oversized messages. Resolves the TODO comment that acknowledged the missing check.