### PR TITLE
Add missing <new> includes for std::nothrow

### DIFF
--- a/src/norm_engine.cpp
+++ b/src/norm_engine.cpp
@@ -1,6 +1,7 @@
 
 #include "precompiled.hpp"
 
+#include <new>
 #include "platform.hpp"
 
 #if defined ZMQ_HAVE_NORM

--- a/src/polling_util.hpp
+++ b/src/polling_util.hpp
@@ -4,6 +4,7 @@
 #define __ZMQ_SOCKET_POLLING_UTIL_HPP_INCLUDED__
 
 #include <stdlib.h>
+#include <new>
 #include <vector>
 
 #if defined ZMQ_HAVE_WINDOWS

--- a/src/proxy.cpp
+++ b/src/proxy.cpp
@@ -3,6 +3,7 @@
 #include "precompiled.hpp"
 
 #include <stddef.h>
+#include <new>
 #include "poller.hpp"
 #include "proxy.hpp"
 #include "likely.hpp"

--- a/src/reaper.cpp
+++ b/src/reaper.cpp
@@ -2,6 +2,7 @@
 
 #include "precompiled.hpp"
 #include "macros.hpp"
+#include <new>
 #include "reaper.hpp"
 #include "socket_base.hpp"
 #include "err.hpp"

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 
 #include "precompiled.hpp"
+#include <new>
 #include "macros.hpp"
 #include "session_base.hpp"
 #include "i_engine.hpp"

--- a/src/socket_poller.cpp
+++ b/src/socket_poller.cpp
@@ -7,6 +7,7 @@
 #include "macros.hpp"
 
 #include <limits.h>
+#include <new>
 
 static bool is_thread_safe (const zmq::socket_base_t &socket_)
 {

--- a/src/stream_connecter_base.cpp
+++ b/src/stream_connecter_base.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #include <limits>
+#include <new>
 
 zmq::stream_connecter_base_t::stream_connecter_base_t (
   zmq::io_thread_t *io_thread_,

--- a/src/stream_listener_base.cpp
+++ b/src/stream_listener_base.cpp
@@ -13,6 +13,8 @@
 #include <winsock2.h>
 #endif
 
+#include <new>
+
 zmq::stream_listener_base_t::stream_listener_base_t (
   zmq::io_thread_t *io_thread_,
   zmq::socket_base_t *socket_,

--- a/src/ws_engine.cpp
+++ b/src/ws_engine.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include <cstring>
+#include <new>
 
 #include "compat.hpp"
 #include "tcp.hpp"


### PR DESCRIPTION
Without the <new> include, compilation may fail:

```
src/polling_util.hpp:28:30: error: no member named 'nothrow' in namespace 'std'
   28 |             _buf = new (std::nothrow) T[nitems_];
      |                              ^~~~~~~
```