### PR TITLE
Fix GSSAPI ZAP auth: honour negative ZAP responses

### DIFF
--- a/src/gssapi_server.cpp
+++ b/src/gssapi_server.cpp
@@ -100,7 +100,6 @@ int zmq::gssapi_server_t::process_handshake_command (msg_t *msg_)
         //  Use ZAP protocol (RFC 27) to authenticate the user.
         //  Note that rc will be -1 only if ZAP is not set up, but if it was
         //  requested and it does not work properly the program will abort.
-        bool expecting_zap_reply = false;
         int rc = session->zap_connect ();
         if (rc == 0) {
             send_zap_request ();
@@ -108,10 +107,16 @@ int zmq::gssapi_server_t::process_handshake_command (msg_t *msg_)
             if (rc != 0) {
                 if (rc == -1)
                     return -1;
-                expecting_zap_reply = true;
+                //  ZAP reply not yet available, wait asynchronously
+                state = expect_zap_reply;
+            } else {
+                //  Synchronous ZAP reply: honour the status code
+                state = status_code[0] == '2' ? send_ready : closing;
             }
+        } else {
+            //  ZAP not configured; allow the connection
+            state = send_ready;
         }
-        state = expecting_zap_reply ? expect_zap_reply : send_ready;
         return 0;
     }
 
@@ -166,13 +171,17 @@ int zmq::gssapi_server_t::zap_msg_available ()
     }
     const int rc = receive_and_process_zap_reply ();
     if (rc == 0)
-        state = send_ready;
+        state = status_code[0] == '2' ? send_ready : closing;
     return rc == -1 ? -1 : 0;
 }
 
 zmq::mechanism_t::status_t zmq::gssapi_server_t::status () const
 {
-    return state == connected ? mechanism_t::ready : mechanism_t::handshaking;
+    if (state == connected)
+        return mechanism_t::ready;
+    if (state == closing)
+        return mechanism_t::error;
+    return mechanism_t::handshaking;
 }
 
 int zmq::gssapi_server_t::produce_next_token (msg_t *msg_)

--- a/src/gssapi_server.hpp
+++ b/src/gssapi_server.hpp
@@ -38,7 +38,8 @@ class gssapi_server_t ZMQ_FINAL : public gssapi_mechanism_base_t,
         expect_zap_reply,
         send_ready,
         recv_ready,
-        connected
+        connected,
+        closing
     };
 
     session_base_t *const session;


### PR DESCRIPTION
Fixes #4912

When a ZAP handler returned 300/400/500, gssapi_server_t ignored the denial and transitioned to send_ready anyway, allowing the connection to proceed unauthenticated.

Root cause: unlike PLAIN/CURVE (which use zap_client_common_handshake_t and override handle_zap_status_code to update the state machine), gssapi_server_t inherits directly from zap_client_t whose handle_zap_status_code only fires a monitor event without touching the GSSAPI state machine.

Fix both paths where ZAP is consulted:

1. Synchronous reply (process_handshake_command): check status_code after receive_and_process_zap_reply() succeeds; go to send_ready only on "2xx", otherwise go to the new `closing` state.

2. Asynchronous reply (zap_msg_available): same status_code check instead of always setting send_ready.

Add a `closing` state to the state machine and make status() return mechanism_t::error for it so the session tears down the connection.