### PR TITLE
WSS: use hostname from URL if not specified

### DIFF
--- a/src/wss_engine.cpp
+++ b/src/wss_engine.cpp
@@ -2,6 +2,9 @@
 
 #include "precompiled.hpp"
 #include "wss_engine.hpp"
+#ifndef ZMQ_HAVE_WINDOWS
+#include <arpa/inet.h>
+#endif
 
 static int verify_certificate_callback (gnutls_session_t session)
 {
@@ -24,6 +27,16 @@ static int verify_certificate_callback (gnutls_session_t session)
     return 0;
 }
 
+static bool is_domain_name(const char* hostname)
+{
+    if (*hostname == '[' || strchr (hostname, ':') != NULL) // IPv6 address
+        return false;
+    // Check for IPv4 address with inet_pton
+    struct in_addr buf;
+    if (inet_pton(AF_INET, hostname, &buf) == 1)
+        return false;
+    return true;
+}
 
 zmq::wss_engine_t::wss_engine_t (fd_t fd_,
                                  const options_t &options_,
@@ -61,13 +74,15 @@ zmq::wss_engine_t::wss_engine_t (fd_t fd_,
         rc = gnutls_init (&_tls_session, GNUTLS_CLIENT | GNUTLS_NONBLOCK);
         zmq_assert (rc == GNUTLS_E_SUCCESS);
 
-        if (!hostname_.empty ())
+        if (!hostname_.empty ()) {
             gnutls_server_name_set (_tls_session, GNUTLS_NAME_DNS,
                                     hostname_.c_str (), hostname_.size ());
-
-        gnutls_session_set_ptr (
-          _tls_session,
-          hostname_.empty () ? NULL : const_cast<char *> (hostname_.c_str ()));
+            gnutls_session_set_ptr (_tls_session, const_cast<char*> (hostname_.c_str ()));
+        } else if (is_domain_name (address_.host ())) {
+            gnutls_server_name_set (_tls_session, GNUTLS_NAME_DNS,
+                                    address_.host (), strlen (address_.host ()));
+            gnutls_session_set_ptr (_tls_session, const_cast<char*> (address_.host ()));
+        }
 
         rc = gnutls_credentials_set (_tls_session, GNUTLS_CRD_CERTIFICATE,
                                      _tls_client_cred);


### PR DESCRIPTION
## Motivation

Currently, when using WSS client, TLS hostname must be set with `ZMQ_WSS_HOSTNAME` option, otherwise no SNI is sent to server, and the server may reject the handshake. This means if we want to connect one ZMQ socket to multiple WSS servers, we need to write something like this:

```C
zmq_setsockopt(sock, ZMQ_WSS_HOSTNAME, "host1", strlen("host1"));
zmq_connect(sock, "wss://host1:443/path/to/websocket");
zmq_setsockopt(sock, ZMQ_WSS_HOSTNAME, "host2", strlen("host2"));
zmq_connect(sock, "wss://host2:443/path/to/websocket");
...
```

Which is a bit cumbersome compared to other transports.

Since in production, TLS without SNI is rarely used, it might be beneficial to have WSS client send the SNI by default.

## Proposal

When `ZMQ_WSS_HOSTNAME` is empty, and when the WSS URL contains a valid domain name, use domain name in URL as the TLS hostname. `ZMQ_WSS_HOSTNAME` still works in case we need to override the hostname. Other wss-related options are unaffected.