### PR TITLE
Add experimental Linux shared-memory IPC transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -992,6 +992,7 @@ set(cxx-sources
     server.cpp
     session_base.cpp
     shm_engine.cpp
+    shm_state.cpp
     signaler.cpp
     socket_base.cpp
     socks.cpp
@@ -1131,6 +1132,7 @@ set(cxx-sources
     shm_engine.hpp
     shm_fd.hpp
     shm_ring.hpp
+    shm_state.hpp
     signaler.hpp
     socket_base.hpp
     socket_poller.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1627,6 +1627,9 @@ if(BUILD_SHARED)
       inproc_lat
       inproc_thr
       proxy_thr)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(APPEND perf-tools shm_pair_thr)
+  endif()
 
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug") # Why?
     option(WITH_PERF_TOOL "Build with perf-tools" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -991,6 +991,7 @@ set(cxx-sources
     select.cpp
     server.cpp
     session_base.cpp
+    shm_engine.cpp
     signaler.cpp
     socket_base.cpp
     socks.cpp
@@ -1126,6 +1127,10 @@ set(cxx-sources
     select.hpp
     server.hpp
     session_base.hpp
+    shm_channel.hpp
+    shm_engine.hpp
+    shm_fd.hpp
+    shm_ring.hpp
     signaler.hpp
     socket_base.hpp
     socket_poller.hpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -198,6 +198,8 @@ src_libzmq_la_SOURCES = \
 	src/shm_engine.hpp \
 	src/shm_fd.hpp \
 	src/shm_ring.hpp \
+	src/shm_state.cpp \
+	src/shm_state.hpp \
 	src/signaler.cpp \
 	src/signaler.hpp \
 	src/socket_base.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -404,6 +404,11 @@ noinst_PROGRAMS = \
 	perf/inproc_thr \
 	perf/proxy_thr
 
+if ON_LINUX
+noinst_PROGRAMS += \
+	perf/shm_pair_thr
+endif
+
 perf_local_lat_LDADD = src/libzmq.la
 perf_local_lat_SOURCES = perf/local_lat.cpp
 
@@ -424,6 +429,9 @@ perf_inproc_thr_SOURCES = perf/inproc_thr.cpp
 
 perf_proxy_thr_LDADD = src/libzmq.la
 perf_proxy_thr_SOURCES = perf/proxy_thr.cpp
+
+perf_shm_pair_thr_LDADD = src/libzmq.la
+perf_shm_pair_thr_SOURCES = perf/shm_pair_thr.cpp
 
 if ENABLE_STATIC
 noinst_PROGRAMS += \

--- a/Makefile.am
+++ b/Makefile.am
@@ -193,6 +193,11 @@ src_libzmq_la_SOURCES = \
 	src/server.hpp \
 	src/session_base.cpp \
 	src/session_base.hpp \
+	src/shm_channel.hpp \
+	src/shm_engine.cpp \
+	src/shm_engine.hpp \
+	src/shm_fd.hpp \
+	src/shm_ring.hpp \
 	src/signaler.cpp \
 	src/signaler.hpp \
 	src/socket_base.cpp \
@@ -1010,11 +1015,27 @@ tests_test_security_gssapi_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 endif
 
 if ON_LINUX
-test_apps += tests/test_abstract_ipc
+test_apps += \
+	tests/test_abstract_ipc \
+	tests/test_pair_shm \
+	tests/test_shm_channel \
+	tests/test_shm_ring
 
 tests_test_abstract_ipc_SOURCES = tests/test_abstract_ipc.cpp
 tests_test_abstract_ipc_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
 tests_test_abstract_ipc_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+
+tests_test_pair_shm_SOURCES = tests/test_pair_shm.cpp
+tests_test_pair_shm_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
+tests_test_pair_shm_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+
+tests_test_shm_channel_SOURCES = tests/test_shm_channel.cpp
+tests_test_shm_channel_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
+tests_test_shm_channel_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
+
+tests_test_shm_ring_SOURCES = tests/test_shm_ring.cpp
+tests_test_shm_ring_LDADD = ${TESTUTIL_LIBS} src/libzmq.la
+tests_test_shm_ring_CPPFLAGS = ${TESTUTIL_CPPFLAGS}
 
 # TODO: gets stuck even with long timeout running under Github Actions
 if !VALGRIND_ENABLED

--- a/include/zmq.h
+++ b/include/zmq.h
@@ -237,6 +237,10 @@ ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg_);
 ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_);
 ZMQ_EXPORT int zmq_msg_init_data (
   zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
+ZMQ_EXPORT int
+zmq_shm_msg_init (void *s_, zmq_msg_t *msg_, size_t size_);
+ZMQ_EXPORT int
+zmq_shm_msg_send (zmq_msg_t *msg_, void *s_, int flags_);
 ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_);
 ZMQ_EXPORT int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_);
 ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg_);
@@ -353,6 +357,7 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
 /*  Message options                                                           */
 #define ZMQ_MORE 1
 #define ZMQ_SHARED 3
+#define ZMQ_SHM 4
 
 /*  Send/recv options.                                                        */
 #define ZMQ_DONTWAIT 1

--- a/perf/shm_pair_thr.cpp
+++ b/perf/shm_pair_thr.cpp
@@ -1,0 +1,509 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include "../include/zmq.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#if defined __linux__
+#include <sched.h>
+#endif
+
+namespace
+{
+enum bench_mode_t
+{
+    mode_ipc,
+    mode_shm_copy,
+    mode_shm_direct
+};
+
+struct usage_t
+{
+    double user_s;
+    double system_s;
+};
+
+struct affinity_t
+{
+    int parent_cpu;
+    int child_cpu;
+};
+
+enum scan_mode_t
+{
+    scan_sample,
+    scan_full
+};
+
+static uint64_t now_us ()
+{
+    struct timespec ts;
+    if (clock_gettime (CLOCK_MONOTONIC, &ts) != 0)
+        return 0;
+    return static_cast<uint64_t> (ts.tv_sec) * UINT64_C (1000000)
+           + static_cast<uint64_t> (ts.tv_nsec) / UINT64_C (1000);
+}
+
+static double timeval_to_s (const struct timeval &tv_)
+{
+    return static_cast<double> (tv_.tv_sec)
+           + static_cast<double> (tv_.tv_usec) / 1000000.0;
+}
+
+static usage_t total_usage ()
+{
+    struct rusage self_usage;
+    struct rusage child_usage;
+    memset (&self_usage, 0, sizeof self_usage);
+    memset (&child_usage, 0, sizeof child_usage);
+    getrusage (RUSAGE_SELF, &self_usage);
+    getrusage (RUSAGE_CHILDREN, &child_usage);
+
+    usage_t usage;
+    usage.user_s = timeval_to_s (self_usage.ru_utime)
+                   + timeval_to_s (child_usage.ru_utime);
+    usage.system_s = timeval_to_s (self_usage.ru_stime)
+                     + timeval_to_s (child_usage.ru_stime);
+    return usage;
+}
+
+static void fill_payload (void *data_, size_t size_, uint64_t seq_)
+{
+    unsigned char *const data = static_cast<unsigned char *> (data_);
+    memset (data, static_cast<int> (seq_ & 0xffu), size_);
+    if (size_ >= sizeof seq_)
+        memcpy (data, &seq_, sizeof seq_);
+}
+
+static uint64_t sample_payload (const void *data_, size_t size_)
+{
+    const unsigned char *const data =
+      static_cast<const unsigned char *> (data_);
+    uint64_t sum = 0;
+    if (size_)
+        sum += data[0];
+    if (size_ > 1)
+        sum += data[size_ - 1];
+    if (size_ > 4096)
+        sum += data[size_ / 2];
+    return sum;
+}
+
+static uint64_t scan_payload (const void *data_, size_t size_)
+{
+    const unsigned char *const data =
+      static_cast<const unsigned char *> (data_);
+    uint64_t sum = 0;
+    for (size_t i = 0; i != size_; ++i)
+        sum += data[i];
+    return sum;
+}
+
+static const char *mode_name (bench_mode_t mode_)
+{
+    switch (mode_) {
+        case mode_ipc:
+            return "ipc";
+        case mode_shm_copy:
+            return "shm-copy";
+        case mode_shm_direct:
+            return "shm-direct";
+    }
+    return "unknown";
+}
+
+static int parse_mode (const char *value_, bench_mode_t *mode_)
+{
+    if (strcmp (value_, "ipc") == 0) {
+        *mode_ = mode_ipc;
+        return 0;
+    }
+    if (strcmp (value_, "shm-copy") == 0) {
+        *mode_ = mode_shm_copy;
+        return 0;
+    }
+    if (strcmp (value_, "shm-direct") == 0) {
+        *mode_ = mode_shm_direct;
+        return 0;
+    }
+    return -1;
+}
+
+static const char *scan_name (scan_mode_t mode_)
+{
+    return mode_ == scan_full ? "full" : "sample";
+}
+
+static int env_scan_mode (scan_mode_t *mode_)
+{
+    const char *const value = getenv ("ZMQ_SHM_PAIR_THR_SCAN");
+    if (!value || !*value || strcmp (value, "sample") == 0) {
+        *mode_ = scan_sample;
+        return 0;
+    }
+    if (strcmp (value, "full") == 0) {
+        *mode_ = scan_full;
+        return 0;
+    }
+    fprintf (stderr, "invalid ZMQ_SHM_PAIR_THR_SCAN\n");
+    return -1;
+}
+
+static int checked (int rc_, const char *what_)
+{
+    if (rc_ == -1) {
+        fprintf (stderr, "%s: %s\n", what_, zmq_strerror (errno));
+        return -1;
+    }
+    return 0;
+}
+
+static int env_cpu (const char *name_)
+{
+    const char *const value = getenv (name_);
+    if (!value || !*value)
+        return -1;
+    char *end = NULL;
+    const long cpu = strtol (value, &end, 10);
+    if (!end || *end || cpu < 0 || cpu > 65535) {
+        fprintf (stderr, "invalid %s\n", name_);
+        return -2;
+    }
+    return static_cast<int> (cpu);
+}
+
+static int pin_to_cpu (int cpu_)
+{
+    if (cpu_ < 0)
+        return 0;
+#if defined __linux__
+    cpu_set_t set;
+    CPU_ZERO (&set);
+    CPU_SET (cpu_, &set);
+    if (sched_setaffinity (0, sizeof set, &set) != 0) {
+        perror ("sched_setaffinity");
+        return -1;
+    }
+    return 0;
+#else
+    (void) cpu_;
+    fprintf (stderr, "CPU pinning is only supported on Linux\n");
+    return -1;
+#endif
+}
+
+static int send_regular (void *socket_,
+                         unsigned char *buffer_,
+                         size_t size_,
+                         uint64_t seq_)
+{
+    fill_payload (buffer_, size_, seq_);
+    const int rc = zmq_send (socket_, buffer_, size_, 0);
+    if (rc == -1) {
+        fprintf (stderr, "zmq_send: %s\n", zmq_strerror (errno));
+        return -1;
+    }
+    if (static_cast<size_t> (rc) != size_) {
+        fprintf (stderr, "zmq_send: short send\n");
+        return -1;
+    }
+    return 0;
+}
+
+static int send_direct (void *socket_, size_t size_, uint64_t seq_)
+{
+    zmq_msg_t msg;
+    while (zmq_shm_msg_init (socket_, &msg, size_) == -1) {
+        if (errno != EAGAIN) {
+            fprintf (stderr, "zmq_shm_msg_init: %s\n", zmq_strerror (errno));
+            return -1;
+        }
+        usleep (100);
+    }
+    fill_payload (zmq_msg_data (&msg), size_, seq_);
+    const int rc = zmq_shm_msg_send (&msg, socket_, 0);
+    if (rc == -1) {
+        fprintf (stderr, "zmq_shm_msg_send: %s\n", zmq_strerror (errno));
+        zmq_msg_close (&msg);
+        return -1;
+    }
+    if (static_cast<size_t> (rc) != size_) {
+        fprintf (stderr, "zmq_shm_msg_send: short send\n");
+        zmq_msg_close (&msg);
+        return -1;
+    }
+    if (checked (zmq_msg_close (&msg), "zmq_msg_close") != 0)
+        return -1;
+    return 0;
+}
+
+static int sender_main (const char *endpoint_,
+                        bench_mode_t mode_,
+                        size_t message_size_,
+                        uint64_t message_count_,
+                        int child_cpu_)
+{
+    if (pin_to_cpu (child_cpu_) != 0)
+        return 1;
+
+    void *ctx = zmq_ctx_new ();
+    if (!ctx) {
+        fprintf (stderr, "zmq_ctx_new: %s\n", zmq_strerror (errno));
+        return 1;
+    }
+    void *socket = zmq_socket (ctx, ZMQ_PAIR);
+    if (!socket) {
+        fprintf (stderr, "zmq_socket: %s\n", zmq_strerror (errno));
+        return 1;
+    }
+    if (checked (zmq_connect (socket, endpoint_), "zmq_connect") != 0)
+        return 1;
+
+    unsigned char *buffer = NULL;
+    if (mode_ != mode_shm_direct) {
+        buffer = static_cast<unsigned char *> (malloc (message_size_));
+        if (!buffer) {
+            fprintf (stderr, "malloc failed\n");
+            return 1;
+        }
+    }
+
+    for (uint64_t i = 0; i != message_count_ + 1; ++i) {
+        const int rc = mode_ == mode_shm_direct
+                         ? send_direct (socket, message_size_, i)
+                         : send_regular (socket, buffer, message_size_, i);
+        if (rc != 0) {
+            free (buffer);
+            return 1;
+        }
+    }
+
+    free (buffer);
+    if (checked (zmq_close (socket), "zmq_close") != 0)
+        return 1;
+    if (checked (zmq_ctx_term (ctx), "zmq_ctx_term") != 0)
+        return 1;
+    return 0;
+}
+
+static pid_t start_sender (const char *program_,
+                           const char *endpoint_,
+                           bench_mode_t mode_,
+                           size_t message_size_,
+                           uint64_t message_count_,
+                           int child_cpu_)
+{
+    char size_arg[32];
+    char count_arg[32];
+    char cpu_arg[32];
+    snprintf (size_arg, sizeof size_arg, "%zu", message_size_);
+    snprintf (count_arg, sizeof count_arg, "%" PRIu64, message_count_);
+    snprintf (cpu_arg, sizeof cpu_arg, "%d", child_cpu_);
+
+    const pid_t child = fork ();
+    if (child == -1)
+        return -1;
+    if (child == 0) {
+        execl (program_, program_, "--sender", endpoint_, mode_name (mode_),
+               size_arg, count_arg, cpu_arg,
+               static_cast<char *> (NULL));
+        perror ("execl");
+        _exit (127);
+    }
+    return child;
+}
+
+static int recv_one (void *socket_,
+                     size_t message_size_,
+                     scan_mode_t scan_mode_,
+                     uint64_t *checksum_)
+{
+    zmq_msg_t msg;
+    if (checked (zmq_msg_init (&msg), "zmq_msg_init") != 0)
+        return -1;
+    const int rc = zmq_msg_recv (&msg, socket_, 0);
+    if (rc == -1) {
+        fprintf (stderr, "zmq_msg_recv: %s\n", zmq_strerror (errno));
+        zmq_msg_close (&msg);
+        return -1;
+    }
+    if (static_cast<size_t> (rc) != message_size_) {
+        fprintf (stderr, "zmq_msg_recv: expected %zu, got %d\n",
+                 message_size_, rc);
+        zmq_msg_close (&msg);
+        return -1;
+    }
+    *checksum_ +=
+      scan_mode_ == scan_full
+        ? scan_payload (zmq_msg_data (&msg), zmq_msg_size (&msg))
+        : sample_payload (zmq_msg_data (&msg), zmq_msg_size (&msg));
+    if (checked (zmq_msg_close (&msg), "zmq_msg_close") != 0)
+        return -1;
+    return 0;
+}
+
+static int run (const char *program_,
+                bench_mode_t mode_,
+                size_t message_size_,
+                uint64_t message_count_)
+{
+    affinity_t affinity;
+    affinity.parent_cpu = env_cpu ("ZMQ_SHM_PAIR_THR_PARENT_CPU");
+    affinity.child_cpu = env_cpu ("ZMQ_SHM_PAIR_THR_CHILD_CPU");
+    if (affinity.parent_cpu == -2 || affinity.child_cpu == -2)
+        return 1;
+    scan_mode_t scan_mode = scan_sample;
+    if (env_scan_mode (&scan_mode) != 0)
+        return 1;
+
+    char path[128];
+    snprintf (path, sizeof path, "/tmp/libzmq-shm-pair-thr-%ld",
+              static_cast<long> (getpid ()));
+    unlink (path);
+
+    char endpoint[160];
+    snprintf (endpoint, sizeof endpoint, "%s://%s",
+              mode_ == mode_ipc ? "ipc" : "shm", path);
+
+    const usage_t before = total_usage ();
+    void *ctx = zmq_ctx_new ();
+    if (!ctx) {
+        fprintf (stderr, "zmq_ctx_new: %s\n", zmq_strerror (errno));
+        return 1;
+    }
+    void *socket = zmq_socket (ctx, ZMQ_PAIR);
+    if (!socket) {
+        fprintf (stderr, "zmq_socket: %s\n", zmq_strerror (errno));
+        return 1;
+    }
+    if (checked (zmq_bind (socket, endpoint), "zmq_bind") != 0)
+        return 1;
+
+    const pid_t child = start_sender (program_, endpoint, mode_, message_size_,
+                                      message_count_, affinity.child_cpu);
+    if (child == -1) {
+        perror ("fork");
+        return 1;
+    }
+
+    if (pin_to_cpu (affinity.parent_cpu) != 0)
+        return 1;
+
+    uint64_t checksum = 0;
+    if (recv_one (socket, message_size_, scan_mode, &checksum) != 0)
+        return 1;
+
+    const uint64_t start_us = now_us ();
+    for (uint64_t i = 0; i != message_count_; ++i)
+        if (recv_one (socket, message_size_, scan_mode, &checksum) != 0)
+            return 1;
+    const uint64_t elapsed_us = now_us () - start_us;
+
+    int status = 0;
+    if (waitpid (child, &status, 0) != child) {
+        perror ("waitpid");
+        return 1;
+    }
+    if (!WIFEXITED (status) || WEXITSTATUS (status) != 0) {
+        fprintf (stderr, "sender failed\n");
+        return 1;
+    }
+
+    const usage_t after = total_usage ();
+    checked (zmq_close (socket), "zmq_close");
+    checked (zmq_ctx_term (ctx), "zmq_ctx_term");
+    unlink (path);
+
+    const double elapsed_s =
+      static_cast<double> (elapsed_us ? elapsed_us : 1) / 1000000.0;
+    const double msg_s = static_cast<double> (message_count_) / elapsed_s;
+    const double gib_s =
+      static_cast<double> (message_count_)
+      * static_cast<double> (message_size_) / elapsed_s
+      / (1024.0 * 1024.0 * 1024.0);
+    const double user_s = after.user_s - before.user_s;
+    const double system_s = after.system_s - before.system_s;
+    const double cpu_s = user_s + system_s;
+
+    printf ("mode,scan,message_size,message_count,parent_cpu,child_cpu,elapsed_us,msg_per_s,gib_per_s,user_s,system_s,cpu_s,cpu_us_per_msg,checksum\n");
+    printf ("%s,%s,%zu,%" PRIu64 ",%d,%d,%" PRIu64 ",%.3f,%.6f,%.6f,%.6f,%.6f,%.6f,%" PRIu64 "\n",
+            mode_name (mode_), scan_name (scan_mode), message_size_,
+            message_count_, affinity.parent_cpu, affinity.child_cpu,
+            elapsed_us, msg_s, gib_s, user_s,
+            system_s, cpu_s,
+            cpu_s * 1000000.0 / static_cast<double> (message_count_),
+            checksum);
+    return 0;
+}
+}
+
+int main (int argc, char **argv)
+{
+    if (argc == 7 && strcmp (argv[1], "--sender") == 0) {
+        bench_mode_t mode;
+        if (parse_mode (argv[3], &mode) != 0) {
+            fprintf (stderr, "unknown mode: %s\n", argv[3]);
+            return 1;
+        }
+
+        char *end = NULL;
+        const unsigned long long message_size = strtoull (argv[4], &end, 10);
+        if (!end || *end || message_size == 0) {
+            fprintf (stderr, "invalid message size\n");
+            return 1;
+        }
+        end = NULL;
+        const unsigned long long message_count = strtoull (argv[5], &end, 10);
+        if (!end || *end || message_count == 0) {
+            fprintf (stderr, "invalid message count\n");
+            return 1;
+        }
+        end = NULL;
+        const long child_cpu = strtol (argv[6], &end, 10);
+        if (!end || *end || child_cpu < -1 || child_cpu > 65535) {
+            fprintf (stderr, "invalid child CPU\n");
+            return 1;
+        }
+
+        return sender_main (argv[2], mode, static_cast<size_t> (message_size),
+                            static_cast<uint64_t> (message_count),
+                            static_cast<int> (child_cpu));
+    }
+
+    if (argc != 4) {
+        printf ("usage: shm_pair_thr <ipc|shm-copy|shm-direct> "
+                "<message-size> <message-count>\n");
+        return 1;
+    }
+
+    bench_mode_t mode;
+    if (parse_mode (argv[1], &mode) != 0) {
+        fprintf (stderr, "unknown mode: %s\n", argv[1]);
+        return 1;
+    }
+
+    char *end = NULL;
+    const unsigned long long message_size = strtoull (argv[2], &end, 10);
+    if (!end || *end || message_size == 0) {
+        fprintf (stderr, "invalid message size\n");
+        return 1;
+    }
+    end = NULL;
+    const unsigned long long message_count = strtoull (argv[3], &end, 10);
+    if (!end || *end || message_count == 0) {
+        fprintf (stderr, "invalid message count\n");
+        return 1;
+    }
+
+    return run (argv[0], mode, static_cast<size_t> (message_size),
+                static_cast<uint64_t> (message_count));
+}

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -57,7 +57,11 @@ zmq::address_t::~address_t ()
 #endif
 
 #if defined ZMQ_HAVE_IPC
-    else if (protocol == protocol_name::ipc) {
+    else if (protocol == protocol_name::ipc
+#if defined ZMQ_HAVE_LINUX
+             || protocol == protocol_name::shm
+#endif
+    ) {
         LIBZMQ_DELETE (resolved.ipc_addr);
     }
 #endif
@@ -95,6 +99,14 @@ int zmq::address_t::to_string (std::string &addr_) const
 #if defined ZMQ_HAVE_IPC
     if (protocol == protocol_name::ipc && resolved.ipc_addr)
         return resolved.ipc_addr->to_string (addr_);
+#if defined ZMQ_HAVE_LINUX
+    if (protocol == protocol_name::shm && resolved.ipc_addr) {
+        const int rc = resolved.ipc_addr->to_string (addr_);
+        if (rc == 0 && addr_.compare (0, 6, "ipc://") == 0)
+            addr_.replace (0, 6, "shm://");
+        return rc;
+    }
+#endif
 #endif
 #if defined ZMQ_HAVE_TIPC
     if (protocol == protocol_name::tipc && resolved.tipc_addr)

--- a/src/address.hpp
+++ b/src/address.hpp
@@ -56,6 +56,9 @@ static const char wss[] = "wss";
 #if defined ZMQ_HAVE_IPC
 static const char ipc[] = "ipc";
 #endif
+#if defined ZMQ_HAVE_LINUX
+static const char shm[] = "shm";
+#endif
 #if defined ZMQ_HAVE_TIPC
 static const char tipc[] = "tipc";
 #endif

--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -16,6 +16,14 @@
 #include "ipc_address.hpp"
 #include "session_base.hpp"
 
+#if defined ZMQ_HAVE_LINUX
+#include "shm_engine.hpp"
+#include "shm_fd.hpp"
+#include "socket_base.hpp"
+#include <sys/mman.h>
+#include <sys/stat.h>
+#endif
+
 #if defined ZMQ_HAVE_WINDOWS
 #include <afunix.h>
 #else
@@ -29,11 +37,21 @@ zmq::ipc_connecter_t::ipc_connecter_t (class io_thread_t *io_thread_,
                                        class session_base_t *session_,
                                        const options_t &options_,
                                        address_t *addr_,
-                                       bool delayed_start_) :
+                                       bool delayed_start_,
+                                       bool use_shm_) :
     stream_connecter_base_t (
-      io_thread_, session_, options_, addr_, delayed_start_)
+      io_thread_, session_, options_, addr_, delayed_start_),
+    _use_shm (use_shm_),
+    _waiting_for_shm_fd (false),
+    _shm_handshake_timer_started (false)
 {
+#if defined ZMQ_HAVE_LINUX
+    zmq_assert (_addr->protocol == protocol_name::ipc
+                || _addr->protocol == protocol_name::shm);
+#else
     zmq_assert (_addr->protocol == protocol_name::ipc);
+    zmq_assert (!_use_shm);
+#endif
 }
 
 void zmq::ipc_connecter_t::out_event ()
@@ -48,7 +66,141 @@ void zmq::ipc_connecter_t::out_event ()
         return;
     }
 
-    create_engine (fd, get_socket_name<ipc_address_t> (fd, socket_end_local));
+    std::string local_address =
+      get_socket_name<ipc_address_t> (fd, socket_end_local);
+#if defined ZMQ_HAVE_LINUX
+    if (_use_shm) {
+        _s = fd;
+        _handle = add_fd (_s);
+        set_pollin (_handle);
+        _waiting_for_shm_fd = true;
+        if (options.handshake_ivl > 0) {
+            add_timer (options.handshake_ivl, shm_handshake_timer_id);
+            _shm_handshake_timer_started = true;
+        }
+        return;
+    }
+#endif
+    create_engine (fd, local_address);
+}
+
+#if defined ZMQ_HAVE_LINUX
+void zmq::ipc_connecter_t::in_event ()
+{
+    if (!_waiting_for_shm_fd) {
+        out_event ();
+        return;
+    }
+    receive_shm_engine ();
+}
+
+void zmq::ipc_connecter_t::fail_shm_handshake ()
+{
+    if (_shm_handshake_timer_started) {
+        cancel_timer (shm_handshake_timer_id);
+        _shm_handshake_timer_started = false;
+    }
+    _waiting_for_shm_fd = false;
+    rm_handle ();
+    close ();
+    add_reconnect_timer ();
+}
+
+void zmq::ipc_connecter_t::receive_shm_engine ()
+{
+    zmq_assert (_waiting_for_shm_fd);
+
+    int shm_fd = -1;
+    size_t size = 0;
+    if (shm_recv_fd (_s, &shm_fd, &size) != 0) {
+        if (errno != EAGAIN && errno != EWOULDBLOCK)
+            fail_shm_handshake ();
+        return;
+    }
+
+    const size_t expected_size = shm_engine_t::mapping_size ();
+    struct stat stat_buf;
+    if (size != expected_size || fstat (shm_fd, &stat_buf) != 0
+        || stat_buf.st_size != static_cast<off_t> (expected_size)) {
+        ::close (shm_fd);
+        errno = EPROTO;
+        fail_shm_handshake ();
+        return;
+    }
+
+    void *const mapping = shm_map_fd (shm_fd, size);
+    const int saved_errno = errno;
+    ::close (shm_fd);
+    errno = saved_errno;
+    if (mapping == MAP_FAILED) {
+        fail_shm_handshake ();
+        return;
+    }
+
+    bool valid = false;
+    {
+        shm_channel_t channel (mapping, size, false);
+        valid = channel.valid ();
+    }
+    if (!valid) {
+        munmap (mapping, size);
+        errno = EPROTO;
+        fail_shm_handshake ();
+        return;
+    }
+
+    std::string local_address =
+      get_socket_name<ipc_address_t> (_s, socket_end_local);
+    if (local_address.compare (0, 6, "ipc://") == 0)
+        local_address.replace (0, 6, "shm://");
+
+    const fd_t fd = _s;
+    _s = retired_fd;
+    _waiting_for_shm_fd = false;
+    if (_shm_handshake_timer_started) {
+        cancel_timer (shm_handshake_timer_id);
+        _shm_handshake_timer_started = false;
+    }
+    rm_handle ();
+
+    const endpoint_uri_pair_t endpoint_pair (local_address, _endpoint,
+                                             endpoint_type_connect);
+    shm_engine_t *const engine = new (std::nothrow)
+      shm_engine_t (fd, mapping, size, false, endpoint_pair);
+    alloc_assert (engine);
+    zmq_assert (engine->valid ());
+
+    send_attach (_session, engine);
+    terminate ();
+    _socket->event_connected (endpoint_pair, fd);
+}
+#else
+void zmq::ipc_connecter_t::in_event ()
+{
+    out_event ();
+}
+#endif
+
+void zmq::ipc_connecter_t::timer_event (int id_)
+{
+#if defined ZMQ_HAVE_LINUX
+    if (id_ == shm_handshake_timer_id) {
+        zmq_assert (_shm_handshake_timer_started);
+        _shm_handshake_timer_started = false;
+        fail_shm_handshake ();
+        return;
+    }
+#endif
+    stream_connecter_base_t::timer_event (id_);
+}
+
+void zmq::ipc_connecter_t::process_term (int linger_)
+{
+    if (_shm_handshake_timer_started) {
+        cancel_timer (shm_handshake_timer_id);
+        _shm_handshake_timer_started = false;
+    }
+    stream_connecter_base_t::process_term (linger_);
 }
 
 void zmq::ipc_connecter_t::start_connecting ()

--- a/src/ipc_connecter.cpp
+++ b/src/ipc_connecter.cpp
@@ -110,9 +110,8 @@ void zmq::ipc_connecter_t::receive_shm_engine ()
 {
     zmq_assert (_waiting_for_shm_fd);
 
-    int shm_fd = -1;
-    size_t size = 0;
-    if (shm_recv_fd (_s, &shm_fd, &size) != 0) {
+    int fds[3];
+    if (shm_recv_fds (_s, fds) != 0) {
         if (errno != EAGAIN && errno != EWOULDBLOCK)
             fail_shm_handshake ();
         return;
@@ -120,30 +119,36 @@ void zmq::ipc_connecter_t::receive_shm_engine ()
 
     const size_t expected_size = shm_engine_t::mapping_size ();
     struct stat stat_buf;
-    if (size != expected_size || fstat (shm_fd, &stat_buf) != 0
+    if (fstat (fds[0], &stat_buf) != 0
         || stat_buf.st_size != static_cast<off_t> (expected_size)) {
-        ::close (shm_fd);
+        ::close (fds[0]);
+        ::close (fds[1]);
+        ::close (fds[2]);
         errno = EPROTO;
         fail_shm_handshake ();
         return;
     }
 
-    void *const mapping = shm_map_fd (shm_fd, size);
+    void *const mapping = shm_map_fd (fds[0], expected_size);
     const int saved_errno = errno;
-    ::close (shm_fd);
+    ::close (fds[0]);
     errno = saved_errno;
     if (mapping == MAP_FAILED) {
+        ::close (fds[1]);
+        ::close (fds[2]);
         fail_shm_handshake ();
         return;
     }
 
     bool valid = false;
     {
-        shm_channel_t channel (mapping, size, false);
+        shm_channel_t channel (mapping, expected_size, false);
         valid = channel.valid ();
     }
     if (!valid) {
-        munmap (mapping, size);
+        munmap (mapping, expected_size);
+        ::close (fds[1]);
+        ::close (fds[2]);
         errno = EPROTO;
         fail_shm_handshake ();
         return;
@@ -165,8 +170,18 @@ void zmq::ipc_connecter_t::receive_shm_engine ()
 
     const endpoint_uri_pair_t endpoint_pair (local_address, _endpoint,
                                              endpoint_type_connect);
+    shm_state_t *const state = shm_state_t::create (
+      mapping, expected_size, false, fd, fds[1]);
+    if (!state) {
+        const int state_errno = errno;
+        ::close (fds[2]);
+        ::close (fd);
+        errno = state_errno;
+        add_reconnect_timer ();
+        return;
+    }
     shm_engine_t *const engine = new (std::nothrow)
-      shm_engine_t (fd, mapping, size, false, endpoint_pair);
+      shm_engine_t (fd, fds[2], state, endpoint_pair);
     alloc_assert (engine);
     zmq_assert (engine->valid ());
 

--- a/src/ipc_connecter.hpp
+++ b/src/ipc_connecter.hpp
@@ -5,6 +5,8 @@
 
 #if defined ZMQ_HAVE_IPC
 
+#include <string>
+
 #include "fd.hpp"
 #include "stream_connecter_base.hpp"
 
@@ -19,11 +21,23 @@ class ipc_connecter_t ZMQ_FINAL : public stream_connecter_base_t
                      zmq::session_base_t *session_,
                      const options_t &options_,
                      address_t *addr_,
-                     bool delayed_start_);
+                     bool delayed_start_,
+                     bool use_shm_ = false);
 
   private:
+    enum
+    {
+        shm_handshake_timer_id = 2
+    };
+
+    void process_term (int linger_);
+
     //  Handlers for I/O events.
+    void in_event ();
     void out_event ();
+    void timer_event (int id_);
+    void receive_shm_engine ();
+    void fail_shm_handshake ();
 
     //  Internal function to start the actual connection establishment.
     void start_connecting ();
@@ -36,6 +50,10 @@ class ipc_connecter_t ZMQ_FINAL : public stream_connecter_base_t
     //  Get the file descriptor of newly created connection. Returns
     //  retired_fd if the connection was unsuccessful.
     fd_t connect ();
+
+    bool _use_shm;
+    bool _waiting_for_shm_fd;
+    bool _shm_handshake_timer_started;
 
     ZMQ_NON_COPYABLE_NOR_MOVABLE (ipc_connecter_t)
 };

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -21,6 +21,7 @@
 #include "shm_engine.hpp"
 #include "shm_fd.hpp"
 #include "session_base.hpp"
+#include <sys/eventfd.h>
 #include <sys/mman.h>
 #endif
 
@@ -101,11 +102,27 @@ void zmq::ipc_listener_t::create_shm_engine (fd_t fd_)
 
     void *const mapping = shm_map_fd (shm_fd, size);
     if (mapping == MAP_FAILED
-        || shm_engine_t::initialize_mapping (mapping, size) != 0
-        || shm_send_fd (fd_, shm_fd, size) != 0) {
+        || shm_engine_t::initialize_mapping (mapping, size) != 0) {
         const int saved_errno = errno;
         if (mapping != MAP_FAILED)
             munmap (mapping, size);
+        ::close (shm_fd);
+        ::close (fd_);
+        errno = saved_errno;
+        return;
+    }
+
+    const int server_release_fd = eventfd (0, EFD_NONBLOCK | EFD_CLOEXEC);
+    const int client_release_fd = eventfd (0, EFD_NONBLOCK | EFD_CLOEXEC);
+    const int fds[3] = {shm_fd, server_release_fd, client_release_fd};
+    if (server_release_fd == -1 || client_release_fd == -1
+        || shm_send_fds (fd_, fds) != 0) {
+        const int saved_errno = errno;
+        if (server_release_fd != -1)
+            ::close (server_release_fd);
+        if (client_release_fd != -1)
+            ::close (client_release_fd);
+        munmap (mapping, size);
         ::close (shm_fd);
         ::close (fd_);
         errno = saved_errno;
@@ -116,8 +133,17 @@ void zmq::ipc_listener_t::create_shm_engine (fd_t fd_)
     const endpoint_uri_pair_t endpoint_pair (
       get_socket_name (fd_, socket_end_local),
       get_socket_name (fd_, socket_end_remote), endpoint_type_bind);
+    shm_state_t *const state =
+      shm_state_t::create (mapping, size, true, fd_, client_release_fd);
+    if (!state) {
+        const int saved_errno = errno;
+        ::close (server_release_fd);
+        ::close (fd_);
+        errno = saved_errno;
+        return;
+    }
     shm_engine_t *const engine = new (std::nothrow)
-      shm_engine_t (fd_, mapping, size, true, endpoint_pair);
+      shm_engine_t (fd_, server_release_fd, state, endpoint_pair);
     alloc_assert (engine);
     zmq_assert (engine->valid ());
 

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -17,6 +17,13 @@
 #include "socket_base.hpp"
 #include "address.hpp"
 
+#if defined ZMQ_HAVE_LINUX
+#include "shm_engine.hpp"
+#include "shm_fd.hpp"
+#include "session_base.hpp"
+#include <sys/mman.h>
+#endif
+
 #ifdef ZMQ_HAVE_WINDOWS
 #ifdef ZMQ_IOTHREAD_POLLER_USE_SELECT
 #error On Windows, IPC does not work with POLLER=select, use POLLER=epoll instead, or disable IPC transport
@@ -50,9 +57,15 @@
 
 zmq::ipc_listener_t::ipc_listener_t (io_thread_t *io_thread_,
                                      socket_base_t *socket_,
-                                     const options_t &options_) :
-    stream_listener_base_t (io_thread_, socket_, options_), _has_file (false)
+                                     const options_t &options_,
+                                     bool use_shm_) :
+    stream_listener_base_t (io_thread_, socket_, options_),
+    _has_file (false),
+    _use_shm (use_shm_)
 {
+#if !defined ZMQ_HAVE_LINUX
+    zmq_assert (!_use_shm);
+#endif
 }
 
 void zmq::ipc_listener_t::in_event ()
@@ -68,14 +81,67 @@ void zmq::ipc_listener_t::in_event ()
     }
 
     //  Create the engine object for this connection.
-    create_engine (fd);
+#if defined ZMQ_HAVE_LINUX
+    if (_use_shm)
+        create_shm_engine (fd);
+    else
+#endif
+        create_engine (fd);
 }
+
+#if defined ZMQ_HAVE_LINUX
+void zmq::ipc_listener_t::create_shm_engine (fd_t fd_)
+{
+    const size_t size = shm_engine_t::mapping_size ();
+    const int shm_fd = shm_create_fd (size);
+    if (shm_fd == -1) {
+        ::close (fd_);
+        return;
+    }
+
+    void *const mapping = shm_map_fd (shm_fd, size);
+    if (mapping == MAP_FAILED
+        || shm_engine_t::initialize_mapping (mapping, size) != 0
+        || shm_send_fd (fd_, shm_fd, size) != 0) {
+        const int saved_errno = errno;
+        if (mapping != MAP_FAILED)
+            munmap (mapping, size);
+        ::close (shm_fd);
+        ::close (fd_);
+        errno = saved_errno;
+        return;
+    }
+    ::close (shm_fd);
+
+    const endpoint_uri_pair_t endpoint_pair (
+      get_socket_name (fd_, socket_end_local),
+      get_socket_name (fd_, socket_end_remote), endpoint_type_bind);
+    shm_engine_t *const engine = new (std::nothrow)
+      shm_engine_t (fd_, mapping, size, true, endpoint_pair);
+    alloc_assert (engine);
+    zmq_assert (engine->valid ());
+
+    io_thread_t *const io_thread = choose_io_thread (options.affinity);
+    zmq_assert (io_thread);
+    session_base_t *const session =
+      session_base_t::create (io_thread, false, _socket, options, NULL);
+    errno_assert (session);
+    session->inc_seqnum ();
+    launch_child (session);
+    send_attach (session, engine, false);
+    _socket->event_accepted (endpoint_pair, fd_);
+}
+#endif
 
 std::string
 zmq::ipc_listener_t::get_socket_name (zmq::fd_t fd_,
                                       socket_end_t socket_end_) const
 {
-    return zmq::get_socket_name<ipc_address_t> (fd_, socket_end_);
+    std::string endpoint =
+      zmq::get_socket_name<ipc_address_t> (fd_, socket_end_);
+    if (_use_shm && endpoint.compare (0, 6, "ipc://") == 0)
+        endpoint.replace (0, 6, "shm://");
+    return endpoint;
 }
 
 int zmq::ipc_listener_t::set_local_address (const char *addr_)
@@ -115,6 +181,8 @@ int zmq::ipc_listener_t::set_local_address (const char *addr_)
     }
 
     address.to_string (_endpoint);
+    if (_use_shm && _endpoint.compare (0, 6, "ipc://") == 0)
+        _endpoint.replace (0, 6, "shm://");
 
     if (options.use_fd != -1) {
         _s = options.use_fd;

--- a/src/ipc_listener.hpp
+++ b/src/ipc_listener.hpp
@@ -17,7 +17,8 @@ class ipc_listener_t ZMQ_FINAL : public stream_listener_base_t
   public:
     ipc_listener_t (zmq::io_thread_t *io_thread_,
                     zmq::socket_base_t *socket_,
-                    const options_t &options_);
+                    const options_t &options_,
+                    bool use_shm_ = false);
 
     //  Set address to listen on.
     int set_local_address (const char *addr_);
@@ -28,6 +29,7 @@ class ipc_listener_t ZMQ_FINAL : public stream_listener_base_t
   private:
     //  Handlers for I/O events.
     void in_event ();
+    void create_shm_engine (fd_t fd_);
 
     //  Filter new connections if the OS provides a mechanism to get
     //  the credentials of the peer process.  Called from accept().
@@ -51,6 +53,8 @@ class ipc_listener_t ZMQ_FINAL : public stream_listener_base_t
 
     //  Name of the file associated with the UNIX domain address.
     std::string _filename;
+
+    bool _use_shm;
 
     ZMQ_NON_COPYABLE_NOR_MOVABLE (ipc_listener_t)
 };

--- a/src/msg.cpp
+++ b/src/msg.cpp
@@ -498,6 +498,16 @@ bool zmq::msg_t::is_zcmsg () const
     return _u.base.type == type_zclmsg;
 }
 
+bool zmq::msg_t::external_storage_matches (msg_free_fn *ffn_,
+                                           void **hint_) const
+{
+    if (!is_zcmsg () || _u.zclmsg.content->ffn != ffn_)
+        return false;
+    if (hint_)
+        *hint_ = _u.zclmsg.content->hint;
+    return true;
+}
+
 bool zmq::msg_t::is_join () const
 {
     return _u.base.type == type_join;

--- a/src/msg.hpp
+++ b/src/msg.hpp
@@ -126,6 +126,7 @@ class msg_t
     bool is_cmsg () const;
     bool is_lmsg () const;
     bool is_zcmsg () const;
+    bool external_storage_matches (msg_free_fn *ffn_, void **hint_) const;
     uint32_t get_routing_id () const;
     int set_routing_id (uint32_t routing_id_);
     int reset_routing_id ();

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -614,9 +614,20 @@ void zmq::session_base_t::start_connecting (bool wait_)
         }
     }
 #if defined ZMQ_HAVE_IPC
-    else if (_addr->protocol == protocol_name::ipc) {
+    else if (_addr->protocol == protocol_name::ipc
+#if defined ZMQ_HAVE_LINUX
+             || _addr->protocol == protocol_name::shm
+#endif
+    ) {
         connecter = new (std::nothrow)
-          ipc_connecter_t (io_thread, this, options, _addr, wait_);
+          ipc_connecter_t (
+            io_thread, this, options, _addr, wait_,
+#if defined ZMQ_HAVE_LINUX
+            _addr->protocol == protocol_name::shm
+#else
+            false
+#endif
+          );
     }
 #endif
 #if defined ZMQ_HAVE_TIPC

--- a/src/shm_channel.hpp
+++ b/src/shm_channel.hpp
@@ -9,7 +9,6 @@
 
 #include <new>
 #include <stddef.h>
-#include <string.h>
 
 namespace zmq
 {
@@ -31,7 +30,6 @@ class shm_channel_t
         const size_t required = memory_size (slot_count_, payload_capacity_);
         if (!memory_ || required == 0 || memory_size_ < required)
             return -1;
-        memset (memory_, 0, required);
         header_t *const header = static_cast<header_t *> (memory_);
         header->magic = channel_magic ();
         header->version = 1;

--- a/src/shm_channel.hpp
+++ b/src/shm_channel.hpp
@@ -110,6 +110,16 @@ class shm_channel_t
         _send->publish_write (position_);
     }
 
+    bool set_send_flags (uint64_t position_, unsigned char flags_)
+    {
+        frame_t *const frame = static_cast<frame_t *> (
+          _send->try_acquire_write (position_));
+        if (!frame)
+            return false;
+        frame->flags = flags_;
+        return true;
+    }
+
     bool try_receive (uint64_t position_,
                       const void **data_,
                       size_t *size_,
@@ -149,7 +159,7 @@ class shm_channel_t
     {
         size_t size;
         unsigned char flags;
-        unsigned char padding[7];
+        unsigned char padding[cache_line_size - sizeof (size_t) - 1];
     };
 
     struct header_t

--- a/src/shm_channel.hpp
+++ b/src/shm_channel.hpp
@@ -1,0 +1,181 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#ifndef __ZMQ_SHM_CHANNEL_HPP_INCLUDED__
+#define __ZMQ_SHM_CHANNEL_HPP_INCLUDED__
+
+#include "macros.hpp"
+#include "shm_ring.hpp"
+#include "stdint.hpp"
+
+#include <new>
+#include <stddef.h>
+#include <string.h>
+
+namespace zmq
+{
+class shm_channel_t
+{
+  public:
+    static size_t memory_size (uint32_t slot_count_, size_t payload_capacity_)
+    {
+        const size_t ring_size = shm_ring_t::memory_size (
+          slot_count_, sizeof (frame_t) + payload_capacity_);
+        return ring_size == 0 ? 0 : cache_line_size + 2 * ring_size;
+    }
+
+    static int initialize (void *memory_,
+                           size_t memory_size_,
+                           uint32_t slot_count_,
+                           size_t payload_capacity_)
+    {
+        const size_t required = memory_size (slot_count_, payload_capacity_);
+        if (!memory_ || required == 0 || memory_size_ < required)
+            return -1;
+        memset (memory_, 0, required);
+        header_t *const header = static_cast<header_t *> (memory_);
+        header->magic = channel_magic ();
+        header->version = 1;
+        header->slot_count = slot_count_;
+        header->payload_capacity = payload_capacity_;
+        header->ring_size =
+          shm_ring_t::memory_size (slot_count_,
+                                   sizeof (frame_t) + payload_capacity_);
+        header->mapping_size = required;
+
+        unsigned char *const base = static_cast<unsigned char *> (memory_);
+        if (shm_ring_t::initialize (base + cache_line_size, header->ring_size,
+                                    slot_count_,
+                                    sizeof (frame_t) + payload_capacity_)
+            != 0)
+            return -1;
+        return shm_ring_t::initialize (
+          base + cache_line_size + header->ring_size, header->ring_size,
+          slot_count_, sizeof (frame_t) + payload_capacity_);
+    }
+
+    shm_channel_t (void *memory_, size_t memory_size_, bool server_) :
+        _send (NULL), _receive (NULL), _payload_capacity (0), _valid (false)
+    {
+        unsigned char *const base = static_cast<unsigned char *> (memory_);
+        if (!base || memory_size_ < cache_line_size)
+            return;
+        const header_t *const header =
+          reinterpret_cast<const header_t *> (base);
+        if (header->magic != channel_magic () || header->version != 1
+            || header->mapping_size != memory_size (
+                 header->slot_count, header->payload_capacity)
+            || memory_size_ < header->mapping_size)
+            return;
+
+        unsigned char *const first = base + cache_line_size;
+        unsigned char *const second = first + header->ring_size;
+        _send = new (std::nothrow)
+          shm_ring_t (server_ ? first : second, header->ring_size);
+        _receive = new (std::nothrow)
+          shm_ring_t (server_ ? second : first, header->ring_size);
+        if (!_send || !_receive || !_send->valid () || !_receive->valid ()) {
+            delete _send;
+            delete _receive;
+            _send = NULL;
+            _receive = NULL;
+            return;
+        }
+        _payload_capacity = header->payload_capacity;
+        _valid = true;
+    }
+
+    ~shm_channel_t ()
+    {
+        delete _send;
+        delete _receive;
+    }
+
+    bool valid () const { return _valid; }
+
+    void *try_reserve_send (uint64_t position_,
+                            size_t size_,
+                            unsigned char flags_)
+    {
+        if (!_valid || size_ > _payload_capacity)
+            return NULL;
+        void *const storage = _send->try_acquire_write (position_);
+        if (!storage)
+            return NULL;
+        frame_t *const frame = new (storage) frame_t;
+        frame->size = size_;
+        frame->flags = flags_;
+        return frame + 1;
+    }
+
+    void publish_send (uint64_t position_)
+    {
+        _send->publish_write (position_);
+    }
+
+    bool try_receive (uint64_t position_,
+                      const void **data_,
+                      size_t *size_,
+                      unsigned char *flags_) const
+    {
+        if (!_valid || !data_ || !size_ || !flags_)
+            return false;
+        const frame_t *const frame = static_cast<const frame_t *> (
+          _receive->try_acquire_read (position_));
+        if (!frame)
+            return false;
+        if (frame->size > _payload_capacity)
+            return false;
+        *data_ = frame + 1;
+        *size_ = frame->size;
+        *flags_ = frame->flags;
+        return true;
+    }
+
+    void release_receive (uint64_t position_)
+    {
+        frame_t *const frame = const_cast<frame_t *> (
+          static_cast<const frame_t *> (
+            _receive->try_acquire_read (position_)));
+        if (frame)
+            frame->~frame_t ();
+        _receive->release_read (position_);
+    }
+
+  private:
+    enum
+    {
+        cache_line_size = 64
+    };
+
+    struct frame_t
+    {
+        size_t size;
+        unsigned char flags;
+        unsigned char padding[7];
+    };
+
+    struct header_t
+    {
+        uint64_t magic;
+        uint32_t version;
+        uint32_t slot_count;
+        size_t payload_capacity;
+        size_t ring_size;
+        size_t mapping_size;
+    };
+
+    static uint64_t channel_magic ()
+    {
+        return UINT64_C (0x5a4d5153484d4331);
+    }
+
+    shm_ring_t *_send;
+    shm_ring_t *_receive;
+    size_t _payload_capacity;
+    bool _valid;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (shm_channel_t)
+};
+}
+
+#endif

--- a/src/shm_engine.cpp
+++ b/src/shm_engine.cpp
@@ -1,0 +1,286 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include "precompiled.hpp"
+
+#if defined ZMQ_HAVE_LINUX
+
+#include "shm_engine.hpp"
+
+#include "err.hpp"
+#include "ip.hpp"
+#include "session_base.hpp"
+
+#include <errno.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace
+{
+const uint32_t shm_slot_count = 8;
+const size_t shm_payload_capacity = 8 * 1024 * 1024;
+}
+
+zmq::shm_engine_t::shm_engine_t (
+  fd_t fd_,
+  void *mapping_,
+  size_t mapping_size_,
+  bool server_,
+  const endpoint_uri_pair_t &endpoint_) :
+    _plugged (false),
+    _fd (fd_),
+    _mapping (mapping_),
+    _mapping_size (mapping_size_),
+    _channel (mapping_, mapping_size_, server_),
+    _session (NULL),
+    _handle (static_cast<handle_t> (NULL)),
+    _endpoint (endpoint_),
+    _send_position (0),
+    _receive_position (0),
+    _out_pending (false),
+    _in_pending (false),
+    _peer_closed (false)
+{
+    const int rc = _out_msg.init ();
+    errno_assert (rc == 0);
+    const int rc2 = _in_msg.init ();
+    errno_assert (rc2 == 0);
+    unblock_socket (_fd);
+}
+
+zmq::shm_engine_t::~shm_engine_t ()
+{
+    zmq_assert (!_plugged);
+    int rc = _out_msg.close ();
+    errno_assert (rc == 0);
+    rc = _in_msg.close ();
+    errno_assert (rc == 0);
+    if (_mapping != MAP_FAILED) {
+        rc = munmap (_mapping, _mapping_size);
+        errno_assert (rc == 0);
+        _mapping = MAP_FAILED;
+    }
+    if (_fd != retired_fd) {
+        rc = close (_fd);
+        errno_assert (rc == 0);
+        _fd = retired_fd;
+    }
+}
+
+size_t zmq::shm_engine_t::mapping_size ()
+{
+    return shm_channel_t::memory_size (shm_slot_count,
+                                       shm_payload_capacity);
+}
+
+int zmq::shm_engine_t::initialize_mapping (void *mapping_,
+                                           size_t mapping_size_)
+{
+    return shm_channel_t::initialize (mapping_, mapping_size_, shm_slot_count,
+                                      shm_payload_capacity);
+}
+
+bool zmq::shm_engine_t::valid () const
+{
+    return _fd != retired_fd && _mapping != MAP_FAILED && _channel.valid ();
+}
+
+void zmq::shm_engine_t::plug (io_thread_t *io_thread_,
+                              session_base_t *session_)
+{
+    zmq_assert (!_plugged);
+    zmq_assert (session_);
+    _plugged = true;
+    _session = session_;
+    io_object_t::plug (io_thread_);
+    _handle = add_fd (_fd);
+    set_pollin (_handle);
+    restart_output ();
+}
+
+void zmq::shm_engine_t::terminate ()
+{
+    zmq_assert (_plugged);
+    _plugged = false;
+    rm_fd (_handle);
+    _handle = static_cast<handle_t> (NULL);
+    io_object_t::unplug ();
+    delete this;
+}
+
+bool zmq::shm_engine_t::notify_peer (bool allow_closed_)
+{
+    if (_peer_closed)
+        return allow_closed_;
+
+    const unsigned char byte = 1;
+    ssize_t rc;
+    do {
+        rc = send (_fd, &byte, sizeof byte, MSG_NOSIGNAL);
+    } while (rc == -1 && errno == EINTR);
+    if (rc == 1 || (rc == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)))
+        return true;
+    if (allow_closed_ && rc == -1
+        && (errno == EPIPE || errno == ECONNRESET || errno == ENOTCONN)) {
+        _peer_closed = true;
+        return true;
+    }
+    error (connection_error);
+    return false;
+}
+
+bool zmq::shm_engine_t::pump_output ()
+{
+    while (true) {
+        if (!_out_pending) {
+            const int rc = _session->pull_msg (&_out_msg);
+            if (rc == -1) {
+                errno_assert (errno == EAGAIN);
+                return true;
+            }
+            _out_pending = true;
+        }
+
+        if (_out_msg.size () > shm_payload_capacity) {
+            error (protocol_error);
+            return false;
+        }
+
+        void *const data = _channel.try_reserve_send (
+          _send_position, _out_msg.size (),
+          static_cast<unsigned char> (_out_msg.flags () & ~msg_t::shared));
+        if (!data)
+            return true;
+
+        if (_out_msg.size ())
+            memcpy (data, _out_msg.data (), _out_msg.size ());
+        _channel.publish_send (_send_position++);
+
+        int rc = _out_msg.close ();
+        errno_assert (rc == 0);
+        rc = _out_msg.init ();
+        errno_assert (rc == 0);
+        _out_pending = false;
+
+        if (!notify_peer (false))
+            return false;
+    }
+}
+
+bool zmq::shm_engine_t::pump_input ()
+{
+    while (true) {
+        if (_in_pending) {
+            if (_session->push_msg (&_in_msg) == -1) {
+                errno_assert (errno == EAGAIN);
+                return true;
+            }
+            _in_pending = false;
+        }
+
+        const void *data = NULL;
+        size_t size = 0;
+        unsigned char flags = 0;
+        if (!_channel.try_receive (_receive_position, &data, &size, &flags)) {
+            _session->flush ();
+            return true;
+        }
+
+        int rc = _in_msg.close ();
+        errno_assert (rc == 0);
+        rc = _in_msg.init_size (size);
+        if (rc == -1) {
+            const int saved_errno = errno;
+            rc = _in_msg.init ();
+            errno_assert (rc == 0);
+            errno = saved_errno;
+            error (protocol_error);
+            return false;
+        }
+        if (size)
+            memcpy (_in_msg.data (), data, size);
+        _in_msg.set_flags (
+          static_cast<unsigned char> (flags & ~msg_t::shared));
+
+        _channel.release_receive (_receive_position++);
+        if (!notify_peer (true))
+            return false;
+
+        if (_session->push_msg (&_in_msg) == -1) {
+            errno_assert (errno == EAGAIN);
+            _in_pending = true;
+            _session->flush ();
+            return true;
+        }
+    }
+}
+
+void zmq::shm_engine_t::in_event ()
+{
+    unsigned char buffer[64];
+    while (true) {
+        const ssize_t rc = recv (_fd, buffer, sizeof buffer, 0);
+        if (rc > 0)
+            continue;
+        if (rc == 0) {
+            _peer_closed = true;
+            break;
+        }
+        if (errno == EINTR)
+            continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+            break;
+        error (connection_error);
+        return;
+    }
+
+    if (!pump_input ())
+        return;
+    if (_peer_closed) {
+        if (input_drained ())
+            error (connection_error);
+        return;
+    }
+    pump_output ();
+}
+
+bool zmq::shm_engine_t::restart_input ()
+{
+    if (!pump_input ())
+        return false;
+    if (_peer_closed && input_drained ()) {
+        error (connection_error);
+        return false;
+    }
+    return true;
+}
+
+void zmq::shm_engine_t::restart_output ()
+{
+    pump_output ();
+}
+
+const zmq::endpoint_uri_pair_t &zmq::shm_engine_t::get_endpoint () const
+{
+    return _endpoint;
+}
+
+bool zmq::shm_engine_t::input_drained () const
+{
+    if (_in_pending)
+        return false;
+    const void *data = NULL;
+    size_t size = 0;
+    unsigned char flags = 0;
+    return !_channel.try_receive (_receive_position, &data, &size, &flags);
+}
+
+void zmq::shm_engine_t::error (error_reason_t reason_)
+{
+    zmq_assert (_session);
+    _session->engine_error (false, reason_);
+    terminate ();
+}
+
+#endif

--- a/src/shm_engine.cpp
+++ b/src/shm_engine.cpp
@@ -9,10 +9,10 @@
 #include "err.hpp"
 #include "ip.hpp"
 #include "session_base.hpp"
+#include "socket_base.hpp"
 
 #include <errno.h>
 #include <string.h>
-#include <sys/mman.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -24,24 +24,23 @@ const size_t shm_payload_capacity = 8 * 1024 * 1024;
 
 zmq::shm_engine_t::shm_engine_t (
   fd_t fd_,
-  void *mapping_,
-  size_t mapping_size_,
-  bool server_,
+  fd_t release_fd_,
+  shm_state_t *state_,
   const endpoint_uri_pair_t &endpoint_) :
     _plugged (false),
     _fd (fd_),
-    _mapping (mapping_),
-    _mapping_size (mapping_size_),
-    _channel (mapping_, mapping_size_, server_),
+    _release_fd (release_fd_),
+    _state (state_),
     _session (NULL),
     _handle (static_cast<handle_t> (NULL)),
+    _release_handle (static_cast<handle_t> (NULL)),
     _endpoint (endpoint_),
-    _send_position (0),
     _receive_position (0),
     _out_pending (false),
     _in_pending (false),
     _peer_closed (false)
 {
+    zmq_assert (_state);
     const int rc = _out_msg.init ();
     errno_assert (rc == 0);
     const int rc2 = _in_msg.init ();
@@ -56,16 +55,21 @@ zmq::shm_engine_t::~shm_engine_t ()
     errno_assert (rc == 0);
     rc = _in_msg.close ();
     errno_assert (rc == 0);
-    if (_mapping != MAP_FAILED) {
-        rc = munmap (_mapping, _mapping_size);
-        errno_assert (rc == 0);
-        _mapping = MAP_FAILED;
-    }
+    if (_session)
+        _session->get_socket ()->unregister_shm_state (_state);
+    _state->clear_control_fd (_fd);
     if (_fd != retired_fd) {
         rc = close (_fd);
         errno_assert (rc == 0);
         _fd = retired_fd;
     }
+    if (_release_fd != retired_fd) {
+        rc = close (_release_fd);
+        errno_assert (rc == 0);
+        _release_fd = retired_fd;
+    }
+    _state->drop_ref ();
+    _state = NULL;
 }
 
 size_t zmq::shm_engine_t::mapping_size ()
@@ -83,7 +87,7 @@ int zmq::shm_engine_t::initialize_mapping (void *mapping_,
 
 bool zmq::shm_engine_t::valid () const
 {
-    return _fd != retired_fd && _mapping != MAP_FAILED && _channel.valid ();
+    return _fd != retired_fd && _release_fd != retired_fd && _state->valid ();
 }
 
 void zmq::shm_engine_t::plug (io_thread_t *io_thread_,
@@ -93,9 +97,13 @@ void zmq::shm_engine_t::plug (io_thread_t *io_thread_,
     zmq_assert (session_);
     _plugged = true;
     _session = session_;
+    _state->set_control_fd (_fd);
+    _session->get_socket ()->register_shm_state (_state);
     io_object_t::plug (io_thread_);
     _handle = add_fd (_fd);
+    _release_handle = add_fd (_release_fd);
     set_pollin (_handle);
+    set_pollin (_release_handle);
     restart_output ();
 }
 
@@ -104,7 +112,9 @@ void zmq::shm_engine_t::terminate ()
     zmq_assert (_plugged);
     _plugged = false;
     rm_fd (_handle);
+    rm_fd (_release_handle);
     _handle = static_cast<handle_t> (NULL);
+    _release_handle = static_cast<handle_t> (NULL);
     io_object_t::unplug ();
     delete this;
 }
@@ -147,15 +157,17 @@ bool zmq::shm_engine_t::pump_output ()
             return false;
         }
 
-        void *const data = _channel.try_reserve_send (
-          _send_position, _out_msg.size (),
-          static_cast<unsigned char> (_out_msg.flags () & ~msg_t::shared));
+        uint64_t position = 0;
+        void *const data = _state->try_reserve_copy (
+          _out_msg.size (),
+          static_cast<unsigned char> (_out_msg.flags () & ~msg_t::shared),
+          &position);
         if (!data)
             return true;
 
         if (_out_msg.size ())
             memcpy (data, _out_msg.data (), _out_msg.size ());
-        _channel.publish_send (_send_position++);
+        _state->publish_copy (position);
 
         int rc = _out_msg.close ();
         errno_assert (rc == 0);
@@ -182,14 +194,15 @@ bool zmq::shm_engine_t::pump_input ()
         const void *data = NULL;
         size_t size = 0;
         unsigned char flags = 0;
-        if (!_channel.try_receive (_receive_position, &data, &size, &flags)) {
+        if (!_state->try_receive (_receive_position, &data, &size, &flags)) {
             _session->flush ();
             return true;
         }
 
         int rc = _in_msg.close ();
         errno_assert (rc == 0);
-        rc = _in_msg.init_size (size);
+        rc = _state->init_received_message (&_in_msg, _receive_position, data,
+                                            size, flags);
         if (rc == -1) {
             const int saved_errno = errno;
             rc = _in_msg.init ();
@@ -198,14 +211,7 @@ bool zmq::shm_engine_t::pump_input ()
             error (protocol_error);
             return false;
         }
-        if (size)
-            memcpy (_in_msg.data (), data, size);
-        _in_msg.set_flags (
-          static_cast<unsigned char> (flags & ~msg_t::shared));
-
-        _channel.release_receive (_receive_position++);
-        if (!notify_peer (true))
-            return false;
+        ++_receive_position;
 
         if (_session->push_msg (&_in_msg) == -1) {
             errno_assert (errno == EAGAIN);
@@ -218,6 +224,16 @@ bool zmq::shm_engine_t::pump_input ()
 
 void zmq::shm_engine_t::in_event ()
 {
+    uint64_t releases = 0;
+    while (true) {
+        const ssize_t rc = read (_release_fd, &releases, sizeof releases);
+        if (rc == static_cast<ssize_t> (sizeof releases))
+            continue;
+        if (rc == -1 && errno == EINTR)
+            continue;
+        break;
+    }
+
     unsigned char buffer[64];
     while (true) {
         const ssize_t rc = recv (_fd, buffer, sizeof buffer, 0);
@@ -273,7 +289,7 @@ bool zmq::shm_engine_t::input_drained () const
     const void *data = NULL;
     size_t size = 0;
     unsigned char flags = 0;
-    return !_channel.try_receive (_receive_position, &data, &size, &flags);
+    return !_state->try_receive (_receive_position, &data, &size, &flags);
 }
 
 void zmq::shm_engine_t::error (error_reason_t reason_)

--- a/src/shm_engine.cpp
+++ b/src/shm_engine.cpp
@@ -55,8 +55,11 @@ zmq::shm_engine_t::~shm_engine_t ()
     errno_assert (rc == 0);
     rc = _in_msg.close ();
     errno_assert (rc == 0);
-    if (_session)
-        _session->get_socket ()->unregister_shm_state (_state);
+    //  Do not call back into the owning socket here.  The engine may outlive
+    //  zmq_close() on the socket while the session is drained asynchronously,
+    //  in which case the socket mutexes have already been destroyed.  The
+    //  socket releases its registered shm_state_t reference from the socket
+    //  thread; this engine only owns the reference passed at construction.
     _state->clear_control_fd (_fd);
     if (_fd != retired_fd) {
         rc = close (_fd);

--- a/src/shm_engine.hpp
+++ b/src/shm_engine.hpp
@@ -1,0 +1,74 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#ifndef __ZMQ_SHM_ENGINE_HPP_INCLUDED__
+#define __ZMQ_SHM_ENGINE_HPP_INCLUDED__
+
+#if defined ZMQ_HAVE_LINUX
+
+#include "endpoint.hpp"
+#include "fd.hpp"
+#include "i_engine.hpp"
+#include "io_object.hpp"
+#include "msg.hpp"
+#include "shm_channel.hpp"
+#include "stdint.hpp"
+
+namespace zmq
+{
+class io_thread_t;
+class session_base_t;
+
+class shm_engine_t ZMQ_FINAL : public io_object_t, public i_engine
+{
+  public:
+    shm_engine_t (fd_t fd_,
+                  void *mapping_,
+                  size_t mapping_size_,
+                  bool server_,
+                  const endpoint_uri_pair_t &endpoint_);
+    ~shm_engine_t ();
+
+    static size_t mapping_size ();
+    static int initialize_mapping (void *mapping_, size_t mapping_size_);
+
+    bool valid () const;
+    bool has_handshake_stage () ZMQ_FINAL { return false; }
+    void plug (io_thread_t *io_thread_, session_base_t *session_);
+    void terminate ();
+    bool restart_input ();
+    void restart_output ();
+    void zap_msg_available () {}
+    void in_event ();
+    void out_event () {}
+    const endpoint_uri_pair_t &get_endpoint () const;
+
+  private:
+    bool pump_input ();
+    bool pump_output ();
+    bool notify_peer (bool allow_closed_);
+    bool input_drained () const;
+    void error (error_reason_t reason_);
+
+    bool _plugged;
+    fd_t _fd;
+    void *_mapping;
+    size_t _mapping_size;
+    shm_channel_t _channel;
+    session_base_t *_session;
+    handle_t _handle;
+    endpoint_uri_pair_t _endpoint;
+    uint64_t _send_position;
+    uint64_t _receive_position;
+    msg_t _out_msg;
+    msg_t _in_msg;
+    bool _out_pending;
+    bool _in_pending;
+    bool _peer_closed;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (shm_engine_t)
+};
+}
+
+#endif
+
+#endif

--- a/src/shm_engine.hpp
+++ b/src/shm_engine.hpp
@@ -10,7 +10,7 @@
 #include "i_engine.hpp"
 #include "io_object.hpp"
 #include "msg.hpp"
-#include "shm_channel.hpp"
+#include "shm_state.hpp"
 #include "stdint.hpp"
 
 namespace zmq
@@ -22,9 +22,8 @@ class shm_engine_t ZMQ_FINAL : public io_object_t, public i_engine
 {
   public:
     shm_engine_t (fd_t fd_,
-                  void *mapping_,
-                  size_t mapping_size_,
-                  bool server_,
+                  fd_t release_fd_,
+                  shm_state_t *state_,
                   const endpoint_uri_pair_t &endpoint_);
     ~shm_engine_t ();
 
@@ -51,13 +50,12 @@ class shm_engine_t ZMQ_FINAL : public io_object_t, public i_engine
 
     bool _plugged;
     fd_t _fd;
-    void *_mapping;
-    size_t _mapping_size;
-    shm_channel_t _channel;
+    fd_t _release_fd;
+    shm_state_t *_state;
     session_base_t *_session;
     handle_t _handle;
+    handle_t _release_handle;
     endpoint_uri_pair_t _endpoint;
-    uint64_t _send_position;
     uint64_t _receive_position;
     msg_t _out_msg;
     msg_t _in_msg;

--- a/src/shm_fd.hpp
+++ b/src/shm_fd.hpp
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#ifndef __ZMQ_SHM_FD_HPP_INCLUDED__
+#define __ZMQ_SHM_FD_HPP_INCLUDED__
+
+#include "stdint.hpp"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001U
+#endif
+
+namespace zmq
+{
+inline int shm_create_fd (size_t size_)
+{
+    if (size_ == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+#if defined SYS_memfd_create
+    const int fd = static_cast<int> (
+      syscall (SYS_memfd_create, "libzmq-shm", MFD_CLOEXEC));
+#else
+    errno = ENOSYS;
+    const int fd = -1;
+#endif
+    if (fd == -1)
+        return -1;
+    if (ftruncate (fd, static_cast<off_t> (size_)) == -1) {
+        const int saved_errno = errno;
+        close (fd);
+        errno = saved_errno;
+        return -1;
+    }
+    return fd;
+}
+
+inline void *shm_map_fd (int fd_, size_t size_)
+{
+    if (fd_ < 0 || size_ == 0) {
+        errno = EINVAL;
+        return MAP_FAILED;
+    }
+    return mmap (NULL, size_, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+}
+
+inline int shm_send_fd (int socket_, int fd_, size_t size_)
+{
+    if (socket_ < 0 || fd_ < 0 || size_ == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    const uint64_t wire_size = size_;
+    struct iovec iov;
+    iov.iov_base = const_cast<uint64_t *> (&wire_size);
+    iov.iov_len = sizeof wire_size;
+
+    union
+    {
+        struct cmsghdr align;
+        unsigned char data[CMSG_SPACE (sizeof (int))];
+    } control;
+    memset (&control, 0, sizeof control);
+
+    struct msghdr message;
+    memset (&message, 0, sizeof message);
+    message.msg_iov = &iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.data;
+    message.msg_controllen = sizeof control.data;
+
+    struct cmsghdr *const cmsg = CMSG_FIRSTHDR (&message);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN (sizeof (int));
+    memcpy (CMSG_DATA (cmsg), &fd_, sizeof fd_);
+
+    ssize_t rc;
+    do {
+        rc = sendmsg (socket_, &message, MSG_NOSIGNAL);
+    } while (rc == -1 && errno == EINTR);
+    return rc == static_cast<ssize_t> (sizeof wire_size) ? 0 : -1;
+}
+
+inline int shm_recv_fd (int socket_, int *fd_, size_t *size_)
+{
+    if (socket_ < 0 || !fd_ || !size_) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    uint64_t wire_size = 0;
+    struct iovec iov;
+    iov.iov_base = &wire_size;
+    iov.iov_len = sizeof wire_size;
+
+    union
+    {
+        struct cmsghdr align;
+        unsigned char data[CMSG_SPACE (sizeof (int))];
+    } control;
+    memset (&control, 0, sizeof control);
+
+    struct msghdr message;
+    memset (&message, 0, sizeof message);
+    message.msg_iov = &iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.data;
+    message.msg_controllen = sizeof control.data;
+
+    ssize_t rc;
+    do {
+#ifdef MSG_CMSG_CLOEXEC
+        rc = recvmsg (socket_, &message, MSG_CMSG_CLOEXEC);
+#else
+        rc = recvmsg (socket_, &message, 0);
+#endif
+    } while (rc == -1 && errno == EINTR);
+    if (rc != static_cast<ssize_t> (sizeof wire_size) || wire_size == 0) {
+        errno = EPROTO;
+        return -1;
+    }
+
+    struct cmsghdr *const cmsg = CMSG_FIRSTHDR (&message);
+    if (!cmsg || cmsg->cmsg_level != SOL_SOCKET
+        || cmsg->cmsg_type != SCM_RIGHTS
+        || cmsg->cmsg_len != CMSG_LEN (sizeof (int))) {
+        errno = EPROTO;
+        return -1;
+    }
+
+    int received_fd = -1;
+    memcpy (&received_fd, CMSG_DATA (cmsg), sizeof received_fd);
+#ifndef MSG_CMSG_CLOEXEC
+    fcntl (received_fd, F_SETFD, FD_CLOEXEC);
+#endif
+    *fd_ = received_fd;
+    *size_ = static_cast<size_t> (wire_size);
+    return 0;
+}
+}
+
+#endif

--- a/src/shm_fd.hpp
+++ b/src/shm_fd.hpp
@@ -172,6 +172,113 @@ inline int shm_recv_fd (int socket_, int *fd_, size_t *size_)
     *size_ = static_cast<size_t> (stat_buf.st_size);
     return 0;
 }
+
+inline int shm_send_fds (int socket_, const int fds_[3])
+{
+    if (socket_ < 0 || !fds_ || fds_[0] < 0 || fds_[1] < 0 || fds_[2] < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    const unsigned char marker = 3;
+    struct iovec iov;
+    iov.iov_base = const_cast<unsigned char *> (&marker);
+    iov.iov_len = sizeof marker;
+
+    union
+    {
+        struct cmsghdr align;
+        unsigned char data[CMSG_SPACE (3 * sizeof (int))];
+    } control;
+    memset (&control, 0, sizeof control);
+
+    struct msghdr message;
+    memset (&message, 0, sizeof message);
+    message.msg_iov = &iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.data;
+    message.msg_controllen = sizeof control.data;
+
+    struct cmsghdr *const cmsg = CMSG_FIRSTHDR (&message);
+    cmsg->cmsg_level = SOL_SOCKET;
+    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_len = CMSG_LEN (3 * sizeof (int));
+    memcpy (CMSG_DATA (cmsg), fds_, 3 * sizeof (int));
+
+    ssize_t rc;
+    do {
+        rc = sendmsg (socket_, &message, MSG_NOSIGNAL);
+    } while (rc == -1 && errno == EINTR);
+    return rc == static_cast<ssize_t> (sizeof marker) ? 0 : -1;
+}
+
+inline int shm_recv_fds (int socket_, int fds_[3])
+{
+    if (socket_ < 0 || !fds_) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    fds_[0] = fds_[1] = fds_[2] = -1;
+    unsigned char marker = 0;
+    struct iovec iov;
+    iov.iov_base = &marker;
+    iov.iov_len = sizeof marker;
+
+    union
+    {
+        struct cmsghdr align;
+        unsigned char data[CMSG_SPACE (3 * sizeof (int))];
+    } control;
+    memset (&control, 0, sizeof control);
+
+    struct msghdr message;
+    memset (&message, 0, sizeof message);
+    message.msg_iov = &iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.data;
+    message.msg_controllen = sizeof control.data;
+
+    ssize_t rc;
+    do {
+#ifdef MSG_CMSG_CLOEXEC
+        rc = recvmsg (socket_, &message, MSG_CMSG_CLOEXEC);
+#else
+        rc = recvmsg (socket_, &message, 0);
+#endif
+    } while (rc == -1 && errno == EINTR);
+    if (rc == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
+        return -1;
+
+    struct cmsghdr *const cmsg = CMSG_FIRSTHDR (&message);
+    if (cmsg && cmsg->cmsg_level == SOL_SOCKET
+        && cmsg->cmsg_type == SCM_RIGHTS
+        && cmsg->cmsg_len >= CMSG_LEN (sizeof (int))) {
+        const size_t bytes = cmsg->cmsg_len - CMSG_LEN (0);
+        const size_t count = bytes / sizeof (int) < 3
+                               ? bytes / sizeof (int)
+                               : 3;
+        memcpy (fds_, CMSG_DATA (cmsg), count * sizeof (int));
+    }
+
+    if (rc != static_cast<ssize_t> (sizeof marker) || marker != 3
+        || (message.msg_flags & MSG_CTRUNC) || !cmsg
+        || cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS
+        || cmsg->cmsg_len != CMSG_LEN (3 * sizeof (int))) {
+        for (size_t i = 0; i != 3; ++i)
+            if (fds_[i] != -1)
+                close (fds_[i]);
+        fds_[0] = fds_[1] = fds_[2] = -1;
+        errno = EPROTO;
+        return -1;
+    }
+
+#ifndef MSG_CMSG_CLOEXEC
+    for (size_t i = 0; i != 3; ++i)
+        fcntl (fds_[i], F_SETFD, FD_CLOEXEC);
+#endif
+    return 0;
+}
 }
 
 #endif

--- a/src/shm_fd.hpp
+++ b/src/shm_fd.hpp
@@ -11,6 +11,7 @@
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/syscall.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #ifndef MFD_CLOEXEC
@@ -58,11 +59,18 @@ inline int shm_send_fd (int socket_, int fd_, size_t size_)
         errno = EINVAL;
         return -1;
     }
+    struct stat stat_buf;
+    if (fstat (fd_, &stat_buf) != 0
+        || stat_buf.st_size != static_cast<off_t> (size_)) {
+        if (errno == 0)
+            errno = EINVAL;
+        return -1;
+    }
 
-    const uint64_t wire_size = size_;
+    const unsigned char marker = 1;
     struct iovec iov;
-    iov.iov_base = const_cast<uint64_t *> (&wire_size);
-    iov.iov_len = sizeof wire_size;
+    iov.iov_base = const_cast<unsigned char *> (&marker);
+    iov.iov_len = sizeof marker;
 
     union
     {
@@ -88,7 +96,7 @@ inline int shm_send_fd (int socket_, int fd_, size_t size_)
     do {
         rc = sendmsg (socket_, &message, MSG_NOSIGNAL);
     } while (rc == -1 && errno == EINTR);
-    return rc == static_cast<ssize_t> (sizeof wire_size) ? 0 : -1;
+    return rc == static_cast<ssize_t> (sizeof marker) ? 0 : -1;
 }
 
 inline int shm_recv_fd (int socket_, int *fd_, size_t *size_)
@@ -98,10 +106,10 @@ inline int shm_recv_fd (int socket_, int *fd_, size_t *size_)
         return -1;
     }
 
-    uint64_t wire_size = 0;
+    unsigned char marker = 0;
     struct iovec iov;
-    iov.iov_base = &wire_size;
-    iov.iov_len = sizeof wire_size;
+    iov.iov_base = &marker;
+    iov.iov_len = sizeof marker;
 
     union
     {
@@ -125,26 +133,43 @@ inline int shm_recv_fd (int socket_, int *fd_, size_t *size_)
         rc = recvmsg (socket_, &message, 0);
 #endif
     } while (rc == -1 && errno == EINTR);
-    if (rc != static_cast<ssize_t> (sizeof wire_size) || wire_size == 0) {
-        errno = EPROTO;
+    if (rc == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
         return -1;
-    }
-
     struct cmsghdr *const cmsg = CMSG_FIRSTHDR (&message);
-    if (!cmsg || cmsg->cmsg_level != SOL_SOCKET
+    int received_fd = -1;
+    if (cmsg && cmsg->cmsg_level == SOL_SOCKET
+        && cmsg->cmsg_type == SCM_RIGHTS
+        && cmsg->cmsg_len >= CMSG_LEN (sizeof (int)))
+        memcpy (&received_fd, CMSG_DATA (cmsg), sizeof received_fd);
+
+    if (rc != static_cast<ssize_t> (sizeof marker) || marker != 1
+        || (message.msg_flags & MSG_CTRUNC) || !cmsg
+        || cmsg->cmsg_level != SOL_SOCKET
         || cmsg->cmsg_type != SCM_RIGHTS
         || cmsg->cmsg_len != CMSG_LEN (sizeof (int))) {
+        if (received_fd != -1)
+            close (received_fd);
         errno = EPROTO;
         return -1;
     }
 
-    int received_fd = -1;
-    memcpy (&received_fd, CMSG_DATA (cmsg), sizeof received_fd);
 #ifndef MSG_CMSG_CLOEXEC
     fcntl (received_fd, F_SETFD, FD_CLOEXEC);
 #endif
+    struct stat stat_buf;
+    if (fstat (received_fd, &stat_buf) != 0) {
+        const int saved_errno = errno;
+        close (received_fd);
+        errno = saved_errno;
+        return -1;
+    }
+    if (stat_buf.st_size <= 0) {
+        close (received_fd);
+        errno = EPROTO;
+        return -1;
+    }
     *fd_ = received_fd;
-    *size_ = static_cast<size_t> (wire_size);
+    *size_ = static_cast<size_t> (stat_buf.st_size);
     return 0;
 }
 }

--- a/src/shm_ring.hpp
+++ b/src/shm_ring.hpp
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#ifndef __ZMQ_SHM_RING_HPP_INCLUDED__
+#define __ZMQ_SHM_RING_HPP_INCLUDED__
+
+#include "stdint.hpp"
+
+#include <stddef.h>
+#include <string.h>
+
+namespace zmq
+{
+class shm_ring_t
+{
+  public:
+    static size_t memory_size (uint32_t slot_count_, size_t slot_size_)
+    {
+        if (slot_count_ < 2 || slot_size_ == 0)
+            return 0;
+        return cache_line_size
+               + static_cast<size_t> (slot_count_)
+                   * slot_stride (slot_size_);
+    }
+
+    static int initialize (void *memory_,
+                           size_t memory_size_,
+                           uint32_t slot_count_,
+                           size_t slot_size_)
+    {
+        const size_t required = memory_size (slot_count_, slot_size_);
+        if (!memory_ || required == 0 || memory_size_ < required)
+            return -1;
+
+        memset (memory_, 0, required);
+        header_t *const header = static_cast<header_t *> (memory_);
+        header->magic = ring_magic ();
+        header->version = 1;
+        header->slot_count = slot_count_;
+        header->slot_size = slot_size_;
+        header->stride = slot_stride (slot_size_);
+        header->mapping_size = required;
+
+        unsigned char *const base = static_cast<unsigned char *> (memory_);
+        for (uint32_t i = 0; i != slot_count_; ++i) {
+            slot_control_t *const control = reinterpret_cast<slot_control_t *> (
+              base + cache_line_size + header->stride * i);
+            atomic_store (&control->sequence, i, __ATOMIC_RELAXED);
+        }
+        return 0;
+    }
+
+    shm_ring_t (void *memory_, size_t memory_size_) :
+        _base (static_cast<unsigned char *> (memory_)), _header (NULL),
+        _valid (false)
+    {
+        if (!_base || memory_size_ < cache_line_size)
+            return;
+        header_t *const header = reinterpret_cast<header_t *> (_base);
+        if (header->magic != ring_magic () || header->version != 1
+            || header->slot_count < 2 || header->slot_size == 0
+            || header->stride != slot_stride (header->slot_size)
+            || header->mapping_size
+                 != memory_size (header->slot_count, header->slot_size)
+            || memory_size_ < header->mapping_size)
+            return;
+        _header = header;
+        _valid = true;
+    }
+
+    bool valid () const { return _valid; }
+
+    void *try_acquire_write (uint64_t position_)
+    {
+        if (!_valid)
+            return NULL;
+        slot_control_t *const control = slot (position_);
+        if (atomic_load (&control->sequence, __ATOMIC_ACQUIRE) != position_)
+            return NULL;
+        return reinterpret_cast<unsigned char *> (control) + cache_line_size;
+    }
+
+    void publish_write (uint64_t position_)
+    {
+        slot_control_t *const control = slot (position_);
+        atomic_store (&control->sequence, position_ + 1, __ATOMIC_RELEASE);
+    }
+
+    const void *try_acquire_read (uint64_t position_) const
+    {
+        if (!_valid)
+            return NULL;
+        slot_control_t *const control = slot (position_);
+        if (atomic_load (&control->sequence, __ATOMIC_ACQUIRE)
+            != position_ + 1)
+            return NULL;
+        return reinterpret_cast<unsigned char *> (control) + cache_line_size;
+    }
+
+    void release_read (uint64_t position_)
+    {
+        slot_control_t *const control = slot (position_);
+        atomic_store (&control->sequence,
+                      position_ + _header->slot_count, __ATOMIC_RELEASE);
+    }
+
+  private:
+    enum
+    {
+        cache_line_size = 64
+    };
+
+    struct header_t
+    {
+        uint64_t magic;
+        uint32_t version;
+        uint32_t slot_count;
+        size_t slot_size;
+        size_t stride;
+        size_t mapping_size;
+    };
+
+    struct slot_control_t
+    {
+        volatile uint64_t sequence;
+        unsigned char padding[cache_line_size - sizeof (uint64_t)];
+    };
+
+    static uint64_t ring_magic () { return UINT64_C (0x5a4d5153484d5231); }
+
+    static size_t align_up (size_t value_)
+    {
+        return (value_ + cache_line_size - 1) & ~(cache_line_size - 1);
+    }
+
+    static size_t slot_stride (size_t slot_size_)
+    {
+        return cache_line_size + align_up (slot_size_);
+    }
+
+    static uint64_t atomic_load (const volatile uint64_t *value_, int order_)
+    {
+        return __atomic_load_n (value_, order_);
+    }
+
+    static void atomic_store (volatile uint64_t *value_,
+                              uint64_t value,
+                              int order_)
+    {
+        __atomic_store_n (value_, value, order_);
+    }
+
+    slot_control_t *slot (uint64_t position_) const
+    {
+        return reinterpret_cast<slot_control_t *> (
+          _base + cache_line_size
+          + _header->stride * (position_ % _header->slot_count));
+    }
+
+    unsigned char *_base;
+    header_t *_header;
+    bool _valid;
+};
+}
+
+#endif

--- a/src/shm_state.cpp
+++ b/src/shm_state.cpp
@@ -1,0 +1,317 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include "precompiled.hpp"
+
+#if defined ZMQ_HAVE_LINUX
+
+#include "shm_state.hpp"
+
+#include "err.hpp"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+zmq::shm_state_t *zmq::shm_state_t::create (void *mapping_,
+                                            size_t mapping_size_,
+                                            bool server_,
+                                            fd_t control_fd_,
+                                            fd_t release_fd_)
+{
+    shm_state_t *const state = new (std::nothrow)
+      shm_state_t (mapping_, mapping_size_, server_, control_fd_, release_fd_);
+    alloc_assert (state);
+    if (!state->valid ()) {
+        delete state;
+        errno = EPROTO;
+        return NULL;
+    }
+    return state;
+}
+
+zmq::shm_state_t::shm_state_t (void *mapping_,
+                               size_t mapping_size_,
+                               bool server_,
+                               fd_t control_fd_,
+                               fd_t release_fd_) :
+    _refs (1),
+    _mapping (mapping_),
+    _mapping_size (mapping_size_),
+    _channel (new (std::nothrow)
+                shm_channel_t (mapping_, mapping_size_, server_)),
+    _control_fd (control_fd_),
+    _release_fd (release_fd_),
+    _send_position (0),
+    _send_reserved (false),
+    _direct_mode (false)
+{
+    alloc_assert (_channel);
+}
+
+zmq::shm_state_t::~shm_state_t ()
+{
+    delete _channel;
+    _channel = NULL;
+    if (_mapping != MAP_FAILED) {
+        const int rc = munmap (_mapping, _mapping_size);
+        errno_assert (rc == 0);
+        _mapping = MAP_FAILED;
+    }
+    if (_release_fd != retired_fd) {
+        const int rc = close (_release_fd);
+        errno_assert (rc == 0);
+        _release_fd = retired_fd;
+    }
+}
+
+void zmq::shm_state_t::add_ref ()
+{
+    _refs.add (1);
+}
+
+void zmq::shm_state_t::drop_ref ()
+{
+    if (!_refs.sub (1))
+        delete this;
+}
+
+bool zmq::shm_state_t::valid () const
+{
+    return _mapping != MAP_FAILED && _channel && _channel->valid ();
+}
+
+void zmq::shm_state_t::set_control_fd (fd_t fd_)
+{
+    scoped_lock_t lock (_sync);
+    _control_fd = fd_;
+}
+
+void zmq::shm_state_t::clear_control_fd (fd_t fd_)
+{
+    scoped_lock_t lock (_sync);
+    if (_control_fd == fd_)
+        _control_fd = retired_fd;
+}
+
+uint64_t zmq::shm_state_t::token_magic ()
+{
+    return UINT64_C (0x5a4d5153484d544b);
+}
+
+zmq::shm_state_t::token_t *
+zmq::shm_state_t::create_token (token_kind_t kind_, uint64_t position_)
+{
+    token_t *const token = static_cast<token_t *> (malloc (sizeof (token_t)));
+    if (!token)
+        return NULL;
+    token->magic = token_magic ();
+    token->state = this;
+    token->position = position_;
+    token->kind = static_cast<unsigned char> (kind_);
+    token->published = 0;
+    add_ref ();
+    return token;
+}
+
+zmq::shm_state_t::token_t *
+zmq::shm_state_t::token_from_message (const msg_t *msg_)
+{
+    void *hint = NULL;
+    if (!msg_ || !msg_->external_storage_matches (&free_message, &hint))
+        return NULL;
+    token_t *const token = static_cast<token_t *> (hint);
+    if (!token || token->magic != token_magic () || !token->state)
+        return NULL;
+    return token;
+}
+
+bool zmq::shm_state_t::is_shm_message (const msg_t *msg_)
+{
+    return token_from_message (msg_) != NULL;
+}
+
+int zmq::shm_state_t::init_direct_message (msg_t *msg_, size_t size_)
+{
+    if (!msg_ || size_ == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    scoped_lock_t lock (_sync);
+    if (_control_fd == retired_fd) {
+        errno = EAGAIN;
+        return -1;
+    }
+    if (_send_reserved) {
+        errno = EAGAIN;
+        return -1;
+    }
+
+    void *const data =
+      _channel->try_reserve_send (_send_position, size_, 0);
+    if (!data) {
+        errno = EAGAIN;
+        return -1;
+    }
+
+    token_t *const token = create_token (direct_send_token, _send_position);
+    if (!token) {
+        errno = ENOMEM;
+        return -1;
+    }
+    _send_reserved = true;
+    const int rc = msg_->init_external_storage (&token->content, data, size_,
+                                                &free_message, token);
+    if (rc != 0) {
+        _send_reserved = false;
+        token->magic = 0;
+        free (token);
+        drop_ref ();
+        return rc;
+    }
+    _direct_mode = true;
+    return 0;
+}
+
+bool zmq::shm_state_t::notify_data ()
+{
+    const unsigned char byte = 1;
+    ssize_t rc;
+    do {
+        rc = send (_control_fd, &byte, sizeof byte, MSG_NOSIGNAL);
+    } while (rc == -1 && errno == EINTR);
+    return rc == 1
+           || (rc == -1 && (errno == EAGAIN || errno == EWOULDBLOCK));
+}
+
+int zmq::shm_state_t::send_direct_message (msg_t *msg_, int flags_)
+{
+    token_t *const token = token_from_message (msg_);
+    if (!token || token->state != this || token->kind != direct_send_token) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (msg_->flags () & msg_t::shared) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    const size_t size = msg_->size ();
+    {
+        scoped_lock_t lock (_sync);
+        if (!_send_reserved || token->position != _send_position
+            || _control_fd == retired_fd) {
+            errno = EAGAIN;
+            return -1;
+        }
+        const unsigned char message_flags =
+          (flags_ & ZMQ_SNDMORE) ? msg_t::more : 0;
+        if (!_channel->set_send_flags (_send_position, message_flags)) {
+            errno = EFAULT;
+            return -1;
+        }
+        _channel->publish_send (_send_position++);
+        _send_reserved = false;
+        token->published = 1;
+        notify_data ();
+    }
+
+    int rc = msg_->close ();
+    errno_assert (rc == 0);
+    rc = msg_->init ();
+    errno_assert (rc == 0);
+    return static_cast<int> (size > INT_MAX ? INT_MAX : size);
+}
+
+void *zmq::shm_state_t::try_reserve_copy (size_t size_,
+                                          unsigned char flags_,
+                                          uint64_t *position_)
+{
+    scoped_lock_t lock (_sync);
+    if (_send_reserved || _direct_mode)
+        return NULL;
+    void *const data =
+      _channel->try_reserve_send (_send_position, size_, flags_);
+    if (!data)
+        return NULL;
+    _send_reserved = true;
+    *position_ = _send_position;
+    return data;
+}
+
+void zmq::shm_state_t::publish_copy (uint64_t position_)
+{
+    scoped_lock_t lock (_sync);
+    zmq_assert (_send_reserved && position_ == _send_position);
+    _channel->publish_send (_send_position++);
+    _send_reserved = false;
+}
+
+bool zmq::shm_state_t::try_receive (uint64_t position_,
+                                    const void **data_,
+                                    size_t *size_,
+                                    unsigned char *flags_) const
+{
+    return _channel->try_receive (position_, data_, size_, flags_);
+}
+
+int zmq::shm_state_t::init_received_message (msg_t *msg_,
+                                             uint64_t position_,
+                                             const void *data_,
+                                             size_t size_,
+                                             unsigned char flags_)
+{
+    token_t *const token = create_token (receive_token, position_);
+    if (!token) {
+        errno = ENOMEM;
+        return -1;
+    }
+    const int rc = msg_->init_external_storage (
+      &token->content, const_cast<void *> (data_), size_, &free_message, token);
+    if (rc != 0) {
+        token->magic = 0;
+        free (token);
+        drop_ref ();
+        return rc;
+    }
+    msg_->set_flags (static_cast<unsigned char> (flags_ & ~msg_t::shared));
+    return 0;
+}
+
+void zmq::shm_state_t::cancel_direct (uint64_t position_)
+{
+    scoped_lock_t lock (_sync);
+    if (_send_reserved && position_ == _send_position)
+        _send_reserved = false;
+}
+
+void zmq::shm_state_t::release_receive (uint64_t position_)
+{
+    _channel->release_receive (position_);
+    if (_release_fd != retired_fd) {
+        const uint64_t value = 1;
+        ssize_t rc;
+        do {
+            rc = write (_release_fd, &value, sizeof value);
+        } while (rc == -1 && errno == EINTR);
+    }
+}
+
+void zmq::shm_state_t::free_message (void *, void *hint_)
+{
+    token_t *const token = static_cast<token_t *> (hint_);
+    zmq_assert (token && token->magic == token_magic ());
+    shm_state_t *const state = token->state;
+    if (token->kind == receive_token)
+        state->release_receive (token->position);
+    else if (!token->published)
+        state->cancel_direct (token->position);
+    token->magic = 0;
+    free (token);
+    state->drop_ref ();
+}
+
+#endif

--- a/src/shm_state.hpp
+++ b/src/shm_state.hpp
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#ifndef __ZMQ_SHM_STATE_HPP_INCLUDED__
+#define __ZMQ_SHM_STATE_HPP_INCLUDED__
+
+#if defined ZMQ_HAVE_LINUX
+
+#include "atomic_counter.hpp"
+#include "fd.hpp"
+#include "macros.hpp"
+#include "msg.hpp"
+#include "mutex.hpp"
+#include "shm_channel.hpp"
+#include "stdint.hpp"
+
+#include <stddef.h>
+
+namespace zmq
+{
+class shm_state_t
+{
+  public:
+    static shm_state_t *create (void *mapping_,
+                                size_t mapping_size_,
+                                bool server_,
+                                fd_t control_fd_,
+                                fd_t release_fd_);
+
+    void add_ref ();
+    void drop_ref ();
+    bool valid () const;
+
+    void set_control_fd (fd_t fd_);
+    void clear_control_fd (fd_t fd_);
+
+    int init_direct_message (msg_t *msg_, size_t size_);
+    int send_direct_message (msg_t *msg_, int flags_);
+    static bool is_shm_message (const msg_t *msg_);
+
+    void *try_reserve_copy (size_t size_,
+                            unsigned char flags_,
+                            uint64_t *position_);
+    void publish_copy (uint64_t position_);
+
+    bool try_receive (uint64_t position_,
+                      const void **data_,
+                      size_t *size_,
+                      unsigned char *flags_) const;
+    int init_received_message (msg_t *msg_,
+                               uint64_t position_,
+                               const void *data_,
+                               size_t size_,
+                               unsigned char flags_);
+
+  private:
+    enum token_kind_t
+    {
+        direct_send_token,
+        receive_token
+    };
+
+    struct token_t
+    {
+        msg_t::content_t content;
+        uint64_t magic;
+        shm_state_t *state;
+        uint64_t position;
+        unsigned char kind;
+        unsigned char published;
+    };
+
+    shm_state_t (void *mapping_,
+                 size_t mapping_size_,
+                 bool server_,
+                 fd_t control_fd_,
+                 fd_t release_fd_);
+    ~shm_state_t ();
+
+    static void free_message (void *data_, void *hint_);
+    static uint64_t token_magic ();
+    static token_t *token_from_message (const msg_t *msg_);
+    token_t *create_token (token_kind_t kind_, uint64_t position_);
+    void cancel_direct (uint64_t position_);
+    void release_receive (uint64_t position_);
+    bool notify_data ();
+
+    atomic_counter_t _refs;
+    void *_mapping;
+    size_t _mapping_size;
+    shm_channel_t *_channel;
+    mutable mutex_t _sync;
+    fd_t _control_fd;
+    fd_t _release_fd;
+    uint64_t _send_position;
+    bool _send_reserved;
+    bool _direct_mode;
+
+    ZMQ_NON_COPYABLE_NOR_MOVABLE (shm_state_t)
+};
+}
+
+#endif
+
+#endif

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -289,14 +289,7 @@ int zmq::socket_base_t::get_peer_state (const void *routing_id_,
 zmq::socket_base_t::~socket_base_t ()
 {
 #if defined ZMQ_HAVE_LINUX
-    shm_state_t *shm_state = NULL;
-    {
-        scoped_lock_t lock (_shm_sync);
-        shm_state = _shm_state;
-        _shm_state = NULL;
-    }
-    if (shm_state)
-        shm_state->drop_ref ();
+    release_shm_state ();
 #endif
 
     if (_mailbox)
@@ -1427,18 +1420,16 @@ void zmq::socket_base_t::register_shm_state (shm_state_t *state_)
         old_state->drop_ref ();
 }
 
-void zmq::socket_base_t::unregister_shm_state (shm_state_t *state_)
+void zmq::socket_base_t::release_shm_state ()
 {
-    bool removed = false;
+    shm_state_t *shm_state = NULL;
     {
         scoped_lock_t lock (_shm_sync);
-        if (_shm_state == state_) {
-            _shm_state = NULL;
-            removed = true;
-        }
+        shm_state = _shm_state;
+        _shm_state = NULL;
     }
-    if (removed)
-        state_->drop_ref ();
+    if (shm_state)
+        shm_state->drop_ref ();
 }
 
 int zmq::socket_base_t::shm_msg_init (msg_t *msg_, size_t size_)
@@ -1976,6 +1967,10 @@ void zmq::socket_base_t::pipe_terminated (pipe_t *pipe_)
 
     // Remove the pipe from _endpoints (set it to NULL).
     const std::string &identifier = pipe_->get_endpoint_pair ().identifier ();
+#if defined ZMQ_HAVE_LINUX
+    if (identifier.compare (0, 6, "shm://") == 0)
+        release_shm_state ();
+#endif
     if (!identifier.empty ()) {
         std::pair<endpoints_t::iterator, endpoints_t::iterator> range;
         range = _endpoints.equal_range (identifier);

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -22,6 +22,10 @@
 #endif
 
 #include "socket_base.hpp"
+
+#if defined ZMQ_HAVE_LINUX
+#include "shm_state.hpp"
+#endif
 #include "tcp_listener.hpp"
 #include "ws_listener.hpp"
 #include "ipc_listener.hpp"
@@ -230,6 +234,11 @@ zmq::socket_base_t::socket_base_t (ctx_t *parent_,
                                    bool thread_safe_) :
     own_t (parent_, tid_),
     _sync (),
+#if defined ZMQ_HAVE_LINUX
+    _shm_sync (),
+    _shm_state (NULL),
+    _shm_send_mode (shm_send_mode_none),
+#endif
     _tag (0xbaddecaf),
     _ctx_terminated (false),
     _destroyed (false),
@@ -279,6 +288,17 @@ int zmq::socket_base_t::get_peer_state (const void *routing_id_,
 
 zmq::socket_base_t::~socket_base_t ()
 {
+#if defined ZMQ_HAVE_LINUX
+    shm_state_t *shm_state = NULL;
+    {
+        scoped_lock_t lock (_shm_sync);
+        shm_state = _shm_state;
+        _shm_state = NULL;
+    }
+    if (shm_state)
+        shm_state->drop_ref ();
+#endif
+
     if (_mailbox)
         LIBZMQ_DELETE (_mailbox);
 
@@ -1313,6 +1333,17 @@ int zmq::socket_base_t::send (msg_t *msg_, int flags_)
         return -1;
     }
 
+#if defined ZMQ_HAVE_LINUX
+    {
+        scoped_lock_t lock (_shm_sync);
+        if (unlikely (_shm_send_mode == shm_send_mode_direct)) {
+            errno = ENOTSUP;
+            return -1;
+        }
+        _shm_send_mode = shm_send_mode_copy;
+    }
+#endif
+
     //  Clear any user-visible flags that are set on the message.
     msg_->reset_flags (msg_t::more);
 
@@ -1378,6 +1409,120 @@ int zmq::socket_base_t::send (msg_t *msg_, int flags_)
 
     return 0;
 }
+
+#if defined ZMQ_HAVE_LINUX
+void zmq::socket_base_t::register_shm_state (shm_state_t *state_)
+{
+    zmq_assert (state_);
+    shm_state_t *old_state = NULL;
+    {
+        scoped_lock_t lock (_shm_sync);
+        if (_shm_state == state_)
+            return;
+        state_->add_ref ();
+        old_state = _shm_state;
+        _shm_state = state_;
+    }
+    if (old_state)
+        old_state->drop_ref ();
+}
+
+void zmq::socket_base_t::unregister_shm_state (shm_state_t *state_)
+{
+    bool removed = false;
+    {
+        scoped_lock_t lock (_shm_sync);
+        if (_shm_state == state_) {
+            _shm_state = NULL;
+            removed = true;
+        }
+    }
+    if (removed)
+        state_->drop_ref ();
+}
+
+int zmq::socket_base_t::shm_msg_init (msg_t *msg_, size_t size_)
+{
+    scoped_optional_lock_t sync_lock (_thread_safe ? &_sync : NULL);
+    if (unlikely (_ctx_terminated)) {
+        errno = ETERM;
+        return -1;
+    }
+    if (unlikely (!msg_)) {
+        errno = EFAULT;
+        return -1;
+    }
+    if (size_ == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (options.type != ZMQ_PAIR) {
+        errno = ENOTSUP;
+        return -1;
+    }
+    if (process_commands (0, false) != 0)
+        return -1;
+
+    shm_state_t *state = NULL;
+    {
+        scoped_lock_t lock (_shm_sync);
+        if (_shm_send_mode == shm_send_mode_copy) {
+            errno = ENOTSUP;
+            return -1;
+        }
+        state = _shm_state;
+        if (state)
+            state->add_ref ();
+        if (state)
+            _shm_send_mode = shm_send_mode_direct;
+    }
+    if (!state) {
+        errno = EAGAIN;
+        return -1;
+    }
+    const int rc = state->init_direct_message (msg_, size_);
+    state->drop_ref ();
+    return rc;
+}
+
+int zmq::socket_base_t::shm_msg_send (msg_t *msg_, int flags_)
+{
+    scoped_optional_lock_t sync_lock (_thread_safe ? &_sync : NULL);
+    if (unlikely (_ctx_terminated)) {
+        errno = ETERM;
+        return -1;
+    }
+    if (unlikely (!msg_ || !msg_->check ())) {
+        errno = EFAULT;
+        return -1;
+    }
+    if (options.type != ZMQ_PAIR) {
+        errno = ENOTSUP;
+        return -1;
+    }
+    if (process_commands (0, false) != 0)
+        return -1;
+
+    shm_state_t *state = NULL;
+    {
+        scoped_lock_t lock (_shm_sync);
+        if (_shm_send_mode != shm_send_mode_direct) {
+            errno = EINVAL;
+            return -1;
+        }
+        state = _shm_state;
+        if (state)
+            state->add_ref ();
+    }
+    if (!state) {
+        errno = EAGAIN;
+        return -1;
+    }
+    const int rc = state->send_direct_message (msg_, flags_);
+    state->drop_ref ();
+    return rc;
+}
+#endif
 
 int zmq::socket_base_t::recv (msg_t *msg_, int flags_)
 {

--- a/src/socket_base.cpp
+++ b/src/socket_base.cpp
@@ -336,6 +336,9 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_) const
 #if defined ZMQ_HAVE_IPC
         && protocol_ != protocol_name::ipc
 #endif
+#if defined ZMQ_HAVE_LINUX
+        && protocol_ != protocol_name::shm
+#endif
         && protocol_ != protocol_name::tcp
 #ifdef ZMQ_HAVE_WS
         && protocol_ != protocol_name::ws
@@ -365,6 +368,19 @@ int zmq::socket_base_t::check_protocol (const std::string &protocol_) const
         errno = EPROTONOSUPPORT;
         return -1;
     }
+
+#if defined ZMQ_HAVE_LINUX
+    if (protocol_ == protocol_name::shm
+        && (options.mechanism != ZMQ_NULL || !options.zap_domain.empty ())) {
+        errno = ENOCOMPATPROTO;
+        return -1;
+    }
+    if (protocol_ == protocol_name::shm && options.type != ZMQ_PAIR
+        && options.type != ZMQ_PUSH && options.type != ZMQ_PULL) {
+        errno = ENOCOMPATPROTO;
+        return -1;
+    }
+#endif
 
     //  Check whether socket type and transport protocol match.
     //  Specifically, multicast protocols can't be combined with
@@ -701,9 +717,20 @@ int zmq::socket_base_t::bind (const char *endpoint_uri_)
 #endif
 
 #if defined ZMQ_HAVE_IPC
-    if (protocol == protocol_name::ipc) {
+    if (protocol == protocol_name::ipc
+#if defined ZMQ_HAVE_LINUX
+        || protocol == protocol_name::shm
+#endif
+    ) {
         ipc_listener_t *listener =
-          new (std::nothrow) ipc_listener_t (io_thread, this, options);
+          new (std::nothrow) ipc_listener_t (
+            io_thread, this, options,
+#if defined ZMQ_HAVE_LINUX
+            protocol == protocol_name::shm
+#else
+            false
+#endif
+          );
         alloc_assert (listener);
         int rc = listener->set_local_address (address.c_str ());
         if (rc != 0) {
@@ -1011,7 +1038,11 @@ int zmq::socket_base_t::connect_internal (const char *endpoint_uri_)
 #endif
 
 #if defined ZMQ_HAVE_IPC
-    else if (protocol == protocol_name::ipc) {
+    else if (protocol == protocol_name::ipc
+#if defined ZMQ_HAVE_LINUX
+             || protocol == protocol_name::shm
+#endif
+    ) {
         paddr->resolved.ipc_addr = new (std::nothrow) ipc_address_t ();
         alloc_assert (paddr->resolved.ipc_addr);
         int rc = paddr->resolved.ipc_addr->resolve (address.c_str ());

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -68,7 +68,6 @@ class socket_base_t : public own_t,
     int shm_msg_init (zmq::msg_t *msg_, size_t size_);
     int shm_msg_send (zmq::msg_t *msg_, int flags_);
     void register_shm_state (shm_state_t *state_);
-    void unregister_shm_state (shm_state_t *state_);
 #endif
     void add_signaler (signaler_t *s_);
     void remove_signaler (signaler_t *s_);
@@ -264,6 +263,7 @@ class socket_base_t : public own_t,
     mutex_t _shm_sync;
     shm_state_t *_shm_state;
     shm_send_mode_t _shm_send_mode;
+    void release_shm_state ();
 #endif
     uint32_t _tag;
 

--- a/src/socket_base.hpp
+++ b/src/socket_base.hpp
@@ -27,6 +27,9 @@ namespace zmq
 class ctx_t;
 class msg_t;
 class pipe_t;
+#if defined ZMQ_HAVE_LINUX
+class shm_state_t;
+#endif
 
 class socket_base_t : public own_t,
                       public array_item_t<>,
@@ -61,6 +64,12 @@ class socket_base_t : public own_t,
     int term_endpoint (const char *endpoint_uri_);
     int send (zmq::msg_t *msg_, int flags_);
     int recv (zmq::msg_t *msg_, int flags_);
+#if defined ZMQ_HAVE_LINUX
+    int shm_msg_init (zmq::msg_t *msg_, size_t size_);
+    int shm_msg_send (zmq::msg_t *msg_, int flags_);
+    void register_shm_state (shm_state_t *state_);
+    void unregister_shm_state (shm_state_t *state_);
+#endif
     void add_signaler (signaler_t *s_);
     void remove_signaler (signaler_t *s_);
     int close ();
@@ -245,6 +254,17 @@ class socket_base_t : public own_t,
     void extract_flags (const msg_t *msg_);
 
     //  Used to check whether the object is a socket.
+#if defined ZMQ_HAVE_LINUX
+    enum shm_send_mode_t
+    {
+        shm_send_mode_none,
+        shm_send_mode_copy,
+        shm_send_mode_direct
+    };
+    mutex_t _shm_sync;
+    shm_state_t *_shm_state;
+    shm_send_mode_t _shm_send_mode;
+#endif
     uint32_t _tag;
 
     //  If true, associated context was already terminated.

--- a/src/zmq.cpp
+++ b/src/zmq.cpp
@@ -56,6 +56,9 @@ struct iovec
 
 #include "proxy.hpp"
 #include "socket_base.hpp"
+#if defined ZMQ_HAVE_LINUX
+#include "shm_state.hpp"
+#endif
 #include "stdint.hpp"
 #include "config.hpp"
 #include "likely.hpp"
@@ -614,6 +617,36 @@ int zmq_msg_init_data (
       ->init_data (data_, size_, ffn_, hint_);
 }
 
+int zmq_shm_msg_init (void *s_, zmq_msg_t *msg_, size_t size_)
+{
+    zmq::socket_base_t *s = as_socket_base_t (s_);
+    if (!s)
+        return -1;
+#if defined ZMQ_HAVE_LINUX
+    return s->shm_msg_init (reinterpret_cast<zmq::msg_t *> (msg_), size_);
+#else
+    LIBZMQ_UNUSED (msg_);
+    LIBZMQ_UNUSED (size_);
+    errno = ENOTSUP;
+    return -1;
+#endif
+}
+
+int zmq_shm_msg_send (zmq_msg_t *msg_, void *s_, int flags_)
+{
+    zmq::socket_base_t *s = as_socket_base_t (s_);
+    if (!s)
+        return -1;
+#if defined ZMQ_HAVE_LINUX
+    return s->shm_msg_send (reinterpret_cast<zmq::msg_t *> (msg_), flags_);
+#else
+    LIBZMQ_UNUSED (msg_);
+    LIBZMQ_UNUSED (flags_);
+    errno = ENOTSUP;
+    return -1;
+#endif
+}
+
 int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_)
 {
     zmq::socket_base_t *s = as_socket_base_t (s_);
@@ -680,6 +713,15 @@ int zmq_msg_get (const zmq_msg_t *msg_, int property_)
                        || (((zmq::msg_t *) msg_)->flags () & zmq::msg_t::shared)
                      ? 1
                      : 0;
+        case ZMQ_SHM:
+#if defined ZMQ_HAVE_LINUX
+            return zmq::shm_state_t::is_shm_message (
+                     reinterpret_cast<const zmq::msg_t *> (msg_))
+                     ? 1
+                     : 0;
+#else
+            return 0;
+#endif
         default:
             errno = EINVAL;
             return -1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,7 +129,7 @@ if(NOT WIN32)
   endif()
 
   if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    list(APPEND tests test_abstract_ipc test_shm_ring)
+    list(APPEND tests test_abstract_ipc test_shm_ring test_shm_channel)
 
     if(ZMQ_HAVE_TIPC)
       list(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,7 +129,7 @@ if(NOT WIN32)
   endif()
 
   if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    list(APPEND tests test_abstract_ipc test_shm_ring test_shm_channel)
+    list(APPEND tests test_abstract_ipc test_shm_ring test_shm_channel test_pair_shm)
 
     if(ZMQ_HAVE_TIPC)
       list(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,7 +129,7 @@ if(NOT WIN32)
   endif()
 
   if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    list(APPEND tests test_abstract_ipc)
+    list(APPEND tests test_abstract_ipc test_shm_ring)
 
     if(ZMQ_HAVE_TIPC)
       list(

--- a/tests/test_pair_shm.cpp
+++ b/tests/test_pair_shm.cpp
@@ -4,6 +4,7 @@
 #include "testutil_unity.hpp"
 
 #include <assert.h>
+#include <new>
 #include <stdio.h>
 #include <string.h>
 #include <sys/wait.h>
@@ -16,6 +17,24 @@ void setUp ()
 void tearDown ()
 {
 }
+
+struct direct_payload_t
+{
+    explicit direct_payload_t (uint32_t value_) :
+        magic (UINT32_C (0x53484d31)), value (value_)
+    {
+    }
+
+    ~direct_payload_t () { ++*destruction_count (); }
+
+    uint32_t *destruction_count ()
+    {
+        return reinterpret_cast<uint32_t *> (this + 1);
+    }
+
+    uint32_t magic;
+    uint32_t value;
+};
 
 void test_pair_roundtrip_across_processes ()
 {
@@ -100,7 +119,7 @@ void test_pair_drains_shared_ring_before_peer_close ()
         _exit (0);
     }
 
-    for (int i = 0; i != 55; ++i) {
+    for (int i = 0; i != 56; ++i) {
         int value = -1;
         TEST_ASSERT_EQUAL_INT (sizeof value,
                                zmq_recv (server, &value, sizeof value, 0));
@@ -112,7 +131,7 @@ void test_pair_drains_shared_ring_before_peer_close ()
     TEST_ASSERT_TRUE (WIFEXITED (status));
     TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
 
-    for (int i = 55; i != 64; ++i) {
+    for (int i = 56; i != 64; ++i) {
         int value = -1;
         TEST_ASSERT_EQUAL_INT (sizeof value,
                                zmq_recv (server, &value, sizeof value, 0));
@@ -144,6 +163,10 @@ void test_pair_roundtrip_in_one_context ()
     char request[4];
     TEST_ASSERT_EQUAL_INT (4, zmq_recv (server, request, sizeof request, 0));
     TEST_ASSERT_EQUAL_MEMORY ("ping", request, 4);
+    zmq_msg_t direct_message;
+    TEST_ASSERT_FAILURE_ERRNO (
+      ENOTSUP,
+      zmq_shm_msg_init (client, &direct_message, sizeof (uint32_t)));
     zmq_close (client);
     zmq_close (server);
     zmq_ctx_term (ctx);
@@ -167,9 +190,283 @@ void test_shm_rejects_unsupported_options ()
 
     void *router = zmq_socket (ctx, ZMQ_ROUTER);
     TEST_ASSERT_NOT_NULL (router);
+    zmq_msg_t direct_message;
+    TEST_ASSERT_FAILURE_ERRNO (
+      ENOTSUP, zmq_shm_msg_init (router, &direct_message, sizeof (uint32_t)));
     TEST_ASSERT_FAILURE_ERRNO (ENOCOMPATPROTO, zmq_bind (router, endpoint));
     zmq_close (router);
     zmq_ctx_term (ctx);
+}
+
+void test_pair_direct_message_across_processes ()
+{
+    char endpoint[128];
+    snprintf (endpoint, sizeof endpoint, "shm:///tmp/libzmq-shm-direct-%d",
+              static_cast<int> (getpid ()));
+
+    void *server_ctx = zmq_ctx_new ();
+    TEST_ASSERT_NOT_NULL (server_ctx);
+    void *server = zmq_socket (server_ctx, ZMQ_PAIR);
+    TEST_ASSERT_NOT_NULL (server);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (server, endpoint));
+
+    const pid_t child = fork ();
+    TEST_ASSERT_NOT_EQUAL (-1, child);
+    if (child == 0) {
+        void *client_ctx = zmq_ctx_new ();
+        assert (client_ctx);
+        void *client = zmq_socket (client_ctx, ZMQ_PAIR);
+        assert (client);
+        assert (zmq_connect (client, endpoint) == 0);
+
+        zmq_msg_t message;
+        const size_t message_size =
+          sizeof (direct_payload_t) + sizeof (uint32_t);
+        while (zmq_shm_msg_init (client, &message, message_size) == -1) {
+            assert (errno == EAGAIN);
+            usleep (1000);
+        }
+        direct_payload_t *const payload =
+          new (zmq_msg_data (&message)) direct_payload_t (42);
+        *payload->destruction_count () = 0;
+        assert (zmq_shm_msg_send (&message, client, 0)
+                == static_cast<int> (message_size));
+        assert (zmq_msg_close (&message) == 0);
+        assert (zmq_send (client, "mixed", 5, ZMQ_DONTWAIT) == -1);
+        assert (errno == ENOTSUP);
+
+        char reply[4];
+        assert (zmq_recv (client, reply, sizeof reply, 0) == 4);
+        assert (memcmp (reply, "done", 4) == 0);
+        zmq_close (client);
+        zmq_ctx_term (client_ctx);
+        _exit (0);
+    }
+
+    zmq_msg_t message;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&message));
+    const size_t message_size =
+      sizeof (direct_payload_t) + sizeof (uint32_t);
+    TEST_ASSERT_EQUAL_INT (
+      message_size, zmq_msg_recv (&message, server, 0));
+    TEST_ASSERT_EQUAL_INT (1, zmq_msg_get (&message, ZMQ_SHM));
+    direct_payload_t *const payload =
+      static_cast<direct_payload_t *> (zmq_msg_data (&message));
+    TEST_ASSERT_EQUAL_HEX32 (UINT32_C (0x53484d31), payload->magic);
+    TEST_ASSERT_EQUAL_UINT32 (42, payload->value);
+    uint32_t *const destruction_count = payload->destruction_count ();
+    TEST_ASSERT_EQUAL_UINT32 (0, *destruction_count);
+    payload->~direct_payload_t ();
+    TEST_ASSERT_EQUAL_UINT32 (1, *destruction_count);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&message));
+    TEST_ASSERT_EQUAL_INT (4, zmq_send (server, "done", 4, 0));
+
+    int status = 0;
+    TEST_ASSERT_EQUAL (child, waitpid (child, &status, 0));
+    TEST_ASSERT_TRUE (WIFEXITED (status));
+    TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
+    zmq_close (server);
+    zmq_ctx_term (server_ctx);
+}
+
+void test_pair_direct_slot_released_on_message_close ()
+{
+    char endpoint[128];
+    snprintf (endpoint, sizeof endpoint, "shm:///tmp/libzmq-shm-loan-%d",
+              static_cast<int> (getpid ()));
+
+    int full_pipe[2];
+    int released_pipe[2];
+    TEST_ASSERT_SUCCESS_ERRNO (pipe (full_pipe));
+    TEST_ASSERT_SUCCESS_ERRNO (pipe (released_pipe));
+
+    void *server_ctx = zmq_ctx_new ();
+    TEST_ASSERT_NOT_NULL (server_ctx);
+    void *server = zmq_socket (server_ctx, ZMQ_PAIR);
+    TEST_ASSERT_NOT_NULL (server);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (server, endpoint));
+
+    const pid_t child = fork ();
+    TEST_ASSERT_NOT_EQUAL (-1, child);
+    if (child == 0) {
+        close (full_pipe[0]);
+        close (released_pipe[1]);
+        void *client_ctx = zmq_ctx_new ();
+        assert (client_ctx);
+        void *client = zmq_socket (client_ctx, ZMQ_PAIR);
+        assert (client);
+        assert (zmq_connect (client, endpoint) == 0);
+
+        zmq_msg_t original;
+        while (zmq_shm_msg_init (client, &original, sizeof (uint32_t)) == -1) {
+            assert (errno == EAGAIN);
+            usleep (1000);
+        }
+        *static_cast<uint32_t *> (zmq_msg_data (&original)) = 99;
+        zmq_msg_t alias;
+        assert (zmq_msg_init (&alias) == 0);
+        assert (zmq_msg_copy (&alias, &original) == 0);
+        assert (zmq_shm_msg_send (&original, client, 0) == -1);
+        assert (errno == EINVAL);
+        assert (zmq_msg_close (&alias) == 0);
+        assert (zmq_msg_close (&original) == 0);
+
+        for (uint32_t i = 0; i != 8; ++i) {
+            zmq_msg_t message;
+            while (zmq_shm_msg_init (client, &message, sizeof i) == -1) {
+                assert (errno == EAGAIN);
+                usleep (1000);
+            }
+            *static_cast<uint32_t *> (zmq_msg_data (&message)) = i;
+            assert (zmq_shm_msg_send (&message, client, 0) == sizeof i);
+            assert (zmq_msg_close (&message) == 0);
+        }
+
+        zmq_msg_t ninth;
+        assert (zmq_shm_msg_init (client, &ninth, sizeof (uint32_t)) == -1);
+        assert (errno == EAGAIN);
+        const unsigned char marker = 1;
+        assert (write (full_pipe[1], &marker, sizeof marker)
+                == static_cast<ssize_t> (sizeof marker));
+        unsigned char released = 0;
+        assert (read (released_pipe[0], &released, sizeof released)
+                == static_cast<ssize_t> (sizeof released));
+        assert (released == marker);
+        assert (zmq_shm_msg_init (client, &ninth, sizeof (uint32_t)) == -1);
+        assert (errno == EAGAIN);
+        assert (write (full_pipe[1], &marker, sizeof marker)
+                == static_cast<ssize_t> (sizeof marker));
+        assert (read (released_pipe[0], &released, sizeof released)
+                == static_cast<ssize_t> (sizeof released));
+        assert (released == marker);
+
+        while (zmq_shm_msg_init (client, &ninth, sizeof (uint32_t)) == -1) {
+            assert (errno == EAGAIN);
+            usleep (1000);
+        }
+        *static_cast<uint32_t *> (zmq_msg_data (&ninth)) = 8;
+        assert (zmq_shm_msg_send (&ninth, client, 0) == sizeof (uint32_t));
+        assert (zmq_msg_close (&ninth) == 0);
+
+        close (full_pipe[1]);
+        close (released_pipe[0]);
+        zmq_close (client);
+        zmq_ctx_term (client_ctx);
+        _exit (0);
+    }
+
+    close (full_pipe[1]);
+    close (released_pipe[0]);
+    zmq_msg_t messages[8];
+    for (uint32_t i = 0; i != 8; ++i) {
+        TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&messages[i]));
+        TEST_ASSERT_EQUAL_INT (
+          sizeof (uint32_t), zmq_msg_recv (&messages[i], server, 0));
+        TEST_ASSERT_EQUAL_INT (1, zmq_msg_get (&messages[i], ZMQ_SHM));
+        TEST_ASSERT_EQUAL_UINT32 (
+          i, *static_cast<uint32_t *> (zmq_msg_data (&messages[i])));
+    }
+    zmq_msg_t first_alias;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&first_alias));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_copy (&first_alias, &messages[0]));
+
+    unsigned char marker = 0;
+    TEST_ASSERT_EQUAL_INT (
+      sizeof marker, read (full_pipe[0], &marker, sizeof marker));
+    TEST_ASSERT_EQUAL_UINT8 (1, marker);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&messages[0]));
+    TEST_ASSERT_EQUAL_INT (
+      sizeof marker, write (released_pipe[1], &marker, sizeof marker));
+    TEST_ASSERT_EQUAL_INT (
+      sizeof marker, read (full_pipe[0], &marker, sizeof marker));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&first_alias));
+    TEST_ASSERT_EQUAL_INT (
+      sizeof marker, write (released_pipe[1], &marker, sizeof marker));
+
+    zmq_msg_t ninth;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&ninth));
+    TEST_ASSERT_EQUAL_INT (
+      sizeof (uint32_t), zmq_msg_recv (&ninth, server, 0));
+    TEST_ASSERT_EQUAL_INT (1, zmq_msg_get (&ninth, ZMQ_SHM));
+    TEST_ASSERT_EQUAL_UINT32 (
+      8, *static_cast<uint32_t *> (zmq_msg_data (&ninth)));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&ninth));
+    for (size_t i = 1; i != 8; ++i)
+        TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&messages[i]));
+
+    close (full_pipe[0]);
+    close (released_pipe[1]);
+    int status = 0;
+    TEST_ASSERT_EQUAL (child, waitpid (child, &status, 0));
+    TEST_ASSERT_TRUE (WIFEXITED (status));
+    TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
+    zmq_close (server);
+    zmq_ctx_term (server_ctx);
+}
+
+void test_pair_direct_message_outlives_socket_and_context ()
+{
+    char endpoint[128];
+    snprintf (endpoint, sizeof endpoint, "shm:///tmp/libzmq-shm-outlive-%d",
+              static_cast<int> (getpid ()));
+
+    void *server_ctx = zmq_ctx_new ();
+    TEST_ASSERT_NOT_NULL (server_ctx);
+    void *server = zmq_socket (server_ctx, ZMQ_PAIR);
+    TEST_ASSERT_NOT_NULL (server);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (server, endpoint));
+
+    const pid_t child = fork ();
+    TEST_ASSERT_NOT_EQUAL (-1, child);
+    if (child == 0) {
+        void *client_ctx = zmq_ctx_new ();
+        assert (client_ctx);
+        void *client = zmq_socket (client_ctx, ZMQ_PAIR);
+        assert (client);
+        assert (zmq_connect (client, endpoint) == 0);
+
+        zmq_msg_t message;
+        const size_t message_size =
+          sizeof (direct_payload_t) + sizeof (uint32_t);
+        while (zmq_shm_msg_init (client, &message, message_size) == -1) {
+            assert (errno == EAGAIN);
+            usleep (1000);
+        }
+        direct_payload_t *const payload =
+          new (zmq_msg_data (&message)) direct_payload_t (77);
+        *payload->destruction_count () = 0;
+        assert (zmq_shm_msg_send (&message, client, 0)
+                == static_cast<int> (message_size));
+        assert (zmq_msg_close (&message) == 0);
+        zmq_close (client);
+        zmq_ctx_term (client_ctx);
+        _exit (0);
+    }
+
+    zmq_msg_t message;
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_init (&message));
+    const size_t message_size =
+      sizeof (direct_payload_t) + sizeof (uint32_t);
+    TEST_ASSERT_EQUAL_INT (
+      message_size, zmq_msg_recv (&message, server, 0));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_close (server));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_ctx_term (server_ctx));
+
+    TEST_ASSERT_EQUAL_INT (1, zmq_msg_get (&message, ZMQ_SHM));
+    direct_payload_t *const payload =
+      static_cast<direct_payload_t *> (zmq_msg_data (&message));
+    TEST_ASSERT_EQUAL_HEX32 (UINT32_C (0x53484d31), payload->magic);
+    TEST_ASSERT_EQUAL_UINT32 (77, payload->value);
+    uint32_t *const destruction_count = payload->destruction_count ();
+    TEST_ASSERT_EQUAL_UINT32 (0, *destruction_count);
+    payload->~direct_payload_t ();
+    TEST_ASSERT_EQUAL_UINT32 (1, *destruction_count);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_msg_close (&message));
+
+    int status = 0;
+    TEST_ASSERT_EQUAL (child, waitpid (child, &status, 0));
+    TEST_ASSERT_TRUE (WIFEXITED (status));
+    TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
 }
 
 int main ()
@@ -180,5 +477,8 @@ int main ()
     RUN_TEST (test_pair_drains_shared_ring_before_peer_close);
     RUN_TEST (test_pair_roundtrip_in_one_context);
     RUN_TEST (test_shm_rejects_unsupported_options);
+    RUN_TEST (test_pair_direct_message_across_processes);
+    RUN_TEST (test_pair_direct_slot_released_on_message_close);
+    RUN_TEST (test_pair_direct_message_outlives_socket_and_context);
     return UNITY_END ();
 }

--- a/tests/test_pair_shm.cpp
+++ b/tests/test_pair_shm.cpp
@@ -1,0 +1,184 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include "testutil.hpp"
+#include "testutil_unity.hpp"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+void setUp ()
+{
+}
+
+void tearDown ()
+{
+}
+
+void test_pair_roundtrip_across_processes ()
+{
+    char endpoint[128];
+    snprintf (endpoint, sizeof endpoint, "shm:///tmp/libzmq-shm-%d",
+              static_cast<int> (getpid ()));
+
+    void *server_ctx = zmq_ctx_new ();
+    TEST_ASSERT_NOT_NULL (server_ctx);
+    void *server = zmq_socket (server_ctx, ZMQ_PAIR);
+    TEST_ASSERT_NOT_NULL (server);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (server, endpoint));
+
+    const pid_t child = fork ();
+    TEST_ASSERT_NOT_EQUAL (-1, child);
+    if (child == 0) {
+        void *client_ctx = zmq_ctx_new ();
+        assert (client_ctx);
+        void *client = zmq_socket (client_ctx, ZMQ_PAIR);
+        assert (client);
+        assert (zmq_connect (client, endpoint) == 0);
+        assert (zmq_send (client, "pi", 2, ZMQ_SNDMORE) == 2);
+        assert (zmq_send (client, "ng", 2, 0) == 2);
+        char reply[4];
+        assert (zmq_recv (client, reply, sizeof reply, 0) == 4);
+        assert (memcmp (reply, "pong", 4) == 0);
+        zmq_close (client);
+        zmq_ctx_term (client_ctx);
+        _exit (0);
+    }
+
+    char request[2];
+    TEST_ASSERT_EQUAL_INT (2, zmq_recv (server, request, sizeof request, 0));
+    TEST_ASSERT_EQUAL_MEMORY ("pi", request, 2);
+    int more = 0;
+    size_t more_size = sizeof more;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_getsockopt (server, ZMQ_RCVMORE, &more, &more_size));
+    TEST_ASSERT_EQUAL_INT (1, more);
+    TEST_ASSERT_EQUAL_INT (2, zmq_recv (server, request, sizeof request, 0));
+    TEST_ASSERT_EQUAL_MEMORY ("ng", request, 2);
+    TEST_ASSERT_EQUAL_INT (4, zmq_send (server, "pong", 4, 0));
+
+    int status = 0;
+    TEST_ASSERT_EQUAL (child, waitpid (child, &status, 0));
+    TEST_ASSERT_TRUE (WIFEXITED (status));
+    TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
+    zmq_close (server);
+    zmq_ctx_term (server_ctx);
+}
+
+void test_pair_drains_shared_ring_before_peer_close ()
+{
+    char endpoint[128];
+    snprintf (endpoint, sizeof endpoint, "shm:///tmp/libzmq-shm-drain-%d",
+              static_cast<int> (getpid ()));
+
+    void *server_ctx = zmq_ctx_new ();
+    TEST_ASSERT_NOT_NULL (server_ctx);
+    void *server = zmq_socket (server_ctx, ZMQ_PAIR);
+    TEST_ASSERT_NOT_NULL (server);
+    const int hwm = 1;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (server, ZMQ_RCVHWM, &hwm, sizeof hwm));
+    const int timeout = 5000;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof timeout));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (server, endpoint));
+
+    const pid_t child = fork ();
+    TEST_ASSERT_NOT_EQUAL (-1, child);
+    if (child == 0) {
+        void *client_ctx = zmq_ctx_new ();
+        assert (client_ctx);
+        void *client = zmq_socket (client_ctx, ZMQ_PAIR);
+        assert (client);
+        assert (zmq_connect (client, endpoint) == 0);
+        for (int i = 0; i != 64; ++i)
+            assert (zmq_send (client, &i, sizeof i, 0) == sizeof i);
+        zmq_close (client);
+        zmq_ctx_term (client_ctx);
+        _exit (0);
+    }
+
+    for (int i = 0; i != 55; ++i) {
+        int value = -1;
+        TEST_ASSERT_EQUAL_INT (sizeof value,
+                               zmq_recv (server, &value, sizeof value, 0));
+        TEST_ASSERT_EQUAL_INT (i, value);
+    }
+
+    int status = 0;
+    TEST_ASSERT_EQUAL (child, waitpid (child, &status, 0));
+    TEST_ASSERT_TRUE (WIFEXITED (status));
+    TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
+
+    for (int i = 55; i != 64; ++i) {
+        int value = -1;
+        TEST_ASSERT_EQUAL_INT (sizeof value,
+                               zmq_recv (server, &value, sizeof value, 0));
+        TEST_ASSERT_EQUAL_INT (i, value);
+    }
+    zmq_close (server);
+    zmq_ctx_term (server_ctx);
+}
+
+void test_pair_roundtrip_in_one_context ()
+{
+    char endpoint[128];
+    snprintf (endpoint, sizeof endpoint, "shm:///tmp/libzmq-shm-context-%d",
+              static_cast<int> (getpid ()));
+
+    void *ctx = zmq_ctx_new ();
+    TEST_ASSERT_NOT_NULL (ctx);
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_ctx_set (ctx, ZMQ_IO_THREADS, 1));
+    void *server = zmq_socket (ctx, ZMQ_PAIR);
+    void *client = zmq_socket (ctx, ZMQ_PAIR);
+    TEST_ASSERT_NOT_NULL (server);
+    TEST_ASSERT_NOT_NULL (client);
+    const int timeout = 5000;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof timeout));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_bind (server, endpoint));
+    TEST_ASSERT_SUCCESS_ERRNO (zmq_connect (client, endpoint));
+    TEST_ASSERT_EQUAL_INT (4, zmq_send (client, "ping", 4, 0));
+    char request[4];
+    TEST_ASSERT_EQUAL_INT (4, zmq_recv (server, request, sizeof request, 0));
+    TEST_ASSERT_EQUAL_MEMORY ("ping", request, 4);
+    zmq_close (client);
+    zmq_close (server);
+    zmq_ctx_term (ctx);
+}
+
+void test_shm_rejects_unsupported_options ()
+{
+    char endpoint[128];
+    snprintf (endpoint, sizeof endpoint, "shm:///tmp/libzmq-shm-secure-%d",
+              static_cast<int> (getpid ()));
+
+    void *ctx = zmq_ctx_new ();
+    TEST_ASSERT_NOT_NULL (ctx);
+    void *server = zmq_socket (ctx, ZMQ_PAIR);
+    TEST_ASSERT_NOT_NULL (server);
+    const int enabled = 1;
+    TEST_ASSERT_SUCCESS_ERRNO (
+      zmq_setsockopt (server, ZMQ_PLAIN_SERVER, &enabled, sizeof enabled));
+    TEST_ASSERT_FAILURE_ERRNO (ENOCOMPATPROTO, zmq_bind (server, endpoint));
+    zmq_close (server);
+
+    void *router = zmq_socket (ctx, ZMQ_ROUTER);
+    TEST_ASSERT_NOT_NULL (router);
+    TEST_ASSERT_FAILURE_ERRNO (ENOCOMPATPROTO, zmq_bind (router, endpoint));
+    zmq_close (router);
+    zmq_ctx_term (ctx);
+}
+
+int main ()
+{
+    setup_test_environment ();
+    UNITY_BEGIN ();
+    RUN_TEST (test_pair_roundtrip_across_processes);
+    RUN_TEST (test_pair_drains_shared_ring_before_peer_close);
+    RUN_TEST (test_pair_roundtrip_in_one_context);
+    RUN_TEST (test_shm_rejects_unsupported_options);
+    return UNITY_END ();
+}

--- a/tests/test_shm_channel.cpp
+++ b/tests/test_shm_channel.cpp
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include "testutil_unity.hpp"
+#include "../src/shm_channel.hpp"
+#include "../src/shm_fd.hpp"
+
+#include <assert.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+void setUp ()
+{
+}
+
+void tearDown ()
+{
+}
+
+void test_bidirectional_channel_across_independent_mappings ()
+{
+    const uint32_t slot_count = 8;
+    const size_t payload_capacity = 1024;
+    const size_t mapping_size =
+      zmq::shm_channel_t::memory_size (slot_count, payload_capacity);
+    const int fd = zmq::shm_create_fd (mapping_size);
+    TEST_ASSERT_GREATER_OR_EQUAL (0, fd);
+    void *const server_mapping = zmq::shm_map_fd (fd, mapping_size);
+    TEST_ASSERT_NOT_EQUAL (MAP_FAILED, server_mapping);
+    TEST_ASSERT_EQUAL_INT (
+      0, zmq::shm_channel_t::initialize (server_mapping, mapping_size,
+                                         slot_count, payload_capacity));
+
+    int sockets[2];
+    TEST_ASSERT_EQUAL_INT (0, socketpair (AF_UNIX, SOCK_STREAM, 0, sockets));
+    const pid_t child = fork ();
+    TEST_ASSERT_NOT_EQUAL (-1, child);
+    if (child == 0) {
+        close (sockets[0]);
+        close (fd);
+        munmap (server_mapping, mapping_size);
+        int received_fd = -1;
+        size_t received_size = 0;
+        assert (zmq::shm_recv_fd (sockets[1], &received_fd, &received_size)
+                == 0);
+        void *const client_mapping =
+          zmq::shm_map_fd (received_fd, received_size);
+        assert (client_mapping != MAP_FAILED);
+        zmq::shm_channel_t channel (client_mapping, received_size, false);
+        assert (channel.valid ());
+
+        const void *data = NULL;
+        size_t size = 0;
+        unsigned char flags = 0;
+        while (!channel.try_receive (0, &data, &size, &flags)) {
+        }
+        assert (size == 4 && memcmp (data, "ping", 4) == 0 && flags == 3);
+        channel.release_receive (0);
+
+        void *payload = NULL;
+        while (!payload)
+            payload = channel.try_reserve_send (0, 4, 7);
+        memcpy (payload, "pong", 4);
+        channel.publish_send (0);
+        munmap (client_mapping, received_size);
+        close (received_fd);
+        close (sockets[1]);
+        _exit (0);
+    }
+
+    close (sockets[1]);
+    TEST_ASSERT_EQUAL_INT (0, zmq::shm_send_fd (sockets[0], fd, mapping_size));
+    zmq::shm_channel_t channel (server_mapping, mapping_size, true);
+    TEST_ASSERT_TRUE (channel.valid ());
+    void *payload = NULL;
+    while (!payload)
+        payload = channel.try_reserve_send (0, 4, 3);
+    memcpy (payload, "ping", 4);
+    channel.publish_send (0);
+
+    const void *data = NULL;
+    size_t size = 0;
+    unsigned char flags = 0;
+    while (!channel.try_receive (0, &data, &size, &flags)) {
+    }
+    TEST_ASSERT_EQUAL_UINT64 (4, size);
+    TEST_ASSERT_EQUAL_MEMORY ("pong", data, 4);
+    TEST_ASSERT_EQUAL_UINT8 (7, flags);
+    channel.release_receive (0);
+
+    int status = 0;
+    TEST_ASSERT_EQUAL (child, waitpid (child, &status, 0));
+    TEST_ASSERT_TRUE (WIFEXITED (status));
+    TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
+    munmap (server_mapping, mapping_size);
+    close (fd);
+    close (sockets[0]);
+}
+
+int main ()
+{
+    UNITY_BEGIN ();
+    RUN_TEST (test_bidirectional_channel_across_independent_mappings);
+    return UNITY_END ();
+}

--- a/tests/test_shm_channel.cpp
+++ b/tests/test_shm_channel.cpp
@@ -77,6 +77,7 @@ void test_bidirectional_channel_across_independent_mappings ()
     void *payload = NULL;
     while (!payload)
         payload = channel.try_reserve_send (0, 4, 3);
+    TEST_ASSERT_EQUAL_UINT64 (0, reinterpret_cast<size_t> (payload) % 64);
     memcpy (payload, "ping", 4);
     channel.publish_send (0);
 

--- a/tests/test_shm_ring.cpp
+++ b/tests/test_shm_ring.cpp
@@ -1,0 +1,115 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+#include "testutil_unity.hpp"
+#include "../src/shm_ring.hpp"
+
+#include <assert.h>
+#include <new>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace
+{
+struct counters_t
+{
+    volatile uint32_t constructed;
+    volatile uint32_t destroyed;
+};
+
+counters_t *counters;
+
+struct message_t
+{
+    uint64_t sequence;
+    unsigned char payload[256];
+
+    message_t (uint64_t sequence_) : sequence (sequence_)
+    {
+        __atomic_add_fetch (&counters->constructed, 1, __ATOMIC_RELAXED);
+        memset (payload, static_cast<unsigned char> (sequence_),
+                sizeof payload);
+    }
+
+    ~message_t ()
+    {
+        __atomic_add_fetch (&counters->destroyed, 1, __ATOMIC_RELAXED);
+    }
+};
+}
+
+void setUp ()
+{
+}
+
+void tearDown ()
+{
+}
+
+void test_spsc_ring_preserves_cross_process_object_lifetime ()
+{
+    const uint32_t slot_count = 8;
+    const uint64_t message_count = 10000;
+    const size_t mapping_size =
+      zmq::shm_ring_t::memory_size (slot_count, sizeof (message_t));
+    void *const mapping =
+      mmap (NULL, mapping_size, PROT_READ | PROT_WRITE,
+            MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    TEST_ASSERT_NOT_EQUAL (MAP_FAILED, mapping);
+    TEST_ASSERT_EQUAL_INT (
+      0, zmq::shm_ring_t::initialize (mapping, mapping_size, slot_count,
+                                      sizeof (message_t)));
+
+    counters = static_cast<counters_t *> (
+      mmap (NULL, sizeof (counters_t), PROT_READ | PROT_WRITE,
+            MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+    TEST_ASSERT_NOT_EQUAL (MAP_FAILED, counters);
+    counters->constructed = 0;
+    counters->destroyed = 0;
+
+    const pid_t child = fork ();
+    TEST_ASSERT_NOT_EQUAL (-1, child);
+    if (child == 0) {
+        zmq::shm_ring_t ring (mapping, mapping_size);
+        assert (ring.valid ());
+        for (uint64_t i = 0; i != message_count; ++i) {
+            const message_t *message = NULL;
+            while (!message)
+                message = static_cast<const message_t *> (
+                  ring.try_acquire_read (i));
+            assert (message->sequence == i);
+            assert (message->payload[0]
+                    == static_cast<unsigned char> (i));
+            const_cast<message_t *> (message)->~message_t ();
+            ring.release_read (i);
+        }
+        _exit (0);
+    }
+
+    zmq::shm_ring_t ring (mapping, mapping_size);
+    TEST_ASSERT_TRUE (ring.valid ());
+    for (uint64_t i = 0; i != message_count; ++i) {
+        void *storage = NULL;
+        while (!storage)
+            storage = ring.try_acquire_write (i);
+        new (storage) message_t (i);
+        ring.publish_write (i);
+    }
+
+    int status = 0;
+    TEST_ASSERT_EQUAL (child, waitpid (child, &status, 0));
+    TEST_ASSERT_TRUE (WIFEXITED (status));
+    TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
+    TEST_ASSERT_EQUAL_UINT32 (message_count, counters->constructed);
+    TEST_ASSERT_EQUAL_UINT32 (message_count, counters->destroyed);
+    TEST_ASSERT_EQUAL_INT (0, munmap (counters, sizeof (counters_t)));
+    TEST_ASSERT_EQUAL_INT (0, munmap (mapping, mapping_size));
+}
+
+int main ()
+{
+    UNITY_BEGIN ();
+    RUN_TEST (test_spsc_ring_preserves_cross_process_object_lifetime);
+    return UNITY_END ();
+}

--- a/tests/test_shm_ring.cpp
+++ b/tests/test_shm_ring.cpp
@@ -1,12 +1,14 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 
 #include "testutil_unity.hpp"
+#include "../src/shm_fd.hpp"
 #include "../src/shm_ring.hpp"
 
 #include <assert.h>
 #include <new>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -107,9 +109,61 @@ void test_spsc_ring_preserves_cross_process_object_lifetime ()
     TEST_ASSERT_EQUAL_INT (0, munmap (mapping, mapping_size));
 }
 
+void test_memfd_transfer_supports_independent_mapping ()
+{
+    const size_t mapping_size = 4096;
+    int sockets[2];
+    TEST_ASSERT_EQUAL_INT (0, socketpair (AF_UNIX, SOCK_STREAM, 0, sockets));
+
+    const int fd = zmq::shm_create_fd (mapping_size);
+    TEST_ASSERT_GREATER_OR_EQUAL (0, fd);
+    uint64_t *const parent_mapping = static_cast<uint64_t *> (
+      zmq::shm_map_fd (fd, mapping_size));
+    TEST_ASSERT_NOT_EQUAL (MAP_FAILED, parent_mapping);
+    parent_mapping[0] = UINT64_C (0x1122334455667788);
+    parent_mapping[1] = 0;
+
+    const pid_t child = fork ();
+    TEST_ASSERT_NOT_EQUAL (-1, child);
+    if (child == 0) {
+        close (sockets[0]);
+        close (fd);
+        munmap (parent_mapping, mapping_size);
+
+        int received_fd = -1;
+        size_t received_size = 0;
+        assert (zmq::shm_recv_fd (sockets[1], &received_fd, &received_size)
+                == 0);
+        assert (received_size == mapping_size);
+        uint64_t *const child_mapping = static_cast<uint64_t *> (
+          zmq::shm_map_fd (received_fd, received_size));
+        assert (child_mapping != MAP_FAILED);
+        assert (child_mapping[0] == UINT64_C (0x1122334455667788));
+        child_mapping[1] = UINT64_C (0x8877665544332211);
+        munmap (child_mapping, received_size);
+        close (received_fd);
+        close (sockets[1]);
+        _exit (0);
+    }
+
+    close (sockets[1]);
+    TEST_ASSERT_EQUAL_INT (
+      0, zmq::shm_send_fd (sockets[0], fd, mapping_size));
+    int status = 0;
+    TEST_ASSERT_EQUAL (child, waitpid (child, &status, 0));
+    TEST_ASSERT_TRUE (WIFEXITED (status));
+    TEST_ASSERT_EQUAL_INT (0, WEXITSTATUS (status));
+    TEST_ASSERT_EQUAL_UINT64 (UINT64_C (0x8877665544332211),
+                              parent_mapping[1]);
+    TEST_ASSERT_EQUAL_INT (0, munmap (parent_mapping, mapping_size));
+    close (fd);
+    close (sockets[0]);
+}
+
 int main ()
 {
     UNITY_BEGIN ();
     RUN_TEST (test_spsc_ring_preserves_cross_process_object_lifetime);
+    RUN_TEST (test_memfd_transfer_supports_independent_mapping);
     return UNITY_END ();
 }


### PR DESCRIPTION
## Summary

This is a draft implementation of a Linux-only shared-memory IPC transport for local processes.

The PR adds:

- a new experimental `shm://` transport path for `ZMQ_PAIR`
- a Unix-domain-socket handshake that transfers shared resources with `SCM_RIGHTS`
- shared payload storage backed by `memfd_create` and `mmap(MAP_SHARED)`
- bidirectional SPSC slot rings for process-to-process message movement
- eventfd-based wakeups and peer liveness handling
- direct shared-slot message APIs, `zmq_shm_msg_init` and `zmq_shm_msg_send`
- `ZMQ_SHM` message inspection so applications can tell when received payload storage is shared
- tests for the ring/channel primitives, fd transfer, shm pair roundtrips, direct shared-slot messages, slot release, and messages outliving socket/context teardown

## Motivation

The existing `ipc://` transport uses Unix domain sockets, so payload bytes still pass through kernel socket buffers. For large same-host messages this can dominate cost. This draft explores using UDS only for connection setup, fd transfer, wakeups, and liveness, while moving payloads through shared memory.

The direct-message path lets an application reserve a shared slot, construct payload data directly in that slot, send the message, and release the slot when the last `zmq_msg_t` reference is closed. That is the application-to-application zero-copy case this draft is trying to evaluate.

## Design Notes

- The implementation is Linux-only and guarded with `ZMQ_HAVE_LINUX`.
- `shm://` reuses the IPC address path for bind/connect but installs a shared-memory engine after the UDS handshake.
- The listener creates the shared mapping and transfers the memfd plus eventfds to the peer.
- Each connection owns two fixed-size SPSC rings, one per direction.
- Regular `zmq_send` copies application data into a shared slot.
- `zmq_shm_msg_init` reserves a shared slot before construction, initializes a `msg_t` over that storage, and binds slot release to the message finalizer.
- The shared mapping remains referenced while received messages still point into it, even if the socket/context has already been closed.

## Related Work

- Related to #3241, which asked about shared-memory process transport. The discussion there confirmed that libzmq did not support POSIX shared-memory IPC at that time.
- Related to #4802, which exposes external message storage to avoid control-block allocation. This PR uses a similar lifetime primitive internally, but it is not a replacement: this PR adds a transport-level shared-memory data path.

## Draft Status

This is intentionally opened as a draft to get early feedback on the transport shape and public API before hardening it further.

Open areas before this should be considered ready:

- decide whether the public API should remain as `zmq_shm_msg_init/send`, be draft-gated, or be shaped differently
- decide whether `shm://` should be a separate transport or an IPC backend option
- expand resource-exhaustion and multi-peer behavior beyond the current MVP tests
- add documentation once the API direction is agreed
- publish the full benchmark matrix in the PR discussion

## Validation

- `git diff --check upstream/master..HEAD`
- targeted Linux tests were added for `test_shm_ring`, `test_shm_channel`, and `test_pair_shm`

This has not been marked ready for review yet because the API and production-hardening questions above need maintainer feedback first.
